### PR TITLE
Fix `instantiate` error message

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -527,7 +527,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing, kwarg
         return
     end
     if !isfile(ctx.env.manifest_file) && manifest == true
-        cmderror("manifest at $(ctx.env.manifest) does not exist")
+        cmderror("manifest at $(ctx.env.manifest_file) does not exist")
     end
     update_registry(ctx)
     urls = Dict{}


### PR DESCRIPTION
I assume this was the intention. I don't think we wanted to print a whole dictionary.