### PR TITLE
Increase isolation of test utilities

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,11 +4,13 @@ function temp_pkg_dir(fn::Function)
     local old_depot_path
     local old_home_project
     local old_active_project
+    local old_julia_pkg_devdir
     try
         old_load_path = copy(LOAD_PATH)
         old_depot_path = copy(DEPOT_PATH)
         old_home_project = Base.HOME_PROJECT[]
         old_active_project = Base.ACTIVE_PROJECT[]
+        old_julia_pkg_devdir = get(ENV, "JULIA_PKG_DEVDIR", nothing)
         empty!(LOAD_PATH)
         empty!(DEPOT_PATH)
         Base.HOME_PROJECT[] = nothing
@@ -17,6 +19,7 @@ function temp_pkg_dir(fn::Function)
             mktempdir() do depot_dir
                 push!(LOAD_PATH, "@", "@v#.#", "@stdlib")
                 push!(DEPOT_PATH, depot_dir)
+                ENV["JULIA_PKG_DEVDIR"] = joinpath(depot_dir, "dev")
                 fn(env_dir)
             end
         end
@@ -27,6 +30,11 @@ function temp_pkg_dir(fn::Function)
         append!(DEPOT_PATH, old_depot_path)
         Base.HOME_PROJECT[] = old_home_project
         Base.ACTIVE_PROJECT[] = old_active_project
+        if old_julia_pkg_devdir === nothing
+            delete!(ENV, "JULIA_PKG_DEVDIR")
+        else
+            ENV["JULIA_PKG_DEVDIR"] = old_julia_pkg_devdir
+        end
     end
 end
 


### PR DESCRIPTION
Currently, anything which is `dev`ed by the tests will contaminate the user's home directory by writing to `~/.julia/dev`. I set up the main test utility to follow the temporary `DEPOT_PATH` instead.

This brings up a question for me: why is this not the default behavior?

One of the tests seemed to think it was: [here](https://github.com/JuliaLang/Pkg.jl/blob/1599d42e4dc9e961afdfa507f0263b69c33bb9a0/test/repl.jl#L46). If this is the intention, then a one-line change [here](https://github.com/JuliaLang/Pkg.jl/blob/1599d42e4dc9e961afdfa507f0263b69c33bb9a0/src/Pkg.jl#L10) should do the trick. FWIW, the docs make it seem like the only two alternatives are `~/.julia/dev` or explicitly specifying with `JULIA_PKG_DEVDIR`.