### PR TITLE
RFC: new targets design

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1088,6 +1088,15 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
         @info "No changes"
         return
     end
+    deps_names = collect(keys(ctx.env.project["deps"]))
+    if haskey(ctx.env.project, "targets")
+        filter!(ctx.env.project["targets"]) do (target, deps)
+            !isempty(filter!(in(deps_names), deps))
+        end
+        if isempty(ctx.env.project["targets"])
+            delete!(ctx.env.project, "targets")
+        end
+    end
     # only keep reachable manifest entires
     prune_manifest(ctx.env)
     # update project & manifest

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -262,14 +262,18 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Require
 end
 
 # Resolve a set of versions given package version specs
-function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})::Dict{UUID,VersionNumber}
+function resolve_versions!(
+    ctx::Context,
+    pkgs::Vector{PackageSpec},
+    target::Union{Nothing, String} = nothing,
+)::Dict{UUID,VersionNumber}
     printpkgstyle(ctx, :Resolving, "package versions...")
     # anything not mentioned is fixed
     uuids = UUID[pkg.uuid for pkg in pkgs]
     uuid_to_name = Dict{UUID, String}(uuid => stdlib for (uuid, stdlib) in ctx.stdlibs)
     uuid_to_name[uuid_julia] = "julia"
 
-    for (name::String, uuidstr::String) in ctx.env.project["deps"]
+    for (name::String, uuidstr::String) in get_deps(ctx, target)
         uuid = UUID(uuidstr)
         uuid_to_name[uuid] = name
 
@@ -748,6 +752,11 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
     need_to_resolve = false
     is_project = Types.is_project(localctx.env, pkg)
 
+    target = nothing
+    if pkg.special_action == PKGSPEC_TESTED
+        target = "test"
+    end
+
     if is_project # testing the project itself
         # the project might have changes made to it so need to resolve
         need_to_resolve = true
@@ -757,7 +766,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         localctx.env.pkg = nothing
         localctx.env.project["deps"][pkg.name] = string(pkg.uuid)
         localctx.env.manifest[pkg.name] = [Dict(
-            "deps" => mainctx.env.project["deps"],
+            "deps" => get_deps(mainctx, target),
             "uuid" => string(pkg.uuid),
             "path" => dirname(localctx.env.project_file),
             "version" => string(pkg.version)
@@ -775,21 +784,17 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
                 collect_deps!(seen, PackageSpec(dpkg, UUID(duuid)))
             end
         end
-        # Only put `pkg` and its deps (revursively) in the temp project
+        # Only put `pkg` and its deps (recursively) in the temp project
         empty!(localctx.env.project["deps"])
         localctx.env.project["deps"][pkg.name] = string(pkg.uuid)
 
         seen_uuids = Set{UUID}()
-        collect_deps!(seen_uuids, pkg)# Only put `pkg` and its deps (recursively) in the temp project
+        collect_deps!(seen_uuids, pkg) # Only put `pkg` and its deps (recursively) in the temp project
 
     end
 
     pkgs = PackageSpec[]
-    target = ""
-    if pkg.special_action == PKGSPEC_TESTED
-        target = "test"
-    end
-    if !isempty(target)
+    if target !== nothing
         collect_target_deps!(localctx, pkgs, pkg, target)
     end
 
@@ -833,7 +838,12 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
     end
 end
 
-function collect_target_deps!(ctx::Context, pkgs::Vector{PackageSpec}, pkg::PackageSpec, target::String)
+function collect_target_deps!(
+    ctx::Context,
+    pkgs::Vector{PackageSpec},
+    pkg::PackageSpec,
+    target::String,
+)
     # Find the path to the package
     if pkg.uuid in keys(ctx.stdlibs)
         path = Types.stdlib_path(pkg.name)
@@ -872,17 +882,13 @@ function collect_target_deps!(ctx::Context, pkgs::Vector{PackageSpec}, pkg::Pack
     # Collect target deps from Project
     if project !== nothing
         targets = project["targets"]
-        haskey(targets, target) || return pkgs
-        targets = project["targets"]
-        target_info = targets[target]
-        haskey(target_info, "deps") || return pkgs
-        targets = project["targets"]
-        deps = target_info["deps"]
-        for (pkg, uuid) in deps
-            push!(pkgs, PackageSpec(pkg, UUID(uuid)))
+        haskey(targets, target) || return
+        for pkg in targets[target]
+            uuid = UUID(ctx.env.project["deps"][pkg])
+            push!(pkgs, PackageSpec(pkg, uuid))
         end
     end
-    return nothing
+    return
 end
 
 # Pkg2 test/REQUIRE compatibility

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -404,6 +404,51 @@ temp_pkg_dir() do project_path
     end
 end
 
+temp_pkg_dir() do project_path
+    cd(project_path) do
+        project = """
+        [deps]
+        Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+        Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+        UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+        [targets]
+        test = ["Markdown", "Test"]
+        """
+        write("Project.toml", project)
+        Pkg.activate(".")
+        @testset "resolve ignores targets" begin
+            Pkg.resolve()
+            @test read("Manifest.toml", String) == """
+            [[UUIDs]]
+            uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+            """
+        end
+        @testset "remove target/non-target deps" begin
+            Pkg.rm("Markdown")
+            @test read("Project.toml", String) == """
+            [deps]
+            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+            UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+            [targets]
+            test = ["Test"]
+            """
+            Pkg.rm("UUIDs")
+            @test read("Project.toml", String) == """
+            [deps]
+            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+            [targets]
+            test = ["Test"]
+            """
+            Pkg.rm("Test")
+            @test read("Project.toml", String) == ""
+        end
+        Pkg.activate()
+    end
+end
+
 include("repl.jl")
 
 end # module

--- a/test/test_packages/BigProject/Project.toml
+++ b/test/test_packages/BigProject/Project.toml
@@ -4,8 +4,8 @@ authors = ["Some One <someone@email.com>"]
 version = "0.1.0"
 
 [deps]
-
-
-[targets.test.deps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Example", "Test"]


### PR DESCRIPTION
Instead of writing
```toml
[deps]
Required = "<uuid>"

[targets.build.deps]
Compiler = "<uuid>"

[targets.test.deps]
Test = "<uuid>"
QuickCheck = "<uuid>"
```
with this design one would write:
```toml
[deps]
Compiler = "<uuid>"   # build-only
Required = "<uuid>"   # required
Test = "<uuid>"       # test-only 
QuickCheck = "<uuid>" # test-only

[targets]
build = ["Compiler"]
test = ["Test", "QuickCheck"]
```
In other words:
- all dependencies are listed with their UUIDs in the main `[deps]` section
- the `[targets]` section is just about defining subsets of these dependencies
- if you ignore `[targets]` you can resolve anything that any target might load
- the `main` target is everything that's not explicitly in any other target
- the dependencies of a target are the `main` targets plus the listed ones

Incidentally, this PR causes a lot of places where we were previously only looking at the main deps—i.e. those in `[deps]`—to now consider all deps because all of them are in the main `[deps]` section. As far as I can tell, this is mostly more correct and all of these places should previously have been merging target deps into the main deps. The only place that should really consider targets and subset the deps because of them is when resolving versions: only the main deps are actually required. Overall, I think this is a simplification and improvement but I want to get feedback.

I have a similar design for `[options]` and system-specific dependencies (expressed via options).