### PR TITLE
WIP: add package converter (creating Project.toml from REQUIRE)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -707,6 +707,7 @@ Similar to other package managers, the Julia package manager respects [semantic 
 As an example, a version specifier is given as e.g. `1.2.3` is therefore assumed to be compatible with the versions `[1.2.3 - 2.0.0)` where `)` is a non-inclusive upper bound.
 More specifically, a version specifier is either given as a **caret specifier**, e.g. `^1.2.3`  or a **tilde specifier** `~1.2.3`.
 Caret specifiers are the default and hence `1.2.3 == ^1.2.3`. The difference between a caret and tilde is described in the next section.
+The intersection of multiple version specifiers can be formed by comma separating indiviual version specifiers.
 
 ##### Caret specifiers
 
@@ -737,6 +738,16 @@ This gives the following example.
 ~1.2.3 = [1.2.3, 1.2.4)
 ~1.2 = [1.2.0, 1.3.0)
 ~1 = [1.0.0, 2.0.0)
+```
+
+#### Inequality specifiers
+
+Inequalities can also be used to specify version ranges:
+
+```
+>= 1.2.3 = [1.2.3,  ∞)
+= 1.2.3 = [1.2.3, 1.2.3]
+< 1.2.3 = [0.0.0, 1.2.2]
 ```
 
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -38,6 +38,7 @@ include("Resolve.jl")
 include("Operations.jl")
 include("API.jl")
 include("REPLMode.jl")
+include("require_to_project.jl")
 
 # Define new variables so tab comleting Pkg. works.
 const add         = API.add

--- a/src/require_to_project.jl
+++ b/src/require_to_project.jl
@@ -1,0 +1,97 @@
+function create_project(path::String)
+    ctx = Context()
+
+    # Package data
+    path = abspath(path)
+    m = match(Types.reg_pkg, path)
+    m === nothing && cmderror("cannot determine package name from URL: $(path)")
+    pkgname = m.captures[1]
+
+    mainpkg = PackageSpec(pkgname)
+    registry_resolve!(ctx.env, [mainpkg])
+    if !has_uuid(mainpkg)
+        uuid = UUIDs.uuid1()
+        @info "Unregistered package, giving it a new UUID: $uuid"
+        mainpkg.version = v"0.1.0"
+    else
+        uuid = mainpkg.uuid
+        @info "Registered package, using already given UUID: $(mainpkg.uuid)"
+        Operations.set_maximum_version_registry!(ctx.env, mainpkg)
+        v = mainpkg.version
+        # Remove the build
+        mainpkg.version = VersionNumber(v.major, v.minor, v.patch)
+    end
+
+    # Dependency data
+    dep_pkgs = PackageSpec[]
+    test_pkgs = PackageSpec[]
+    compatibility = Pair{String, String}[]
+
+    reqfiles = [joinpath(path, "REQUIRE"), joinpath(path, "test", "REQUIRE")]
+    for (reqfile, pkgs) in zip(reqfiles, [dep_pkgs, test_pkgs])
+        if isfile(reqfile)
+            for r in Pkg2.Reqs.read(reqfile)
+                r isa Pkg2.Reqs.Requirement || continue
+                r.package == "julia" && continue
+                push!(pkgs, PackageSpec(r.package))
+                intervals = r.versions.intervals
+                if length(intervals) != 1
+                    @warn "Project.toml creator cannot handle multiple requirements for $(r.package), ignoring"
+                else
+                    l = intervals[1].lower
+                    h = intervals[1].upper
+                    if l != v"0.0.0-"
+                        # no upper bound
+                        if h == typemax(VersionNumber)
+                            push!(compatibility, r.package => string(">=", VersionNumber(l.major, l.minor, l.patch)))
+                        else # assume semver
+                            push!(compatibility, r.package => string(">=", VersionNumber(l.major, l.minor, l.patch), ", ",
+                                                                     "<", VersionNumber(h.major, h.minor, h.patch)))
+                        end
+                    end
+                end
+            end
+            registry_resolve!(ctx.env, pkgs)
+            ensure_resolved(ctx.env, pkgs)
+        end
+    end
+
+    stdlib_deps = Operations.find_stdlib_deps(ctx, path)
+    for (stdlib_uuid, stdlib) in stdlib_deps
+        pkg = PackageSpec(stdlib, stdlib_uuid)
+        if stdlib == "Test"
+            push!(test_pkgs, pkg)
+        else
+            push!(dep_pkgs, pkg)
+        end
+    end
+
+    # Write project
+
+    project = Dict(
+        "name" => pkgname,
+        "uuid" => string(uuid),
+        "version" => string(mainpkg.version),
+        "deps" => Dict(pkg.name => string(pkg.uuid) for pkg in dep_pkgs)
+    )
+
+    if !isempty(compatibility)
+        project["compat"] =
+            Dict(name => ver for (name, ver) in compatibility)
+    end
+
+    if !isempty(test_pkgs)
+        project["targets"] =
+            Dict("test" =>
+                Dict("deps" =>
+                    Dict(pkg.name => string(pkg.uuid) for pkg in test_pkgs)
+                )
+            )
+    end
+
+    open(joinpath(path, "Project.toml"), "w") do io
+        TOML.print(io, project, sorted=true, by=key -> (Types.project_key_order(key), key))
+    end
+
+    @info "Added Project.toml to $(path)"
+end

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -247,21 +247,27 @@ Base.show(io::IO, s::VersionSpec) = print(io, "VersionSpec(\"", s, "\")")
 # Semver notation #
 ###################
 
-const ver_reg = r"^([~^]?)?[v]?([0-9]+?)(?:\.([0-9]+?))?(?:\.([0-9]+?))?$"
 
 function semver_spec(s::String)
+    s = replace(s, " " => "")
     ranges = VersionRange[]
     for ver in split(s, ',')
-        push!(ranges, semver_interval(strip(ver)))
+        range = nothing
+        found_match = false
+        for (ver_reg, f) in ver_regs
+            if occursin(ver_reg, ver)
+                range = f(match(ver_reg, ver))
+                found_match = true
+                break
+            end
+        end
+        found_match || error("invalid version specifier: $s")
+        push!(ranges, range)
     end
     return VersionSpec(ranges)
 end
 
-function semver_interval(s::AbstractString)
-    if !occursin(ver_reg, s)
-        error("invalid version specifier: $s")
-    end
-    m = match(ver_reg, s)
+function semver_interval(m::RegexMatch)
     @assert length(m.captures) == 4
     n_significant = count(x -> x !== nothing, m.captures) - 1
     typ, _major, _minor, _patch = m.captures
@@ -269,7 +275,7 @@ function semver_interval(s::AbstractString)
     minor = (n_significant < 2) ? 0 : parse(Int, _minor)
     patch = (n_significant < 3) ? 0 : parse(Int, _patch)
     if n_significant == 3 && major == 0 && minor == 0 && patch == 0
-        error("invalid version: $s")
+        error("invalid version: \"0.0.0\"")
     end
     # Default type is :caret
     vertyp = (typ == "" || typ == "^") ? :caret : :tilde
@@ -296,3 +302,43 @@ function semver_interval(s::AbstractString)
         end
     end
 end
+
+const _inf = Pkg.Types.VersionBound("*")
+function inequality_interval(m::RegexMatch)
+    @assert length(m.captures) == 4
+    typ, _major, _minor, _patch = m.captures
+    n_significant = count(x -> x !== nothing, m.captures) - 1
+    major =                           parse(Int, _major)
+    minor = (n_significant < 2) ? 0 : parse(Int, _minor)
+    patch = (n_significant < 3) ? 0 : parse(Int, _patch)
+    if n_significant == 3 && major == 0 && minor == 0 && patch == 0
+        error("invalid version: $s")
+    end
+    v = VersionBound(major, minor, patch)
+    if typ == "<"
+        nil = VersionBound(0, 0, 0)
+        if v[3] == 0
+            if v[2] == 0
+                v1 = VersionBound(v[1]-1)
+            else
+                v1 = VersionBound(v[1], v[2]-1)
+            end
+        else
+            v1 = VersionBound(v[1], v[2], v[3]-1)
+        end
+        return VersionRange(nil, v1)
+    elseif typ == "="
+        return VersionRange(v)
+    elseif typ == ">="
+           return VersionRange(v, _inf)
+    else
+        error("invalid prefix $typ")
+    end
+end
+
+const version = "v?([0-9]+?)(?:\\.([0-9]+?))?(?:\\.([0-9]+?))?"
+const ver_regs =
+[
+    Regex("^([~^]?)?$version\$") => semver_interval, # 0.5 ^0.4 ~0.3.2
+    Regex("^((?:>=)|(?:=)|(?:<)|(?:=))v?$version\$")  => inequality_interval,# < 0.2 >= 0.5,2
+]

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -56,6 +56,35 @@ import Pkg.Types: semver_spec, VersionSpec
     @test  v"0.0.0"   in semver_spec("0.0")
     @test  v"0.0.99"  in semver_spec("0.0")
     @test !(v"0.1.0"  in semver_spec("0.0"))
+
+    @test semver_spec("<1.2.3") == VersionSpec("0.0.0 - 1.2.2")
+    @test semver_spec("<1.2") == VersionSpec("0.0.0 - 1.1")
+    @test semver_spec("<1") == VersionSpec("0.0.0 - 0")
+    @test semver_spec("<2") == VersionSpec("0.0.0 - 1")
+    @test semver_spec("<0.2.3") == VersionSpec("0.0.0 - 0.2.2")
+    @test semver_spec("<2.0.3") == VersionSpec("0.0.0 - 2.0.2")
+    @test   v"0.2.3" in semver_spec("<0.2.4")
+    @test !(v"0.2.4" in semver_spec("<0.2.4"))
+
+    @test semver_spec("=1.2.3") == VersionSpec("1.2.3")
+    @test semver_spec("=1.2") == VersionSpec("1.2.0")
+    @test semver_spec("  =1") == VersionSpec("1.0.0")
+    @test   v"1.2.3" in semver_spec("=1.2.3")
+    @test !(v"1.2.4" in semver_spec("=1.2.3"))
+    @test !(v"1.2.2" in semver_spec("=1.2.3"))
+
+
+    @test semver_spec(">=   1.2.3") == VersionSpec("1.2.3-*")
+    @test semver_spec(">=1.2  ") == VersionSpec("1.2.0-*")
+    @test semver_spec("  >=  1") == VersionSpec("1.0.0-*")
+    @test   v"1.0.0" in semver_spec(">=1")
+    @test   v"0.0.1" in semver_spec(">=0")
+    @test   v"1.2.3" in semver_spec(">=1.2.3")
+    @test !(v"1.2.2" in semver_spec(">=1.2.3"))
+
+    @test_throws ErrorException semver_spec("^^0.2.3")
+    @test_throws ErrorException semver_spec("^^0.2.3.4")
+    @test_throws ErrorException semver_spec("0.0.0")
 end
 
 # TODO: Should rewrite these tests not to rely on internals like field names


### PR DESCRIPTION
As an example:

```
julia> Pkg.create_project("DataFrames")
[ Info: Registered package, using already given UUID: a93c6f00-e57d-5684-b7b6-d8193f3e46c0
[ Info: Added Project.toml to /Users/kristoffer/.julia/dev/DataFrames

shell> cat DataFrames/Project.toml
name = "DataFrames"
uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
version = "0.11.6"

[deps]
CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
DataStreams = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
SortingAlgorithms = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"

[compat]
CategoricalArrays = "0.3.5"
CodecZlib = "0.4.0"
Compat = "0.59.0"
DataStreams = "0.3.0"
Missings = "0.2.3"
StatsBase = "0.11.0"
WeakRefStrings = "0.4.0"

[targets.test.deps]
DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
```

The tricky thing is what to set the `compat` section to. The problem is that packages do not agree on what the minor version is used for pre 1.0. Many packages sees bumping the minor version as breaking but other do not.

So in this example `Compat = "0.59.0"` would give the range `[0.59.0, 0.60.0)` which would exclude a bunch of the recent Compat versions which is wrong.
We could introduce a notation that is something like `>= 0.3.5` to indicate [0.3.5, inf)` which would be the most accurate conversion of the existing bound in REQUIRE but we do want people to use the semver version since that would be more proper...

Thoughts?