### PR TITLE
Use declarative format when disallowing `develop` revisions

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -397,9 +397,6 @@ function package_args(args::Vector{Token}, spec::CommandSpec)::Vector{PackageSpe
         elseif arg isa VersionRange
             pkgs[end].version = arg
         elseif arg isa Rev
-            if spec.kind == CMD_DEVELOP
-                pkgerror("a git revision cannot be given to `develop`")
-            end
             pkg = pkgs[end]
             if pkg.repo == nothing
                 pkg.repo = Types.GitRepo("", arg.rev)
@@ -1020,7 +1017,7 @@ pkg> add Example=7876af07-990d-54b4-ab0e-23690620f79a
 ),( CMD_DEVELOP,
     ["develop", "dev"],
     do_develop!,
-    (ARG_ALL, []),
+    (ARG_VERSION, []),
     [
         ("local", OPT_SWITCH, :shared => false),
         ("shared", OPT_SWITCH, :shared => true),


### PR DESCRIPTION
Introduced in #581. The declarative system already supports this.

I definitely could have used better names for this:
- `ARG_RAW` : don't do any checking on the kinds of arguments
- `ARG_PKG`: only allow package identifiers (i.e. the `String`s which `parse_package` understands)
- `ARG_VERSION`: allow `Example` and `Example@0.1.0`, but not `Example#foo`
- `ARG_REV`: allow `Example` and `Example#foo`, but not `Example@0.1.0`
- `ARG_ALL`: allow any kind of package specification

Maybe specifying the negation would be more natural?
- `ARG_RAW` -> `ARG_RAW`
- `ARG_PKG` -> `ARG_PKG_BARE`
- `ARG_VERSION` -> `ARG_PKG_NO_REV`
- `ARG_REV` -> `ARG_PKG_NO_VERSION`
- `ARG_ALL` -> `ARG_PKG`

If so, I can change it