### PR TITLE
WIP/RFH: Download packages from GitLab as tarballs

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -620,9 +620,10 @@ end
 """
     setprotocol!(proto::Union{Nothing, AbstractString}=nothing)
 
-Set the protocol used to access GitHub-hosted packages when `add`ing a url or `develop`ing a package.
+Set the protocol used to access packages hosted on GitHub or GitLab when `add`ing a url or
+`develop`ing a package.
 Defaults to delegating the choice to the package developer (`proto == nothing`).
-Other choices for `proto` are `"https` or `git`.
+Other choices for `proto` are `"https"` or `"git"`.
 """
 setprotocol!(proto::Union{Nothing, AbstractString}=nothing) = GitTools.setprotocol!(proto)
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -463,7 +463,12 @@ function install_archive(
         if archive_url != nothing
             path = tempname() * randstring(6) * ".tar.gz"
             url_success = true
-            cmd = BinaryProvider.gen_download_cmd(archive_url, path);
+            cmd = BinaryProvider.gen_download_cmd(archive_url, path)
+            @show cmd
+            # Workaround PowerShell decoding '%2F' (GitLab requires encoded '/')
+            if occursin("powershell", cmd.exec[1])
+                cmd = BinaryProvider.gen_download_cmd(replace(archive_url, "%" => "%25"), path)
+            end
             @show cmd
             try
                 run(cmd, (devnull, devnull, devnull))

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -469,6 +469,7 @@ function install_archive(
                 run(cmd, (devnull, devnull, devnull))
                 println("Downloaded tarball.")
             catch e
+                @show e
                 e isa InterruptException && rethrow(e)
                 url_success = false
             end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -438,8 +438,12 @@ end
 # Package installation #
 ########################
 function get_archive_url_for_version(url::String, ref)
-    if (m = match(r"https://github.com/(.*?)/(.*?).git", url)) != nothing
+    if (m = match(r"https://github.com/(.*?)/(.*?).git", url)) !== nothing
         return "https://api.github.com/repos/$(m.captures[1])/$(m.captures[2])/tarball/$(ref)"
+    elseif (m = match(r"https://gitlab([^/]+)/(.*?)/(.*?).git", url)) !== nothing
+        host, org, proj = m.captures
+        proj = replace(proj, "." => "%2E")
+        return "https://gitlab$(host)/api/v4/projects/$(org)%2F$(proj)/repository/archive?sha=$(ref)"
     end
     return nothing
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -443,7 +443,7 @@ function get_archive_url_for_version(url::String, ref)
     elseif (m = match(r"https://gitlab([^/]+)/(.*?)/(.*?).git", url)) !== nothing
         host, org, proj = m.captures
         proj = replace(proj, "." => "%2E")
-        return "https://gitlab$(host)/api/v4/projects/$(org)%2F$(proj)/repository/archive?sha=$(ref)"
+        return "https://gitlab$(host)/api/v4/projects/$(org)%2F$(proj)/repository/archive?tree=$(ref)"
     end
     return nothing
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -459,12 +459,15 @@ function install_archive(
 )::Bool
     for url in urls
         archive_url = get_archive_url_for_version(url, hash)
+        @show archive_url
         if archive_url != nothing
             path = tempname() * randstring(6) * ".tar.gz"
             url_success = true
             cmd = BinaryProvider.gen_download_cmd(archive_url, path);
+            @show cmd
             try
                 run(cmd, (devnull, devnull, devnull))
+                println("Downloaded tarball.")
             catch e
                 e isa InterruptException && rethrow(e)
                 url_success = false
@@ -473,9 +476,12 @@ function install_archive(
             dir = joinpath(tempdir(), randstring(12))
             mkpath(dir)
             cmd = BinaryProvider.gen_unpack_cmd(path, dir);
+            @show cmd
+
             # Might fail to extract an archive (Pkg#190)
             try
                 run(cmd, (devnull, devnull, devnull))
+                println("Unpacked tarball.")
             catch e
                 e isa InterruptException && rethrow(e)
                 @warn "failed to extract archive downloaded from $(archive_url)"
@@ -597,6 +603,9 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
                     continue
                 end
                 try
+                    @show urls[pkg.uuid]
+                    @show hashes[pkg.uuid]
+                    @show path
                     success = install_archive(urls[pkg.uuid], hashes[pkg.uuid], path)
                     if success && mode == :add
                         set_readonly(path) # In add mode, files should be read-only

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -331,7 +331,8 @@ const PackageSpec = Types.PackageSpec
 """
     Pkg.setprotocol!(proto::Union{Nothing, AbstractString}=nothing)
 
-Set the protocol used to access GitHub-hosted packages when `add`ing a url or `develop`ing a package.
+Set the protocol used to access packages hosted on GitHub or GitLab when `add`ing a url or
+`develop`ing a package.
 Defaults to 'https', with `proto == nothing` delegating the choice to the package developer.
 """
 const setprotocol! = API.setprotocol!

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -544,6 +544,16 @@ temp_pkg_dir() do project_path
     end
 end
 
+@testset "Pkg.add tarballs from GitLab" begin
+    glreg = joinpath(first(DEPOT_PATH), "registries", "GitLabExampleRegistry")
+    close(LibGit2.clone("https://gitlab.com/ararslan/GitLabExampleRegistry", glreg))
+    Pkg.update()
+    Pkg.add("GitLabExample", use_only_tarballs_for_downloads=true)
+    @test Pkg.API.__installed()["GitLabExample"] == v"0.1.0"
+    Pkg.rm("GitLabExample")
+    rm(joinpath(glreg), force=true, recursive=true)
+end
+
 include("repl.jl")
 include("api.jl")
 


### PR DESCRIPTION
When a URL is recognized to be GitLab, we can use their API to download a tarball like we do with GitHub. This avoids having to download entire Git repos for GitLab-hosted packages.

Note however that self-hosted GitLab instances don't necessarily have to have "gitlab" in their URLs, but those that do typically start with "gitlab," so it provides a reasonable heuristic. For testing purposes, I've made a registry and an example package in my personal GitLab account on GitLab's public server: https://gitlab.com/ararslan/GitLabExampleRegistry and https://gitlab.com/ararslan/GitLabExample.jl.

~~As it stands, this PR doesn't test that a tarball is actually being used as opposed to a Git repo. Any suggestions for how best to do that would be welcome.~~ I _think_ what I have now should do it.