### PR TITLE
Remove OS-specific shell commands from Pkg docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -180,7 +180,7 @@ managed by system administrators.
 
 The Pkg REPL-mode is entered from the Julia REPL using the key `]`.
 
-```
+```julia-repl
 (v1.0) pkg>
 ```
 
@@ -206,7 +206,7 @@ The most frequently used one is `add` and its usage is described first.
 
 In the Pkg REPL packages can be added with the `add` command followed by the name of the package, for example:
 
-```
+```julia-repl
 (v1.0) pkg> add Example
    Cloning default registries into /Users/kristoffer/.julia/registries
    Cloning registry General from "https://github.com/JuliaRegistries/General.git"
@@ -227,7 +227,7 @@ The status update shows a short form of the package UUID to the left, then the p
 Since standard libraries (e.g. `Test`) are shipped with Julia, they do not have a version. The project status contains the packages
 you have added yourself, in this case, `Example`:
 
-```
+```julia-repl
 (v1.0) pkg> st
     Status `Project.toml`
   [7876af07] Example v0.5.1
@@ -235,7 +235,7 @@ you have added yourself, in this case, `Example`:
 
 The manifest status, in addition, includes the dependencies of explicitly added packages.
 
-```
+```julia-repl
 (v1.0) pkg> st --manifest
     Status `Manifest.toml`
   [7876af07] Example v0.5.1
@@ -246,7 +246,7 @@ It is possible to add multiple packages in one command as `pkg> add A B C`.
 
 After a package is added to the project, it can be loaded in Julia:
 
-```
+```julia-repl
 julia> using Example
 
 julia> Example.hello("User")
@@ -255,7 +255,7 @@ julia> Example.hello("User")
 
 A specific version can be installed by appending a version after a `@` symbol, e.g. `@v0.4`, to the package name:
 
-```
+```julia-repl
 (v1.0) pkg> add Example@0.4
  Resolving package versions...
   Updating `~/.julia/environments/v1.0/Project.toml`
@@ -267,7 +267,7 @@ A specific version can be installed by appending a version after a `@` symbol, e
 If the master branch (or a certain commit SHA) of `Example` has a hotfix that has not yet included in a registered version,
 we can explicitly track a branch (or commit) by appending `#branch` (or `#commit`) to the package name:
 
-```
+```julia-repl
 (v1.0) pkg> add Example#master
   Updating git-repo `https://github.com/JuliaLang/Example.jl.git`
  Resolving package versions...
@@ -282,7 +282,7 @@ When updating packages, we will pull updates from that branch.
 
 To go back to tracking the registry version of `Example`, the command `free` is used:
 
-```
+```julia-repl
 (v1.0) pkg> free Example
  Resolving package versions...
   Updating `~/.julia/environments/v1.0/Project.toml`
@@ -296,7 +296,7 @@ To go back to tracking the registry version of `Example`, the command `free` is 
 
 If a package is not in a registry, it can still be added by instead of the package name giving the URL to the repository to `add`.
 
-```
+```julia-repl
 (v1.0) pkg> add https://github.com/fredrikekre/ImportMacros.jl
   Updating git-repo `https://github.com/fredrikekre/ImportMacros.jl`
  Resolving package versions...
@@ -329,7 +329,7 @@ However, when you are developing a package, it is more convenient to load packag
 
 Let's try to `dev` a registered package:
 
-```
+```julia-repl
 (v1.0) pkg> dev Example
   Updating git-repo `https://github.com/JuliaLang/Example.jl.git`
  Resolving package versions...
@@ -346,7 +346,7 @@ Note that the package manager will never touch any of the files at a tracked pat
 If we try to `dev` a package at some branch that already exists at `~/.julia/dev/` the package manager we will simply use the existing path.
 For example:
 
