### PR TITLE
improve printing when running tagets

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -141,6 +141,8 @@ function print_diff(io::IO, ctx::Context, diff::Vector{DiffEntry}, status=false)
         pkgid = Base.PkgId(x.uuid, x.name)
         package_downloaded = pkgid in keys(Base.loaded_modules) ||
                              Base.locate_package(pkgid) !== nothing
+        # Package download detection doesnt work properly when runn running targets
+        ctx.currently_running_target && (package_downloaded = true)
         if x.old != nothing && x.new != nothing
             if x.old ≈ x.new
                 verb = ' '

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -6,7 +6,7 @@ import LibGit2
 
 import REPL
 using REPL.TerminalMenus
-using ..Types, ..GraphType, ..Resolve, ..Pkg2, ..BinaryProvider, ..GitTools
+using ..Types, ..GraphType, ..Resolve, ..Pkg2, ..BinaryProvider, ..GitTools, ..Display
 import ..depots, ..devdir, ..Types.uuid_julia
 
 function find_installed(name::String, uuid::UUID, sha1::SHA1)
@@ -746,6 +746,7 @@ end
 function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::PackageSpec; might_need_to_resolve=false)
     # localctx is the context for the temporary environment we run the testing / building in
     localctx = deepcopy(mainctx)
+    localctx.currently_running_target = true
     # If pkg or its dependencies are checked out, we will need to resolve
     # unless we already have resolved for the current environment, which the calleer indicates
     # with `might_need_to_resolve`
@@ -833,8 +834,11 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         end
         write_env(localctx, display_diff = false)
         will_resolve && build_versions(localctx, new)
+
         sep = Sys.iswindows() ? ';' : ':'
-        withenv(f, "JULIA_LOAD_PATH" => "@$sep$tmpdir$sep$(Types.stdlib_dir())")
+        withenv("JULIA_LOAD_PATH" => "@$sep$tmpdir$sep$(Types.stdlib_dir())") do
+            f(localctx)
+        end
     end
 end
 
@@ -1019,7 +1023,8 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
                 @error "Error building `$name`$last_lines: \n$log_show$full_log_at"
             end
         end
-        with_dependencies_loadable_at_toplevel(ctx, PackageSpec(name, uuid, version); might_need_to_resolve=might_need_to_resolve) do
+        with_dependencies_loadable_at_toplevel(ctx, PackageSpec(name, uuid, version);
+                                               might_need_to_resolve=might_need_to_resolve) do localctx
             run_build()
         end
     end
@@ -1267,7 +1272,11 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
                 push!(pkgs_errored, pkg.name)
             end
         end
-        with_dependencies_loadable_at_toplevel(ctx, pkg; might_need_to_resolve=true) do
+        with_dependencies_loadable_at_toplevel(ctx, pkg; might_need_to_resolve=true) do localctx
+            if !Types.is_project_uuid(ctx.env, pkg.uuid)
+                Display.status(localctx, PKGMODE_MANIFEST)
+            end
+
             run_test()
         end
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -337,6 +337,7 @@ Base.@kwdef mutable struct Context
     graph_verbose::Bool = false
     stdlibs::Dict{UUID,String} = gather_stdlib_uuids()
     # Remove next field when support for Pkg2 CI scripts is removed
+    currently_running_target::Bool =false
     old_pkg2_clone_name::String = ""
 end
 
@@ -1077,7 +1078,7 @@ function write_env(ctx::Context; display_diff=true)
     project = deepcopy(env.project)
     isempty(project["deps"]) && delete!(project, "deps")
     if !isempty(project) || ispath(env.project_file)
-        if display_diff
+        if display_diff && !(ctx.currently_running_target)
             printpkgstyle(ctx, :Updating, pathrepr(ctx, env.project_file))
             Pkg.Display.print_project_diff(ctx, old_env, env)
         end
@@ -1090,7 +1091,7 @@ function write_env(ctx::Context; display_diff=true)
     end
     # update the manifest file
     if !isempty(env.manifest) || ispath(env.manifest_file)
-        if display_diff
+        if display_diff && !(ctx.currently_running_target)
             printpkgstyle(ctx, :Updating, pathrepr(ctx, env.manifest_file))
             Pkg.Display.print_manifest_diff(ctx, old_env, env)
         end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -337,7 +337,7 @@ Base.@kwdef mutable struct Context
     graph_verbose::Bool = false
     stdlibs::Dict{UUID,String} = gather_stdlib_uuids()
     # Remove next field when support for Pkg2 CI scripts is removed
-    currently_running_target::Bool =false
+    currently_running_target::Bool = false
     old_pkg2_clone_name::String = ""
 end
 


### PR DESCRIPTION
We used to print the diff vs the current project when testing a dependency. This was typically always very spammy and non-interesting. This instead just shows the "absolute" (non-diff) dependencies that are used when testing.