### PR TITLE
Add `start` command to REPL API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,6 @@ desc = "The next-generation Julia package manager."
 keywords = ["package", "management"]
 license = "MIT"
 name = "Pkg"
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -655,7 +655,7 @@ Testing...
 
 #### Test-specific dependencies
 
-Sometimes one might to want to use some packages only at testing time but not enforce a dependency on them when the package is used.
+Sometimes one might want to use some packages only at testing time but not enforce a dependency on them when the package is used.
 This is possible by adding dependencies to a "test target" to the Project file. Here we add the `Test` standard library as a
 test-only dependency by adding the following to the Project file:
 
@@ -748,7 +748,7 @@ The REPL command `precompile` can be used to precompile all the dependencies in 
 (HelloWorld) pkg> update; precompile
 ```
 
-do update the dependencies and then precompile them.
+to update the dependencies and then precompile them.
 
 ## Preview mode
 
@@ -770,7 +770,7 @@ However, nothing would be installed and your `Project.toml` and `Manifest.toml` 
 
 ## Using someone else's project
 
-Simple clone their project using e.g. `git clone`, `cd` to the project directory and call
+Simply clone their project using e.g. `git clone`, `cd` to the project directory and call
 
 ```
 (v0.7) pkg> activate

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,9 +92,9 @@ since that could conflict with the configuration of the main application.
 !!! note
     **Projects _vs._ Packages _vs._ Applications:**
 
-    1. Project is an umbrella term: packages and applications are kinds of projects.
-    2. Packages should have UUIDs, applications can have a UUIDs but don't need them.
-    3. Applications can provide global configuration, whereas packages cannot.
+    1. **Project** is an umbrella term: packages and applications are kinds of projects.
+    2. **Packages** should have UUIDs, applications can have a UUIDs but don't need them.
+    3. **Applications** can provide global configuration, whereas packages cannot.
 
 **Library (future work):** a compiled binary dependency (not written in Julia)
 packaged to be used by a Julia project. These are currently typically built in-
