### PR TITLE
give packages without project uuids based on their name instead of a random uuid

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -599,7 +599,8 @@ function parse_package!(ctx, pkg, project_path)
         if !is_registered
             # This is an unregistered old style package, give it a UUID and a version
             if !has_uuid(pkg)
-                pkg.uuid = uuid5("UNREG_PKG", pkg.name)
+                uuid_unreg_pkg = UUID(0xa9a2672e746f11e833ef119c5b888869)
+                pkg.uuid = uuid5(uid_unreg_pkg, pkg.name)
                 @info "Assigning UUID $(pkg.uuid) to $(pkg.name)"
             end
             pkg.version = v"0.0"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -600,7 +600,7 @@ function parse_package!(ctx, pkg, project_path)
             # This is an unregistered old style package, give it a UUID and a version
             if !has_uuid(pkg)
                 uuid_unreg_pkg = UUID(0xa9a2672e746f11e833ef119c5b888869)
-                pkg.uuid = uuid5(uid_unreg_pkg, pkg.name)
+                pkg.uuid = uuid5(uuid_unreg_pkg, pkg.name)
                 @info "Assigning UUID $(pkg.uuid) to $(pkg.name)"
             end
             pkg.version = v"0.0"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -597,9 +597,9 @@ function parse_package!(ctx, pkg, project_path)
         reg_uuids = registered_uuids(env, pkg.name)
         is_registered = !isempty(reg_uuids)
         if !is_registered
-            # This is an unregistered old style package, give it a random UUID and a version
+            # This is an unregistered old style package, give it a UUID and a version
             if !has_uuid(pkg)
-                pkg.uuid = UUIDs.uuid1()
+                pkg.uuid = uuid5("UNREG_PKG", pkg.name)
                 @info "Assigning UUID $(pkg.uuid) to $(pkg.name)"
             end
             pkg.version = v"0.0"


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/Pkg.jl/pull/402#issuecomment-398176050 point 9.

Would be good with a test but I don't want to spend too much time adding test for things that are just for compatibility with REQUIRE.