### PR TITLE
Fix typo in help docs

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -1172,7 +1172,7 @@ The `startup.jl` file is disabled during building unless julia is started with `
     resolve
 
 Resolve the project i.e. run package resolution and update the Manifest. This is useful in case the dependencies of developed
-packages have changed causing the current Manifest to_indices be out of sync.
+packages have changed causing the current Manifest to be out of sync.
     """,
 ),( CMD_ACTIVATE,
     ["activate"],


### PR DESCRIPTION
Pretty sure it is a typo. It git blames back to me..