### PR TITLE
fix unneeded use of pwd in REPL prompt function

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -836,13 +836,11 @@ function promptf()
                 nothing
             end
             if project !== nothing
-                proj_dir = ispath(project_file) ? realpath(project_file) : project_file
-                proj_dir = dirname(proj_dir)
                 projname = get(project, "name", nothing)
-                if startswith(pwd(), proj_dir) && projname !== nothing
+                if projname !== nothing
                     name = projname
                 else
-                    name = basename(proj_dir)
+                    name = basename(dirname(project_file))
                 end
                 prefix = string("(", name, ") ")
                 prev_prefix = prefix

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -550,11 +550,11 @@ end
 
         newname = "NewName"
         set_name(projfile_path, newname)
-        @test Pkg.REPLMode.promptf() == "($env_name) pkg> "
+        @test Pkg.REPLMode.promptf() == "($newname) pkg> "
         cd(env_path) do
-            @test Pkg.REPLMode.promptf() == "($env_name) pkg> "
+            @test Pkg.REPLMode.promptf() == "($newname) pkg> "
         end
-        @test Pkg.REPLMode.promptf() == "($env_name) pkg> "
+        @test Pkg.REPLMode.promptf() == "($newname) pkg> "
 
         newname = "NewNameII"
         set_name(projfile_path, newname)


### PR DESCRIPTION
Likely left when pwd had some importance to the project being used.

Fixes #547 