### PR TITLE
`help` should not error when no docs available

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -545,8 +545,10 @@ function do_help!(command::PkgCommand, repl::REPL.AbstractREPL)
         spec = get(command_specs, arg, nothing)
         spec === nothing &&
             pkgerror("'$arg' does not name a command")
-        spec.help === nothing &&
-            pkgerror("Sorry, I don't have any help for the `$arg` command.")
+        if spec.help === nothing
+            @warn("Sorry, I don't have any help for the `$arg` command.")
+            continue
+        end
         isempty(help_md.content) ||
             push!(help_md.content, md"---")
         push!(help_md.content, spec.help)


### PR DESCRIPTION
Use case is `pkg> help add remove up` when e.g. `remove` does not have docs. Currently the whole command fails. I think it would be better if you just get a warning and get help for the commands which docs are available.