### PR TITLE
RFC: move extra deps into [extras] section

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -689,13 +689,18 @@ Testing...
 
 #### Test-specific dependencies
 
-Sometimes one might want to use some packages only at testing time but not enforce a dependency on them when the package is used.
-This is possible by adding dependencies to a "test target" to the Project file. Here we add the `Test` standard library as a
-test-only dependency by adding the following to the Project file:
+Sometimes one might want to use some packages only at testing time but not
+enforce a dependency on them when the package is used. This is possible by
+adding `[extra]` dependencies and adding a a "test target" to the Project file.
+Here we add the `Test` standard library as a test-only dependency by adding the
+following to the Project file:
 
 ```
-[targets.test.deps]
+[extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]
 ```
 
 We can now use `Test` in the test script and we can see that it gets installed on testing:

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -884,7 +884,7 @@ function collect_target_deps!(
         targets = project["targets"]
         haskey(targets, target) || return
         for pkg in targets[target]
-            uuid = UUID(ctx.env.project["deps"][pkg])
+            uuid = UUID(ctx.env.project["extras"][pkg])
             push!(pkgs, PackageSpec(pkg, uuid))
         end
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -408,42 +408,23 @@ temp_pkg_dir() do project_path
     cd(project_path) do
         project = """
         [deps]
+        UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+        [extras]
         Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
         Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-        UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
         [targets]
         test = ["Markdown", "Test"]
         """
         write("Project.toml", project)
         Pkg.activate(".")
-        @testset "resolve ignores targets" begin
+        @testset "resolve ignores extras" begin
             Pkg.resolve()
             @test read("Manifest.toml", String) == """
             [[UUIDs]]
             uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
             """
-        end
-        @testset "remove target/non-target deps" begin
-            Pkg.rm("Markdown")
-            @test read("Project.toml", String) == """
-            [deps]
-            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-            UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-
-            [targets]
-            test = ["Test"]
-            """
-            Pkg.rm("UUIDs")
-            @test read("Project.toml", String) == """
-            [deps]
-            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-            [targets]
-            test = ["Test"]
-            """
-            Pkg.rm("Test")
-            @test read("Project.toml", String) == ""
         end
         Pkg.activate()
     end

--- a/test/test_packages/BigProject/Project.toml
+++ b/test/test_packages/BigProject/Project.toml
@@ -3,7 +3,7 @@ uuid = "da7e1942-2519-11e8-2822-f5508ce758f0"
 authors = ["Some One <someone@email.com>"]
 version = "0.1.0"
 
-[deps]
+[extras]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 


### PR DESCRIPTION
This is an alternative to defining the main deps as the ones that are not mentioned in any target in the [targets] section. Instead this puts extra dependencies in an [extras] section which has the same layout as [deps]. cc @KristofferC, @fredrikekre; this is similar to Fredrik's proposal in response to #526 but I didn't like the name `[targetdeps]` so I called it `[extras]` instead.