### PR TITLE
[RFC] fold deactivate into no-arg activate

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -548,7 +548,7 @@ end # module
 We can now activate the project and load the package:
 
 ```jl
-pkg> activate
+pkg> activate .
 
 julia> import HelloWorld
 
@@ -773,7 +773,7 @@ However, nothing would be installed and your `Project.toml` and `Manifest.toml` 
 Simply clone their project using e.g. `git clone`, `cd` to the project directory and call
 
 ```
-(v0.7) pkg> activate
+(v0.7) pkg> activate .
 
 (SomeProject) pkg> instantiate
 ```

--- a/src/API.jl
+++ b/src/API.jl
@@ -568,29 +568,26 @@ end
 
 const ACTIVE_ENV = Ref{Union{String,Nothing}}(nothing)
 
-function _activate(env::Union{String,Nothing})
-    if env === nothing
-        @warn "Current directory is not in a project, nothing activated."
-    else
+function activate(path::Union{String,Nothing}=nothing)
+    if path === nothing # reset to default LOAD_PATH
         if !isempty(LOAD_PATH) && ACTIVE_ENV[] === LOAD_PATH[1]
-            LOAD_PATH[1] = env
-        else
-            # TODO: warn if ACTIVE_ENV !== nothing ?
-            pushfirst!(LOAD_PATH, env)
+            popfirst!(LOAD_PATH)
         end
-        ACTIVE_ENV[] = env
+        ACTIVE_ENV[] = nothing
+    else # activate the env found in path
+        env = Base.current_env(path)
+        if env === nothing
+            @warn "Current directory is not in a project, nothing activated."
+        else
+            if !isempty(LOAD_PATH) && ACTIVE_ENV[] === LOAD_PATH[1]
+                LOAD_PATH[1] = env
+            else
+                pushfirst!(LOAD_PATH, env)
+            end
+            ACTIVE_ENV[] = env
+        end
     end
-end
-activate() = _activate(Base.current_env())
-activate(path::String) = _activate(Base.current_env(path))
-
-function deactivate()
-    if !isempty(LOAD_PATH) && ACTIVE_ENV[] === LOAD_PATH[1]
-        popfirst!(LOAD_PATH)
-    else
-        # warn if ACTIVE_ENV !== nothing ?
-    end
-    ACTIVE_ENV[] = nothing
+    return ACTIVE_ENV[]
 end
 
 end # module

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -58,7 +58,6 @@ const resolve     = API.resolve
 const status      = Display.status
 const update      = up
 const activate    = API.activate
-const deactivate  = API.deactivate
 
 # legacy CI script support
 import .API: clone, dir

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -47,7 +47,6 @@ const cmds = Dict(
     "instantiate" => CMD_INSTANTIATE,
     "resolve"     => CMD_RESOLVE,
     "activate"    => CMD_ACTIVATE,
-    "deactivate"  => CMD_DEACTIVATE,
 )
 
 #################
@@ -278,7 +277,6 @@ function do_cmd!(tokens::Vector{Token}, repl)
     cmd.kind == CMD_PRECOMPILE  ? Base.invokelatest(    do_precompile!, ctx, tokens) :
     cmd.kind == CMD_INSTANTIATE ? Base.invokelatest(   do_instantiate!, ctx, tokens) :
     cmd.kind == CMD_ACTIVATE    ? Base.invokelatest(      do_activate!, ctx, tokens) :
-    cmd.kind == CMD_DEACTIVATE  ? Base.invokelatest(    do_deactivate!, ctx, tokens) :
         cmderror("`$cmd` command not yet implemented")
     return
 end
@@ -344,8 +342,6 @@ developed packages
 `gc`: garbage collect packages not used for a significant time
 
 `activate`: set the primary environment the package manager manipulates
-
-`deactivate`: unset the primary environment the package manager manipulates
 """
 
 const helps = Dict(
@@ -792,11 +788,6 @@ function do_activate!(ctx::Context, tokens::Vector{Token})
         end
         return API.activate(abspath(token))
     end
-end
-
-function do_deactivate!(ctx::Context, tokens::Vector{Token})
-    !isempty(tokens) && cmderror("`deactivate` does not take any arguments")
-    API.deactivate()
 end
 
 ######################


### PR DESCRIPTION
This PR removes `pkg> deactivate` in favor of no-arg `pkg> activate`. To activate the environment in `pwd()` you instead ahve to do `pkg> activate .` I think it is cleaner to use only one command, which now works similar to `cd` in that we jump back to something default with no arguments. Another reason why this change makes sense to me is that `pkg> deactivate` does not deactivate environments, it just activates another one (kinda).

I think this behaviour, in combination with `@:` in the default `LOAD_PATH`, results in an intuitive behaviour. Thoughts?