-```
+```julia-repl
 (v1.0) pkg> dev Example
   Updating git-repo `https://github.com/JuliaLang/Example.jl.git`
 [ Info: Path `/Users/kristoffer/.julia/dev/Example` exists and looks like the correct package, using existing path instead of cloning
@@ -360,7 +360,7 @@ The path will be recorded relative to the project file, unless it is given as an
 
 To stop tracking a path and use the registered version again, use `free`
 
-```
+```julia-repl
 (v1.0) pkg> free Example
  Resolving package versions...
   Updating `~/.julia/environments/v1.0/Project.toml`
@@ -395,7 +395,7 @@ to the latest compatible version. Sometimes this is not what you want. You can s
 
 The version of all other packages direct dependencies will stay the same. If you only want to update the minor version of packages, to reduce the risk that your project breaks, you can give the `--minor` flag, e.g:
 
-```
+```julia-repl
 (v1.0) pkg> up --minor Example
 ```
 
@@ -406,7 +406,7 @@ Packages that track a path are never touched by the package manager.
 
 A pinned package will never be updated. A package can be pinned using `pin` as for example
 
-```
+```julia-repl
 (v1.0) pkg> pin Example
  Resolving package versions...
   Updating `~/.julia/environments/v1.0/Project.toml`
@@ -417,7 +417,7 @@ A pinned package will never be updated. A package can be pinned using `pin` as f
 
 Note the pin symbol `⚲` showing that the package is pinned. Removing the pin is done using `free`
 
-```
+```julia-repl
 (v1.0) pkg> free Example
   Updating `~/.julia/environments/v1.0/Project.toml`
   [7876af07] ~ Example v0.5.1 ⚲ ⇒ v0.5.1
@@ -429,7 +429,7 @@ Note the pin symbol `⚲` showing that the package is pinned. Removing the pin i
 
 The tests for a package can be run using `test`command:
 
-```
+```julia-repl
 (v1.0) pkg> test Example
    Testing Example
    Testing Example tests passed
@@ -441,7 +441,7 @@ The build step of a package is automatically run when a package is first install
 The output of the build process is directed to a file.
 To explicitly run the build step for a package the `build` command is used:
 
-```
+```julia-repl
 (v1.0) pkg> build MbedTLS
   Building MbedTLS → `~/.julia/packages/MbedTLS/h1Vu/deps/build.log`
 
@@ -459,7 +459,7 @@ So far we have added packages to the default project at `~/.julia/environments/v
 It should be pointed out if two projects uses the same package at the same version, the content of this package is not duplicated.
 In order to create a new project, create a directory for it and then activate that directory to make it the "active project" which package operations manipulate:
 
-```
+```julia-repl
 julia> mkdir("MyProject")
 
 julia> cd("MyProject")
@@ -473,7 +473,7 @@ julia> cd("MyProject")
 
 Note that the REPL prompt changed when the new project is activated. Since this is a newly created project, the status command show it contains no packages, and in fact, it has no project or manifest file until we add a package to it:
 
-```
+```julia-repl
 julia> readdir()
 0-element Array{String,1}
 
@@ -561,7 +561,7 @@ Pkg keeps a log of all projects used so it can go through the log and see exactl
 and what packages those projects used. The rest can be deleted.
 This is done with the `gc` command:
 
-```
+```julia-repl
 (v1.0) pkg> gc
     Active manifests at:
         `/Users/kristoffer/BinaryProvider/Manifest.toml`
@@ -585,13 +585,13 @@ This file is executed when the package is loaded.
 
 To generate files for a new package, use `pkg> generate`.
 
-```
+```julia-repl
 (v1.0) pkg> generate HelloWorld
 ```
 
 This creates a new project `HelloWorld` with the following files (visualized with the external [`tree` command](https://linux.die.net/man/1/tree)):
 
-```jl
+```julia-repl
 julia> cd("HelloWorld")
 
 shell> tree .
@@ -626,7 +626,7 @@ end # module
 
 We can now activate the project and load the package:
 
-```jl
+```julia-repl
 pkg> activate .
 
 julia> import HelloWorld
@@ -641,7 +641,7 @@ Let’s say we want to use the standard library package `Random` and the registe
 We simply `add` these packages (note how the prompt now shows the name of the newly generated project,
 since we are inside the `HelloWorld` project directory):
 
-```
+```julia-repl
 (HelloWorld) pkg> add Random JSON
  Resolving package versions...
   Updating "~/Documents/HelloWorld/Project.toml"
@@ -673,7 +673,7 @@ end # module
 
 and reloading the package, the new `greet_alien` function that uses `Random` can be used:
 
-```
+```julia-repl
 julia> HelloWorld.greet_alien()
 Hello aT157rHV
 ```
@@ -683,7 +683,7 @@ Hello aT157rHV
 The build step is executed the first time a package is installed or when explicitly invoked with `build`.
 A package is built by executing the file `deps/build.jl`.
 
-```
+```julia-repl
 julia> print(read("deps/build.log",String))
 I am being built...
 
@@ -697,7 +697,7 @@ I am being built...
 
 If the build step fails, the output of the build step is printed to the console
 
-```
+```julia-repl
 julia> print(read("deps/build.log",String))
 error("Ooops")
 
@@ -722,7 +722,7 @@ error("Ooops")
 
 When a package is tested the file `test/runtests.jl` is executed.
 
-```
+```julia-repl
 julia> print(read("test/runtests.jl",String))
 println("Testing...")
 (HelloWorld) pkg> test
@@ -750,7 +750,7 @@ test = ["Test"]
 
 We can now use `Test` in the test script and we can see that it gets installed on testing:
 
-```
+```julia-repl
 julia> print(read("test/runtests.jl",String))
 using Test
 @test 1 == 1
@@ -841,7 +841,7 @@ Inequalities can also be used to specify version ranges:
 
 The REPL command `precompile` can be used to precompile all the dependencies in the project. You can for example do
 
-```
+```julia-repl
 (HelloWorld) pkg> update; precompile
 ```
 
@@ -852,13 +852,13 @@ to update the dependencies and then precompile them.
 If you just want to see the effects of running a command, but not change your state you can `preview` a command.
 For example:
 
-```
+```julia-repl
 (HelloWorld) pkg> preview add Plots
 ```
 
 or
 
-```
+```julia-repl
 (HelloWorld) pkg> preview up
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -445,7 +445,7 @@ To explicitly run the build step for a package the `build` command is used:
 (v1.0) pkg> build MbedTLS
   Building MbedTLS → `~/.julia/packages/MbedTLS/h1Vu/deps/build.log`
 
-shell> cat ~/.julia/packages/MbedTLS/h1Vu/deps/build.log
+julia> print(read("~/.julia/packages/MbedTLS/h1Vu/deps/build.log",String))
 ┌ Warning: `wait(t::Task)` is deprecated, use `fetch(t)` instead.
 │   caller = macro expansion at OutputCollector.jl:63 [inlined]
 └ @ Core OutputCollector.jl:63
@@ -460,10 +460,10 @@ It should be pointed out if two projects uses the same package at the same versi
 In order to create a new project, create a directory for it and then activate that directory to make it the "active project" which package operations manipulate:
 
 ```
-shell> mkdir MyProject
+julia> mkdir("MyProject")
 
-shell> cd MyProject
-/Users/kristoffer/MyProject
+julia> cd("MyProject")
+/Users/UserName/MyProject
 
 (v1.0) pkg> activate .
 
@@ -474,36 +474,80 @@ shell> cd MyProject
 Note that the REPL prompt changed when the new project is activated. Since this is a newly created project, the status command show it contains no packages, and in fact, it has no project or manifest file until we add a package to it:
 
 ```
-shell> ls -l
-total 0
+julia> readdir()
+0-element Array{String,1}
 
 (MyProject) pkg> add Example
-  Updating registry at `~/.julia/registries/General`
-  Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Resolving package versions...
+ Installed Example ─ v0.5.1
   Updating `Project.toml`
   [7876af07] + Example v0.5.1
   Updating `Manifest.toml`
   [7876af07] + Example v0.5.1
+  [2a0f44e3] + Base64
+  [8ba89e20] + Distributed
+  [b77e0a4c] + InteractiveUtils
+  [8f399da3] + Libdl
+  [37e2e46d] + LinearAlgebra
+  [56ddb016] + Logging
+  [d6f4376e] + Markdown
+  [9a3f8284] + Random
+  [9e88b42a] + Serialization
+  [6462fe0b] + Sockets
   [8dfed614] + Test
 
-shell> ls -l
-total 8
--rw-r--r-- 1 stefan staff 207 Jul  3 16:35 Manifest.toml
--rw-r--r-- 1 stefan staff  56 Jul  3 16:35 Project.toml
+julia> readdir()
+2-element Array{String,1}:
+ "Manifest.toml"
+ "Project.toml"
 
-shell> cat Project.toml
+julia> print(read("Project.toml",String))
 [deps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 
-shell> cat Manifest.toml
+> print(read("Manifest.toml",String))
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
 [[Example]]
 deps = ["Test"]
-git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
-uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
 version = "0.5.1"
 
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
 [[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ```
 
@@ -548,7 +592,7 @@ To generate files for a new package, use `pkg> generate`.
 This creates a new project `HelloWorld` with the following files (visualized with the external [`tree` command](https://linux.die.net/man/1/tree)):
 
 ```jl
-shell> cd HelloWorld
+julia> cd("HelloWorld")
 
 shell> tree .
 .
@@ -640,21 +684,21 @@ The build step is executed the first time a package is installed or when explici
 A package is built by executing the file `deps/build.jl`.
 
 ```
-shell> cat deps/build.log
+julia> print(read("deps/build.log",String))
 I am being built...
 
 (HelloWorld) pkg> build
   Building HelloWorld → `deps/build.log`
  Resolving package versions...
 
-shell> cat deps/build.log
+julia> print(read("deps/build.log",String))
 I am being built...
 ```
 
 If the build step fails, the output of the build step is printed to the console
 
 ```
-shell> cat deps/build.jl
+julia> print(read("deps/build.log",String))
 error("Ooops")
 
 (HelloWorld) pkg> build
@@ -679,7 +723,7 @@ error("Ooops")
 When a package is tested the file `test/runtests.jl` is executed.
 
 ```
-shell> cat test/runtests.jl
+julia> print(read("test/runtests.jl",String))
 println("Testing...")
 (HelloWorld) pkg> test
    Testing HelloWorld
@@ -707,7 +751,7 @@ test = ["Test"]
 We can now use `Test` in the test script and we can see that it gets installed on testing:
 
 ```
-shell> cat test/runtests.jl
+julia> print(read("test/runtests.jl",String))
 using Test
 @test 1 == 1
 


### PR DESCRIPTION
It's a little disconcerting that if someone wants to run the Pkg docs but are using Windows they get an error.

```
shell> mkdir MyPackage
ERROR: IOError: could not spawn `mkdir MyPackage`: no such file or directory (ENOENT)
Stacktrace:
 [1] _jl_spawn(::String, ::Array{String,1}, ::Cmd, ::Tuple{RawFD,RawFD,RawFD}) at .\process.jl:367
 [2] (::getfield(Base, Symbol("##495#496")){Cmd})(::Tuple{RawFD,RawFD,RawFD}) at .\process.jl:509
 [3] setup_stdio(::getfield(Base, Symbol("##495#496")){Cmd}, ::Tuple{RawFD,RawFD,RawFD}) at .\process.jl:490
 [4] #_spawn#494(::Nothing, ::Function, ::Cmd, ::Tuple{RawFD,RawFD,RawFD}) at .\process.jl:508
 [5] _spawn at .\process.jl:504 [inlined]
 [6] #run#505(::Bool, ::Function, ::Cmd) at .\process.jl:652
 [7] run at .\process.jl:651 [inlined]
 [8] repl_cmd(::Cmd, ::REPL.Terminals.TTYTerminal) at .\client.jl:77
 [9] top-level scope at none:0
```

Instead of using shell commands, these docs should just be using Julia code so that it's not OS-specific since right now it assumes that the reader is using a shell that matches standard Linux.
