### PR TITLE
Cache stdlib dict

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -773,15 +773,6 @@ function complete_remote_package(partial)
     return cmp
 end
 
-const STDLIB_NAMES = Ref{Vector{String}}()
-function stdlib_names()
-    if !isassigned(STDLIB_NAMES)
-        STDLIB_NAMES[] = filter!(x->isdir(joinpath(Types.stdlib_dir(), x)),
-                                 readdir(Types.stdlib_dir()))
-    end
-    return STDLIB_NAMES[]
-end
-
 function canonical_names()
     names = String[]
     for (super, specs) in pairs(super_specs)
@@ -799,7 +790,8 @@ end
 function complete_installed_packages(options, partial)
     mode = get(options, :mode, nothing)
     pkgs = mode == PKGMODE_MANIFEST ? API.__installed() : API.__installed(PKGMODE_PROJECT)
-    return collect(keys(filter(p->p[1] in stdlib_names() || p[2] !== nothing, pkgs)))
+    stdlib_names = collect(values(Types.stdlib()))
+    return collect(keys(filter(p -> p[1] in stdlib_names || p[2] !== nothing, pkgs)))
 end
 
 function complete_add_dev(options, partial, i1, i2)
@@ -809,7 +801,7 @@ function complete_add_dev(options, partial, i1, i2)
     end
     comps = vcat(comps, complete_remote_package(partial))
     comps = vcat(comps, filter(x->startswith(x,partial) && !(x in comps),
-                              stdlib_names()))
+                               collect(values(Types.stdlib()))))
     return comps, idx, !isempty(comps)
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -572,6 +572,19 @@ end
     end
     rm(dirname(temp); recursive = true, force = true)
 end
+    
+@testset "stdlib_resolve!" begin
+    a = Pkg.Types.PackageSpec(name="Markdown")
+    b = Pkg.Types.PackageSpec(uuid=UUID("9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"))
+    Pkg.Types.stdlib_resolve!(Types.Context(), [a, b])
+    @test a.uuid == UUID("d6f4376e-aef5-505a-96c1-9c027394607a")
+    @test b.name == "Profile"
+
+    x = Pkg.Types.PackageSpec(name="Markdown", uuid=UUID("d6f4376e-aef5-505a-96c1-9c027394607a"))
+    Pkg.Types.stdlib_resolve!(Types.Context(), [x])
+    @test x.name == "Markdown"
+    @test x.uuid == UUID("d6f4376e-aef5-505a-96c1-9c027394607a")
+end
 
 include("repl.jl")
 include("api.jl")


### PR DESCRIPTION
I noticed we where reading through the stdlib directory when creating each `Context` object. Unless I'm missing something, this is unnecessary (and expensive!). Caching the dict makes creating a `Context` object roughly an order of magnitude faster.

I also hope we can completely remove the `stdlibs` field from `Context`. For now, I just left as is, and run a `Base.deepcopy` on the cached dict.

I did make two steps towards removing the `stdlibs` field: rewrite `stdlib_resolve` to not depend on a `Context` object, and replace `keys(ctx.stdlibs)` with `stdlib_uuids`.

Finally, tests for the `stdlib_resolve!` rewrite. They should be useful even if there is disagreement over the PR.