### PR TITLE
Don't mutate argument passed to Pkg.add

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -29,6 +29,7 @@ add_or_develop(pkgs::Vector{String}; kwargs...)            = add_or_develop([che
 add_or_develop(pkgs::Vector{PackageSpec}; kwargs...)       = add_or_develop(Context(), pkgs; kwargs...)
 
 function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, shared::Bool=true, kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
     # All developed packages should go through handle_repos_develop so just give them an empty repo
@@ -73,6 +74,7 @@ rm(pkgs::Vector{String}; kwargs...)            = rm([PackageSpec(pkg) for pkg in
 rm(pkgs::Vector{PackageSpec}; kwargs...)       = rm(Context(), pkgs; kwargs...)
 
 function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     for pkg in pkgs
         # TODO only overwrite pkg.mode if default value ?
         pkg.mode = mode
@@ -166,6 +168,7 @@ up(pkgs::Vector{PackageSpec}; kwargs...)       = up(Context(), pkgs; kwargs...)
 
 function up(ctx::Context, pkgs::Vector{PackageSpec};
             level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode=PKGMODE_PROJECT, do_update_registry=true, kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     for pkg in pkgs
         # TODO only override if they are not already set
         pkg.mode = mode
@@ -205,6 +208,7 @@ pin(pkgs::Vector{String}; kwargs...)            = pin([PackageSpec(pkg) for pkg 
 pin(pkgs::Vector{PackageSpec}; kwargs...)       = pin(Context(), pkgs; kwargs...)
 
 function pin(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
     project_deps_resolve!(ctx.env, pkgs)
@@ -219,6 +223,7 @@ free(pkgs::Vector{String}; kwargs...)            = free([PackageSpec(pkg) for pk
 free(pkgs::Vector{PackageSpec}; kwargs...)       = free(Context(), pkgs; kwargs...)
 
 function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
     registry_resolve!(ctx.env, pkgs)
@@ -250,6 +255,7 @@ test(pkgs::Vector{String}; kwargs...)             = test([PackageSpec(pkg) for p
 test(pkgs::Vector{PackageSpec}; kwargs...)        = test(Context(), pkgs; kwargs...)
 
 function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
     if isempty(pkgs)
@@ -423,6 +429,7 @@ build(pkg::Array{Union{}, 1}) = build(PackageSpec[])
 build(pkg::PackageSpec) = build([pkg])
 build(pkgs::Vector{PackageSpec}) = build(Context(), pkgs)
 function build(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+    pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
     ctx.preview && preview_info()

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -505,6 +505,16 @@ end
     @test Pkg.Types.pathrepr(path) == "`@stdlib/Test`"
 end
 
+
+temp_pkg_dir() do project_path
+    @testset "Pkg.add should not mutate" begin
+        package_names = ["JSON"]
+        packages = PackageSpec.(package_names)
+        Pkg.add(packages)
+        @test [p.name for p in packages] == package_names
+    end
+end
+
 include("repl.jl")
 include("api.jl")
 


### PR DESCRIPTION
Currently, `Pkg.add` modifies the argument `pkg::Vector{PackageSpec}` passed to it in-place even though the name does not end with `!`:

```julia
julia> VERSION
v"1.0.0"

julia> packages = [PackageSpec("JSON")]
1-element Array{Pkg.Types.PackageSpec,1}:
 PackageSpec(name=JSON)

julia> Pkg.add(packages)
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
# ...

julia> packages
158-element Array{Pkg.Types.PackageSpec,1}:
 PackageSpec(name=JSON, uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6, v=v"0.19.0")
 PackageSpec(name=Documenter, uuid=e30172f5-a6a5-5a46-863b-614d45cd2de4, v=v"0.19.6")
# and so on ...
```

I propose to `deepcopy` it before passing it to the destructive internal function.  Note that this PR adds a function `Pkg.API.add_or_develop!`.