@@ -512,7 +512,8 @@ To generate files for a new package, use `pkg> generate`.
 This creates a new project `HelloWorld` with the following files (visualized with the external [`tree` command](https://linux.die.net/man/1/tree)):
 
 ```jl
-julia> cd("HelloWorld")
+shell> cd HelloWorld
+
 shell> tree .
 .
 ├── Project.toml
@@ -769,6 +770,8 @@ However, nothing would be installed and your `Project.toml` and `Manifest.toml` 
 Simple clone their project using e.g. `git clone`, `cd` to the project directory and call
 
 ```
+(v0.7) pkg> activate
+
 (SomeProject) pkg> instantiate
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -470,7 +470,8 @@ Initialized project at /Users/kristoffer/MyProject/Project.toml
     Status `Project.toml`
 ```
 
-Note that the REPL prompt changed when the new project was initiated. Since this is a newly created project, the status command show it contains no packages.
+Note that the REPL prompt changed when the new project was initiated, in other words, Pkg automatically set the current environment to the
+one that just got initiated. Since this is a newly created project, the status command show it contains no packages.
 Packages added here again in a completely separate environment from the one earlier used.
 
 ## Garbage collecting old, unused packages
@@ -544,9 +545,11 @@ greet() = print("Hello World!")
 end # module
 ```
 
-We can now load the project and use it:
+We can now activate the project and load the package:
 
 ```jl
+pkg> activate
+
 julia> import HelloWorld
 
 julia> HelloWorld.greet()

--- a/src/API.jl
+++ b/src/API.jl
@@ -155,8 +155,8 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
     return
 end
 
-resolve() = resolve(Context())
-resolve(ctx::Context) = up(ctx, level=UPLEVEL_FIXED, mode=PKGMODE_MANIFEST, do_update_registry=false)
+resolve(ctx::Context=Context()) =
+    up(ctx, level=UPLEVEL_FIXED, mode=PKGMODE_MANIFEST, do_update_registry=false)
 
 pin(pkg::Union{String, PackageSpec}; kwargs...) = pin([pkg]; kwargs...)
 pin(pkgs::Vector{String}; kwargs...)            = pin([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
@@ -420,6 +420,7 @@ function init(ctx::Context, path::String=pwd(); kwargs...)
     ctx.preview && preview_info()
     Context!(ctx; env = EnvCache(joinpath(path, "Project.toml")))
     Operations.init(ctx)
+    activate(path)
     ctx.preview && preview_info()
     return
 end
@@ -553,6 +554,33 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing, kwarg
     new_git = handle_repos_add!(ctx, pkgs; upgrade_or_add=false)
     new_apply = Operations.apply_versions(ctx, pkgs, hashes, urls)
     Operations.build_versions(ctx, union(new_apply, new_git))
+end
+
+const ACTIVE_ENV = Ref{Union{String,Nothing}}(nothing)
+
+function _activate(env::Union{String,Nothing})
+    if env === nothing
+        @warn "Current directory is not in a project, nothing activated."
+    else
+        if !isempty(LOAD_PATH) && ACTIVE_ENV[] === LOAD_PATH[1]
+            LOAD_PATH[1] = env
+        else
+            # TODO: warn if ACTIVE_ENV !== nothing ?
+            pushfirst!(LOAD_PATH, env)
+        end
+        ACTIVE_ENV[] = env
+    end
+end
+activate() = _activate(Base.current_env())
+activate(path::String) = _activate(Base.current_env(path))
+
+function deactivate()
+    if !isempty(LOAD_PATH) && ACTIVE_ENV[] === LOAD_PATH[1]
+        popfirst!(LOAD_PATH)
+    else
+        # warn if ACTIVE_ENV !== nothing ?
+    end
+    ACTIVE_ENV[] = nothing
 end
 
 end # module

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -429,22 +429,24 @@ function install_git(
     version::Union{VersionNumber,Nothing},
     version_path::String
 )::Nothing
-    creds = LibGit2.CachedCredentials()
-    clones_dir = joinpath(depots()[1], "clones")
-    ispath(clones_dir) || mkpath(clones_dir)
-    repo_path = joinpath(clones_dir, string(uuid))
-    repo = ispath(repo_path) ? LibGit2.GitRepo(repo_path) : begin
-        GitTools.clone(urls[1], repo_path; isbare=true, header = "[$uuid] $name from $(urls[1])", credentials=creds)
-    end
-    git_hash = LibGit2.GitHash(hash.bytes)
-    for url in urls
-        try LibGit2.with(LibGit2.GitObject, repo, git_hash) do g
-            end
-            break # object was found, we can stop
-        catch err
-            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+    repo, git_hash = Base.shred!(LibGit2.CachedCredentials()) do creds
+        clones_dir = joinpath(depots()[1], "clones")
+        ispath(clones_dir) || mkpath(clones_dir)
+        repo_path = joinpath(clones_dir, string(uuid))
+        repo = ispath(repo_path) ? LibGit2.GitRepo(repo_path) : begin
+            GitTools.clone(urls[1], repo_path; isbare=true, header = "[$uuid] $name from $(urls[1])", credentials=creds)
         end
-        GitTools.fetch(repo, url, refspecs=refspecs, credentials=creds)
+        git_hash = LibGit2.GitHash(hash.bytes)
+        for url in urls
+            try LibGit2.with(LibGit2.GitObject, repo, git_hash) do g
+                end
+                break # object was found, we can stop
+            catch err
+                err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+            end
+            GitTools.fetch(repo, url, refspecs=refspecs, credentials=creds)
+        end
+        return repo, git_hash
     end
     tree = try
         LibGit2.GitObject(repo, git_hash)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -57,6 +57,8 @@ const instantiate = API.instantiate
 const resolve     = API.resolve
 const status      = Display.status
 const update      = up
+const activate    = API.activate
+const deactivate  = API.deactivate
 
 # legacy CI script support
 import .API: clone, dir

--- a/src/Pkg2/types.jl
+++ b/src/Pkg2/types.jl
@@ -3,7 +3,7 @@
 module Pkg2Types
 
 export VersionInterval, VersionSet
-import Base: show, isempty, in, intersect, union!, union, ==, hash, copy, deepcopy_internal
+import Base: show, isempty, in, intersect, union!, union, ==, hash, copy
 
 import ...Types: VersionBound, VersionRange
 
@@ -151,6 +151,5 @@ end
 
 ==(A::VersionSet, B::VersionSet) = A.intervals == B.intervals
 hash(s::VersionSet, h::UInt) = hash(s.intervals, h + (0x2fd2ca6efa023f44 % UInt))
-deepcopy_internal(vs::VersionSet, ::IdDict) = copy(vs)
 
 end # module

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -15,7 +15,7 @@ using ..Types, ..Display, ..Operations, ..API
 @enum(CommandKind, CMD_HELP, CMD_STATUS, CMD_SEARCH, CMD_ADD, CMD_RM, CMD_UP,
                    CMD_TEST, CMD_GC, CMD_PREVIEW, CMD_INIT, CMD_BUILD, CMD_FREE,
                    CMD_PIN, CMD_CHECKOUT, CMD_DEVELOP, CMD_GENERATE, CMD_PRECOMPILE,
-                   CMD_INSTANTIATE, CMD_RESOLVE)
+                   CMD_INSTANTIATE, CMD_RESOLVE, CMD_ACTIVATE, CMD_DEACTIVATE)
 
 struct Command
     kind::CommandKind
@@ -24,28 +24,30 @@ end
 Base.show(io::IO, cmd::Command) = print(io, cmd.val)
 
 const cmds = Dict(
-    "help"      => CMD_HELP,
-    "?"         => CMD_HELP,
-    "status"    => CMD_STATUS,
-    "st"        => CMD_STATUS,
-    "add"       => CMD_ADD,
-    "rm"        => CMD_RM,
-    "remove"    => CMD_RM,
-    "up"        => CMD_UP,
-    "update"    => CMD_UP,
-    "test"      => CMD_TEST,
-    "gc"        => CMD_GC,
-    "preview"   => CMD_PREVIEW,
-    "init"      => CMD_INIT,
-    "build"     => CMD_BUILD,
-    "pin"       => CMD_PIN,
-    "free"      => CMD_FREE,
-    "develop"   => CMD_DEVELOP,
-    "dev"       => CMD_DEVELOP,
-    "generate"  => CMD_GENERATE,
-    "precompile" => CMD_PRECOMPILE,
+    "help"        => CMD_HELP,
+    "?"           => CMD_HELP,
+    "status"      => CMD_STATUS,
+    "st"          => CMD_STATUS,
+    "add"         => CMD_ADD,
+    "rm"          => CMD_RM,
+    "remove"      => CMD_RM,
+    "up"          => CMD_UP,
+    "update"      => CMD_UP,
+    "test"        => CMD_TEST,
+    "gc"          => CMD_GC,
+    "preview"     => CMD_PREVIEW,
+    "init"        => CMD_INIT,
+    "build"       => CMD_BUILD,
+    "pin"         => CMD_PIN,
+    "free"        => CMD_FREE,
+    "develop"     => CMD_DEVELOP,
+    "dev"         => CMD_DEVELOP,
+    "generate"    => CMD_GENERATE,
+    "precompile"  => CMD_PRECOMPILE,
     "instantiate" => CMD_INSTANTIATE,
-    "resolve"   => CMD_RESOLVE,
+    "resolve"     => CMD_RESOLVE,
+    "activate"    => CMD_ACTIVATE,
+    "deactivate"  => CMD_DEACTIVATE,
 )
 
 #################
@@ -258,23 +260,25 @@ function do_cmd!(tokens::Vector{Token}, repl)
     end
     # Using invokelatest to hide the functions from inference.
     # Otherwise it would try to infer everything here.
-    cmd.kind == CMD_INIT     ? Base.invokelatest(          do_init!, ctx, tokens) :
-    cmd.kind == CMD_HELP     ? Base.invokelatest(          do_help!, ctx, tokens, repl) :
-    cmd.kind == CMD_RM       ? Base.invokelatest(            do_rm!, ctx, tokens) :
-    cmd.kind == CMD_ADD      ? Base.invokelatest(do_add_or_develop!, ctx, tokens, CMD_ADD) :
-    cmd.kind == CMD_CHECKOUT ? Base.invokelatest(do_add_or_develop!, ctx, tokens, CMD_DEVELOP) :
-    cmd.kind == CMD_DEVELOP  ? Base.invokelatest(do_add_or_develop!, ctx, tokens, CMD_DEVELOP) :
-    cmd.kind == CMD_UP       ? Base.invokelatest(            do_up!, ctx, tokens) :
-    cmd.kind == CMD_STATUS   ? Base.invokelatest(        do_status!, ctx, tokens) :
-    cmd.kind == CMD_TEST     ? Base.invokelatest(          do_test!, ctx, tokens) :
-    cmd.kind == CMD_GC       ? Base.invokelatest(            do_gc!, ctx, tokens) :
-    cmd.kind == CMD_BUILD    ? Base.invokelatest(         do_build!, ctx, tokens) :
-    cmd.kind == CMD_PIN      ? Base.invokelatest(           do_pin!, ctx, tokens) :
-    cmd.kind == CMD_FREE     ? Base.invokelatest(          do_free!, ctx, tokens) :
-    cmd.kind == CMD_GENERATE ? Base.invokelatest(      do_generate!, ctx, tokens) :
-    cmd.kind == CMD_RESOLVE  ? Base.invokelatest(       do_resolve!, ctx, tokens) :
-    cmd.kind == CMD_PRECOMPILE ? Base.invokelatest(  do_precompile!, ctx, tokens) :
-    cmd.kind == CMD_INSTANTIATE ? Base.invokelatest(do_instantiate!, ctx, tokens) :
+    cmd.kind == CMD_INIT        ? Base.invokelatest(          do_init!, ctx, tokens) :
+    cmd.kind == CMD_HELP        ? Base.invokelatest(          do_help!, ctx, tokens, repl) :
+    cmd.kind == CMD_RM          ? Base.invokelatest(            do_rm!, ctx, tokens) :
+    cmd.kind == CMD_ADD         ? Base.invokelatest(do_add_or_develop!, ctx, tokens, CMD_ADD) :
+    cmd.kind == CMD_CHECKOUT    ? Base.invokelatest(do_add_or_develop!, ctx, tokens, CMD_DEVELOP) :
+    cmd.kind == CMD_DEVELOP     ? Base.invokelatest(do_add_or_develop!, ctx, tokens, CMD_DEVELOP) :
+    cmd.kind == CMD_UP          ? Base.invokelatest(            do_up!, ctx, tokens) :
+    cmd.kind == CMD_STATUS      ? Base.invokelatest(        do_status!, ctx, tokens) :
+    cmd.kind == CMD_TEST        ? Base.invokelatest(          do_test!, ctx, tokens) :
+    cmd.kind == CMD_GC          ? Base.invokelatest(            do_gc!, ctx, tokens) :
+    cmd.kind == CMD_BUILD       ? Base.invokelatest(         do_build!, ctx, tokens) :
+    cmd.kind == CMD_PIN         ? Base.invokelatest(           do_pin!, ctx, tokens) :
+    cmd.kind == CMD_FREE        ? Base.invokelatest(          do_free!, ctx, tokens) :
+    cmd.kind == CMD_GENERATE    ? Base.invokelatest(      do_generate!, ctx, tokens) :
+    cmd.kind == CMD_RESOLVE     ? Base.invokelatest(       do_resolve!, ctx, tokens) :
+    cmd.kind == CMD_PRECOMPILE  ? Base.invokelatest(    do_precompile!, ctx, tokens) :
+    cmd.kind == CMD_INSTANTIATE ? Base.invokelatest(   do_instantiate!, ctx, tokens) :
+    cmd.kind == CMD_ACTIVATE    ? Base.invokelatest(      do_activate!, ctx, tokens) :
+    cmd.kind == CMD_DEACTIVATE  ? Base.invokelatest(    do_deactivate!, ctx, tokens) :
         cmderror("`$cmd` command not yet implemented")
     return
 end
@@ -338,6 +342,10 @@ developed packages
 `precompile`: precompile all the project dependencies
 
 `gc`: garbage collect packages not used for a significant time
+
+`activate`: set the primary environment the package manager manipulates
+
+`deactivate`: unset the primary environment the package manager manipulates
 """
 
 const helps = Dict(
@@ -773,6 +781,15 @@ function do_resolve!(ctx::Context, tokens::Vector{Token})
     API.resolve(ctx)
 end
 
+function do_activate!(ctx::Context, tokens::Vector{Token})
+    !isempty(tokens) && cmderror("`activate` does not take any arguments")
+    API.activate()
+end
+
+function do_deactivate!(ctx::Context, tokens::Vector{Token})
+    !isempty(tokens) && cmderror("`deactivate` does not take any arguments")
+    API.deactivate()
+end
 
 ######################
 # REPL mode creation #

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -736,6 +736,23 @@ function do_init!(ctx::Context, tokens::Vector{Token})
     API.init(ctx)
 end
 
+function do_start!(ctx::Context, tokens::Vector{Token})
+    isempty(tokens) && cmderror("`start` requires a project name as an argument")
+    local pkg
+    while !isempty(tokens)
+        token = popfirst!(tokens)
+        if token isa String
+            pkg = token
+            break # TODO: error message?
+        else
+            cmderror("`start` takes a name of the project to create")
+        end
+    end
+    API.generate(ctx, pkg)
+    printstyled("Changing directory"; color=:green, bold=true)
+    cd(pkg)
+end
+
 function do_generate!(ctx::Context, tokens::Vector{Token})
     isempty(tokens) && cmderror("`generate` requires a project name as an argument")
     local pkg

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -782,8 +782,15 @@ function do_resolve!(ctx::Context, tokens::Vector{Token})
 end
 
 function do_activate!(ctx::Context, tokens::Vector{Token})
-    !isempty(tokens) && cmderror("`activate` does not take any arguments")
-    API.activate()
+    if isempty(tokens)
+        return API.activate()
+    else
+        token = popfirst!(tokens)
+        if !isempty(tokens) || !(token isa String)
+            cmderror("`activate` takes an optional path to the env to activate")
+        end
+        return API.activate(abspath(token))
+    end
 end
 
 function do_deactivate!(ctx::Context, tokens::Vector{Token})

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -415,43 +415,110 @@ end
 casesensitive_isdir(dir::String) = isdir_windows_workaround(dir) && dir in readdir(joinpath(dir, ".."))
 
 function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec})
-    creds = LibGit2.CachedCredentials()
-    env = ctx.env
-    new_uuids = UUID[]
-    for pkg in pkgs
-        pkg.repo == nothing && continue
-        pkg.special_action = PKGSPEC_DEVELOPED
-        isempty(pkg.repo.url) && set_repo_for_pkg!(env, pkg)
+    Base.shred!(LibGit2.CachedCredentials()) do creds
+        env = ctx.env
+        new_uuids = UUID[]
+        for pkg in pkgs
+            pkg.repo == nothing && continue
+            pkg.special_action = PKGSPEC_DEVELOPED
+            isempty(pkg.repo.url) && set_repo_for_pkg!(env, pkg)
 
 
-        if isdir_windows_workaround(pkg.repo.url)
-            # Developing a local package, just point `pkg.path` to it
-            pkg.path = abspath(pkg.repo.url)
-            folder_already_downloaded = true
-            project_path = pkg.repo.url
-            parse_package!(ctx, pkg, project_path)
-        else
-            # We save the repo in case another environement wants to
-            # develop from the same repo, this avoids having to reclone it
-            # from scratch.
-            clone_path = joinpath(depots()[1], "clones")
-            mkpath(clone_path)
-            repo_path = joinpath(clone_path, string(hash(pkg.repo.url), "_full"))
+            if isdir_windows_workaround(pkg.repo.url)
+                # Developing a local package, just point `pkg.path` to it
+                pkg.path = abspath(pkg.repo.url)
+                folder_already_downloaded = true
+                project_path = pkg.repo.url
+                parse_package!(ctx, pkg, project_path)
+            else
+                # We save the repo in case another environement wants to
+                # develop from the same repo, this avoids having to reclone it
+                # from scratch.
+                clone_path = joinpath(depots()[1], "clones")
+                mkpath(clone_path)
+                repo_path = joinpath(clone_path, string(hash(pkg.repo.url), "_full"))
+                repo, just_cloned = ispath(repo_path) ? (LibGit2.GitRepo(repo_path), false) : begin
+                    r = GitTools.clone(pkg.repo.url, repo_path)
+                    GitTools.fetch(r, pkg.repo.url; refspecs=refspecs, credentials=creds)
+                    r, true
+                end
+                if !just_cloned
+                    GitTools.fetch(repo, pkg.repo.url; refspecs=refspecs, credentials=creds)
+                end
+                close(repo)
+
+                # Copy the repo to a temporary place and check out the rev
+                project_path = mktempdir()
+                cp(repo_path, project_path; force=true)
+                repo = LibGit2.GitRepo(project_path)
+                rev = pkg.repo.rev
+                if isempty(rev)
+                    if LibGit2.isattached(repo)
+                        rev = LibGit2.branch(repo)
+                    else
+                        rev = string(LibGit2.GitHash(LibGit2.head(repo)))
+                    end
+                end
+                gitobject, isbranch = checkout_rev!(repo, rev)
+                close(repo); close(gitobject)
+
+                parse_package!(ctx, pkg, project_path)
+                dev_pkg_path = joinpath(Pkg.devdir(), pkg.name)
+                if isdir(dev_pkg_path)
+                    if !isfile(joinpath(dev_pkg_path, "src", pkg.name * ".jl"))
+                        cmderror("Path `$(dev_pkg_path)` exists but it does not contain `src/$(pkg.name).jl")
+                    else
+                        @info "Path `$(dev_pkg_path)` exists and looks like the correct package, using existing path instead of cloning"
+                    end
+                else
+                    mkpath(dev_pkg_path)
+                    mv(project_path, dev_pkg_path; force=true)
+                    push!(new_uuids, pkg.uuid)
+                end
+                pkg.path = dev_pkg_path
+            end
+            @assert pkg.path != nothing
+        end
+        return new_uuids
+    end
+end
+
+function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec}; upgrade_or_add::Bool=true)
+    Base.shred!(LibGit2.CachedCredentials()) do creds
+        env = ctx.env
+        new_uuids = UUID[]
+        for pkg in pkgs
+            pkg.repo == nothing && continue
+            pkg.special_action = PKGSPEC_REPO_ADDED
+            isempty(pkg.repo.url) && set_repo_for_pkg!(env, pkg)
+            clones_dir = joinpath(depots()[1], "clones")
+            mkpath(clones_dir)
+            repo_path = joinpath(clones_dir, string(hash(pkg.repo.url)))
             repo, just_cloned = ispath(repo_path) ? (LibGit2.GitRepo(repo_path), false) : begin
