### PR TITLE
don't use startup.jl when precompiling, building and testing

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -504,7 +504,7 @@ function precompile(ctx::Context)
         printpkgstyle(ctx, :Precompiling, pkg * " [$i of $(length(needs_to_be_precompiled))]")
         run(pipeline(ignorestatus(```
         $(Base.julia_cmd()) -O$(Base.JLOptions().opt_level) --color=no --history-file=no
-        --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
+        --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         --compiled-modules="yes"
         --depwarn=no
         --eval $code

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -972,7 +972,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
             """
         cmd = ```
             $(Base.julia_cmd()) -O0 --color=no --history-file=no
-            --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
+            --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
             --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
             --eval $code
             ```
@@ -1224,7 +1224,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
             --color=$(Base.have_color ? "yes" : "no")
             --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
             --check-bounds=yes
-            --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
+            --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
             --eval $code
         ```
         run_test = () -> begin

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -504,7 +504,8 @@ const helps = Dict(
 
     Run the tests for package `pkg`. This is done by running the file `test/runtests.jl`
     in the package directory. The option `--coverage` can be used to run the tests with
-    coverage enabled.
+    coverage enabled. The `startup.jl` file is disabled during testing unless
+    julia is started with `--startup-file=yes`.
     """, CMD_GC => md"""
 
     Deletes packages that cannot be reached from any existing environment.
@@ -518,8 +519,9 @@ const helps = Dict(
 
         build pkg[=uuid] ...
 
-    Run the build script in deps/build.jl for each package in `pkg`` and all of their dependencies in depth-first recursive order.
+    Run the build script in `deps/build.jl` for each package in `pkg` and all of their dependencies in depth-first recursive order.
     If no packages are given, runs the build scripts for all packages in the manifest.
+    The `startup.jl` file is disabled during building unless julia is started with `--startup-file=yes`.
     """, CMD_PIN => md"""
 
         pin pkg[=uuid] ...
@@ -550,6 +552,7 @@ const helps = Dict(
         precompile
 
     Precompile all the dependencies of the project by running `import` on all of them in a new process.
+    The `startup.jl` file is disabled during precompilation unless julia is started with `--startup-file=yes`.
     """, CMD_INSTANTIATE => md"""
         instantiate
         instantiate [-m|--manifest]


### PR DESCRIPTION
don't use startup.jl when precompiling, building and testing unless the user has explicitly asked for it with
```
  --startup-file=yes
```

For testing I think not loading `startup.jl` is the correct choice since you don't want local things to affect testing. Not sure about building and precompiling, those are local things in some sense and perhaps the startup file should be run in those cases...

fix #435