### PR TITLE
Rework the meaning of `pkg> activate Foo`

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -324,7 +324,11 @@ function do_cmd!(tokens::Vector{Token}, repl)
             cmderror("misplaced token: ", token)
         end
     end
-    cmd.kind == CMD_ACTIVATE && return Base.invokelatest(do_activate!, tokens)
+
+    if cmd.kind == CMD_ACTIVATE
+        return Base.invokelatest(do_activate!, Base.active_project() === nothing ?
+            nothing : EnvCache(env_opt), tokens)
+    end
 
     ctx = Context(env = EnvCache(env_opt))
     if cmd.kind == CMD_PREVIEW
@@ -816,15 +820,31 @@ function do_resolve!(ctx::Context, tokens::Vector{Token})
     API.resolve(ctx)
 end
 
-function do_activate!(tokens::Vector{Token})
+function do_activate!(env::Union{EnvCache,Nothing}, tokens::Vector{Token})
     if isempty(tokens)
         return API.activate()
     else
-        token = popfirst!(tokens)
-        if !isempty(tokens) || !(token isa String)
+        path = popfirst!(tokens)
+        if !isempty(tokens) || !(path isa String)
             cmderror("`activate` takes an optional path to the env to activate")
         end
-        return API.activate(abspath(token))
+        devpath = nothing
+        if env !== nothing && haskey(env.project["deps"], path)
+            uuid = UUID(env.project["deps"][path])
+            info = manifest_info(env, uuid)
+            devpath = haskey(info, "path") ? info["path"] : nothing
+        end
+        # `pkg> activate path` does the following
+        # 1. if path exists, activate that
+        # 2. if path exists in deps, and the dep is deved, activate that path (`devpath` above)
+        # 3. activate the non-existing directory (e.g. as in `pkg> activate .` for initing a new env)
+        if Types.isdir_windows_workaround(path)
+            API.activate(abspath(path))
+        elseif devpath !== nothing
+            API.activate(abspath(devpath))
+        else
+            API.activate(abspath(path))
+        end
     end
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -245,6 +245,32 @@ temp_pkg_dir() do project_path; cd(project_path) do
 end # cd
 end # temp_pkg_dir
 
+# activate
+cd(mktempdir()) do
+    path = pwd()
+    pkg"activate ."
+    mkdir("Foo")
+    cd(mkdir("modules")) do
+        pkg"generate Foo"
+    end
+    pkg"develop modules/Foo"
+    pkg"activate Foo" # activate path Foo over deps Foo
+    @test Base.active_project() == joinpath(path, "Foo", "Project.toml")
+    pkg"activate ."
+    rm("Foo"; force=true, recursive=true)
+    pkg"activate Foo" # activate path from developed Foo
+    @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
+    pkg"activate ."
+    pkg"activate ./Foo" # activate empty directory Foo (sidestep the developed Foo)
+    @test Base.active_project() == joinpath(path, "Foo", "Project.toml")
+    pkg"activate ."
+    pkg"activate Bar" # activate empty directory Bar
+    @test Base.active_project() == joinpath(path, "Bar", "Project.toml")
+    pkg"activate ."
+    pkg"add Example" # non-deved deps should not be activated
+    pkg"activate Example"
+    @test Base.active_project() == joinpath(path, "Example", "Project.toml")
+end
 
 test_complete(s) = Pkg.REPLMode.completions(s,lastindex(s))
 apply_completion(str) = begin


### PR DESCRIPTION
Rework the meaning of `pkg> activate Foo` to do the following:

  1. If Foo is an existing path, activate that
  2. If Foo is a developed dependency of the current environment, activate that
  3. Activate the (non-existing) directory Foo

To sidestep 2. above, and activate a non-existing directory Foo even though there is a developed dependency Foo, use `pkg> activate ./Foo`.