### PR TITLE
rename CommandError to PkgError

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -17,7 +17,7 @@ include("generate.jl")
 
 function check_package_name(x::String)
     if !(occursin(Pkg.REPLMode.name_re, x))
-         cmderror("$x is not a valid packagename")
+         pkgerror("$x is not a valid packagename")
     end
     return PackageSpec(x)
 end
@@ -37,7 +37,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
     # if julia is passed as a package the solver gets tricked;
     # this catches the error early on
     any(pkg->(pkg.name == "julia"), pkgs) &&
-        cmderror("Trying to $mode julia as a package")
+        pkgerror("Trying to $mode julia as a package")
 
     ctx.preview && preview_info()
     if mode == :develop
@@ -52,7 +52,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
     ensure_resolved(ctx.env, pkgs, registry=true)
 
     any(pkg -> Types.collides_with_project(ctx.env, pkg), pkgs) &&
-        cmderror("Cannot $mode package with the same name or uuid as the project")
+        pkgerror("Cannot $mode package with the same name or uuid as the project")
 
     Operations.add_or_develop(ctx, pkgs; new_git=new_git)
     ctx.preview && preview_info()
@@ -105,7 +105,7 @@ function update_registry(ctx)
                     try
                         GitTools.fetch(repo; refspecs=["+refs/heads/$branch:refs/remotes/origin/$branch"])
                     catch e
-                        e isa CommandError || rethrow(e)
+                        e isa PkgError || rethrow(e)
                         push!(errors, (reg, "failed to fetch from repo"))
                         return
                     end
@@ -217,7 +217,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     for pkg in pkgs
         info = manifest_info(ctx.env, pkg.uuid)
         if !get(info, "pinned", false) && !(pkg.uuid in uuids_in_registry)
-            cmderror("cannot free an unpinned package that does not exist in a registry")
+            pkgerror("cannot free an unpinned package that does not exist in a registry")
         end
     end
     Operations.free(ctx, pkgs)
@@ -236,7 +236,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...
     ctx.preview && preview_info()
     if isempty(pkgs)
         # TODO: Allow this?
-        ctx.env.pkg == nothing && cmderror("trying to test unnamed project")
+        ctx.env.pkg == nothing && pkgerror("trying to test unnamed project")
         push!(pkgs, ctx.env.pkg)
     end
     project_resolve!(ctx.env, pkgs)
@@ -465,7 +465,7 @@ function precompile(ctx::Context)
         paths = Base.find_all_in_cache_path(pkg)
         sourcepath = Base.locate_package(pkg)
         if sourcepath == nothing
-            cmderror("couldn't find path to $(pkg.name) when trying to precompilie project")
+            pkgerror("couldn't find path to $(pkg.name) when trying to precompilie project")
         end
         found_matching_precompile = false
         for path_to_try in paths::Vector{String}
@@ -526,7 +526,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing, kwarg
         return
     end
     if !isfile(ctx.env.manifest_file) && manifest == true
-        cmderror("manifest at $(ctx.env.manifest_file) does not exist")
+        pkgerror("manifest at $(ctx.env.manifest_file) does not exist")
     end
     update_registry(ctx)
     urls = Dict{}
@@ -600,7 +600,7 @@ function activate(path::String; shared::Bool=false)
         end
         # this disallows names such as "Foo/bar", ".", "..", etc
         if basename(abspath(fullpath)) != path
-            cmderror("not a valid name for a shared environment: $(path)")
+            pkgerror("not a valid name for a shared environment: $(path)")
         end
         # unless the shared environment already exists, place it in the first depots
         if !isdir(fullpath)

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -95,9 +95,9 @@ function clone(url, source_path; header=nothing, kwargs...)
         err isa LibGit2.GitError || rethrow(err)
         if (err.class == LibGit2.Error.Net && err.code == LibGit2.Error.EINVALIDSPEC) ||
            (err.class == LibGit2.Error.Repository && err.code == LibGit2.Error.ENOTFOUND)
