### PR TITLE
Do not create a stdlib dict with every `Context`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -54,7 +54,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
     end
     project_deps_resolve!(ctx.env, pkgs)
     registry_resolve!(ctx.env, pkgs)
-    stdlib_resolve!(ctx, pkgs)
+    stdlib_resolve!(pkgs)
     ensure_resolved(ctx.env, pkgs, registry=true)
 
     any(pkg -> Types.collides_with_project(ctx.env, pkg), pkgs) &&

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -504,6 +504,19 @@ end
     @test Pkg.Types.pathrepr(path) == "`@stdlib/Test`"
 end
 
+@testset "stdlib_resolve!" begin
+    a = Pkg.Types.PackageSpec(name="Markdown")
+    b = Pkg.Types.PackageSpec(uuid=UUID("9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"))
+    Pkg.Types.stdlib_resolve!([a, b])
+    @test a.uuid == UUID("d6f4376e-aef5-505a-96c1-9c027394607a")
+    @test b.name == "Profile"
+
+    x = Pkg.Types.PackageSpec(name="Markdown", uuid=UUID("d6f4376e-aef5-505a-96c1-9c027394607a"))
+    Pkg.Types.stdlib_resolve!([x])
+    @test x.name == "Markdown"
+    @test x.uuid == UUID("d6f4376e-aef5-505a-96c1-9c027394607a")
+end
+
 include("repl.jl")
 include("api.jl")
 


### PR DESCRIPTION
The stdlib name->UUID mapping should be pretty stable over time, I can't think of a good reason to create one on every operation.

Also created a dict where the names are the keys so the resolver should be a little faster. If this PR gets turned down, I think we should at least keep that since I suspect most people type in the name of the library and not the UUID, or maybe thats just me... :laughing: .

Also, more tests. I don't think the UUIDs of the stdlibs should change over time, right?