### PR TITLE
fix initializing REPL mode

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -335,7 +335,7 @@ import .REPLMode: @pkg_str
 export @pkg_str, PackageSpec
 
 
-#function __init__()
+function __init__()
     if isdefined(Base, :active_repl)
         REPLMode.repl_init(Base.active_repl)
     else
@@ -346,7 +346,7 @@ export @pkg_str, PackageSpec
             end
         end
     end
-#end
+end
 
 module PrecompileArea
     using ..Types

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -655,7 +655,7 @@ REPL.REPLDisplay(repl::MiniREPL) = repl.display
 
 const minirepl = Ref{MiniREPL}()
 
-#= __init__() = =# minirepl[] = MiniREPL()
+__init__() = minirepl[] = MiniREPL()
 
 macro pkg_str(str::String)
     :($(do_cmd)(minirepl[], $str; do_rethrow=true))


### PR DESCRIPTION
The `__init__` functions were disabled because we ran without precompilation but now precompilation is the default so need to enable it here.