### PR TITLE
WIP: support test-dependencies

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -751,6 +751,15 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         end
     end
 
+    pkgs = PackageSpec[]
+    target = ""
+    if pkg.special_action == PKGSPEC_TESTED
+        target = "test"
+    end
+    if !isempty(target)
+        collect_target_deps!(localctx, pkgs, pkg, target)
+    end
+
     mktempdir() do tmpdir
         localctx.env.project_file = joinpath(tmpdir, "Project.toml")
         localctx.env.manifest_file = joinpath(tmpdir, "Manifest.toml")
@@ -763,31 +772,9 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
             end
         end
 
-        pkgs = PackageSpec[]
-        if pkg.special_action == PKGSPEC_TESTED
-            # Find path to pkg being tested (exploit Base.locate_package instead?)
-            if pkg.uuid in keys(localctx.stdlibs)
-                path = Types.stdlib_path(pkg.name)
-            elseif Types.is_project_uuid(localctx.env, pkg.uuid)
-                path = dirname(mainctx.env.project_file)
-            else
-                info = manifest_info(localctx.env, pkg.uuid)
-                path = haskey(info, "path") ? project_rel_path(localctx, info["path"]) : find_installed(pkg.name, pkg.uuid, SHA1(info["git-tree-sha1"]))
-            end
-
-            # Collect test/REQUIRE packages if they exist
-            test_reqfile = joinpath(path, "test", "REQUIRE")
-            if isfile(test_reqfile)
-                for r in Pkg2.Reqs.read(test_reqfile)
-                    r isa Pkg2.Reqs.Requirement || continue
-                    pkg_name, vspec = r.package, VersionSpec(VersionRange[r.versions.intervals...])
-                    push!(pkgs, PackageSpec(pkg_name, vspec))
-                end
-                registry_resolve!(localctx.env, pkgs)
-                ensure_resolved(localctx.env, pkgs; registry=true)
-                add_or_develop(localctx, pkgs)
-                need_to_resolve = false # add resolves
-            end
+        if !isempty(pkgs)
+            add_or_develop(localctx, pkgs)
+            need_to_resolve = false # add resolves
         end
 
         local new
@@ -803,6 +790,51 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         sep = Sys.iswindows() ? ';' : ':'
         withenv(f, "JULIA_LOAD_PATH" => "@$sep$tmpdir$sep$(Types.stdlib_dir())")
     end
+end
+
+function collect_target_deps!(ctx::Context, pkgs::Vector{PackageSpec}, pkg::PackageSpec, target::String)
+    # Find the path to the package
+    if pkg.uuid in keys(ctx.stdlibs)
+        path = Types.stdlib_path(pkg.name)
+    elseif Types.is_project_uuid(ctx.env, pkg.uuid)
+        path = dirname(ctx.env.project_file)
+    else
+        info = manifest_info(ctx.env, pkg.uuid)
+        path = haskey(info, "path") ? project_rel_path(ctx, info["path"]) : find_installed(pkg.name, pkg.uuid, SHA1(info["git-tree-sha1"]))
+    end
+
+    if !haskey(ctx.env.project, "targets")
+        if target == "test"
+            pkg2_test_target_compatibility!(ctx, path, pkgs)
+        end
+        return pkgs
+    end
+    targets = ctx.env.project["targets"]
+    haskey(targets, target) || return pkgs
+    targets = ctx.env.project["targets"]
+    target_info = targets[target]
+    haskey(target_info, "deps") || return pkgs
+    targets = ctx.env.project["targets"]
+    deps = target_info["deps"]
+    for (pkg, uuid) in deps
+        push!(pkgs, PackageSpec(pkg, UUID(uuid)))
+    end
+    return nothing
+end
+
+# Pkg2 test/REQUIRE compatibility
+function pkg2_test_target_compatibility!(ctx, path, pkgs)
+    test_reqfile = joinpath(path, "test", "REQUIRE")
+    if isfile(test_reqfile)
+        for r in Pkg2.Reqs.read(test_reqfile)
+            r isa Pkg2.Reqs.Requirement || continue
+            pkg_name, vspec = r.package, VersionSpec(VersionRange[r.versions.intervals...])
+            push!(pkgs, PackageSpec(pkg_name, vspec))
+        end
+        registry_resolve!(ctx.env, pkgs)
+        ensure_resolved(ctx.env, pkgs; registry=true)
+    end
+    return nothing
 end
 
 function any_package_not_installed(ctx)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -264,39 +264,40 @@ temp_pkg_dir() do project_path; cd(project_path) do
     end
 end end
 
