### PR TITLE
remove ability to give a git revision to devved packages

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -350,13 +350,13 @@ If we try to `dev` a package at some branch that already exists at `~/.julia/dev
 For example:
 
 ```
-(v0.7) pkg> dev Example#master
+(v0.7) pkg> dev Example
   Updating git-repo `https://github.com/JuliaLang/Example.jl.git`
 [ Info: Path `/Users/kristoffer/.julia/dev/Example` exists and looks like the correct package, using existing path instead of cloning
 ```
 
-Note the info message saying that it is using the existing path. This means that you cannot use `dev` to e.g. change branches of
-an already developed package.
+Note the info message saying that it is using the existing path. As a general rule, the package manager will
+never touch files that are tracking a path.
 
 If `dev` is used on a local path, that path to that package is recorded and used when loading that package.
 The path will be recorded relative to the project file, unless it is given as an absolute path.

--- a/src/API.jl
+++ b/src/API.jl
@@ -34,7 +34,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
         if mode == :develop
             pkg.repo == nothing && (pkg.repo = Types.GitRepo())
             if !isempty(pkg.repo.rev)
-                cmderror("git revision cannot be given to `develop`")
+                pkgerror("git revision cannot be given to `develop`")
             end
         end
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -31,7 +31,12 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
 
     # All developed packages should go through handle_repos_develop so just give them an empty repo
     for pkg in pkgs
-        mode == :develop && pkg.repo == nothing && (pkg.repo = Types.GitRepo())
+        if mode == :develop
+            pkg.repo == nothing && (pkg.repo = Types.GitRepo())
+            if !isempty(pkg.repo.rev)
+                cmderror("git revision cannot be given to `develop`")
+            end
+        end
     end
 
     # if julia is passed as a package the solver gets tricked;

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -397,6 +397,9 @@ function package_args(args::Vector{Token}, spec::CommandSpec)::Vector{PackageSpe
         elseif arg isa VersionRange
             pkgs[end].version = arg
         elseif arg isa Rev
+            if spec.kind == CMD_DEVELOP
+                cmderror("a git revision cannot be given to `develop`")
+            end
             pkg = pkgs[end]
             if pkg.repo == nothing
                 pkg.repo = Types.GitRepo("", arg.rev)
@@ -1023,7 +1026,7 @@ pkg> add Example=7876af07-990d-54b4-ab0e-23690620f79a
         ("shared", OPT_SWITCH, :shared => true),
     ],
     md"""
-    develop [--shared|--local] pkg[=uuid] [#rev] ...
+    develop [--shared|--local] pkg[=uuid] ...
 
 Make a package available for development. If `pkg` is an existing local path that path will be recorded in
 the manifest and used. Otherwise, a full git clone of `pkg` at rev `rev` is made. The location of the clone is

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -398,7 +398,7 @@ function package_args(args::Vector{Token}, spec::CommandSpec)::Vector{PackageSpe
             pkgs[end].version = arg
         elseif arg isa Rev
             if spec.kind == CMD_DEVELOP
-                cmderror("a git revision cannot be given to `develop`")
+                pkgerror("a git revision cannot be given to `develop`")
             end
             pkg = pkgs[end]
             if pkg.repo == nothing

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -543,13 +543,10 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                 project_path = mktempdir()
                 cp(repo_path, project_path; force=true)
                 LibGit2.with(LibGit2.GitRepo(project_path)) do repo
-                    rev = pkg.repo.rev
-                    if isempty(rev)
-                        if LibGit2.isattached(repo)
-                            rev = LibGit2.branch(repo)
-                        else
-                            rev = string(LibGit2.GitHash(LibGit2.head(repo)))
-                        end
+                    if LibGit2.isattached(repo)
+                        rev = LibGit2.branch(repo)
+                    else
+                        rev = string(LibGit2.GitHash(LibGit2.head(repo)))
                     end
                     gitobject, isbranch = get_object_branch(repo, rev)
                     try

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -511,7 +511,9 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                     # Relative paths are given relative pwd() so we
                     # translate that to be relative the project instead.
                     # `realpath` is needed to expand symlinks before taking the relative path.
-                    pkg.path = relpath(realpath(abspath(pkg.repo.url)), realpath(dirname(ctx.env.project_file)))
+                    project_dir = dirname(ctx.env.project_file)
+                    isdir(project_dir) && (project_dir = realpath(project_dir))
+                    pkg.path = relpath(realpath(abspath(pkg.repo.url)), project_dir)
                 end
                 folder_already_downloaded = true
                 project_path = pkg.repo.url

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -179,6 +179,7 @@ temp_pkg_dir() do project_path
         Pkg.rm(TEST_PKG.name)
         mktempdir() do devdir
             withenv("JULIA_PKG_DEVDIR" => devdir) do
+                @test_throws CommandError Pkg.develop(PackageSpec(url="bleh", rev="blurg"))
                 Pkg.develop(TEST_PKG.name)
                 @test isinstalled(TEST_PKG)
                 @test Pkg.installed()[TEST_PKG.name] > old_v

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -179,7 +179,7 @@ temp_pkg_dir() do project_path
         Pkg.rm(TEST_PKG.name)
         mktempdir() do devdir
             withenv("JULIA_PKG_DEVDIR" => devdir) do
-                @test_throws CommandError Pkg.develop(PackageSpec(url="bleh", rev="blurg"))
+                @test_throws PkgError Pkg.develop(PackageSpec(url="bleh", rev="blurg"))
                 Pkg.develop(TEST_PKG.name)
                 @test isinstalled(TEST_PKG)
                 @test Pkg.installed()[TEST_PKG.name] > old_v

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -42,16 +42,7 @@ temp_pkg_dir() do project_path
             end
         end
 
-        pkg"dev Example"
-        devdir = joinpath(DEPOT_PATH[1], "dev", "Example")
-        @test isdir(devdir)
-        rm(devdir; recursive=true)
-        @test !isdir(devdir)
-        pkg"dev Example#DO_NOT_REMOVE"
-        @test isdir(devdir)
-        LibGit2.with(LibGit2.GitRepo(devdir)) do repo
-            @test LibGit2.branch(repo) == "DO_NOT_REMOVE"
-        end
+        @test_throws CommandError pkg"dev Example#blergh"
 
         withenv("USER" => "Test User") do
             pkg"generate Foo"

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -42,7 +42,7 @@ temp_pkg_dir() do project_path
             end
         end
 
-        @test_throws CommandError pkg"dev Example#blergh"
+        @test_throws PkgError pkg"dev Example#blergh"
 
         withenv("USER" => "Test User") do
             pkg"generate Foo"
@@ -204,10 +204,6 @@ temp_pkg_dir() do project_path; cd(project_path) do
                     @test Pkg.installed()["UnregisteredWithoutProject"] == v"0.0.0"
                     Pkg.test("UnregisteredWithoutProject")
                     Pkg.test("UnregisteredWithProject")
-
-                    pkg"develop Example#c37b675"
-                    @test Base.find_package("Example") ==  joinpath(tmp, "Example", "src", "Example.jl")
-                    Pkg.test("Example")
                 end
             finally
                 empty!(DEPOT_PATH)


### PR DESCRIPTION
Doing `dev Foo#branch1` and then `dev Foo#branch2` and then not get a change of branch is confusing. For now, just allow downloading the repo at the main branch and then one can just use git to get the repo in whatever state is desired.