### PR TITLE
allow using a path kword arg to PackageSpec

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -284,7 +284,7 @@ const activate = API.activate
 
 """
     PackageSpec(name::String, [uuid::UUID, version::VersionNumber])
-    PackageSpec(; name, url, rev, version, mode, level)
+    PackageSpec(; name, url, path, rev, version, mode, level)
 
 A `PackageSpec` is a representation of a package with various metadata.
 This includes:
@@ -293,8 +293,8 @@ This includes:
   * The package unique `uuid`.
   * A `version` (for example when adding a package. When upgrading, can also be an instance of
    the enum [`UpgradeLevel`](@ref)
-  * A `url` (which might also be a local path) and an optional git `rev`ision.
-   `rev` could be a branch name or a git commit SHA.
+  * A `url` and an optional git `rev`ision. `rev` could be a branch name or a git commit SHA.
+  * A local path `path`. This is equivalent to using the `url` argument but can be more descriptive.
   * A `mode`, which is an instance of the enum [`PackageMode`](@ref) which can be either `PKGMODE_PROJECT` or
    `PKGMODE_MANIFEST`, defaults to `PKGMODE_PROJECT`. Used in e.g. [`Pkg.rm`](@ref).
 
@@ -309,8 +309,8 @@ Below is a comparison between the REPL version and the `PackageSpec` version:
 | `Package@0.2`        | `PackageSpec(name="Package", version="0.2")`  |
 | `Package=a67d...`    | `PackageSpec(name="Package", uuid="a67d..."`  |
 | `Package#master`     | `PackageSpec(name="Package", rev="master")`   |
-| `local/path#feature` | `PackageSpec(url="local/path"; rev="feature)` |
-| `www.mypkg.com`      | `PackageSpec("url=www.mypkg.com")`              |
+| `local/path#feature` | `PackageSpec(path="local/path"; rev="feature)` |
+| `www.mypkg.com`      | `PackageSpec(url="www.mypkg.com")`              |
 | `--manifest Package` | `PackageSpec(name="Package", mode=PKGSPEC_MANIFEST)`|
 | `--major Package`    | `PackageSpec(name="Package", version=PKGLEVEL_MAJOR`)|
 """

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -666,22 +666,6 @@ long_commands = []
 all_options_sorted = []
 long_options = []
 
-all_commands_sorted = sort(collect(String,keys(command_specs)))
-long_commands = filter(c -> length(c) > 2, all_commands_sorted)
-function all_options()
-    all_opts = []
-    for command in values(command_specs)
-        for opt_spec in command.option_specs
-            push!(all_opts, opt_spec.name)
-            opt_spec.short_name !== nothing && push!(all_opts, opt_spec.short_name)
-        end
-    end
-    unique!(all_opts)
-    return all_opts
-end
-all_options_sorted = [length(opt) > 1 ? "--$opt" : "-$opt" for opt in sort!(all_options())]
-long_options = filter(c -> length(c) > 2, all_options_sorted)
-
 struct PkgCompletionProvider <: LineEdit.CompletionProvider end
 
 function LineEdit.complete_line(c::PkgCompletionProvider, s)
@@ -1207,7 +1191,7 @@ is modified.
 ], #package
 ] #command_declarations
 
-super_specs = SuperSpecs(command_declarations) # TODO should this go here ?
+super_specs = SuperSpecs(command_declarations)
 command_specs = super_specs["package"]
 all_commands_sorted = sort(collect(String,keys(command_specs)))
 long_commands = filter(c -> length(c) > 2, all_commands_sorted)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -151,7 +151,6 @@ mutable struct PackageSpec
     special_action::PackageSpecialAction # If the package is currently being pinned, freed etc
     repo::Union{Nothing,GitRepo}
 end
-PackageSpec() = PackageSpec("", UUID(zero(UInt128)), VersionSpec(), PKGMODE_PROJECT, nothing, PKGSPEC_NOTHING, nothing)
 PackageSpec(name::AbstractString, uuid::UUID, version::VersionTypes,
             mode::PackageMode=PKGMODE_PROJECT, path=nothing, special_action=PKGSPEC_NOTHING,
             repo=nothing) = PackageSpec(String(name), uuid, version, mode, path, special_action, repo)
@@ -168,9 +167,14 @@ function PackageSpec(repo::GitRepo)
 end
 
 # kwarg constructor
-function PackageSpec(;name::AbstractString="", uuid::Union{String, UUID}=UUID(0), version::Union{VersionNumber, String} = "*",
-                     url = nothing, rev = nothing, mode::PackageMode = PKGMODE_PROJECT)
-    if url !== nothing || rev !== nothing
+function PackageSpec(;name::AbstractString="", uuid::Union{String, UUID}=UUID(0),
+                     version::Union{VersionNumber, String, VersionSpec} = VersionSpec(),
+                     url = nothing, rev = nothing, path=nothing, mode::PackageMode = PKGMODE_PROJECT)
+    if url !== nothing || path !== nothing || rev !== nothing
+        if path !== nothing || url !== nothing
+            path !== nothing && url !== nothing && cmderror("cannot specify both path and url")
+            url = url == nothing ? path : url
+        end
         repo = GitRepo(url=url, rev=rev)
     else
         repo = nothing
@@ -189,7 +193,7 @@ function Base.show(io::IO, pkg::PackageSpec)
     f = ["name" => pkg.name, "uuid" => has_uuid(pkg) ? pkg.uuid : "", "v" => (vstr == "VersionSpec(\"*\")" ? "" : vstr)]
     if pkg.repo !== nothing
         if !isempty(pkg.repo.url)
-            push!(f, "url/path" => pkg.repo.url)
+            push!(f, "url/path" => string("\"", pkg.repo.url, "\""))
         end
         if !isempty(pkg.repo.rev)
             push!(f, "rev" => pkg.repo.rev)

--- a/test/api.jl
+++ b/test/api.jl
@@ -10,7 +10,7 @@ using Pkg, Test
         cd(mkdir("modules")) do
             Pkg.generate("Foo")
         end
-        Pkg.develop(Pkg.Types.PackageSpec(url="modules/Foo")) # to avoid issue #542
+        Pkg.develop(Pkg.Types.PackageSpec(path="modules/Foo")) # to avoid issue #542
         Pkg.activate("Foo") # activate path Foo over deps Foo
         @test Base.active_project() == joinpath(path, "Foo", "Project.toml")
         Pkg.activate(".")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -399,7 +399,7 @@ temp_pkg_dir() do project_path
         @testset "inconsistent repo state" begin
             package_path = joinpath(project_path, "Example")
             LibGit2.with(LibGit2.clone("https://github.com/JuliaLang/Example.jl", package_path)) do repo
-                Pkg.add(PackageSpec(url=package_path))
+                Pkg.add(PackageSpec(path=package_path))
             end
             rm(joinpath(package_path, ".git"); force=true, recursive=true)
             @test_throws CommandError Pkg.update()


### PR DESCRIPTION
Also fixes https://github.com/JuliaLang/Pkg.jl/issues/556. Seems this chunk of code was copy pasted and occurred in two different places @00vareladavid 