### PR TITLE
Stop trying to be lazy

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -904,7 +904,7 @@ function complete_remote_package(s, i1, i2)
     cmp = String[]
     julia_version = VERSION
     for reg in Types.registries(;clone_default=false)
-        data = TOML.parsefile(joinpath(reg, "Registry.toml"))
+        data = Types.read_registry(joinpath(reg, "Registry.toml"))
         for (uuid, pkginfo) in data["packages"]
             name = pkginfo["name"]
             if startswith(name, s)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -842,13 +842,12 @@ function registries(; clone_default=true)::Vector{String}
     return [r for d in depots() for r in registries(d)]
 end
 
-
+# path -> (mtime, TOML Dict)
 const REGISTRY_CACHE = Dict{String, Tuple{Float64, Dict{String, Any}}}()
 
 function read_registry(reg_file)
     t = mtime(reg_file)
     if haskey(REGISTRY_CACHE, reg_file)
-        println("Cache hit")
         prev_t, registry = REGISTRY_CACHE[reg_file]
         t == prev_t && return registry
     end


### PR DESCRIPTION
It seems a bit silly that tab completion is allowed to fully TOML parse all the registries (and it does so very fast), while we are constructing this big regular expression to avoid parsing it for the resolver (where there is much more of other stuff going on). It also ties us to using a custom regex parser which might break if someone outputs TOML in another format.

We can also introduce a cache here so that we only need to reparse Registry.toml in case it is updated. This means that often it is only required to be parsed a single time during the session. 