### PR TITLE
Expand symlinks in find_project_file.

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -256,7 +256,7 @@ function find_project_file(env::Union{Nothing,String}=nothing)
     @assert project_file isa String &&
         (isfile(project_file) || !ispath(project_file) ||
          isdir(project_file) && isempty(readdir(project_file)))
-     return project_file
+    return safe_realpath(project_file)
 end
 
 mutable struct EnvCache

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -284,7 +284,8 @@ temp_pkg_dir() do project_path
 
     @testset "check logging" begin
         usage = Pkg.TOML.parse(String(read(joinpath(Pkg.logdir(), "manifest_usage.toml"))))
-        @test any(x -> startswith(x, joinpath(project_path, "Manifest.toml")), keys(usage))
+        manifest = Types.safe_realpath(joinpath(project_path, "Manifest.toml"))
+        @test any(x -> startswith(x, manifest), keys(usage))
     end
 
     @testset "adding nonexisting packages" begin


### PR DESCRIPTION
I have symlinked `environments/v1.0` and`environments/v1.1` to `environments/v1`. #548 removed a call to `realpath` in `promptf` with the result that the symlink was shown in the prompt.

### Before #548
Note the expanded symlink in the prompt, but not for the project file.
```
(v1) pkg> st
    Status `~/.julia/environments/v1.0/Project.toml`
```

### After #548
None of the links expanded
```
(v1.0) pkg> st
    Status `~/.julia/environments/v1.0/Project.toml`
```
### After this PR
This PR restores the pre-#548 behavior (which I liked better) and additionally expands the symlink for the displayed path, the result with this PR is thus
```
(v1) pkg> st
    Status `~/.julia/environments/v1/Project.toml`
```

Opinions?