### PR TITLE
Fix for improperly isolated testset

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -7,7 +7,7 @@ using REPL.TerminalMenus
 
 depots() = Base.DEPOT_PATH
 logdir() = joinpath(depots()[1], "logs")
-devdir() = get(ENV, "JULIA_PKG_DEVDIR", joinpath(homedir(), ".julia", "dev"))
+devdir() = get(ENV, "JULIA_PKG_DEVDIR", joinpath(depots()[1], "dev"))
 const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 
 have_warned_session = false

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -26,8 +26,8 @@ end
     @test_throws CommandError pkg"generate"
 end
 
-mktempdir() do project_path
-    cd(project_path) do
+temp_pkg_dir() do project_path
+    with_pkg_env(project_path; change_dir=true) do;
         withenv("USER" => "Test User") do
             pkg"generate HelloWorld"
             LibGit2.close((LibGit2.init(".")))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -65,3 +65,16 @@ function with_temp_env(f, env_name::AbstractString="Dummy")
         Pkg.activate()
     end
 end
+
+function with_pkg_env(fn::Function, path::AbstractString="."; change_dir=false)
+    Pkg.activate(path)
+    try
+        if change_dir
+            cd(fn, path)
+        else
+            fn()
+        end
+    finally
+        Pkg.activate()
+    end
+end


### PR DESCRIPTION
This testset was failing locally because it was reading `Pkg`'s manifest file instead of a newly generated one.