### PR TITLE
Better path printing

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -96,7 +96,7 @@ function update_registry(ctx)
     else
         for reg in registries()
             if isdir(joinpath(reg, ".git"))
-                regpath = pathrepr(ctx, reg)
+                regpath = pathrepr(reg)
                 printpkgstyle(ctx, :Updating, "registry at " * regpath)
                 LibGit2.with(LibGit2.GitRepo, reg) do repo
                     if LibGit2.isdirty(repo)

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -56,14 +56,14 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
         m₁ = filter_manifest(in_project(project₁["deps"]), manifest₁)
         diff = manifest_diff(ctx, m₀, m₁)
         if !use_as_api
-            printpkgstyle(ctx, :Status, pathrepr(ctx, env.project_file), #=ignore_indent=# true)
+            printpkgstyle(ctx, :Status, pathrepr(env.project_file), #=ignore_indent=# true)
             print_diff(ctx, diff, #=status=# true)
         end
     end
     if mode == PKGMODE_MANIFEST
         diff = manifest_diff(ctx, manifest₀, manifest₁)
         if !use_as_api
-            printpkgstyle(ctx, :Status, pathrepr(ctx, env.manifest_file), #=ignore_indent=# true)
+            printpkgstyle(ctx, :Status, pathrepr(env.manifest_file), #=ignore_indent=# true)
             print_diff(ctx, diff, #=status=# true)
         end
     elseif mode == PKGMODE_COMBINED
@@ -73,7 +73,7 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
         c_diff = filter!(x->x.old != x.new, manifest_diff(ctx, m₀, m₁))
         if !isempty(c_diff)
             if !use_as_api
-                printpkgstyle(ctx, :Status, pathrepr(ctx, env.manifest_file), #=ignore_indent=# true)
+                printpkgstyle(ctx, :Status, pathrepr(env.manifest_file), #=ignore_indent=# true)
                 print_diff(ctx, c_diff, #=status=# true)
             end
             diff = Base.vcat(c_diff, diff)
@@ -116,7 +116,7 @@ revstring(str::String) = occursin(r"\b([a-f0-9]{40})\b", str) ? str[1:7] : str
 vstring(ctx::Context, a::VerInfo) =
     string((a.ver == nothing && a.hash != nothing) ? "[$(string(a.hash)[1:16])]" : "",
            a.ver != nothing ? "v$(a.ver)" : "",
-           a.path != nothing ? " [$(pathrepr(ctx, a.path))]" : "",
+           a.path != nothing ? " [$(pathrepr(a.path))]" : "",
            a.repo != nothing ? " #$(revstring(a.repo.rev)) ($(a.repo.url))" : "",
            a.pinned == true ? " ⚲" : "",
            )

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1048,7 +1048,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
     for (uuid, name, hash_or_path, build_file, version) in builds
         log_file = splitext(build_file)[1] * ".log"
         printpkgstyle(ctx, :Building,
-            rpad(name * " ", max_name + 1, "─") * "→ " * Types.pathrepr(ctx, log_file))
+            rpad(name * " ", max_name + 1, "─") * "→ " * Types.pathrepr(log_file))
         code = """
             $(Base.load_path_setup_code(false))
             cd($(repr(dirname(build_file))))

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1113,20 +1113,8 @@ function printpkgstyle(ctx::Context, cmd::Symbol, text::String, ignore_indent::B
 end
 
 
-function pathrepr(ctx::Union{Nothing, Context}, path::String, base::String=pwd())
-    project_path = dirname(ctx.env.project_file)
-    path = joinpath(project_path, path)
-    if startswith(path, project_path) && startswith(base, project_path)
-        # We are in project and path is in project
-        path = relpath(path, base)
-    end
-    if !Sys.iswindows() && isabspath(path)
-        home = joinpath(homedir(), "")
-        if startswith(path, home)
-            path = joinpath("~", path[nextind(path, lastindex(home)):end])
-        end
-    end
-    return "`" * path * "`"
+function pathrepr(path::String)
+    return "`" * Base.contractuser(path) * "`"
 end
 
 function project_key_order(key::String)
@@ -1149,7 +1137,7 @@ function write_env(ctx::Context; display_diff=true)
     isempty(project["deps"]) && delete!(project, "deps")
     if !isempty(project) || ispath(env.project_file)
         if display_diff && !(ctx.currently_running_target)
-            printpkgstyle(ctx, :Updating, pathrepr(ctx, env.project_file))
+            printpkgstyle(ctx, :Updating, pathrepr(env.project_file))
             Pkg.Display.print_project_diff(ctx, old_env, env)
         end
         if !ctx.preview
@@ -1162,7 +1150,7 @@ function write_env(ctx::Context; display_diff=true)
     # update the manifest file
     if !isempty(env.manifest) || ispath(env.manifest_file)
         if display_diff && !(ctx.currently_running_target)
-            printpkgstyle(ctx, :Updating, pathrepr(ctx, env.manifest_file))
+            printpkgstyle(ctx, :Updating, pathrepr(env.manifest_file))
             Pkg.Display.print_manifest_diff(ctx, old_env, env)
         end
         manifest = deepcopy(env.manifest)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -333,7 +333,7 @@ is_project_uuid(env::EnvCache, uuid::UUID) =
 ###########
 # Context #
 ###########
-stdlib_dir() = joinpath(Sys.BINDIR, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)")
+stdlib_dir() = normpath(joinpath(Sys.BINDIR, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"))
 stdlib_path(stdlib::String) = joinpath(stdlib_dir(), stdlib)
 function gather_stdlib_uuids()
     stdlibs = Dict{UUID,String}()
@@ -1114,6 +1114,10 @@ end
 
 
 function pathrepr(path::String)
+    # print stdlib paths as @stdlib/Name
+    if startswith(path, stdlib_dir())
+        path = "@stdlib/" * basename(path)
+    end
     return "`" * Base.contractuser(path) * "`"
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -499,6 +499,11 @@ end
     end
 end
 
+@testset "printing of stdlib paths, issue #605" begin
+    path = Pkg.Types.stdlib_path("Test")
+    @test Pkg.Types.pathrepr(path) == "`@stdlib/Test`"
+end
+
 include("repl.jl")
 include("api.jl")
 


### PR DESCRIPTION
Packages that are tracked by path now just print the path (without trying to be clever about where the project is, or what pwd is). Also print stdlib paths, e.g. when testing, as `@stdlib/Test`, fix #605 .

bors try