### PR TITLE
Build version tags on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
 branches:
   only:
     - master
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi


### PR DESCRIPTION
Only building `master` means that Documenter will only have the 'latest' version of the documentation. Building version tags as well means that you can go back and see the documentation for older versions, plus you'll get the 'stable' option, which is probably what you'll want to people to from the readme in the near future.

I've used this in several of my packages.