### PR TITLE
Registry functionality with REPL and API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 docs/build
 /Manifest.toml
 /docs/Manifest.toml
+.DS_Store
+/test/registries/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Pkg v1.1.0 Release Notes
 New features
 ------------
 
+* Pkg now implements an interface for working with registries ([#588]).
+
 Bug fixes
 ----------
 
@@ -22,3 +24,4 @@ Deprecated or removed
 [#634]: https://github.com/JuliaLang/Pkg.jl/pull/634
 [#639]: https://github.com/JuliaLang/Pkg.jl/pull/639
 [#642]: https://github.com/JuliaLang/Pkg.jl/pull/642
+[#588]: https://github.com/JuliaLang/Pkg.jl/pull/588

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,7 +1,12 @@
 # [**10.** API Reference](@id API-Reference)
 
-This section describes the "API mode" of interacting with Pkg.jl which is recommended for non-interactive usage,
-in i.e. scripts. In the REPL mode packages (with associated version, UUID, URL etc) are parsed from strings,
+This section describes the function interface, or "API mode"
+for interacting with Pkg.jl. The function API is recommended
+for non-interactive usage, in i.e. scripts.
+
+## [**10.1.** Package API Reference](@id Package-API-Reference)
+
+In the REPL mode packages (with associated version, UUID, URL etc) are parsed from strings,
 for example, `"Package#master"`,`"Package@v0.1"`, `"www.mypkg.com/MyPkg#my/feature"`.
 It is possible to use strings as arguments for simple commands in the API mode (like `Pkg.add(["PackageA", "PackageB"])`,
 more complicated commands, that e.g. specify URLs or version range, uses a more structured format over strings.
@@ -23,4 +28,18 @@ Pkg.free
 Pkg.instantiate
 Pkg.resolve
 Pkg.setprotocol!
+```
+
+
+## [**10.2.** Registry API Reference](@id Registry-API-Reference)
+
+The function API for registries uses [`RegistrySpec`](@ref)s, similar to
+[`PackageSpec`](@ref).
+
+```@docs
+RegistrySpec
+Pkg.Registry.add
+Pkg.Registry.rm
+Pkg.Registry.update
+Pkg.Registry.status
 ```

--- a/docs/src/registries.md
+++ b/docs/src/registries.md
@@ -1,3 +1,83 @@
 # **7.** Registries
 
-TODD: Write about stuff
+Registries contain information about packages, such as
+available releases, dependencies and where it can be downloaded.
+The `General` registry (https://github.com/JuliaRegistries/General)
+is the default one, and is installed automatically.
+
+## **7.1.** Managing registries
+
+Registries can be added, removed and updated from either the Pkg REPL
+or by using the functional API. In this section we will describe the
+REPL interface. The functional registry API is documented in
+the [Registry API Reference](@ref) section.
+
+### Adding registries
+
+A custom registry can be added with the `registry add` command
+from the Pkg REPL. Usually this will be done with a URL to the
+registry. Here we add the `General` registry
+
+```
+pkg> registry add https://github.com/JuliaRegistries/General
+   Cloning registry from "https://github.com/JuliaRegistries/General"
+     Added registry `General` to `~/.julia/registries/General`
+```
+
+and now all the packages registered in `General` are available for e.g. adding.
+To see which registries are currently installed you can use the `registry status`
+(or `registry st`) command
+
+```
+pkg> registry st
+Registry Status
+ [23338594] General (https://github.com/JuliaRegistries/General.git)
+```
+
+Registries are always added to the user depot, which is the first entry in `DEPOT_PATH`.
+
+### Removing registries
+
+Registries can be removed with the `registry remove` (or `registry rm`) command.
+Here we remove the `General` registry
+
+```
+pkg> registry rm General
+  Removing registry `General` from ~/.julia/registries/General
+
+pkg> registry st
+Registry Status
+  (no registries found)
+```
+
+In case there are multiple registries named `General` installed you have to
+disambiguate with the `uuid`, just as when manipulating packages, e.g.
+
+```
+pkg> registry rm General=23338594-aafe-5451-b93e-139f81909106
+  Removing registry `General` from ~/.julia/registries/General
+```
+
+### Updating registries
+
+The `registry update` (or `registry up`) command is available to update registries.
+Here we update the `General` registry,
+
+```
+pkg> registry up General
+  Updating registry at `~/.julia/registries/General`
+  Updating git-repo `https://github.com/JuliaRegistries/General`
+```
+
+and to update all installed user registries just do
+
+```
+pkg> registry up
+  Updating registry at `~/.julia/registries/General`
+  Updating git-repo `https://github.com/JuliaRegistries/General`
+```
+
+
+## **7.2.** Creating a registry
+
+TBW: Describe registry file structure etc.

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -85,6 +85,7 @@ function normalize_url(url::AbstractString)
 end
 
 function clone(url, source_path; header=nothing, kwargs...)
+    @assert !isdir(source_path) || isempty(readdir(source_path))
     Pkg.Types.printpkgstyle(stdout, :Cloning, header == nothing ? "git-repo `$url`" : header)
     transfer_payload = MiniProgressBar(header = "Fetching:", color = Base.info_color())
     callbacks = LibGit2.Callbacks(

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -9,6 +9,7 @@ export @pkg_str
 export PackageSpec
 export PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT
 export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
+export Registry, RegistrySpec
 
 depots() = Base.DEPOT_PATH
 function depots1()
@@ -35,6 +36,7 @@ include("GraphType.jl")
 include("Resolve.jl")
 include("Operations.jl")
 include("API.jl")
+include("Registry.jl")
 include("REPLMode.jl")
 
 import .REPLMode: @pkg_str
@@ -336,6 +338,26 @@ Defaults to 'https', with `proto == nothing` delegating the choice to the packag
 """
 const setprotocol! = API.setprotocol!
 
+"""
+    RegistrySpec(name::String)
+    RegistrySpec(; name, url, path)
+
+A `RegistrySpec` is a representation of a registry with various metadata, much like
+[`PackageSpec`](@ref).
+
+Most registry functions in Pkg take a `Vector` of `RegistrySpec` and do the operation
+on all the registries in the vector.
+
+Below is a comparison between the REPL version and the `RegistrySpec` version:
+
+| `REPL`               | `API`                                           |
+|:---------------------|:------------------------------------------------|
+| `Registry`           | `RegistrySpec("Registry")`                      |
+| `Registry=a67d...`   | `RegistrySpec(name="Registry", uuid="a67d..."`  |
+| `local/path`         | `RegistrySpec(path="local/path")`               |
+| `www.myregistry.com` | `RegistrySpec(url="www.myregistry.com")`        |
+"""
+const RegistrySpec = Types.RegistrySpec
 
 
 function __init__()

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -1,0 +1,90 @@
+module Registry
+
+import ..Pkg, ..Types, ..API
+using ..Pkg: depots1
+using ..Types: RegistrySpec, Context
+
+
+"""
+    Pkg.Registry.add(url::String)
+    Pkg.Registry.add(registry::RegistrySpec)
+
+Add new package registries.
+
+# Examples
+```julia
+Pkg.Registry.add("General")
+Pkg.Registry.add(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
+Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
+```
+"""
+function add end
+add(reg::Union{String,RegistrySpec}) = add([reg])
+add(regs::Vector{String}) = add([RegistrySpec(name = name) for name in regs])
+add(regs::Vector{RegistrySpec}) = add(Context(), regs)
+add(ctx::Context, regs::Vector{RegistrySpec}) =
+    Types.clone_or_cp_registries(ctx, regs)
+
+"""
+    Pkg.Registry.rm(registry::String)
+    Pkg.Registry.rm(registry::RegistrySpec)
+
+Remove registries.
+
+# Examples
+```julia
+Pkg.Registry.rm("General")
+Pkg.Registry.rm(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
+```
+"""
+function rm end
+rm(reg::Union{String,RegistrySpec}) = rm([reg])
+rm(regs::Vector{String}) = rm([RegistrySpec(name = name) for name in regs])
+rm(regs::Vector{RegistrySpec}) = rm(Context(), regs)
+rm(ctx::Context, regs::Vector{RegistrySpec}) = Types.remove_registries(ctx, regs)
+
+"""
+    Pkg.Registry.update()
+    Pkg.Registry.update(registry::RegistrySpec)
+    Pkg.Registry.update(registry::Vector{RegistrySpec})
+
+Update registries. If no registries are given, update
+all available registries.
+
+# Examples
+```julia
+Pkg.Registry.update()
+Pkg.Registry.update("General")
+Pkg.Registry.update(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
+```
+"""
+function update end
+update(reg::Union{String,RegistrySpec}) = update([reg])
+update(regs::Vector{String}) = update([RegistrySpec(name = name) for name in regs])
+update(regs::Vector{RegistrySpec} = Types.collect_registries(depots1())) =
+    update(Context(), regs)
+update(ctx::Context, regs::Vector{RegistrySpec} = Types.collect_registries(depots1())) =
+    Types.update_registries(ctx, regs)
+
+"""
+    Pkg.Registry.status()
+
+Display information about available registries.
+"""
+function status()
+    regs = Types.collect_registries()
+    regs = unique(r -> r.uuid, regs) # Maybe not?
+    Types.printpkgstyle(stdout, Symbol("Registry Status"), "")
+    if isempty(regs)
+        println("  (no registries found)")
+    else
+        for reg in regs
+            printstyled(" [$(string(reg.uuid)[1:8])]"; color = :light_black)
+            print(" $(reg.name)")
+            reg.url === nothing || print(" ($(reg.url))")
+            println()
+        end
+    end
+end
+
+end # module

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -546,5 +546,6 @@ end
 
 include("repl.jl")
 include("api.jl")
+include("registry.jl")
 
 end # module

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -1,0 +1,241 @@
+module RegistryTests
+
+using Pkg, UUIDs, LibGit2, Test
+using Pkg: depots1
+using Pkg.REPLMode: pkgstr
+using Pkg.Types: PkgError
+
+include("utils.jl")
+
+
+function setup_test_registries(dir = pwd())
+    # Set up two registries with the same name, with different uuid
+    pkg_uuids = ["c5f1542f-b8aa-45da-ab42-05303d706c66", "d7897d3a-8e65-4b65-bdc8-28ce4e859565"]
+    reg_uuids = ["e9fceed0-5623-4384-aff0-6db4c442647a", "a8e078ad-b4bd-4e09-a52f-c464826eef9d"]
+    for i in 1:2
+        regpath = joinpath(dir, "RegistryFoo$(i)")
+        mkpath(joinpath(regpath, "Example"))
+        write(joinpath(regpath, "Registry.toml"), """
+            name = "RegistryFoo"
+            uuid = "$(reg_uuids[i])"
+            repo = "https://github.com"
+            [packages]
+            $(pkg_uuids[i]) = { name = "Example$(i)", path = "Example" }
+            """)
+        write(joinpath(regpath, "Example", "Package.toml"), """
+            name = "Example$(i)"
+            uuid = "$(pkg_uuids[i])"
+            repo = "https://github.com/JuliaLang/Example.jl.git"
+            """)
+        write(joinpath(regpath, "Example", "Versions.toml"), """
+            ["0.5.1"]
+            git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+            """)
+        write(joinpath(regpath, "Example", "Deps.toml"), """
+            ["0.5"]
+            julia = "0.6-1.0"
+            """)
+        write(joinpath(regpath, "Example", "Compat.toml"), """
+            ["0.5"]
+            julia = "0.6-1.0"
+            """)
+        LibGit2.with(LibGit2.init(regpath)) do repo
+            LibGit2.add!(repo, "*")
+            LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
+        end
+    end
+end
+
+function test_installed(registries)
+    @test setdiff(
+        UUID[r.uuid for r in registries],
+        UUID[r.uuid for r in Pkg.Types.collect_registries()]
+        ) == UUID[]
+end
+
+function is_pkg_available(pkg::PackageSpec)
+    uuids = UUID[]
+    for registry in Pkg.Types.collect_registries()
+        reg_dict = Pkg.Types.read_registry(joinpath(registry.path, "Registry.toml"))
+        for (uuid, pkginfo) in reg_dict["packages"]
+            push!(uuids, UUID(uuid))
+        end
+    end
+    return in(pkg.uuid, uuids)
+end
+
+function with_depot2(f)
+    Base.DEPOT_PATH[1:2] .= Base.DEPOT_PATH[2:-1:1]
+    f()
+    Base.DEPOT_PATH[1:2] .= Base.DEPOT_PATH[2:-1:1]
+end
+
+
+@testset "registries" begin
+    temp_pkg_dir() do depot; mktempdir() do depot2
+        insert!(Base.DEPOT_PATH, 2, depot2)
+        # set up registries
+        regdir = mktempdir()
+        setup_test_registries(regdir)
+        generalurl = Pkg.Types.DEFAULT_REGISTRIES[1].url # hehe
+        General = RegistrySpec(name = "General", uuid = "23338594-aafe-5451-b93e-139f81909106",
+            url = generalurl)
+        Foo1 = RegistrySpec(name = "RegistryFoo", uuid = "e9fceed0-5623-4384-aff0-6db4c442647a",
+            url = joinpath(regdir, "RegistryFoo1"))
+        Foo2 = RegistrySpec(name = "RegistryFoo", uuid = "a8e078ad-b4bd-4e09-a52f-c464826eef9d",
+            url = joinpath(regdir, "RegistryFoo2"))
+
+        # Packages in registries
+        Example  = PackageSpec(name = "Example",  uuid = "7876af07-990d-54b4-ab0e-23690620f79a")
+        Example1 = PackageSpec(name = "Example1", uuid = "c5f1542f-b8aa-45da-ab42-05303d706c66")
+        Example2 = PackageSpec(name = "Example2", uuid = "d7897d3a-8e65-4b65-bdc8-28ce4e859565")
+
+
+        # Add General registry
+        ## Pkg REPL
+        for reg in ("General",
+                    "23338594-aafe-5451-b93e-139f81909106",
+                    "General=23338594-aafe-5451-b93e-139f81909106")
+            pkgstr("registry add $(reg)")
+            test_installed([General])
+
+            pkgstr("registry up $(reg)")
+            test_installed([General])
+            pkgstr("registry rm $(reg)")
+            test_installed([])
+        end
+        ## Registry API
+        for reg in ("General",
+                    RegistrySpec("General"),
+                    RegistrySpec(name = "General"),
+                    RegistrySpec(name = "General", url = generalurl),
+                    RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"),
+                    RegistrySpec(name = "General", uuid = "23338594-aafe-5451-b93e-139f81909106"))
+            Pkg.Registry.add(reg)
+            test_installed([General])
+            @test is_pkg_available(Example)
+            Pkg.Registry.update(reg)
+            test_installed([General])
+            Pkg.Registry.rm(reg)
+            test_installed([])
+            @test !is_pkg_available(Example)
+        end
+
+        # Add registry from URL/local path.
+        pkgstr("registry add $(Foo1.url)")
+        test_installed([Foo1])
+        @test is_pkg_available(Example1)
+        @test !is_pkg_available(Example2)
+        with_depot2(() -> pkgstr("registry add $(Foo2.url)"))
+        test_installed([Foo1, Foo2])
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+
+        # reset installed registries
+        rm.(joinpath.(Base.DEPOT_PATH[1:2], "registries"); force=true, recursive=true)
+
+        Registry.add(RegistrySpec(url = Foo1.url))
+        test_installed([Foo1])
+        @test is_pkg_available(Example1)
+        @test !is_pkg_available(Example2)
+        with_depot2(() -> Registry.add(RegistrySpec(url = Foo2.url)))
+        test_installed([Foo1, Foo2])
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+
+        # Behaviour with conflicting registry names
+        @test_throws PkgError pkgstr("registry up RegistryFoo")
+        @test_throws PkgError Registry.update("RegistryFoo")
+        @test_throws PkgError Registry.update(RegistrySpec("RegistryFoo"))
+        @test_throws PkgError Registry.update(RegistrySpec(name = "RegistryFoo"))
+        @test_throws PkgError pkgstr("registry remove RegistryFoo")
+        @test_throws PkgError Registry.rm("RegistryFoo")
+        @test_throws PkgError Registry.rm(RegistrySpec("RegistryFoo"))
+        @test_throws PkgError Registry.rm(RegistrySpec(name = "RegistryFoo"))
+
+        pkgstr("registry up $(Foo1.uuid)")
+        pkgstr("registry update $(Foo1.name)=$(Foo1.uuid)")
+        Registry.update(RegistrySpec(uuid = Foo1.uuid))
+        Registry.update(RegistrySpec(name = Foo1.name, uuid = Foo1.uuid))
+
+        test_installed([Foo1, Foo2])
+        pkgstr("registry rm $(Foo1.uuid)")
+        test_installed([Foo2])
+        @test !is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        Registry.add(RegistrySpec(url = Foo1.url))
+        test_installed([Foo1, Foo2])
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        pkgstr("registry rm $(Foo1.name)=$(Foo1.uuid)")
+        test_installed([Foo2])
+        @test !is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        pkgstr("registry rm $(Foo2.name)")
+        test_installed([])
+        @test !is_pkg_available(Example1)
+        @test !is_pkg_available(Example2)
+
+        Registry.add(RegistrySpec(url = Foo1.url))
+        with_depot2(() -> Registry.add(RegistrySpec(url = Foo2.url)))
+        test_installed([Foo1, Foo2])
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        Registry.rm(RegistrySpec(uuid = Foo1.uuid))
+        test_installed([Foo2])
+        @test !is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        Registry.add(RegistrySpec(url = Foo1.url))
+        test_installed([Foo1, Foo2])
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        Registry.rm(RegistrySpec(name = Foo1.name, uuid = Foo1.uuid))
+        test_installed([Foo2])
+        @test !is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        Registry.rm(RegistrySpec(Foo2.name))
+        test_installed([])
+        @test !is_pkg_available(Example1)
+        @test !is_pkg_available(Example2)
+
+        # multiple registries on the same time
+        pkgstr("registry add General $(Foo1.url)")
+        with_depot2(() -> pkgstr("registry add $(Foo2.url)"))
+        test_installed([General, Foo1, Foo2])
+        @test is_pkg_available(Example)
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        pkgstr("registry up General $(Foo1.uuid) $(Foo2.name)=$(Foo2.uuid)")
+        pkgstr("registry rm General $(Foo1.uuid) $(Foo2.name)=$(Foo2.uuid)")
+        test_installed([])
+        @test !is_pkg_available(Example)
+        @test !is_pkg_available(Example1)
+        @test !is_pkg_available(Example2)
+
+        Registry.add([RegistrySpec("General"),
+                      RegistrySpec(url = Foo1.url)])
+        with_depot2(() -> Registry.add([RegistrySpec(url = Foo2.url)]))
+        test_installed([General, Foo1, Foo2])
+        @test is_pkg_available(Example)
+        @test is_pkg_available(Example1)
+        @test is_pkg_available(Example2)
+        Registry.update([RegistrySpec("General"),
+                         RegistrySpec(uuid = Foo1.uuid),
+                         RegistrySpec(name = Foo2.name, uuid = Foo2.uuid)])
+        Registry.rm([RegistrySpec("General"),
+                     RegistrySpec(uuid = Foo1.uuid),
+                     RegistrySpec(name = Foo2.name, uuid = Foo2.uuid)])
+        test_installed([])
+        @test !is_pkg_available(Example)
+        @test !is_pkg_available(Example1)
+        @test !is_pkg_available(Example2)
+
+        # Trying to add a registry with the same name as existing one
+        pkgstr("registry add $(Foo1.url)")
+        @test_throws PkgError pkgstr("registry add $(Foo2.url)")
+        @test_throws PkgError Registry.add([RegistrySpec(url = Foo2.url)])
+
+    end end
+end
+
+end # module

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -367,7 +367,7 @@ end
 # Autocompletions
 temp_pkg_dir() do project_path; cd(project_path) do
     @testset "tab completion" begin
-        Pkg.Types.registries()
+        Pkg.Types.collect_registries()
         pkg"activate ."
         c, r = test_complete("add Exam")
         @test "Example" in c

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,7 @@ module PkgTests
 include("pkg.jl")
 include("resolve.jl")
 
+# clean up locally cached registry
+rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)
+
 end # module


### PR DESCRIPTION
This adds some registry functionality.

| REPL | API |
|:-----|:-----|
| `pkg> registry add General` | `Pkg.Registry.add("General")` |
| `pkg> registry add General=uuid` | `Pkg.Registry.add(RegistrySpec(name="General", uuid = uuid))` |
| `pkg> registry add www.registry.com` | `Pkg.Registry.add(RegistrySpec(url="www.registry.com")` |

and similar with `registry up`/`Pkg.Registry.up` and `registry rm`/`Pkg.Registry.rm`

This also differentiates registries based on uuid, instead of just name. This means that registries are now stored in `.julia/registries/name/uuidslug` instead of just `.julia/registries/name`.

### Demo
```
pkg> registry add General
   Cloning registry from "https://github.com/JuliaRegistries/General.git"
     Added registry `General` to `~/.julia/registries/General`

pkg> registry add https://github.com/fredrikekre/Registry"
   Cloning registry from "https://github.com/fredrikekre/Registry"
     Added registry `Registry` to `~/.julia/registries/Registry`

pkg> registry st
Registry Status 
 [23338594] General (https://github.com/JuliaRegistries/General.git)
 [ae0cb698] Registry (https://github.com/fredrikekre/Registry.git)

pkg> registry up General
  Updating registry at `~/.julia/registries/General/SxLXF`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`

pkg> registry up
  Updating registry at `~/.julia/registries/General/SxLXF`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Updating registry at `~/.julia/registries/Registry/xhgIZ`
  Updating git-repo `https://github.com/fredrikekre/Registry`

pkg> registry rm General
  Removing registry `General` from ~/.julia/registries/General/SxLXF

pkg> registry rm Registry
  Removing registry `Registry` from ~/.julia/registries/Registry/xhgIZ
```

fix #453