### PR TITLE
only update the registry on add once per session

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -7,7 +7,7 @@ import Dates
 import LibGit2
 
 import ..depots, ..logdir, ..devdir, ..print_first_command_header
-import ..Operations, ..Display, ..GitTools, ..Pkg
+import ..Operations, ..Display, ..GitTools, ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION
 using ..Types, ..TOML
 
 
@@ -25,11 +25,13 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, k
     print_first_command_header()
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
+    if !UPDATED_REGISTRY_THIS_SESSION[]
+        update_registry(ctx)
+    end
     if mode == :develop
         new_git = handle_repos_develop!(ctx, pkgs)
     else
         new_git = handle_repos_add!(ctx, pkgs; upgrade_or_add=true)
-        update_registry(ctx)
     end
     project_deps_resolve!(ctx.env, pkgs)
     registry_resolve!(ctx.env, pkgs)
@@ -115,6 +117,7 @@ function update_registry(ctx)
         end
         @warn warn_str
     end
+    UPDATED_REGISTRY_THIS_SESSION[] = true
     return
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -8,6 +8,7 @@ using REPL.TerminalMenus
 depots() = Base.DEPOT_PATH
 logdir() = joinpath(depots()[1], "logs")
 devdir() = get(ENV, "JULIA_PKG_DEVDIR", joinpath(homedir(), ".julia", "dev"))
+const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 
 have_warned_session = false
 function print_first_command_header()


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/294.

It's annoying to have to do the whole registry update when you are adding another package just after another. `update` will always update it so I think this is a nice balance.