-                r = GitTools.clone(pkg.repo.url, repo_path)
+                r = GitTools.clone(pkg.repo.url, repo_path, isbare=true, credentials=creds)
                 GitTools.fetch(r, pkg.repo.url; refspecs=refspecs, credentials=creds)
                 r, true
             end
-            if !just_cloned
-                GitTools.fetch(repo, pkg.repo.url; refspecs=refspecs, credentials=creds)
+            info = manifest_info(env, pkg.uuid)
+            pinned = (info != nothing && get(info, "pinned", false))
+            if upgrade_or_add && !pinned && !just_cloned
+                rev = pkg.repo.rev
+                try
+                    GitTools.fetch(repo, pkg.repo.url; refspecs=refspecs, credentials=creds)
+                catch e
+                    e isa LibGit2.GitError || rethrow(e)
+                    cmderror("failed to fetch from $(pkg.repo.url), error: $e")
+                end
             end
-            close(repo)
+            if upgrade_or_add && !pinned
+                rev = pkg.repo.rev
+            else
+                # Not upgrading so the rev should be the current git-tree-sha
+                rev = info["git-tree-sha1"]
+                pkg.version = VersionNumber(info["version"])
+            end
 
-            # Copy the repo to a temporary place and check out the rev
-            project_path = mktempdir()
-            cp(repo_path, project_path; force=true)
-            repo = LibGit2.GitRepo(project_path)
-            rev = pkg.repo.rev
+            # see if we can get rev as a branch
             if isempty(rev)
                 if LibGit2.isattached(repo)
                     rev = LibGit2.branch(repo)
