### PR TITLE
Throw PkgError instead of ErrorException

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -240,13 +240,13 @@ function find_project_file(env::Union{Nothing,String}=nothing)
     project_file = nothing
     if env isa Nothing
         project_file = Base.active_project()
-        project_file == nothing && error("no active project")
+        project_file == nothing && pkgerror("no active project")
     elseif startswith(env, '@')
         project_file = Base.load_path_expand(env)
-        project_file === nothing && error("package environment does not exist: $env")
+        project_file === nothing && pkgerror("package environment does not exist: $env")
     elseif env isa String
         if isdir(env)
-            isempty(readdir(env)) || error("environment is a package directory: $env")
+            isempty(readdir(env)) || pkgerror("environment is a package directory: $env")
             project_file = joinpath(env, Base.project_names[end])
         else
             project_file = endswith(env, ".toml") ? abspath(env) :


### PR DESCRIPTION
Hides e.g. the following stacktrace
```
pkg> st
ERROR: no active project
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] find_project_file(::Nothing) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/Types.jl:243
 [3] Pkg.Types.EnvCache(::Nothing) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/Types.jl:285 (repeats 2 times)
 [4] Type at ./none:0 [inlined]
 [5] Context!(::Array{Pair{Symbol,Any},1}) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/Types.jl:367
 [6] Context! at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/REPLMode.jl:497 [inlined]
 [7] do_status!(::Dict{Symbol,Any}, ::Array{String,1}, ::Dict{Symbol,Any}) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/REPLMode.jl:569
 [8] #invokelatest#1(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Any, ::Any, ::Vararg{Any,N} where N) at ./essentials.jl:686
 [9] invokelatest(::Any, ::Any, ::Vararg{Any,N} where N) at ./essentials.jl:685
 [10] do_cmd!(::Pkg.REPLMode.PkgCommand, ::REPL.LineEditREPL) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/REPLMode.jl:542
 [11] #do_cmd#30(::Bool, ::Function, ::REPL.LineEditREPL, ::String) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/REPLMode.jl:507
 [12] do_cmd at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/REPLMode.jl:503 [inlined]
 [13] (::getfield(Pkg.REPLMode, Symbol("##41#44")){REPL.LineEditREPL,REPL.LineEdit.Prompt})(::REPL.LineEdit.MIState, ::Base.GenericIOBuffer{Array{UInt8,1}}, ::Bool) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/Pkg/src/REPLMode.jl:842
 [14] #invokelatest#1 at ./essentials.jl:686 [inlined]
 [15] invokelatest at ./essentials.jl:685 [inlined]
 [16] run_interface(::REPL.Terminals.TextTerminal, ::REPL.LineEdit.ModalInterface, ::REPL.LineEdit.MIState) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/REPL/src/LineEdit.jl:2261
 [17] run_frontend(::REPL.LineEditREPL, ::REPL.REPLBackendRef) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/REPL/src/REPL.jl:1029
 [18] run_repl(::REPL.AbstractREPL, ::Any) at /home/fredrik/julia10/usr/share/julia/stdlib/v1.0/REPL/src/REPL.jl:191
 [19] (::getfield(Base, Symbol("##720#722")){Bool,Bool,Bool,Bool})(::Module) at ./logging.jl:311
 [20] #invokelatest#1 at ./essentials.jl:686 [inlined]
 [21] invokelatest at ./essentials.jl:685 [inlined]
 [22] macro expansion at ./logging.jl:308 [inlined]
 [23] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./client.jl:330
 [24] exec_options(::Base.JLOptions) at ./client.jl:242
 [25] _start() at ./client.jl:421
```

bors try