### PR TITLE
make generate start packages at 1.0.0 instead of 0.1.0

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -55,7 +55,7 @@ function project(pkg::String, dir::String; preview::Bool)
             authors = $authorstr
             name = "$pkg"
             uuid = "$(UUIDs.uuid1())"
-            version = "0.1.0"
+            version = "1.0.0"
 
             [deps]
             """


### PR DESCRIPTION
See e.g. https://docs.npmjs.com/getting-started/semantic-versioning#semver-for-publishers. SemVer before 1.0 is "under specified" and while we make the same interpretation as cargo when it comes to pre 1.0.0 versions, it is just better if things start at 1.0.0.