@@ -460,110 +527,45 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec})
                 end
             end
             gitobject, isbranch = checkout_rev!(repo, rev)
-            close(repo); close(gitobject)
-
-            parse_package!(ctx, pkg, project_path)
-            dev_pkg_path = joinpath(Pkg.devdir(), pkg.name)
-            if isdir(dev_pkg_path)
-                if !isfile(joinpath(dev_pkg_path, "src", pkg.name * ".jl"))
-                    cmderror("Path `$(dev_pkg_path)` exists but it does not contain `src/$(pkg.name).jl")
-                else
-                    @info "Path `$(dev_pkg_path)` exists and looks like the correct package, using existing path instead of cloning"
+            if !isbranch
+                # If the user gave a shortened commit SHA, might as well update it to the full one
+                pkg.repo.rev = string(LibGit2.GitHash(gitobject))
+            end
+            git_tree = LibGit2.peel(LibGit2.GitTree, gitobject)
+            @assert git_tree isa LibGit2.GitTree
+            pkg.repo.git_tree_sha1 = SHA1(string(LibGit2.GitHash(git_tree)))
+            version_path = nothing
+            folder_already_downloaded = false
+            if has_uuid(pkg) && has_name(pkg)
+                version_path = Pkg.Operations.find_installed(pkg.name, pkg.uuid, pkg.repo.git_tree_sha1)
+                isdir(version_path) && (folder_already_downloaded = true)
+                info = manifest_info(env, pkg.uuid)
+                if info != nothing && get(info, "git-tree-sha1", "") == string(pkg.repo.git_tree_sha1) && folder_already_downloaded
+                    # Same tree sha and this version already downloaded, nothing left to do
+                    pkg.version = VersionNumber(info["version"])
+                    continue
                 end
