### PR TITLE
Make package files read-only for Pkg.add

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -61,7 +61,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
     any(pkg -> Types.collides_with_project(ctx.env, pkg), pkgs) &&
         pkgerror("Cannot $mode package with the same name or uuid as the project")
 
-    Operations.add_or_develop(ctx, pkgs; new_git=new_git)
+    Operations.add_or_develop(ctx, pkgs; new_git=new_git, mode=mode)
     ctx.preview && preview_info()
     return
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -59,6 +59,17 @@ function load_package_data_raw(T::Type, path::String)
     return data
 end
 
+function set_readonly(path)
+    for (root, dirs, files) in walkdir(path)
+        for file in files
+            filepath = joinpath(root, file)
+            fmode = filemode(filepath)
+            chmod(filepath, fmode & (typemax(fmode) ⊻ 0o222))
+        end
+    end
+    return nothing
+end
+
 #######################################
 # Dependency gathering and resolution #
 #######################################
@@ -534,12 +545,12 @@ function install_git(
 end
 
 # install & update manifest
-function apply_versions(ctx::Context, pkgs::Vector{PackageSpec})::Vector{UUID}
+function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}; mode=:add)::Vector{UUID}
     hashes, urls = version_data!(ctx, pkgs)
-    apply_versions(ctx, pkgs, hashes, urls)
+    apply_versions(ctx, pkgs, hashes, urls; mode=mode)
 end
 
-function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UUID,SHA1}, urls::Dict{UUID,Vector{String}})
+function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UUID,SHA1}, urls::Dict{UUID,Vector{String}}; mode=:add)
     BinaryProvider.probe_platform_engines!()
     new_versions = UUID[]
 
@@ -582,6 +593,9 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
                 end
                 try
                     success = install_archive(urls[pkg.uuid], hashes[pkg.uuid], path)
+                    if success && mode == :add
+                        set_readonly(path) # In add mode, files should be read-only
+                    end
                     if ctx.use_only_tarballs_for_downloads && !success
                         pkgerror("failed to get tarball from $(urls[pkg.uuid])")
                     end
@@ -614,6 +628,9 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
         uuid = pkg.uuid
         if !ctx.preview
             install_git(ctx, pkg.uuid, pkg.name, hashes[uuid], urls[uuid], pkg.version::VersionNumber, path)
+            if mode == :add
+                set_readonly(path)
+            end
         end
         vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
         @info "Installed $(rpad(pkg.name * " ", max_name + 2, "─")) $vstr"
@@ -1162,7 +1179,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     write_env(ctx)
 end
 
-function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID[])
+function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID[], mode=:add)
     # copy added name/UUIDs into project
     for pkg in pkgs
         ctx.env.project["deps"][pkg.name] = string(pkg.uuid)
@@ -1182,7 +1199,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID[
     end
     # resolve & apply package versions
     resolve_versions!(ctx, pkgs)
-    new_apply = apply_versions(ctx, pkgs)
+    new_apply = apply_versions(ctx, pkgs; mode=mode)
     write_env(ctx) # write env before building
     build_versions(ctx, union(new_apply, new_git))
 end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -126,6 +126,7 @@ temp_pkg_dir() do project_path
         Pkg.add(TEST_PKG.name)
         @test isinstalled(TEST_PKG)
         @eval import $(Symbol(TEST_PKG.name))
+        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
         Pkg.rm(TEST_PKG.name; preview = true)
         @test isinstalled(TEST_PKG)
         Pkg.rm(TEST_PKG.name)
@@ -318,6 +319,8 @@ temp_pkg_dir() do project_path
     @testset "libgit2 downloads" begin
         Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
         @test haskey(Pkg.installed(), TEST_PKG.name)
+        @eval import $(Symbol(TEST_PKG.name))
+        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
         Pkg.rm(TEST_PKG.name)
     end
 


### PR DESCRIPTION
Closes #32.

Test fail for me locally with a JSON error, but hopefully that's just because an existing JSON installation or something. Tests passed at https://github.com/JuliaLang/julia/pull/29439, for whatever that is worth.

Error:
```julia
ERROR: LoadError: LoadError: LoadError: Unsatisfiable requirements detected for package JSON [682c06a0]:
 JSON [682c06a0] log:
 ├─possible versions are: [0.1.0-0.1.1, 0.2.0-0.2.4, 0.3.0-0.3.9, 0.4.0-0.4.6, 0.5.0-0.5.4, 0.6.0-0.6.1, 0.7.0-0.7.1, 0.8.0-0.8.3, 0.9.0-0.9.1, 0.10.0, 0.11.0, 0.12.0, 0.13.0, 0.14.0, 0.15.0-0.15.2, 0.16.0-0.16.4, 0.17.1-0.17.2, 0.18.0, 0.19.0] or uninstalled
 ├─restricted to versions 0.16.0-0.16 by an explicit requirement, leaving only versions 0.16.0-0.16.4
 └─restricted by julia compatibility requirements to versions: [0.18.0, 0.19.0] or uninstalled — no versions left
```