### PR TITLE
Request: API.write_manifest and API.get_manifest

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -238,6 +238,35 @@ function installed(mode::PackageMode=PKGMODE_MANIFEST)
     return version_status
 end
 
+
+"""
+    get_manifest([ctx::Context])::Dict
+
+Get a serializable representation of manifest.
+See also [`write_manifest`](@ref).
+"""
+function get_manifest(ctx::Context=Context())::Dict
+    return Types.get_manifest(ctx.env)
+end
+
+
+"""
+    write_manifest(file_or_io, [ctx::Context])
+
+Write Manifest.toml to `file_or_io`.
+See also [`get_manifest`](@ref).
+"""
+function write_manifest(file::String, args...)
+    open(file, "w") do io
+        write_manifest(io, args...)
+    end
+end
+
+function write_manifest(io::IO, ctx::Context=Context())
+    TOML.print(io, get_manifest(ctx), sorted=true)
+end
+
+
 function gc(ctx::Context=Context(); kwargs...)
     print_first_command_header()
     function recursive_dir_size(path)

--- a/src/API.jl
+++ b/src/API.jl
@@ -240,30 +240,38 @@ end
 
 
 """
-    get_manifest([ctx::Context])::Dict
+    get_manifest([ctx::Context]; develop_info=false)::Dict
 
 Get a serializable representation of manifest.
+
+If `develop_info` is `true`, each package entry includes the following extra
+information about Git repositories of development mode packages:
+
+- `repo-rev` (`String`): Git hash of the checked out revision.
+- `is-clean` (`Bool`): `true` if and only if the Git repository has no
+  uncommitted changes.
+
 See also [`write_manifest`](@ref).
 """
-function get_manifest(ctx::Context=Context())::Dict
-    return Types.get_manifest(ctx.env)
+function get_manifest(ctx::Context=Context(); kwargs...)::Dict
+    return Types.get_manifest(ctx.env; kwargs...)
 end
 
 
 """
-    write_manifest(file_or_io, [ctx::Context])
+    write_manifest(file_or_io, [ctx::Context]; develop_info=false)
 
 Write Manifest.toml to `file_or_io`.
 See also [`get_manifest`](@ref).
 """
-function write_manifest(file::String, args...)
+function write_manifest(file::String, args...; kwargs...)
     open(file, "w") do io
-        write_manifest(io, args...)
+        write_manifest(io, args...; kwargs...)
     end
 end
 
-function write_manifest(io::IO, ctx::Context=Context())
-    TOML.print(io, get_manifest(ctx), sorted=true)
+function write_manifest(io::IO, ctx::Context=Context(); kwargs...)
+    TOML.print(io, get_manifest(ctx; kwargs...), sorted=true)
 end
 
 


### PR DESCRIPTION
Context: I have a few packages for my scientific computing. For reproducibility, I need to store the exact state of all Julia packages used when running my computation.

Pkg3's manifest file is a perfect record for this purpose. All I need is an API to dump manifest into a file.  This is what I added in the first commit.

However default manifest file is not enough.  During research, I don't know what I'm doing and I'm constantly changing the code.  Bumping up version numbers every time I edit the code is not reasonable.  So, I'd like to have an option to store Git revision and if the repository is clean or not.  To record this info, I added `develop_info` keyword argument to the API.

In sum, the API I'd like to have look like:

> ```julia
> get_manifest([ctx::Context]; develop_info=false)::Dict
> ```
>
> Get a serializable representation of manifest.
> 
> If `develop_info` is `true`, each package entry includes the following extra
> information about Git repositories of development mode packages:
> 
> - `repo-rev` (`String`): Git hash of the checked out revision.
> - `is-clean` (`Bool`): `true` if and only if the Git repository has no
>   uncommitted changes.
>
> ```julia
> write_manifest(file_or_io, [ctx::Context]; develop_info=false)
> ```
>
> Write Manifest.toml to `file_or_io`.

I feel that `develop_info` option is slightly outside the scope of Pkg3.  But implementing it outside Pkg3 still requires something like `AIP.get_manifest`.

Of course, I need to add tests for the APIs I added.  I'll write them if those APIs are OK to add.