### PR TITLE
add support for "ssh" protocol

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -75,8 +75,13 @@ setprotocol!(proto::Union{Nothing, AbstractString}=nothing) = GIT_PROTOCOL[] = p
 # TODO: extend this to more urls
 function normalize_url(url::AbstractString)
     m = match(GITHUB_REGEX, url)
-    (m === nothing || GIT_PROTOCOL[] === nothing) ?
-        url : "$(GIT_PROTOCOL[])://github.com/$(m.captures[1]).git"
+    if m === nothing || GIT_PROTOCOL[] === nothing
+        url
+    elseif GIT_PROTOCOL[] == "ssh"
+        "ssh://git@github.com/$(m.captures[1]).git"
+    else
+        "$(GIT_PROTOCOL[])://github.com/$(m.captures[1]).git"
+    end
 end
 
 function clone(url, source_path; header=nothing, kwargs...)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -259,6 +259,23 @@ temp_pkg_dir() do project_path
                 end
             end
         end
+        mktempdir() do devdir
+            withenv("JULIA_PKG_DEVDIR" => devdir) do
+                try
+                    https_url = "https://github.com/JuliaLang/Example.jl.git"
+                    ssh_url = "ssh://git@github.com/JuliaLang/Example.jl.git"
+                    @test Pkg.GitTools.normalize_url(https_url) == https_url
+                    Pkg.setprotocol!("ssh")
+                    @test Pkg.GitTools.normalize_url(https_url) == ssh_url
+                    # TODO: figure out how to test this without
+                    #       having to deploy a ssh key on github
+                    #Pkg.develop("Example")
+                    #@test isinstalled(TEST_PKG)
+                finally
+                    Pkg.setprotocol!()
+                end
+            end
+        end
     end
 
     @testset "check logging" begin


### PR DESCRIPTION
This is a minimalistic change to support the use of `Pkg.setprotocol!("ssh")` to fix #653.

My naive reasoning here is that since "github" is hardcoded anyway, one might as well adapt the URL string for when using the ~~"git"~~ "ssh" protocol.

Note though that this only works if the repo has not been cloned into ".julia/clones"  already using the defaul setting (i.e. https). If that is the case then `dev Example` will say

```
  Updating git-repo `git@github.com:JuliaLang/Example.jl.git`
```

while `git remote -v` in that new dev-ed directory will still show `origin` using the `https` version.
Not sure where to fix that.