-mktempdir() do tmp
-    cp(joinpath(@__DIR__, "test_packages", "BigProject"), joinpath(tmp, "BigProject"))
-    cd(joinpath(tmp, "BigProject")) do
-        try
-            pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
-            pkg"build"
-            @eval using BigProject
-            pkg"build BigProject"
-            @test_throws CommandError pkg"add BigProject"
-            pkg"test SubModule"
-            pkg"test SubModule2"
-            pkg"test BigProject"
-            pkg"test"
-            current_example = Pkg.API.installed()["Example"]
-            old_project = read("Project.toml", String)
-            open("Project.toml"; append=true) do io
-                print(io, """
+temp_pkg_dir() do project_path; cd(project_path) do
+    mktempdir() do tmp
+        cp(joinpath(@__DIR__, "test_packages", "BigProject"), joinpath(tmp, "BigProject"))
+        cd(joinpath(tmp, "BigProject")) do
+            try
+                pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+                pkg"build"
+                @eval using BigProject
+                pkg"build BigProject"
+                @test_throws CommandError pkg"add BigProject"
+                pkg"test SubModule"
+                pkg"test SubModule2"
+                pkg"test BigProject"
+                pkg"test"
+                current_json = Pkg.API.installed()["JSON"]
+                old_project = read("Project.toml", String)
+                open("Project.toml"; append=true) do io
+                    print(io, """
 
-                [compatibility]
-                Example = "0.4.0"
-                """
-                )
+                    [compatibility]
+                    JSON = "0.16.0"
+                    """
+                    )
+                end
+                pkg"up"
+                @test Pkg.API.installed()["JSON"].minor == 16
+                write("Project.toml", old_project)
+                pkg"up"
+                @test Pkg.API.installed()["JSON"] == current_json
+            finally
+                popfirst!(LOAD_PATH)
             end
-            pkg"up"
-            @test Pkg.API.installed()["Example"].minor == 4
-            write("Project.toml", old_project)
-            pkg"up"
-            @test Pkg.API.installed()["Example"] == current_example
-        finally
-            popfirst!(LOAD_PATH)
         end
     end
-end
-
+end; end
 
 end # module

--- a/test/test_packages/BigProject/Manifest.toml
+++ b/test/test_packages/BigProject/Manifest.toml
@@ -1,11 +1,77 @@
-[[Example]]
-deps = ["Test"]
-git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
-uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
-version = "0.5.1"
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "IterativeEigensolvers", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "SuiteSparse", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "e891dc2ba653107604985bc5ab7294d9de83630f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "0.66.0"
+
+[[Dates]]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterativeEigensolvers]]
+uuid = "de555fa4-b82f-55e7-8b71-53f60bbc027d"
+
+[[JSON]]
+deps = ["Compat", "Nullables", "Sockets", "Unicode"]
+git-tree-sha1 = "e2f6776e8bfd310b2ade13fba1faf99d8967d58f"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.17.2"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Markdown]]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Nullables]]
+deps = ["Compat"]
+git-tree-sha1 = "23258f849603ad4fed3ce7dbcb8c0658920fa5ef"
+uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
+version = "0.0.5"
+
+[[Pkg]]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SubModule]]
 path = "SubModule"
@@ -17,5 +83,14 @@ path = "SubModule2"
 uuid = "2d3cad7e-26b9-11e8-3e8d-a543003d541d"
 version = "0.1.0"
 
+[[SuiteSparse]]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
 [[Test]]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/test_packages/BigProject/Project.toml
+++ b/test/test_packages/BigProject/Project.toml
@@ -4,7 +4,11 @@ uuid = "da7e1942-2519-11e8-2822-f5508ce758f0"
 version = "0.1.0"
 
 [deps]
-Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SubModule = "0d404dc8-25d6-11e8-300e-11c8e584fb95"
 SubModule2 = "2d3cad7e-26b9-11e8-3e8d-a543003d541d"
+
+[targets.test.deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This allows one to write e.g.

```
[targets.test.deps]
Example = "7876af07-990d-54b4-ab0e-23690620f79a"
Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
```

to load these only when testing.

WIP because the way TOML.jl prints this back in the Project file is something like:

```
[targets.test.deps]
    [targets.test]
        [targets.test.deps]
        Example = "7876af07-990d-54b4-ab0e-23690620f79a"
        Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
```