### PR TITLE
Enable testing on master while bors is crashing...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ branches:
 stages:
   - name: test
     # test only on bors trying and bors staging
-    if: branch IN (trying, staging)
+    if: branch IN (trying, staging, master)
   - name: docs
     # build docs on bors trying, bors staging, master and for tags
     if: branch IN (trying, staging) OR (branch = master AND type = push) OR tag IS present


### PR DESCRIPTION
```
{{:badmatch, {:error, :merge_branch, 404}},
 [{BorsNG.GitHub, :merge_branch!, 2,
   [file: 'lib/github/github.ex', line: 90]},
  {Enum, :"-reduce/3-lists^foldl/2-0-", 3,
   [file: 'lib/enum.ex', line: 1755]},
  {BorsNG.Worker.Batcher, :start_waiting_batch, 1,
   [file: 'lib/worker/batcher.ex', line: 266]},
  {BorsNG.Worker.Batcher, :poll, 1,
   [file: 'lib/worker/batcher.ex', line: 194]},
  {BorsNG.Worker.Batcher, :handle_cast, 2,
   [file: 'lib/worker/batcher.ex', line: 77]},
  {:gen_server, :try_dispatch, 4,
   [file: 'gen_server.erl', line: 616]},
  {:gen_server, :handle_msg, 6,
   [file: 'gen_server.erl', line: 686]},
  {:proc_lib, :init_p_do_apply, 3,
   [file: 'proc_lib.erl', line: 247]}]}
```