### PR TITLE
add path completions to add/dev in repl

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -697,9 +697,20 @@ function complete_package(s, i1, i2, lastcommand, project_opt)
     if lastcommand in [CMD_STATUS, CMD_RM, CMD_UP, CMD_TEST, CMD_BUILD, CMD_FREE, CMD_PIN]
         return complete_installed_package(s, i1, i2, project_opt)
     elseif lastcommand in [CMD_ADD, CMD_DEVELOP]
-        return complete_remote_package(s, i1, i2)
+        if occursin(Base.Filesystem.path_separator_re, s)
+            return complete_local_path(s, i1, i2)
+        else
+            rps = complete_remote_package(s, i1, i2)
+            lps = complete_local_path(s, i1, i2)
+            return vcat(rps[1], lps[1]), isempty(rps[1]) ? lps[2] : i1:i2, length(rps[1]) + length(lps[1]) > 0
+        end
     end
     return String[], 0:-1, false
+end
+
+function complete_local_path(s, i1, i2)
+    cmp = REPL.REPLCompletions.complete_path(s, i2)
+    [REPL.REPLCompletions.completion_text(p) for p in cmp[1]], cmp[2], !isempty(cmp[1])
 end
 
 function complete_installed_package(s, i1, i2, project_opt)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -342,69 +342,79 @@ end
 test_complete(s) = Pkg.REPLMode.completions(s,lastindex(s))
 apply_completion(str) = begin
     c, r, s = test_complete(str)
-    @test s == true
     str[1:prevind(str, first(r))]*first(c)
 end
 
 # Autocompletions
 temp_pkg_dir() do project_path; cd(project_path) do
-    Pkg.Types.registries()
-    pkg"activate ."
-    c, r = test_complete("add Exam")
-    @test "Example" in c
-    c, r = test_complete("rm Exam")
-    @test isempty(c)
-    Pkg.REPLMode.pkgstr("develop $(joinpath(@__DIR__, "test_packages", "RequireDependency"))")
+    @testset "tab completion" begin
+        Pkg.Types.registries()
+        pkg"activate ."
+        c, r = test_complete("add Exam")
+        @test "Example" in c
+        c, r = test_complete("rm Exam")
+        @test isempty(c)
+        Pkg.REPLMode.pkgstr("develop $(joinpath(@__DIR__, "test_packages", "RequireDependency"))")
 
-    c, r = test_complete("rm RequireDep")
-    @test "RequireDependency" in c
-    c, r = test_complete("rm -p RequireDep")
-    @test "RequireDependency" in c
-    c, r = test_complete("rm --project RequireDep")
-    @test "RequireDependency" in c
-    c, r = test_complete("rm Exam")
-    @test isempty(c)
-    c, r = test_complete("rm -p Exam")
-    @test isempty(c)
-    c, r = test_complete("rm --project Exam")
-    @test isempty(c)
+        c, r = test_complete("rm RequireDep")
+        @test "RequireDependency" in c
+        c, r = test_complete("rm -p RequireDep")
+        @test "RequireDependency" in c
+        c, r = test_complete("rm --project RequireDep")
+        @test "RequireDependency" in c
+        c, r = test_complete("rm Exam")
+        @test isempty(c)
+        c, r = test_complete("rm -p Exam")
+        @test isempty(c)
+        c, r = test_complete("rm --project Exam")
+        @test isempty(c)
 
-    c, r = test_complete("rm -m RequireDep")
-    @test "RequireDependency" in c
-    c, r = test_complete("rm --manifest RequireDep")
-    @test "RequireDependency" in c
-    c, r = test_complete("rm -m Exam")
-    @test "Example" in c
-    c, r = test_complete("rm --manifest Exam")
-    @test "Example" in c
+        c, r = test_complete("rm -m RequireDep")
+        @test "RequireDependency" in c
+        c, r = test_complete("rm --manifest RequireDep")
+        @test "RequireDependency" in c
+        c, r = test_complete("rm -m Exam")
+        @test "Example" in c
+        c, r = test_complete("rm --manifest Exam")
+        @test "Example" in c
 
-    c, r = test_complete("rm RequireDep")
-    @test "RequireDependency" in c
-    c, r = test_complete("rm Exam")
-    @test isempty(c)
-    c, r = test_complete("rm -m Exam")
-    c, r = test_complete("rm -m Exam")
-    @test "Example" in c
+        c, r = test_complete("rm RequireDep")
+        @test "RequireDependency" in c
+        c, r = test_complete("rm Exam")
+        @test isempty(c)
+        c, r = test_complete("rm -m Exam")
+        c, r = test_complete("rm -m Exam")
+        @test "Example" in c
 
-    pkg"add Example"
-    c, r = test_complete("rm Exam")
-    @test "Example" in c
-    c, r = test_complete("add --man")
-    @test "--manifest" in c
-    c, r = test_complete("rem")
-    @test "remove" in c
-    @test apply_completion("rm E") == "rm Example"
-    @test apply_completion("add Exampl") == "add Example"
+        pkg"add Example"
+        c, r = test_complete("rm Exam")
+        @test "Example" in c
+        c, r = test_complete("add --man")
+        @test "--manifest" in c
+        c, r = test_complete("rem")
+        @test "remove" in c
+        @test apply_completion("rm E") == "rm Example"
+        @test apply_completion("add Exampl") == "add Example"
 
-    c, r = test_complete("preview r")
-    @test "remove" in c
-    c, r = test_complete("help r")
-    @test "remove" in c
-    @test !("rm" in c)
+        c, r = test_complete("preview r")
+        @test "remove" in c
+        c, r = test_complete("help r")
+        @test "remove" in c
+        @test !("rm" in c)
 
-    c, r = test_complete("add REPL")
-    # Filtered by version
-    @test !("REPL" in c)
+        c, r = test_complete("add REPL")
+        # Filtered by version
+        @test !("REPL" in c)
+
+        mkdir("testdir")
+        c, r = test_complete("add ")
+        @test Sys.iswindows() ? ("testdir\\\\" in c) : ("testdir/" in c)
+        @test "Example" in c
+        @test apply_completion("add tes") == (Sys.iswindows() ? "add testdir\\\\" : "add testdir/")
+        @test apply_completion("add ./tes") == (Sys.iswindows() ? "add ./testdir\\\\" : "add ./testdir/")
+        c, r = test_complete("dev ./")
+        @test (Sys.iswindows() ? ("testdir\\\\" in c) : ("testdir/" in c))
+    end
 end end
 
 temp_pkg_dir() do project_path; cd(project_path) do


### PR DESCRIPTION
These are only triggered if there's a path separator in the string to be completed, which I think is a pretty sensible behaviour.
If you want to test this locally, call `Pkg.REPLMode.repl_init(Base.active_repl)` after `import Pkg`.

Fixes #408 