### PR TITLE
Use `mktempdir` shim (until bugfix is complete)

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -178,7 +178,7 @@ temp_pkg_dir() do project_path
         Pkg.add(TEST_PKG.name)
         old_v = Pkg.installed()[TEST_PKG.name]
         Pkg.rm(TEST_PKG.name)
-        mktempdir() do devdir
+        tempdir_util() do devdir
             withenv("JULIA_PKG_DEVDIR" => devdir) do
                 Pkg.REPLMode.pkgstr("develop $(TEST_PKG.name)")
                 @test isinstalled(TEST_PKG)
@@ -231,7 +231,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "protocols" begin
-        mktempdir() do devdir
+        tempdir_util() do devdir
             withenv("JULIA_PKG_DEVDIR" => devdir) do
                 try
                     Pkg.setprotocol!("notarealprotocol")
@@ -261,7 +261,7 @@ temp_pkg_dir() do project_path
     Pkg.rm(TEST_PKG.name)
 
     @testset "legacy CI script" begin
-        mktempdir() do dir
+        tempdir_util() do dir
             LibGit2.with(LibGit2.clone("https://github.com/JuliaLang/Example.jl", joinpath(dir, "Example.jl"))) do r
                 cd(joinpath(dir, "Example.jl")) do
                     let Pkg = Pkg
@@ -280,7 +280,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "up in Project without manifest" begin
-        mktempdir() do dir
+        tempdir_util() do dir
             cp(joinpath(@__DIR__, "test_packages", "UnregisteredWithProject"), joinpath(dir, "UnregisteredWithProject"))
             cd(joinpath(dir, "UnregisteredWithProject")) do
                with_current_env() do
@@ -292,7 +292,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "failing building a package should throw" begin
-        mktempdir() do path
+        tempdir_util() do path
             cd(path) do
                 Pkg.generate("FailBuildPkg")
                 cd("FailBuildPkg")
@@ -314,7 +314,7 @@ temp_pkg_dir() do project_path
 end
 
 @testset "preview generate" begin
-    mktempdir() do tmp
+    tempdir_util() do tmp
         cd(tmp) do
             Pkg.generate("Foo"; preview=true)
             @test !isdir(joinpath(tmp, "Foo"))
@@ -324,7 +324,7 @@ end
 
 temp_pkg_dir() do project_path
     @testset "test should instantiate" begin
-        mktempdir() do dir
+        tempdir_util() do dir
             cp(joinpath(@__DIR__, "test_packages", "UnregisteredWithProject"), joinpath(dir, "UnregisteredWithProject"))
             cd(joinpath(dir, "UnregisteredWithProject")) do
                 with_current_env() do
@@ -351,7 +351,7 @@ temp_pkg_dir() do project_path
         end
 
         cd(project_path) do
-            mktempdir() do tmp; cd(tmp) do
+            tempdir_util() do tmp; cd(tmp) do
                 pkg_name = "FooBar"
                 # create a project and grab its uuid
                 Pkg.generate(pkg_name)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -26,7 +26,7 @@ end
     @test_throws CommandError pkg"generate"
 end
 
-mktempdir() do project_path
+tempdir_util() do project_path
     cd(project_path) do
         withenv("USER" => "Test User") do
             pkg"generate HelloWorld"
@@ -93,7 +93,7 @@ end
     @test repr(tokens[1][3]) == "VersionRange(\"0.5.0\")"
 end
 
-temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
+temp_pkg_dir() do project_path; cd(project_path) do; tempdir_util() do tmp_pkg_path
     pkg"activate ."
     pkg"add Example"
     @test isinstalled(TEST_PKG)
@@ -147,7 +147,7 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
         Pkg.REPLMode.pkgstr("add $p2#$c")
     end
 
-    mktempdir() do tmp_dev_dir
+    tempdir_util() do tmp_dev_dir
     withenv("JULIA_PKG_DEVDIR" => tmp_dev_dir) do
         pkg"develop Example"
 
@@ -161,7 +161,7 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
                 empty!(DEPOT_PATH)
                 write("Project.toml", proj)
                 write("Manifest.toml", manifest)
-                mktempdir() do depot_dir
+                tempdir_util() do depot_dir
                     pushfirst!(DEPOT_PATH, depot_dir)
                     pkg"instantiate"
                     @test Pkg.installed()[pkg2] == v"0.2.0"
@@ -179,8 +179,8 @@ end # temp_pkg_dir
 
 
 temp_pkg_dir() do project_path; cd(project_path) do
-    mktempdir() do tmp
-        mktempdir() do depot_dir
+    tempdir_util() do tmp
+        tempdir_util() do depot_dir
             old_depot = copy(DEPOT_PATH)
             try
                 empty!(DEPOT_PATH)
@@ -214,8 +214,8 @@ temp_pkg_dir() do project_path; cd(project_path) do
         end # withenv
     end # mktempdir
     # nested
-    mktempdir() do other_dir
-        mktempdir() do tmp;
+    tempdir_util() do other_dir
+        tempdir_util() do tmp;
             cd(tmp)
             withenv("USER" => "Test User") do
                 pkg"generate HelloWorld"
@@ -311,7 +311,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
 end end
 
 temp_pkg_dir() do project_path; cd(project_path) do
-    mktempdir() do tmp
+    tempdir_util() do tmp
         cp(joinpath(@__DIR__, "test_packages", "BigProject"), joinpath(tmp, "BigProject"))
         cd(joinpath(tmp, "BigProject"))
         with_current_env() do

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -8,7 +8,7 @@ function tempdir_util(fn::Function)
             rm(tempdir; recursive=true, force=true)
         catch ex
             if ex isa SystemError && ex.prefix == "rmdir" && ex.errnum == 13
-                @warn "tempdir_util: error while cleaning up: $ex"
+                @error "tempdir_util: error while cleaning up: $ex"
             else
                 throw(ex)
             end


### PR DESCRIPTION
What if we use this until the LibGit stuff is sorted out? It should allow people to test changes on the CI without being bothered by the LibGit bug. Thankfully the only place (so far) that the bug manifests itself is when cleaning up temporary directories. I've tried my best not to inadvertently catch unrelated exceptions. Its kind of a hack, but its limited to test code and should only be temporary.