### PR TITLE
`depots()[1]` -> `depots1()`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -7,7 +7,7 @@ import LibGit2
 import REPL
 using REPL.TerminalMenus
 using ..Types, ..GraphType, ..Resolve, ..Pkg2, ..BinaryProvider, ..GitTools, ..Display
-import ..depots, ..devdir, ..Types.uuid_julia
+import ..depots, ..depots1, ..devdir, ..Types.uuid_julia
 
 function find_installed(name::String, uuid::UUID, sha1::SHA1)
     slug = Base.version_slug(uuid, sha1)
@@ -15,7 +15,7 @@ function find_installed(name::String, uuid::UUID, sha1::SHA1)
         path = abspath(depot, "packages", name, slug)
         ispath(path) && return path
     end
-    return abspath(depots()[1], "packages", name, slug)
+    return abspath(depots1(), "packages", name, slug)
 end
 
 function load_versions(path::String)
@@ -479,7 +479,7 @@ function install_git(
     tree = nothing
     try
         repo, git_hash = Base.shred!(LibGit2.CachedCredentials()) do creds
-            clones_dir = joinpath(depots()[1], "clones")
+            clones_dir = joinpath(depots1(), "clones")
             ispath(clones_dir) || mkpath(clones_dir)
             repo_path = joinpath(clones_dir, string(uuid))
             repo = ispath(repo_path) ? LibGit2.GitRepo(repo_path) : begin

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -5,8 +5,14 @@ import REPL
 using REPL.TerminalMenus
 
 depots() = Base.DEPOT_PATH
-logdir() = joinpath(depots()[1], "logs")
-devdir() = get(ENV, "JULIA_PKG_DEVDIR", joinpath(depots()[1], "dev"))
+function depots1()
+    d = depots()
+    isempty(d) && cmderror("no depots found in DEPOT_PATH")
+    return d[1]
+end
+
+logdir() = joinpath(depots1(), "logs")
+devdir() = get(ENV, "JULIA_PKG_DEVDIR", joinpath(depots1(), "dev"))
 const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 
 export PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -9,7 +9,7 @@ using REPL.TerminalMenus
 
 using ..TOML
 import ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION
-import Pkg: GitTools, depots, logdir
+import Pkg: GitTools, depots, depots1, logdir
 
 import Base: SHA1
 using SHA
@@ -518,7 +518,7 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                 # We save the repo in case another environement wants to
                 # develop from the same repo, this avoids having to reclone it
                 # from scratch.
-                clone_path = joinpath(depots()[1], "clones")
+                clone_path = joinpath(depots1(), "clones")
                 mkpath(clone_path)
                 repo_path = joinpath(clone_path, string(hash(pkg.repo.url), "_full"))
                 repo = nothing
@@ -594,7 +594,7 @@ function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec}; upgr
             pkg.repo == nothing && continue
             pkg.special_action = PKGSPEC_REPO_ADDED
             isempty(pkg.repo.url) && set_repo_for_pkg!(env, pkg)
-            clones_dir = joinpath(depots()[1], "clones")
+            clones_dir = joinpath(depots1(), "clones")
             mkpath(clones_dir)
             repo_path = joinpath(clones_dir, string(hash(pkg.repo.url)))
             repo = nothing
@@ -894,7 +894,7 @@ end
 # Return paths of all registries in all depots
 function registries(; clone_default=true)::Vector{String}
     isempty(depots()) && return String[]
-    user_regs = abspath(depots()[1], "registries")
+    user_regs = abspath(depots1(), "registries")
     if clone_default
         if !ispath(user_regs)
             mkpath(user_regs)


### PR DESCRIPTION
When `DEPOT_PATH` is empty, this throws a better error message compared to a `BoundsError`.