### PR TITLE
Fix a bug where the path was stored as relative

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -48,8 +48,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
 
     ctx.preview && preview_info()
     if mode == :develop
-        devdir = shared ? Pkg.devdir() : joinpath(dirname(ctx.env.project_file), "dev")
-        new_git = handle_repos_develop!(ctx, pkgs, devdir)
+        new_git = handle_repos_develop!(ctx, pkgs, shared = shared)
     else
         new_git = handle_repos_add!(ctx, pkgs; upgrade_or_add=true)
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -661,16 +661,6 @@ function find_stdlib_deps(ctx::Context, path::String)
     return stdlib_deps
 end
 
-function relative_project_path_if_in_project(ctx::Context, path::String)
-    # Check if path is in project => relative
-    project_path = dirname(ctx.env.project_file)
-    if startswith(normpath(path), project_path)
-        return relpath(path, project_path)
-    else
-        return abspath(path)
-    end
-end
-
 project_rel_path(ctx::Context, path::String) =
     normpath(joinpath(dirname(ctx.env.project_file), path))
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -498,10 +498,16 @@ function safe_realpath(path)
     a, b = splitdir(path)
     return joinpath(safe_realpath(a), b)
 end
+function relative_project_path(ctx::Context, path::String)
+    # compute path relative the project
+    # realpath needed to expand symlinks before taking the relative path
+    return relpath(safe_realpath(abspath(path)),
+                   safe_realpath(dirname(ctx.env.project_file)))
+end
 
 casesensitive_isdir(dir::String) = isdir_windows_workaround(dir) && dir in readdir(joinpath(dir, ".."))
 
-function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, devdir::String)
+function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}; shared::Bool)
     Base.shred!(LibGit2.CachedCredentials()) do creds
         env = ctx.env
         new_uuids = UUID[]
@@ -519,9 +525,7 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                 else
                     # Relative paths are given relative pwd() so we
                     # translate that to be relative the project instead.
-                    # `realpath` is needed to expand symlinks before taking the relative path.
-                    pkg.path = relpath(safe_realpath(abspath(pkg.repo.url)),
-                                       safe_realpath(dirname(ctx.env.project_file)))
+                    pkg.path = relative_project_path(ctx, pkg.repo.url)
                 end
                 folder_already_downloaded = true
                 project_path = pkg.repo.url
@@ -573,6 +577,7 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                 end
 
                 parse_package!(ctx, pkg, project_path)
+                devdir = shared ? Pkg.devdir() : joinpath(dirname(ctx.env.project_file), "dev")
                 dev_pkg_path = joinpath(devdir, pkg.name)
                 if isdir(dev_pkg_path)
                     if !isfile(joinpath(dev_pkg_path, "src", pkg.name * ".jl"))
@@ -585,9 +590,9 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
                     mv(project_path, dev_pkg_path; force=true)
                     push!(new_uuids, pkg.uuid)
                 end
-                # Save the path as relative if the location is inside the project
-                # (e.g. from `dev --local`), otherwise put in the absolute path.
-                pkg.path = Pkg.Operations.relative_project_path_if_in_project(ctx, dev_pkg_path)
+                # Save the path as relative if it is a --local dev,
+                # otherwise put in the absolute path.
+                pkg.path = shared ? dev_pkg_path : relative_project_path(ctx, dev_pkg_path)
             end
             @assert pkg.path != nothing
             @assert has_uuid(pkg)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -3,6 +3,7 @@
 module REPLTests
 
 using Pkg
+using Pkg.Types: manifest_info, EnvCache
 import Pkg.Types.PkgError
 using UUIDs
 using Test
@@ -308,6 +309,23 @@ cd(mktempdir()) do
     @test manifest["SubModule"][1]["path"] == joinpath("..", "SubModule")
 end
 
+# path should not be relative when devdir() happens to be in project
+# unless user used dev --local.
+temp_pkg_dir() do depot
+    cd(mktempdir()) do
+        uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # Example
+        pkg"activate ."
+        withenv("JULIA_PKG_DEVDIR" => joinpath(pwd(), "dev")) do
+            pkg"dev Example"
+            @test manifest_info(EnvCache(), uuid)["path"] == joinpath(pwd(), "dev", "Example")
+            pkg"dev --shared Example"
+            @test manifest_info(EnvCache(), uuid)["path"] == joinpath(pwd(), "dev", "Example")
+            pkg"dev --local Example"
+            @test manifest_info(EnvCache(), uuid)["path"] == joinpath("dev", "Example")
+        end
+    end
+end
+
 # test relative dev paths (#490) without existing Project.toml
 temp_pkg_dir() do depot
     cd(mktempdir()) do
@@ -324,7 +342,6 @@ temp_pkg_dir() do depot
 end
 
 # develop with --shared and --local
-using Pkg.Types: manifest_info, EnvCache
 cd(mktempdir()) do
     uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # Example
     pkg"activate ."


### PR DESCRIPTION
Fix a bug where the path was stored as relative because `devdir()` happened to be in the project. The path should only be relative if the user used `--local`.