### PR TITLE
prevent a O(n^2) when collecting package names

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -257,43 +257,46 @@ mutable struct EnvCache
     # registered package info:
     uuids::Dict{String,Vector{UUID}}
     paths::Dict{UUID,Vector{String}}
+    names::Dict{UUID,Vector{String}}
+end
 
-    function EnvCache(env::Union{Nothing,String}=nothing)
-        project_file = find_project_file(env)
-        project_dir = dirname(project_file)
-        git = ispath(joinpath(project_dir, ".git")) ? project_dir : nothing
+function EnvCache(env::Union{Nothing,String}=nothing)
+    project_file = find_project_file(env)
+    project_dir = dirname(project_file)
+    git = ispath(joinpath(project_dir, ".git")) ? project_dir : nothing
 
-        project = read_project(project_file)
-        if any(haskey.((project,), ["name", "uuid", "version"]))
-            project_package = PackageSpec(
-                get(project, "name", ""),
-                UUID(get(project, "uuid", 0)),
-                VersionNumber(get(project, "version", "0.0")),
-            )
-        else
-            project_package = nothing
-        end
-        # determine manifest_file name
-        dir = abspath(dirname(project_file))
-        manifest_file = haskey(project, "manifest") ?
-            abspath(project["manifest"]) :
-            manifestfile_path(dir)
-        # use default name if still not determined
-        (manifest_file === nothing) && (manifest_file = joinpath(dir, "Manifest.toml"))
-        write_env_usage(manifest_file)
-        manifest = read_manifest(manifest_file)
-        uuids = Dict{String,Vector{UUID}}()
-        paths = Dict{UUID,Vector{String}}()
-        return new(env,
-            git,
-            project_file,
-            manifest_file,
-            project_package,
-            project,
-            manifest,
-            uuids,
-            paths,)
+    project = read_project(project_file)
+    if any(haskey.((project,), ["name", "uuid", "version"]))
+        project_package = PackageSpec(
+            get(project, "name", ""),
+            UUID(get(project, "uuid", 0)),
+            VersionNumber(get(project, "version", "0.0")),
+        )
+    else
+        project_package = nothing
     end
+    # determine manifest_file name
+    dir = abspath(dirname(project_file))
+    manifest_file = haskey(project, "manifest") ?
+        abspath(project["manifest"]) :
+        manifestfile_path(dir)
+    # use default name if still not determined
+    (manifest_file === nothing) && (manifest_file = joinpath(dir, "Manifest.toml"))
+    write_env_usage(manifest_file)
+    manifest = read_manifest(manifest_file)
+    uuids = Dict{String,Vector{UUID}}()
+    paths = Dict{UUID,Vector{String}}()
+    names = Dict{UUID,Vector{String}}()
+    return EnvCache(env,
+        git,
+        project_file,
+        manifest_file,
+        project_package,
+        project,
+        manifest,
+        uuids,
+        paths,
+        names,)
 end
 
 collides_with_project(env::EnvCache, pkg::PackageSpec) =
@@ -915,6 +918,7 @@ function find_registered!(env::EnvCache,
     # initialize env entries for names and uuids
     for name in names; env.uuids[name] = UUID[]; end
     for uuid in uuids; env.paths[uuid] = String[]; end
+    for uuid in uuids; env.names[uuid] = String[]; end
     # note: empty vectors will be left for names & uuids that aren't found
 
     # search through all registries
@@ -935,6 +939,7 @@ function find_registered!(env::EnvCache,
             path = abspath(registry, Base.unescape_string(m.captures[3]))
             push!(get!(env.uuids, name, typeof(uuid)[]), uuid)
             push!(get!(env.paths, uuid, typeof(path)[]), path)
+            push!(get!(env.names, uuid, typeof(name)[]), name)
         end
         end
     end
@@ -962,7 +967,7 @@ end
 #Get registered names associated with a package uuid
 function registered_names(env::EnvCache, uuid::UUID)::Vector{String}
     find_registered!(env, String[], [uuid])
-    String[n for (n, uuids) in env.uuids for u in uuids if u == uuid]
+    return env.names[uuid]
 end
 
 # Determine a single UUID for a given name, prompting if needed


### PR DESCRIPTION
Since we didn't have a way to go from uuid -> name in the cache, we just brute forced through all the name -> uuid and collected the names for the uuid that matched. In e.g. `deps_graph` this is inside a loop over `uuids` which means this will scale quadratically with the size of the dependency graph. Introduce a direct uuid -> name cache to fix.