### PR TITLE
make installed only look in the project

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -239,9 +239,8 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...
     return
 end
 
-
-function installed(mode::PackageMode=PKGMODE_MANIFEST)
-    diffs = Display.status(Context(), mode, #=use_as_api=# true)
+function installed()
+    diffs = Display.status(Context(), PKGMODE_PROJECT, #=use_as_api=# true)
     version_status = Dict{String, Union{VersionNumber,Nothing}}()
     diffs == nothing && return version_status
     for entry in diffs


### PR DESCRIPTION
The return data structure `Dict{String, VersionRange}` for `Pkg.installed` is inherently flawed since it is using a package name as the key (and there can be multiple packages with the same key).
Package authors that are trying to replace `Pkg.installed()` from the old package manager, naturally find this function and start to use it.

We need to decide what to do here. Just remove it until a suitable replacement is found or alt, like in this PR, limit it to only those packages in the project file, which are known to be unique.

cc @vdayanand @StefanKarpinski