### PR TITLE
Add an environment variable to control concurrency

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -355,6 +355,8 @@ Base.@kwdef mutable struct Context
     preview::Bool = false
     use_libgit2_for_all_downloads::Bool = false
     use_only_tarballs_for_downloads::Bool = false
+    # NOTE: The JULIA_PKG_CONCURRENCY environment variable is likely to be removed in
+    # the future. It currently stands as an unofficial workaround for issue #795.
     num_concurrent_downloads::Int = get(ENV, "JULIA_PKG_CONCURRENCY", 8)
     graph_verbose::Bool = false
     stdlibs::Dict{UUID,String} = gather_stdlib_uuids()

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -357,7 +357,7 @@ Base.@kwdef mutable struct Context
     use_only_tarballs_for_downloads::Bool = false
     # NOTE: The JULIA_PKG_CONCURRENCY environment variable is likely to be removed in
     # the future. It currently stands as an unofficial workaround for issue #795.
-    num_concurrent_downloads::Int = get(ENV, "JULIA_PKG_CONCURRENCY", 8)
+    num_concurrent_downloads::Int = haskey(ENV, "JULIA_PKG_CONCURRENCY") ? parse(Int, ENV["JULIA_PKG_CONCURRENCY"]) : 8
     graph_verbose::Bool = false
     stdlibs::Dict{UUID,String} = gather_stdlib_uuids()
     # Remove next field when support for Pkg2 CI scripts is removed

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -355,7 +355,7 @@ Base.@kwdef mutable struct Context
     preview::Bool = false
     use_libgit2_for_all_downloads::Bool = false
     use_only_tarballs_for_downloads::Bool = false
-    num_concurrent_downloads::Int = 8
+    num_concurrent_downloads::Int = get(ENV, "JULIA_PKG_CONCURRENCY", 8)
     graph_verbose::Bool = false
     stdlibs::Dict{UUID,String} = gather_stdlib_uuids()
     # Remove next field when support for Pkg2 CI scripts is removed

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -528,6 +528,12 @@ end
     @test Pkg.Types.pathrepr(path) == "`@stdlib/Test`"
 end
 
+@testset "Set download concurrency" begin
+    withenv("JULIA_PKG_CONCURRENCY" => 1) do
+        ctx = Pkg.Types.Context()
+        @test ctx.num_concurrent_downloads == 1
+    end
+end
 
 temp_pkg_dir() do project_path
     @testset "Pkg.add should not mutate" begin


### PR DESCRIPTION
This adds an environment variable, tentatively called `JULIA_PKG_CONCURRENCY`, which allows the user to control the number of concurrent downloads that Pkg uses when installing packages, using the previous default of 8 if the variable is not specified.

Setting the number of concurrent downloads to 1 using this variable provides a temporary workaround for #795.

Currently this PR does not document the variable. Suggestions for where that documentation should live would be welcome.