+            end
+            if folder_already_downloaded
+                project_path = version_path
             else
-                mkpath(dev_pkg_path)
-                mv(project_path, dev_pkg_path; force=true)
+                project_path = mktempdir()
+                opts = LibGit2.CheckoutOptions(checkout_strategy=LibGit2.Consts.CHECKOUT_FORCE,
+                    target_directory=Base.unsafe_convert(Cstring, project_path))
+                LibGit2.checkout_tree(repo, git_tree, options=opts)
+            end
+            close(repo); close(git_tree); close(gitobject)
+            parse_package!(ctx, pkg, project_path)
+            if !folder_already_downloaded
+                version_path = Pkg.Operations.find_installed(pkg.name, pkg.uuid, pkg.repo.git_tree_sha1)
+                mkpath(version_path)
+                mv(project_path, version_path; force=true)
                 push!(new_uuids, pkg.uuid)
             end
-            pkg.path = dev_pkg_path
+            @assert pkg.version isa VersionNumber
         end
-        @assert pkg.path != nothing
+        return new_uuids
     end
-    return new_uuids
-end
-
-function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec}; upgrade_or_add::Bool=true)
-    creds = LibGit2.CachedCredentials()
-    env = ctx.env
-    new_uuids = UUID[]
-    for pkg in pkgs
-        pkg.repo == nothing && continue
-        pkg.special_action = PKGSPEC_REPO_ADDED
-        isempty(pkg.repo.url) && set_repo_for_pkg!(env, pkg)
-        clones_dir = joinpath(depots()[1], "clones")
-        mkpath(clones_dir)
-        repo_path = joinpath(clones_dir, string(hash(pkg.repo.url)))
-        repo, just_cloned = ispath(repo_path) ? (LibGit2.GitRepo(repo_path), false) : begin
-            r = GitTools.clone(pkg.repo.url, repo_path, isbare=true, credentials=creds)
-            GitTools.fetch(r, pkg.repo.url; refspecs=refspecs, credentials=creds)
-            r, true
-        end
-        info = manifest_info(env, pkg.uuid)
-        pinned = (info != nothing && get(info, "pinned", false))
-        if upgrade_or_add && !pinned && !just_cloned
-            rev = pkg.repo.rev
-            try
-                GitTools.fetch(repo, pkg.repo.url; refspecs=refspecs, credentials=creds)
-            catch e
-                e isa LibGit2.GitError || rethrow(e)
-                cmderror("failed to fetch from $(pkg.repo.url), error: $e")
-            end
-        end
-        if upgrade_or_add && !pinned
-            rev = pkg.repo.rev
-        else
-            # Not upgrading so the rev should be the current git-tree-sha
-            rev = info["git-tree-sha1"]
-            pkg.version = VersionNumber(info["version"])
-        end
-
-        # see if we can get rev as a branch
-        if isempty(rev)
-            if LibGit2.isattached(repo)
-                rev = LibGit2.branch(repo)
-            else
-                rev = string(LibGit2.GitHash(LibGit2.head(repo)))
-            end
-        end
-        gitobject, isbranch = checkout_rev!(repo, rev)
-        if !isbranch
-            # If the user gave a shortened commit SHA, might as well update it to the full one
-            pkg.repo.rev = string(LibGit2.GitHash(gitobject))
-        end
-        git_tree = LibGit2.peel(LibGit2.GitTree, gitobject)
-        @assert git_tree isa LibGit2.GitTree
-        pkg.repo.git_tree_sha1 = SHA1(string(LibGit2.GitHash(git_tree)))
-        version_path = nothing
-        folder_already_downloaded = false
-        if has_uuid(pkg) && has_name(pkg)
-            version_path = Pkg.Operations.find_installed(pkg.name, pkg.uuid, pkg.repo.git_tree_sha1)
-            isdir(version_path) && (folder_already_downloaded = true)
-            info = manifest_info(env, pkg.uuid)
-            if info != nothing && get(info, "git-tree-sha1", "") == string(pkg.repo.git_tree_sha1) && folder_already_downloaded
-                # Same tree sha and this version already downloaded, nothing left to do
-                pkg.version = VersionNumber(info["version"])
-                continue
-            end
-        end
-        if folder_already_downloaded
-            project_path = version_path
-        else
-            project_path = mktempdir()
-            opts = LibGit2.CheckoutOptions(checkout_strategy=LibGit2.Consts.CHECKOUT_FORCE,
-                target_directory=Base.unsafe_convert(Cstring, project_path))
-            LibGit2.checkout_tree(repo, git_tree, options=opts)
-        end
-        close(repo); close(git_tree); close(gitobject)
-        parse_package!(ctx, pkg, project_path)
-        if !folder_already_downloaded
-            version_path = Pkg.Operations.find_installed(pkg.name, pkg.uuid, pkg.repo.git_tree_sha1)
-            mkpath(version_path)
-            mv(project_path, version_path; force=true)
-            push!(new_uuids, pkg.uuid)
-        end
-        @assert pkg.version isa VersionNumber
-    end
-    return new_uuids
 end
 
 function parse_package!(ctx, pkg, project_path)
@@ -788,12 +790,13 @@ function registries(; clone_default=true)::Vector{String}
     if clone_default
         if !ispath(user_regs)
             mkpath(user_regs)