-            Pkg.Types.cmderror("Git repository not found at '$(url)'")
+            Pkg.Types.pkgerror("Git repository not found at '$(url)'")
         else
-            Pkg.Types.cmderror("failed to clone from $(url), error: $err")
+            Pkg.Types.pkgerror("failed to clone from $(url), error: $err")
         end
     finally
         print(stdout, "\033[2K") # clear line
@@ -126,9 +126,9 @@ function fetch(repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kwargs.
     catch err
         err isa LibGit2.GitError || rethrow(err)
         if (err.class == LibGit2.Error.Repository && err.code == LibGit2.Error.ERROR)
-            Pkg.Types.cmderror("Git repository not found at '$(remoteurl)'")
+            Pkg.Types.pkgerror("Git repository not found at '$(remoteurl)'")
         else
-            Pkg.Types.cmderror("failed to fetch from $(remoteurl), error: $err")
+            Pkg.Types.pkgerror("failed to fetch from $(remoteurl), error: $err")
         end
     finally
         print(stdout, "\033[2K") # clear line

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -32,7 +32,7 @@ function load_package_data(f::Base.Callable, path::String, versions)
             vr = VersionRange(v)
             ver in vr || continue
             dict = get!(data, ver, Dict{String,Any}())
-            haskey(dict, key) && cmderror("$ver/$key is duplicated in $path")
+            haskey(dict, key) && pkgerror("$ver/$key is duplicated in $path")
             dict[key] = f(value)
         end
     end
@@ -48,7 +48,7 @@ function load_package_data_raw(T::Type, path::String)
     for (v, d) in toml, (key, value) in d
         vr = VersionRange(v)
         dict = get!(data, vr, Dict{String,T}())
-        haskey(dict, key) && cmderror("$vr/$key is duplicated in $path")
+        haskey(dict, key) && pkgerror("$vr/$key is duplicated in $path")
         dict[key] = T(value)
     end
     return data
@@ -101,7 +101,7 @@ function collect_fixed!(ctx::Context, pkgs::Vector{PackageSpec}, uuid_to_name::D
 
         path = project_rel_path(ctx, path)
         if !isdir(path)
-            cmderror("path $(path) for package $(pkg.name) no longer exists. Remove the package or `develop` it at a new path")
+            pkgerror("path $(path) for package $(pkg.name) no longer exists. Remove the package or `develop` it at a new path")
         end
 
         uuid_to_pkg[pkg.uuid] = pkg
@@ -327,7 +327,7 @@ function resolve_versions!(
         proj_compat = Types.project_compatibility(ctx, name)
         v = intersect(pkg.version, proj_compat)
         if isempty(v)
-            cmderror(string("for package $(pkg.name) intersection between project compatibility $(proj_compat) ",
+            pkgerror(string("for package $(pkg.name) intersection between project compatibility $(proj_compat) ",
                             "and package version $(pkg.version) is empty"))
         end
         pkg.version = v
@@ -381,7 +381,7 @@ function version_data!(ctx::Context, pkgs::Vector{PackageSpec})
             info = parse_toml(path, "Package.toml")
             if haskey(names, uuid)
                 names[uuid] == info["name"] ||
-                    cmderror("$uuid: name mismatch between registries: ",
+                    pkgerror("$uuid: name mismatch between registries: ",
                              "$(names[uuid]) vs. $(info["name"])")
             else
                 names[uuid] = info["name"]
@@ -568,7 +568,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
                 try
                     success = install_archive(urls[pkg.uuid], hashes[pkg.uuid], path)
                     if ctx.use_only_tarballs_for_downloads && !success
-                        cmderror("failed to get tarball from $(urls[pkg.uuid])")
+                        pkgerror("failed to get tarball from $(urls[pkg.uuid])")
                     end
                     put!(results, (pkg, success, path))
                 catch err
@@ -581,7 +581,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
     missed_packages = Tuple{PackageSpec, String}[]
     for i in 1:length(pkgs_to_install)
         pkg, exc_or_success, bt_or_path = take!(results)
-        exc_or_success isa Exception && cmderror("Error when installing packages:\n", sprint(Base.showerror, exc_or_success, bt_or_path))
+        exc_or_success isa Exception && pkgerror("Error when installing packages:\n", sprint(Base.showerror, exc_or_success, bt_or_path))
         success, path = exc_or_success, bt_or_path
         if success
             vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
@@ -1026,7 +1026,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
                 path = project_rel_path(ctx, info["path"])
                 hash_or_path = path
             else
-                cmderror("Could not find either `git-tree-sha1` or `path` for package $(pkg.name)")
+                pkgerror("Could not find either `git-tree-sha1` or `path` for package $(pkg.name)")
             end
             version = v"0.0"
         end
@@ -1084,7 +1084,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
         end
     end
     if !build_succeeded
-        cmderror("at least one package failed to build")
+        pkgerror("at least one package failed to build")
     end
     return
 end
@@ -1279,7 +1279,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
             elseif pkg.uuid in keys(ctx.stdlibs)
                 version_path = Types.stdlib_path(pkg.name)
             else
-                cmderror("Could not find either `git-tree-sha1` or `path` for package $(pkg.name)")
+                pkgerror("Could not find either `git-tree-sha1` or `path` for package $(pkg.name)")
             end
         end
         testfile = joinpath(version_path, "test", "runtests.jl")
@@ -1290,7 +1290,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
         push!(testfiles, testfile)
     end
     if !isempty(missing_runtests)
-        cmderror(length(missing_runtests) == 1 ? "Package " : "Packages ",
+        pkgerror(length(missing_runtests) == 1 ? "Package " : "Packages ",
                 join(missing_runtests, ", "),
                 " did not provide a `test/runtests.jl` file")
     end
@@ -1338,7 +1338,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
     end
 
     if !isempty(pkgs_errored)
-        cmderror(length(pkgs_errored) == 1 ? "Package " : "Packages ",
+        pkgerror(length(pkgs_errored) == 1 ? "Package " : "Packages ",
                  join(pkgs_errored, ", "),
                  " errored during testing")
     end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -7,7 +7,7 @@ using REPL.TerminalMenus
 depots() = Base.DEPOT_PATH
 function depots1()
     d = depots()
-    isempty(d) && cmderror("no depots found in DEPOT_PATH")
+    isempty(d) && pkgerror("no depots found in DEPOT_PATH")
     return d[1]
 end
 

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -3,7 +3,7 @@ function generate(ctx::Context, path::String; kwargs...)
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
     dir, pkg = dirname(path), basename(path)
-    isdir(path) && cmderror("$(abspath(path)) already exists")
+    isdir(path) && pkgerror("$(abspath(path)) already exists")
     printstyled("Generating"; color=:green, bold=true)
     print(" project $pkg:\n")
     project(pkg, dir; preview=ctx.preview)
@@ -36,7 +36,7 @@ function project(pkg::String, dir::String; preview::Bool)
     end
 
     if name == nothing
-        cmderror("could not determine user, please set ", Sys.iswindows() ? "USERNAME" : "USER",
+        pkgerror("could not determine user, please set ", Sys.iswindows() ? "USERNAME" : "USER",
                  " environment variable")
     end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -213,7 +213,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "invalid pkg name" begin
-        @test_throws CommandError Pkg.add(",sa..,--")
+        @test_throws PkgError Pkg.add(",sa..,--")
     end
 
     @testset "stdlibs as direct dependency" begin
@@ -239,7 +239,7 @@ temp_pkg_dir() do project_path
             withenv("JULIA_PKG_DEVDIR" => devdir) do
                 try
                     Pkg.setprotocol!("notarealprotocol")
-                    @test_throws CommandError Pkg.develop("Example")
+                    @test_throws PkgError Pkg.develop("Example")
                     Pkg.setprotocol!("https")
                     Pkg.develop("Example")
                     @test isinstalled(TEST_PKG)
@@ -257,8 +257,8 @@ temp_pkg_dir() do project_path
 
     @testset "adding nonexisting packages" begin
         nonexisting_pkg = randstring(14)
-        @test_throws CommandError Pkg.add(nonexisting_pkg)
-        @test_throws CommandError Pkg.update(nonexisting_pkg)
+        @test_throws PkgError Pkg.add(nonexisting_pkg)
+        @test_throws PkgError Pkg.update(nonexisting_pkg)
     end
 
     Pkg.rm(TEST_PKG.name)
@@ -279,7 +279,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "add julia" begin
-        @test_throws CommandError Pkg.add("julia")
+        @test_throws PkgError Pkg.add("julia")
     end
 
     @testset "up in Project without manifest" begin
@@ -301,7 +301,7 @@ temp_pkg_dir() do project_path
                 cd("FailBuildPkg")
                 with_current_env() do
                     write_build(pwd(), "error()")
-                    @test_throws CommandError Pkg.build()
+                    @test_throws PkgError Pkg.build()
                 end
             end
         end
@@ -385,9 +385,9 @@ end
 temp_pkg_dir() do project_path
     @testset "invalid repo url" begin
         cd(project_path) do
-            @test_throws CommandError Pkg.add("https://github.com")
+            @test_throws PkgError Pkg.add("https://github.com")
             Pkg.generate("FooBar")
-            @test_throws CommandError Pkg.add("./Foobar")
+            @test_throws PkgError Pkg.add("./Foobar")
         end
     end
 end
@@ -402,7 +402,7 @@ temp_pkg_dir() do project_path
                 Pkg.add(PackageSpec(path=package_path))
             end
             rm(joinpath(package_path, ".git"); force=true, recursive=true)
-            @test_throws CommandError Pkg.update()
+            @test_throws PkgError Pkg.update()
         end
     end
 end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -1,7 +1,7 @@
 module REPLTests
 
 using Pkg
-import Pkg.Types.CommandError
+import Pkg.Types.PkgError
 using UUIDs
 using Test
 import LibGit2
@@ -23,7 +23,7 @@ function git_init_package(tmp, path)
 end
 
 @testset "generate args" begin
-    @test_throws CommandError pkg"generate"
+    @test_throws PkgError pkg"generate"
 end
 
 temp_pkg_dir() do project_path
@@ -58,18 +58,18 @@ temp_pkg_dir() do project_path
         end
         pkg"dev Foo"
         mv(joinpath("Foo", "src", "Foo.jl"), joinpath("Foo", "src", "Foo2.jl"))
-        @test_throws CommandError pkg"dev Foo"
+        @test_throws PkgError pkg"dev Foo"
         mv(joinpath("Foo", "src", "Foo2.jl"), joinpath("Foo", "src", "Foo.jl"))
         write(joinpath("Foo", "Project.toml"), """
             name = "Foo"
         """
         )
-        @test_throws CommandError pkg"dev Foo"
+        @test_throws PkgError pkg"dev Foo"
         write(joinpath("Foo", "Project.toml"), """
             uuid = "b7b78b08-812d-11e8-33cd-11188e330cbe"
         """
         )
-        @test_throws CommandError pkg"dev Foo"
+        @test_throws PkgError pkg"dev Foo"
     end
 end
 
@@ -137,7 +137,7 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
     #@eval import $(Symbol(pkg2))
     @test Pkg.installed()[pkg2] == v"0.1.0"
     Pkg.REPLMode.pkgstr("free $pkg2")
-    @test_throws CommandError Pkg.REPLMode.pkgstr("free $pkg2")
+    @test_throws PkgError Pkg.REPLMode.pkgstr("free $pkg2")
     Pkg.test("UnregisteredWithProject")
 
     write(joinpath(p2, "Project.toml"), """
@@ -266,10 +266,10 @@ cd(mktempdir()) do
     pkg"activate ."
     @test Base.active_project() == joinpath(path, "Project.toml")
     # tests illegal names for shared environments
-    @test_throws Pkg.Types.CommandError pkg"activate --shared ."
-    @test_throws Pkg.Types.CommandError pkg"activate --shared ./Foo"
-    @test_throws Pkg.Types.CommandError pkg"activate --shared Foo/Bar"
-    @test_throws Pkg.Types.CommandError pkg"activate --shared ../Bar"
+    @test_throws Pkg.Types.PkgError pkg"activate --shared ."
+    @test_throws Pkg.Types.PkgError pkg"activate --shared ./Foo"
+    @test_throws Pkg.Types.PkgError pkg"activate --shared Foo/Bar"
+    @test_throws Pkg.Types.PkgError pkg"activate --shared ../Bar"
     # check that those didn't change te enviroment
     @test Base.active_project() == joinpath(path, "Project.toml")
     mkdir("Foo")
@@ -427,7 +427,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
             """
             @eval using BigProject
             pkg"build BigProject"
-            @test_throws CommandError pkg"add BigProject"
+            @test_throws PkgError pkg"add BigProject"
             # the command below also tests multiline input
             Pkg.REPLMode.pkgstr("""
                 test SubModule
@@ -551,8 +551,8 @@ end
     pkg = Pkg.REPLMode.parse_package(path; add_or_develop=true)
     @test (pkg.repo.url == path)
     # errors
-    @test_throws CommandError Pkg.REPLMode.parse_package(url)
-    @test_throws CommandError Pkg.REPLMode.parse_package(path)
+    @test_throws PkgError Pkg.REPLMode.parse_package(url)
+    @test_throws PkgError Pkg.REPLMode.parse_package(path)
 end
 
 @testset "unit test for REPLMode.promptf" begin
@@ -593,18 +593,18 @@ end
 
 @testset "Argument order" begin
     with_temp_env() do
-        @test_throws CommandError Pkg.REPLMode.pkgstr("add FooBar Example#foobar#foobar")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("up Example#foobar@0.0.0")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("pin Example@0.0.0@0.0.1")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("up #foobar")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("add @0.0.1")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("add FooBar Example#foobar#foobar")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up Example#foobar@0.0.0")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("pin Example@0.0.0@0.0.1")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up #foobar")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("add @0.0.1")
     end
 end
 
 @testset "`do_generate!` error paths" begin
     with_temp_env() do
-        @test_throws CommandError Pkg.REPLMode.pkgstr("generate Example Example2")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("generate")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("generate Example Example2")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("generate")
     end
 end
 
@@ -680,9 +680,9 @@ end
 
 @testset "argument count errors" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("activate one two")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("activate one two three")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("precompile Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("activate one two")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("activate one two three")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("precompile Example")
     end
     end
     end
@@ -690,8 +690,8 @@ end
 
 @testset "invalid options" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("rm --minor Example")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("pin --project Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("rm --minor Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("pin --project Example")
     end
     end
     end
@@ -699,11 +699,11 @@ end
 
 @testset "Argument order" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("add FooBar Example#foobar#foobar")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("up Example#foobar@0.0.0")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("pin Example@0.0.0@0.0.1")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("up #foobar")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("add @0.0.1")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("add FooBar Example#foobar#foobar")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up Example#foobar@0.0.0")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("pin Example@0.0.0@0.0.1")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up #foobar")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("add @0.0.1")
     end
     end
     end
@@ -711,8 +711,8 @@ end
 
 @testset "conflicting options" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("up --major --minor")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("rm --project --manifest")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up --major --minor")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("rm --project --manifest")
     end
     end
     end
@@ -720,9 +720,9 @@ end
 
 @testset "gc" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("gc --project")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("gc --minor")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("gc Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("gc --project")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("gc --minor")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("gc Example")
         Pkg.REPLMode.pkgstr("gc")
     end
     end
@@ -731,8 +731,8 @@ end
 
 @testset "precompile" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("precompile --project")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("precompile Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("precompile --project")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("precompile Example")
         Pkg.REPLMode.pkgstr("precompile")
     end
     end
@@ -741,9 +741,9 @@ end
 
 @testset "generate" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("generate --major Example")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("generate --foobar Example")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("generate Example1 Example2")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("generate --major Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("generate --foobar Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("generate Example1 Example2")
         Pkg.REPLMode.pkgstr("generate Example")
     end
     end
@@ -753,7 +753,7 @@ end
 @testset "test" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
         Pkg.add("Example")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("test --project Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("test --project Example")
         Pkg.REPLMode.pkgstr("test --coverage Example")
         Pkg.REPLMode.pkgstr("test Example")
     end
@@ -763,8 +763,8 @@ end
 
 @testset "build" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("build --project")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("build --minor")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("build --project")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("build --minor")
     end
     end
     end
@@ -772,8 +772,8 @@ end
 
 @testset "free" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError Pkg.REPLMode.pkgstr("free --project")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("free --major")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("free --project")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("free --major")
     end
     end
     end
@@ -794,8 +794,8 @@ end
     groups = Pkg.REPLMode.group_words(["a", "b", "c", ";", "a", "b", ";"])
     @test length(groups) == 2
     # errors
-    @test_throws CommandError Pkg.REPLMode.group_words(["a", "b", ";", ";", "a", "b"])
-    @test_throws CommandError Pkg.REPLMode.group_words([";", "add", "Example"])
+    @test_throws PkgError Pkg.REPLMode.group_words(["a", "b", ";", ";", "a", "b"])
+    @test_throws PkgError Pkg.REPLMode.group_words([";", "add", "Example"])
 end
 
 @testset "tests for api opts" begin
@@ -835,11 +835,11 @@ end
 @testset "meta option errors" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
         # unregistered meta options
-        @test_throws CommandError Pkg.REPLMode.pkgstr("--foo=foo add Example")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("--bar add Example")
-        @test_throws CommandError Pkg.REPLMode.pkgstr("-x add Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("--foo=foo add Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("--bar add Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("-x add Example")
         # malformed, but registered meta option
-        @test_throws CommandError Pkg.REPLMode.pkgstr("--env Example")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("--env Example")
     end
     end
     end
@@ -878,15 +878,15 @@ end
     @test qwords[2].word == " forget to "
     @test qwords[3].isquoted
     @test qwords[3].word == "\"test\""
-    @test_throws CommandError Pkg.REPLMode.parse_quotes("Don't")
-    @test_throws CommandError Pkg.REPLMode.parse_quotes("Unterminated \"quot")
+    @test_throws PkgError Pkg.REPLMode.parse_quotes("Don't")
+    @test_throws PkgError Pkg.REPLMode.parse_quotes("Unterminated \"quot")
 end
 
 @testset "argument kinds" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        @test_throws CommandError pkg"pin Example#foo"
-        @test_throws CommandError pkg"test Example#foo"
-        @test_throws CommandError pkg"test Example@v0.0.1"
+        @test_throws PkgError pkg"pin Example#foo"
+        @test_throws PkgError pkg"test Example#foo"
+        @test_throws PkgError pkg"test Example@v0.0.1"
     end
     end
     end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -54,7 +54,7 @@ function load_package_data_raw(T::Type, input::String)
     for (v, d) in toml, (key, value) in d
         vr = VersionRange(v)
         dict = get!(data, vr, Dict{String,T}())
-        haskey(dict, key) && cmderror("$ver/$key is duplicated in $path")
+        haskey(dict, key) && pkgerror("$ver/$key is duplicated in $path")
         dict[key] = T(value)
     end
     return data


### PR DESCRIPTION
CommandError is not really what this is currently used for. It is used when an error happens that is not "Pkg"s fault in the sense that it was something external that failed. When this happens in the REPL mode, we do not show .a backtrace.