### PR TITLE
Make `Pkg.activate(path)` behave like `pkg> activate path`.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -570,7 +570,28 @@ function status(ctx::Context, mode=PKGMODE_PROJECT)
 end
 
 function activate(path::Union{String,Nothing}=nothing)
+    if path !== nothing
+        devpath = nothing
+        env = Base.active_project() === nothing ? nothing : EnvCache()
+        if env !== nothing && haskey(env.project["deps"], path)
+            uuid = UUID(env.project["deps"][path])
+            info = manifest_info(env, uuid)
+            devpath = haskey(info, "path") ? joinpath(dirname(env.project_file), info["path"]) : nothing
+        end
+        # `pkg> activate path`/`Pkg.activate(path)` does the following
+        # 1. if path exists, activate that
+        # 2. if path exists in deps, and the dep is deved, activate that path (`devpath` above)
+        # 3. activate the non-existing directory (e.g. as in `pkg> activate .` for initing a new env)
+        if Types.isdir_windows_workaround(path)
+            path = abspath(path)
+        elseif devpath !== nothing
+            path = abspath(devpath)
+        else
+            path = abspath(path)
+        end
+    end
     Base.ACTIVE_PROJECT[] = Base.load_path_expand(path)
+    return
 end
 
 """

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -612,28 +612,11 @@ do_up!(ctx::Context, args::PkgArguments, api_opts::Vector{APIOption}) =
     API.up(ctx, args; api_opts...)
 
 function do_activate!(ctx::Context, args::PkgArguments, api_opts::Vector{APIOption})
+    # TODO: Remove the ctx argument to this function.
     if isempty(args)
-        return API.activate()
-    end
-
-    path = args[1]
-    env = Base.active_project() === nothing ? nothing : ctx.env
-    devpath = nothing
-    if env !== nothing && haskey(env.project["deps"], path)
-        uuid = UUID(env.project["deps"][path])
-        info = manifest_info(env, uuid)
-        devpath = haskey(info, "path") ? joinpath(dirname(env.project_file), info["path"]) : nothing
-    end
-    # `pkg> activate path` does the following
-    # 1. if path exists, activate that
-    # 2. if path exists in deps, and the dep is deved, activate that path (`devpath`) above
-    # 3. activate the non-existing directory (e.g. as in `pkg> activate . for initing a new dev`)
-    if Types.isdir_windows_workaround(path)
-        API.activate(abspath(path))
-    elseif devpath !== nothing
-        API.activate(abspath(devpath))
+        return API.activate(nothing)
     else
-        API.activate(abspath(path))
+        return API.activate(args[1])
     end
 end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,0 +1,39 @@
+module APITests
+
+using Pkg, Test
+
+@testset "Pkg.activate" begin
+    cd(mktempdir()) do
+        path = pwd()
+        Pkg.activate(".")
+        mkdir("Foo")
+        cd(mkdir("modules")) do
+            Pkg.generate("Foo")
+        end
+        Pkg.develop(Pkg.Types.PackageSpec(url="modules/Foo")) # to avoid issue #542
+        Pkg.activate("Foo") # activate path Foo over deps Foo
+        @test Base.active_project() == joinpath(path, "Foo", "Project.toml")
+        Pkg.activate(".")
+        rm("Foo"; force=true, recursive=true)
+        Pkg.activate("Foo") # activate path from developed Foo
+        @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
+        Pkg.activate(".")
+        Pkg.activate("./Foo") # activate empty directory Foo (sidestep the developed Foo)
+        @test Base.active_project() == joinpath(path, "Foo", "Project.toml")
+        Pkg.activate(".")
+        Pkg.activate("Bar") # activate empty directory Bar
+        @test Base.active_project() == joinpath(path, "Bar", "Project.toml")
+        Pkg.activate(".")
+        Pkg.add("Example") # non-deved deps should not be activated
+        Pkg.activate("Example")
+        @test Base.active_project() == joinpath(path, "Example", "Project.toml")
+        Pkg.activate(".")
+        cd(mkdir("tests"))
+        Pkg.activate("Foo") # activate developed Foo from another directory
+        @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
+        Pkg.activate() # activate home project
+        @test Base.ACTIVE_PROJECT[] === nothing
+    end
+end
+
+end # module APITests

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -430,5 +430,6 @@ temp_pkg_dir() do project_path
 end
 
 include("repl.jl")
+include("api.jl")
 
 end # module

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -282,6 +282,8 @@ cd(mktempdir()) do
     cd(mkdir("tests"))
     pkg"activate Foo" # activate developed Foo from another directory
     @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
+    pkg"activate" # activate home project
+    @test Base.ACTIVE_PROJECT[] === nothing
 end
 
 # test relative dev paths (#490)


### PR DESCRIPTION
Just moves the logic from REPLMode to API and make the REPL mode call API.