### PR TITLE
fix versionrange with old ranges of the type 0.1.0 0.1.0+

### DIFF
--- a/src/Pkg2/types.jl
+++ b/src/Pkg2/types.jl
@@ -28,6 +28,8 @@ function Base.convert(::Type{VersionRange}, a::VersionInterval)
     lb = VersionBound(lower.major, lower.minor, lower.patch)
 
     vb = UInt32[upper.major, upper.minor, upper.patch]
+    # Consider e.g. "0.1.0 0.1.0+" to be the same as VerionRange("0.1.0")
+    # by making the "+" bump the patch version
     if typeof(upper.build) == Tuple{String} && vb[3] != typemax(UInt32)
         vb[3] += 1
     end

--- a/src/Pkg2/types.jl
+++ b/src/Pkg2/types.jl
@@ -28,6 +28,9 @@ function Base.convert(::Type{VersionRange}, a::VersionInterval)
     lb = VersionBound(lower.major, lower.minor, lower.patch)
 
     vb = UInt32[upper.major, upper.minor, upper.patch]
+    if typeof(upper.build) == Tuple{String} && vb[3] != typemax(UInt32)
+        vb[3] += 1
+    end
     i = 3
     while i > 0 && vb[i] == 0
         pop!(vb)


### PR DESCRIPTION
Fixes #293 

```
(Pkg) pkg> add https://github.com/JuliaComputing/Deprecations.jl
[ Info: Assigning UUID 5a972732-6268-11e8-288b-df1ad7efd8ef to Deprecations
  Updating registry at `~/.julia/registries/Uncurated`
  Updating git-repo `https://github.com/JuliaRegistries/Uncurated.git`
 Resolving package versions...

Downloaded Tokenize ────── v0.4.2
Downloaded AbstractTrees ─ v0.1.0
Downloaded CSTParser ───── v0.3.5
```

@carlobaldassi seems ok to you?

Problem was that when using old REQUIRE files things like `0.1.0 0.1.0+` gave empty version ranges.