-            creds = LibGit2.CachedCredentials()
-            printpkgstyle(stdout, :Cloning, "default registries into $user_regs")
-            for (reg, url) in DEFAULT_REGISTRIES
-                path = joinpath(user_regs, reg)
-                repo = GitTools.clone(url, path; header = "registry $reg from $(repr(url))", credentials = creds)
-                close(repo)
+            Base.shred!(LibGit2.CachedCredentials()) do creds
+                printpkgstyle(stdout, :Cloning, "default registries into $user_regs")
+                for (reg, url) in DEFAULT_REGISTRIES
+                    path = joinpath(user_regs, reg)
+                    repo = GitTools.clone(url, path; header = "registry $reg from $(repr(url))", credentials = creds)
+                    close(repo)
+                end
             end
         end
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -11,7 +11,7 @@ using ..TOML
 import ..Pkg
 import Pkg: GitTools, depots, logdir
 
-import Base: SHA1, AbstractEnv
+import Base: SHA1
 using SHA
 
 export UUID, pkgID, SHA1, VersionRange, VersionSpec, empty_versionspec,
@@ -205,7 +205,7 @@ const default_envs = [
 
 mutable struct EnvCache
     # environment info:
-    env::Union{Nothing,String,AbstractEnv}
+    env::Union{Nothing,String}
     git::Union{Nothing,LibGit2.GitRepo}
 
     # paths for files:
@@ -223,26 +223,26 @@ mutable struct EnvCache
     uuids::Dict{String,Vector{UUID}}
     paths::Dict{UUID,Vector{String}}
 
-    function EnvCache(env::Union{Nothing,String,AbstractEnv}=nothing)
+    function EnvCache(env::Union{Nothing,String}=nothing)
         if env isa Nothing
             project_file = nothing
             for entry in LOAD_PATH
-                project_file = Base.find_env(entry)
+                project_file = Base.load_path_expand(entry)
                 project_file isa String && !isdir(project_file) && break
                 project_file = nothing
             end
             if project_file == nothing
                 project_dir = nothing
                 for entry in LOAD_PATH
-                    project_dir = Base.find_env(entry)
+                    project_dir = Base.load_path_expand(entry)
                     project_dir isa String && isdir(project_dir) && break
                     project_dir = nothing
                 end
                 project_dir == nothing && error("No Pkg environment found in LOAD_PATH")
                 project_file = joinpath(project_dir, Base.project_names[end])
             end
-        elseif env isa AbstractEnv
-            project_file = Base.find_env(env)
+        elseif startswith(env, '@')
+            project_file = Base.load_path_expand(env)
             project_file === nothing && error("package environment does not exist: $env")
         elseif env isa String
             if isdir(env)

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -229,7 +229,6 @@ end
 
 Base.:(==)(A::VersionSpec, B::VersionSpec) = A.ranges == B.ranges
 Base.hash(s::VersionSpec, h::UInt) = hash(s.ranges, h + (0x2fd2ca6efa023f44 % UInt))
-Base.deepcopy_internal(vs::VersionSpec, ::IdDict) = copy(vs)
 
 function Base.print(io::IO, s::VersionSpec)
     isempty(s) && return print(io, _empty_symbol)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -235,12 +235,9 @@ temp_pkg_dir() do project_path
         mktempdir() do dir
             cp(joinpath(@__DIR__, "test_packages", "UnregisteredWithProject"), joinpath(dir, "UnregisteredWithProject"))
             cd(joinpath(dir, "UnregisteredWithProject")) do
-                try
-                    pushfirst!(LOAD_PATH, Base.current_env())
+               with_current_env() do
                     Pkg.up()
                     @test haskey(Pkg.installed(), "Example")
-                finally
-                    popfirst!(LOAD_PATH)
                 end
             end
         end
@@ -248,17 +245,13 @@ temp_pkg_dir() do project_path
 
     @testset "failing building a package should throw" begin
         mktempdir() do path
-            try
-                cd(path) do
-                    pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
-                    Pkg.generate("FailBuildPkg")
-                    cd("FailBuildPkg") do
-                        write_build(pwd(), "error()")
-                        @test_throws CommandError Pkg.build()
-                    end
+            cd(path) do
+                Pkg.generate("FailBuildPkg")
+                cd("FailBuildPkg")
+                with_current_env() do
+                    write_build(pwd(), "error()")
+                    @test_throws CommandError Pkg.build()
                 end
-            finally
-                popfirst!(LOAD_PATH)
             end
         end
     end
@@ -286,12 +279,9 @@ temp_pkg_dir() do project_path
         mktempdir() do dir
             cp(joinpath(@__DIR__, "test_packages", "UnregisteredWithProject"), joinpath(dir, "UnregisteredWithProject"))
             cd(joinpath(dir, "UnregisteredWithProject")) do
-                try
-                    pushfirst!(LOAD_PATH, Base.current_env())
+                with_current_env() do
                     Pkg.add("Test") # test https://github.com/JuliaLang/Pkg.jl/issues/324
                     Pkg.test()
-                finally
-                    popfirst!(LOAD_PATH)
                 end
             end
         end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -236,7 +236,7 @@ temp_pkg_dir() do project_path
             cp(joinpath(@__DIR__, "test_packages", "UnregisteredWithProject"), joinpath(dir, "UnregisteredWithProject"))
             cd(joinpath(dir, "UnregisteredWithProject")) do
                 try
-                    pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+                    pushfirst!(LOAD_PATH, Base.current_env())
                     Pkg.up()
                     @test haskey(Pkg.installed(), "Example")
                 finally
@@ -287,7 +287,7 @@ temp_pkg_dir() do project_path
             cp(joinpath(@__DIR__, "test_packages", "UnregisteredWithProject"), joinpath(dir, "UnregisteredWithProject"))
             cd(joinpath(dir, "UnregisteredWithProject")) do
                 try
-                    pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+                    pushfirst!(LOAD_PATH, Base.current_env())
                     Pkg.add("Test") # test https://github.com/JuliaLang/Pkg.jl/issues/324
                     Pkg.test()
                 finally

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -30,12 +30,11 @@ end
 
 mktempdir() do project_path
     cd(project_path) do
-        pushfirst!(LOAD_PATH, project_path)
-        try
-            withenv("USER" => "Test User") do
-                pkg"generate HelloWorld"
-                cd("HelloWorld")
-                LibGit2.init(".")
+        withenv("USER" => "Test User") do
+            pkg"generate HelloWorld"
+            LibGit2.init(".")
+            cd("HelloWorld")
+            with_current_env() do
                 pkg"st"
                 @eval using HelloWorld
                 Base.invokelatest(HelloWorld.greet)
@@ -43,8 +42,6 @@ mktempdir() do project_path
                 Pkg.REPLMode.pkgstr("develop $(joinpath(@__DIR__, "test_packages", "PackageWithBuildSpecificTestDeps"))")
                 Pkg.test("PackageWithBuildSpecificTestDeps")
             end
-        finally
-            popfirst!(LOAD_PATH)
         end
     end
 end
@@ -139,8 +136,6 @@ end # cd
 end # temp_pkg_dir
 
 
-locate_name(pkg) = Base.locate_package(Base.identify_package(pkg))
-
 temp_pkg_dir() do project_path; cd(project_path) do
     mktempdir() do tmp
         mktempdir() do depot_dir
@@ -161,15 +156,15 @@ temp_pkg_dir() do project_path; cd(project_path) do
                     Pkg.REPLMode.pkgstr("develop $(p1_new_path)")
                     Pkg.REPLMode.pkgstr("develop $(p2_new_path)")
                     Pkg.REPLMode.pkgstr("build; precompile")
-                    @test locate_name("UnregisteredWithProject") == joinpath(p1_new_path, "src", "UnregisteredWithProject.jl")
-                    @test locate_name("UnregisteredWithoutProject") == joinpath(p2_new_path, "src", "UnregisteredWithoutProject.jl")
+                    @test Base.find_package("UnregisteredWithProject") == joinpath(p1_new_path, "src", "UnregisteredWithProject.jl")
+                    @test Base.find_package("UnregisteredWithoutProject") == joinpath(p2_new_path, "src", "UnregisteredWithoutProject.jl")
                     @test Pkg.installed()["UnregisteredWithProject"] == v"0.1.0"
                     @test Pkg.installed()["UnregisteredWithoutProject"] == v"0.0.0"
                     Pkg.test("UnregisteredWithoutProject")
                     Pkg.test("UnregisteredWithProject")
 
                     pkg"develop Example#c37b675"
-                    @test locate_name("Example") ==  joinpath(tmp, "Example", "src", "Example.jl")
+                    @test Base.find_package("Example") ==  joinpath(tmp, "Example", "src", "Example.jl")
                     Pkg.test("Example")
                 end
             finally
@@ -179,35 +174,33 @@ temp_pkg_dir() do project_path; cd(project_path) do
         end # withenv
     end # mktempdir
     # nested
-    try
-        pushfirst!(LOAD_PATH, "@")
-        mktempdir() do other_dir
-            mktempdir() do tmp; cd(tmp) do
-                withenv("USER" => "Test User") do
-                    pkg"generate HelloWorld"
-                    cd("HelloWorld") do
+    mktempdir() do other_dir
+        mktempdir() do tmp;
+            cd(tmp)
+            withenv("USER" => "Test User") do
+                pkg"generate HelloWorld"
+                cd("HelloWorld") do
+                    with_current_env() do
                         pkg"generate SubModule1"
                         pkg"generate SubModule2"
                         pkg"develop SubModule1"
                         mkdir("tests")
-                        cd("tests") do
-                            pkg"develop ../SubModule2"
-                        end
+                        cd("tests")
+                        pkg"develop ../SubModule2"
                         @test Pkg.installed()["SubModule1"] == v"0.1.0"
                         @test Pkg.installed()["SubModule2"] == v"0.1.0"
                     end
-                    cp("HelloWorld", joinpath(other_dir, "HelloWorld"))
                 end
-            end end
-            # Check that these didnt generate absolute paths in the Manifest by copying
-            # to another directory
-            cd(joinpath(other_dir, "HelloWorld")) do
-                @test locate_name("SubModule1") == joinpath(pwd(), "SubModule1", "src", "SubModule1.jl")
-                @test locate_name("SubModule2") == joinpath(pwd(), "SubModule2", "src", "SubModule2.jl")
+                cp("HelloWorld", joinpath(other_dir, "HelloWorld"))
+                cd(joinpath(other_dir, "HelloWorld"))
+                with_current_env() do
+                    # Check that these didnt generate absolute paths in the Manifest by copying
+                    # to another directory
+                    @test Base.find_package("SubModule1") == joinpath(pwd(), "SubModule1", "src", "SubModule1.jl")
+                    @test Base.find_package("SubModule2") == joinpath(pwd(), "SubModule2", "src", "SubModule2.jl")
+                end
             end
         end
-    finally
-        popfirst!(LOAD_PATH)
     end
 end # cd
 end # temp_pkg_dir
@@ -222,103 +215,93 @@ end
 
 # Autocompletions
 temp_pkg_dir() do project_path; cd(project_path) do
-    try
-        pushfirst!(LOAD_PATH, ".")
-        Pkg.Types.registries()
-        pkg"init"
-        c, r = test_complete("add Exam")
-        @test "Example" in c
-        c, r = test_complete("rm Exam")
-        @test isempty(c)
-        Pkg.REPLMode.pkgstr("develop $(joinpath(@__DIR__, "test_packages", "RequireDependency"))")
+    Pkg.Types.registries()
+    pkg"init"
+    c, r = test_complete("add Exam")
+    @test "Example" in c
+    c, r = test_complete("rm Exam")
+    @test isempty(c)
+    Pkg.REPLMode.pkgstr("develop $(joinpath(@__DIR__, "test_packages", "RequireDependency"))")
 
-        c, r = test_complete("rm RequireDep")
-        @test "RequireDependency" in c
-        c, r = test_complete("rm -p RequireDep")
-        @test "RequireDependency" in c
-        c, r = test_complete("rm --project RequireDep")
-        @test "RequireDependency" in c
-        c, r = test_complete("rm Exam")
-        @test isempty(c)
-        c, r = test_complete("rm -p Exam")
-        @test isempty(c)
-        c, r = test_complete("rm --project Exam")
-        @test isempty(c)
+    c, r = test_complete("rm RequireDep")
+    @test "RequireDependency" in c
+    c, r = test_complete("rm -p RequireDep")
+    @test "RequireDependency" in c
+    c, r = test_complete("rm --project RequireDep")
+    @test "RequireDependency" in c
+    c, r = test_complete("rm Exam")
+    @test isempty(c)
+    c, r = test_complete("rm -p Exam")
+    @test isempty(c)
+    c, r = test_complete("rm --project Exam")
+    @test isempty(c)
 
-        c, r = test_complete("rm -m RequireDep")
-        @test "RequireDependency" in c
-        c, r = test_complete("rm --manifest RequireDep")
-        @test "RequireDependency" in c
-        c, r = test_complete("rm -m Exam")
-        @test "Example" in c
-        c, r = test_complete("rm --manifest Exam")
-        @test "Example" in c
+    c, r = test_complete("rm -m RequireDep")
+    @test "RequireDependency" in c
+    c, r = test_complete("rm --manifest RequireDep")
+    @test "RequireDependency" in c
+    c, r = test_complete("rm -m Exam")
+    @test "Example" in c
+    c, r = test_complete("rm --manifest Exam")
+    @test "Example" in c
 
-        c, r = test_complete("rm RequireDep")
-        @test "RequireDependency" in c
-        c, r = test_complete("rm Exam")
-        @test isempty(c)
-        c, r = test_complete("rm -m Exam")
-        c, r = test_complete("rm -m Exam")
-        @test "Example" in c
+    c, r = test_complete("rm RequireDep")
+    @test "RequireDependency" in c
+    c, r = test_complete("rm Exam")
+    @test isempty(c)
+    c, r = test_complete("rm -m Exam")
+    c, r = test_complete("rm -m Exam")
+    @test "Example" in c
 
-        pkg"add Example"
-        c, r = test_complete("rm Exam")
-        @test "Example" in c
-        c, r = test_complete("add --man")
-        @test "--manifest" in c
-        c, r = test_complete("rem")
-        @test "remove" in c
-        @test apply_completion("rm E") == "rm Example"
-        @test apply_completion("add Exampl") == "add Example"
+    pkg"add Example"
+    c, r = test_complete("rm Exam")
+    @test "Example" in c
+    c, r = test_complete("add --man")
+    @test "--manifest" in c
+    c, r = test_complete("rem")
+    @test "remove" in c
+    @test apply_completion("rm E") == "rm Example"
+    @test apply_completion("add Exampl") == "add Example"
 
-        c, r = test_complete("preview r")
-        @test "remove" in c
-        c, r = test_complete("help r")
-        @test "remove" in c
-        @test !("rm" in c)
-
-    finally
-        popfirst!(LOAD_PATH)
-    end
+    c, r = test_complete("preview r")
+    @test "remove" in c
+    c, r = test_complete("help r")
+    @test "remove" in c
+    @test !("rm" in c)
 end end
 
 temp_pkg_dir() do project_path; cd(project_path) do
     mktempdir() do tmp
         cp(joinpath(@__DIR__, "test_packages", "BigProject"), joinpath(tmp, "BigProject"))
-        cd(joinpath(tmp, "BigProject")) do
-            try
-                pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
-                pkg"dev SubModule"
-                pkg"dev SubModule2"
-                pkg"add Random"
-                pkg"add Example"
-                pkg"build"
-                @eval using BigProject
-                pkg"build BigProject"
-                @test_throws CommandError pkg"add BigProject"
-                pkg"test SubModule"
-                pkg"test SubModule2"
-                pkg"test BigProject"
-                pkg"test"
-                current_json = Pkg.API.installed()["JSON"]
-                old_project = read("Project.toml", String)
-                open("Project.toml"; append=true) do io
-                    print(io, """
+        cd(joinpath(tmp, "BigProject"))
+        with_current_env() do
+            pkg"dev SubModule"
+            pkg"dev SubModule2"
+            pkg"add Random"
+            pkg"add Example"
+            pkg"build"
+            @eval using BigProject
+            pkg"build BigProject"
+            @test_throws CommandError pkg"add BigProject"
+            pkg"test SubModule"
+            pkg"test SubModule2"
+            pkg"test BigProject"
+            pkg"test"
+            current_json = Pkg.API.installed()["JSON"]
+            old_project = read("Project.toml", String)
+            open("Project.toml"; append=true) do io
+                print(io, """
 
-                    [compat]
-                    JSON = "0.16.0"
-                    """
-                    )
-                end
-                pkg"up"
-                @test Pkg.API.installed()["JSON"].minor == 16
-                write("Project.toml", old_project)
-                pkg"up"
-                @test Pkg.API.installed()["JSON"] == current_json
-            finally
-                popfirst!(LOAD_PATH)
+                [compat]
+                JSON = "0.16.0"
+                """
+                )
             end
+            pkg"up"
+            @test Pkg.API.installed()["JSON"].minor == 16
+            write("Project.toml", old_project)
+            pkg"up"
+            @test Pkg.API.installed()["JSON"] == current_json
         end
     end
 end; end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -30,7 +30,7 @@ end
 
 mktempdir() do project_path
     cd(project_path) do
-        pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+        pushfirst!(LOAD_PATH, project_path)
         try
             withenv("USER" => "Test User") do
                 pkg"generate HelloWorld"
@@ -180,7 +180,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
     end # mktempdir
     # nested
     try
-        pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+        pushfirst!(LOAD_PATH, "@")
         mktempdir() do other_dir
             mktempdir() do tmp; cd(tmp) do
                 withenv("USER" => "Test User") do
@@ -223,7 +223,7 @@ end
 # Autocompletions
 temp_pkg_dir() do project_path; cd(project_path) do
     try
-        pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+        pushfirst!(LOAD_PATH, ".")
         Pkg.Types.registries()
         pkg"init"
         c, r = test_complete("add Exam")
@@ -289,6 +289,10 @@ temp_pkg_dir() do project_path; cd(project_path) do
         cd(joinpath(tmp, "BigProject")) do
             try
                 pushfirst!(LOAD_PATH, Base.parse_load_path("@"))
+                pkg"dev SubModule"
+                pkg"dev SubModule2"
+                pkg"add Random"
+                pkg"add Example"
                 pkg"build"
                 @eval using BigProject
                 pkg"build BigProject"

--- a/test/test_packages/BigProject/.gitignore
+++ b/test/test_packages/BigProject/.gitignore
@@ -1,1 +1,2 @@
 deps/buildartifact
+Manifest.toml

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -40,3 +40,12 @@ function write_build(path, content)
     mkpath(dirname(build_filename))
     write(build_filename, content)
 end
+
+function with_current_env(f)
+    pushfirst!(LOAD_PATH, Base.current_env())
+    try
+        f()
+    finally
+        popfirst!(LOAD_PATH)
+    end
+end


### PR DESCRIPTION
I figure most people issue a `cd` after `generate` when starting a new project (at least that's what makes sense to me, why would you create a project and then go do something else?). From a usability standpoint, it makes sense to provide a command to do both. Thoughts?

Note: this PR is just for reference, I don't know what your policy is and I didn't do extensive testing.