### PR TITLE
Allow trailing backslash in regex

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -482,7 +482,7 @@ end
 
 
 const refspecs = ["+refs/*:refs/remotes/cache/*"]
-const reg_pkg = r"(?:^|[/\\])(\w+?)(?:\.jl)?(?:\.git)?(?:\/)?$"
+const reg_pkg = r"(?:^|[\/\\])(\w+?)(?:\.jl)?(?:\.git)?(?:[\/\\])?$"
 
 # Windows sometimes throw on `isdir`...
 function isdir_windows_workaround(path::String)


### PR DESCRIPTION
Also escapes the forward slash at the beginning, although this appears to not have been an issue.
Fixes #719