### PR TITLE
remove unnecessary version handling when dealing with repos

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -98,7 +98,6 @@ function collect_fixed!(ctx::Context, pkgs::Vector{PackageSpec}, uuid_to_name::D
             path = pkg.path
         elseif info !== nothing && haskey(info, "repo-url")
             path = find_installed(pkg.name, pkg.uuid, SHA1(info["git-tree-sha1"]))
-            pkg.version = VersionNumber(info["version"])
             pkg.repo = Types.GitRepo(info["repo-url"], info["repo-rev"], SHA1(info["git-tree-sha1"]))
         else
             continue
@@ -330,23 +329,33 @@ function resolve_versions!(
             pkg = PackageSpec(name, uuid, ver)
             push!(pkgs, pkg)
         end
-        proj_compat = Types.project_compatibility(ctx, name)
-        v = intersect(pkg.version, proj_compat)
-        if isempty(v)
-            pkgerror(string("for package $(pkg.name) intersection between project compatibility $(proj_compat) ",
-                            "and package version $(pkg.version) is empty"))
-        end
-        pkg.version = v
-    end
-    proj_compat = Types.project_compatibility(ctx, "julia")
-    v = intersect(VERSION, proj_compat)
-    if isempty(v)
-        @warn("julia version requirement for project not satisfied")
     end
 
     # construct data structures for resolver and call it
-    reqs = Requires(pkg.uuid => VersionSpec(pkg.version) for pkg in pkgs if pkg.uuid ≠ uuid_julia)
+    # this also sets pkg.version for fixed packages
     fixed = collect_fixed!(ctx, pkgs, uuid_to_name)
+
+    # compatibility
+    proj_compat = Types.project_compatibility(ctx, "julia")
+    v = intersect(VERSION, proj_compat)
+    if isempty(v)
+        @warn "julia version requirement for project not satisfied" _module=nothing _file=nothing
+    end
+
+    for pkg in pkgs
+        proj_compat = Types.project_compatibility(ctx, pkg.name)
+        v = intersect(pkg.version, proj_compat)
+        if isempty(v)
+            pkgerror(string("empty intersection between $(pkg.name)@$(pkg.version) and project ",
+                            "compatibility $(proj_compat)"))
+        end
+        # Work around not clobbering 0.x.y+ for checked out old type of packages
+        if !(pkg.version isa VersionNumber)
+            pkg.version = v
+        end
+    end
+
+    reqs = Requires(pkg.uuid => VersionSpec(pkg.version) for pkg in pkgs if pkg.uuid ≠ uuid_julia)
     fixed[uuid_julia] = Fixed(VERSION)
     graph = deps_graph(ctx, uuid_to_name, reqs, fixed)
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -590,6 +590,7 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                 pkg.path = Pkg.Operations.relative_project_path_if_in_project(ctx, dev_pkg_path)
             end
             @assert pkg.path != nothing
+            @assert has_uuid(pkg)
         end
         return new_uuids
     end
@@ -687,7 +688,7 @@ function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec};
                 mv(project_path, version_path; force=true)
                 push!(new_uuids, pkg.uuid)
             end
-            @assert pkg.version isa VersionNumber
+            @assert has_uuid(pkg)
         end
         return new_uuids
     finally
@@ -702,14 +703,7 @@ function parse_package!(ctx, pkg, project_path)
         project_data = read_package(project_file)
         pkg.uuid = UUID(project_data["uuid"])
         pkg.name = project_data["name"]
-        if haskey(project_data, "version")
-            pkg.version = VersionNumber(project_data["version"])
-        else
-            @warn "project file for $(pkg.name) at $(project_path) is missing a `version` entry"
-            Pkg.Operations.set_maximum_version_registry!(env, pkg)
-        end
     else
-        # @warn "package $(pkg.name) at $(project_path) will need to have a [Julia]Project.toml file in the future"
         if !isempty(ctx.old_pkg2_clone_name) # remove when legacy CI script support is removed
             pkg.name = ctx.old_pkg2_clone_name
         else
@@ -731,14 +725,9 @@ function parse_package!(ctx, pkg, project_path)
                 pkg.uuid = uuid5(uuid_unreg_pkg, pkg.name)
                 @info "Assigning UUID $(pkg.uuid) to $(pkg.name)"
             end
-            pkg.version = v"0.0"
         else
-            # TODO: Fix
             @assert length(reg_uuids) == 1
             pkg.uuid = reg_uuids[1]
-            # Old style registered package
-            # What version does this package have? We have no idea... let's give it the latest one with a `+`...
-            Pkg.Operations.set_maximum_version_registry!(env, pkg)
         end
     end
 end


### PR DESCRIPTION
This is completely the wrong place to assign versions to packages, that takes place just before calling the resolver.

Only have crappy mobile internet so we'll see what CI says, didn't run locally.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/645
Fixes https://github.com/JuliaLang/Pkg.jl/issues/606

Tests for this are quite hard to make because the code is so stupid.
