### PR TITLE
Structured Project data

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -64,8 +64,8 @@ function status(ctx::Context, args::Vector{PackageSpec}=PackageSpec[];
     end
     if mode == PKGMODE_PROJECT || mode == PKGMODE_COMBINED
         # TODO: handle project deps missing from manifest
-        m₀ = filter_manifest(in_project(project₀["deps"]), manifest₀)
-        m₁ = filter_manifest(in_project(project₁["deps"]), manifest₁)
+        m₀ = filter_manifest(in_project(project₀.deps), manifest₀)
+        m₁ = filter_manifest(in_project(project₁.deps), manifest₁)
         diff = manifest_diff(ctx, m₀, m₁)
         filter_pkgs && filter!(pkgfilter, diff)
         if !use_as_api
@@ -81,7 +81,7 @@ function status(ctx::Context, args::Vector{PackageSpec}=PackageSpec[];
             print_diff(ctx, diff, #=status=# true)
         end
     elseif mode == PKGMODE_COMBINED
-        p = not_in_project(merge(project₀["deps"], project₁["deps"]))
+        p = not_in_project(merge(project₀.deps, project₁.deps))
         m₀ = filter_manifest(p, manifest₀)
         m₁ = filter_manifest(p, manifest₁)
         c_diff = filter!(x->x.old != x.new, manifest_diff(ctx, m₀, m₁))
@@ -98,8 +98,8 @@ function status(ctx::Context, args::Vector{PackageSpec}=PackageSpec[];
 end
 
 function print_project_diff(ctx::Context, env₀::EnvCache, env₁::EnvCache)
-    pm₀ = filter_manifest(in_project(env₀.project["deps"]), env₀.manifest)
-    pm₁ = filter_manifest(in_project(env₁.project["deps"]), env₁.manifest)
+    pm₀ = filter_manifest(in_project(env₀.project.deps), env₀.manifest)
+    pm₁ = filter_manifest(in_project(env₁.project.deps), env₁.manifest)
     diff = filter!(x->x.old != x.new, manifest_diff(ctx, pm₀, pm₁))
     if isempty(diff)
         printstyled(color = color_dark, " [no changes]\n")
@@ -278,7 +278,7 @@ struct InProject{D <: Dict}
     neg::Bool
 end
 function (ip::InProject)(name::String, info::Dict)
-    v = haskey(ip.deps, name) && haskey(info, "uuid") && ip.deps[name] == info["uuid"]
+    v = haskey(ip.deps, name) && haskey(info, "uuid") && ip.deps[name] == UUID(info["uuid"])
     return ip.neg ? !v : v
 end
 in_project(deps::Dict) = InProject(deps, false)

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -927,7 +927,7 @@ function promptf()
                 nothing
             end
             if project !== nothing
-                projname = get(project, "name", nothing)
+                projname = project.name
                 if projname !== nothing
                     name = projname
                 else

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -7,6 +7,7 @@ using Random
 using Dates
 import LibGit2
 import REPL
+import Base.string
 using REPL.TerminalMenus
 
 using ..TOML
@@ -260,6 +261,20 @@ function find_project_file(env::Union{Nothing,String}=nothing)
     return safe_realpath(project_file)
 end
 
+Base.@kwdef mutable struct Project
+    raw::Dict{String,Any} = Dict{String,Any}()
+    # Fields
+    name::Union{String, Nothing} = nothing
+    uuid::Union{UUID, Nothing} = nothing
+    version::Union{VersionTypes, Nothing} = nothing
+    manifest::Union{String, Nothing} = nothing
+    # Sections
+    deps::Dict{String,UUID} = Dict{String,UUID}()
+    extras::Dict{String,UUID} = Dict{String,UUID}()
+    targets::Dict{String,Vector{String}} = Dict{String,Vector{String}}()
+    compat::Dict{String,String} = Dict{String,String}()# TODO Dict{String, VersionSpec}
+end
+
 mutable struct EnvCache
     # environment info:
     env::Union{Nothing,String}
@@ -273,7 +288,7 @@ mutable struct EnvCache
     pkg::Union{PackageSpec, Nothing}
 
     # cache of metadata:
-    project::Dict
+    project::Project
     manifest::Dict
 
     # registered package info:
@@ -286,24 +301,25 @@ function EnvCache(env::Union{Nothing,String}=nothing)
     project_file = find_project_file(env)
     project_dir = dirname(project_file)
     git = ispath(joinpath(project_dir, ".git")) ? project_dir : nothing
-
+    # read project file
     project = read_project(project_file)
-    if any(haskey.((project,), ["name", "uuid", "version"]))
+    # initiaze project package
+    if any(x -> x !== nothing, [project.name, project.uuid, project.version])
         project_package = PackageSpec(
-            get(project, "name", ""),
-            UUID(get(project, "uuid", 0)),
-            VersionNumber(get(project, "version", "0.0")),
+            something(project.name, ""),
+            something(project.uuid, UUID(0)),
+            something(project.version, VersionNumber("0.0")),
         )
     else
         project_package = nothing
     end
-    # determine manifest_file name
-    dir = abspath(dirname(project_file))
-    manifest_file = haskey(project, "manifest") ?
-        abspath(project["manifest"]) :
+    # determine manifest file
+    dir = abspath(project_dir)
+    manifest_file = project.manifest !== nothing ?
+        abspath(project.manifest) :
         manifestfile_path(dir)
     # use default name if still not determined
-    (manifest_file === nothing) && (manifest_file = joinpath(dir, "Manifest.toml"))
+    manifest_file = something(manifest_file, joinpath(dir, "Manifest.toml"))
     write_env_usage(manifest_file)
     manifest = read_manifest(manifest_file)
     uuids = Dict{String,Vector{UUID}}()
@@ -384,20 +400,24 @@ end
 # target === "*"     : main + all extras
 # target === "name"  : named target deps
 
-function deps_names(project::Dict, target::Union{Nothing,String}=nothing)::Vector{String}
-    deps = sort!(collect(keys(project["deps"])))
-    target == "*" && return !haskey(project, "extras") ? deps :
-        sort!(union!(deps, collect(keys(project["extras"]))))
-    haskey(project, "targets") || return deps
-    targets = project["targets"]
-    haskey(targets, target) || return deps
-    return sort!(union!(deps, targets[target]))
+function deps_names(project::Project, target::Union{Nothing,String}=nothing)::Vector{String}
+    deps = collect(keys(project.deps))
+    if target === nothing
+        x = String[]
+    elseif target == "*"
+        x = collect(keys(project.extras))
+    else
+        x = haskey(project.targets, target) ?
+            collect(values(project.targets[target])) :
+            String[]
+    end
+    return sort!(union!(deps, x))
 end
 
-function get_deps(project::Dict, target::Union{Nothing,String}=nothing)
+function get_deps(project::Project, target::Union{Nothing,String}=nothing)
     names = deps_names(project, target)
-    deps = filter(((dep, _),) -> dep in names, project["deps"])
-    extras = get(project, "extras", Dict{String,Any}())
+    deps = filter(((dep, _),) -> dep in names, project.deps)
+    extras = project.extras
     for name in names
         haskey(deps, name) && continue
         haskey(extras, name) ||
@@ -412,13 +432,12 @@ get_deps(ctx::Context, target::Union{Nothing,String}=nothing) =
     get_deps(ctx.env, target)
 
 function project_compatibility(ctx::Context, name::String)
-    v = VersionSpec()
-    project = ctx.env.project
-    compat = get(project, "compat", Dict())
-    if haskey(compat, name)
-        v = VersionSpec(semver_spec(compat[name]))
+    compat = get(ctx.env.project.compat, name, nothing)
+    if compat === nothing
+        return VersionSpec()
+    else
+        return VersionSpec(semver_spec(compat))
     end
-    return v
 end
 
 function write_env_usage(manifest_file::AbstractString)
@@ -433,25 +452,74 @@ function write_env_usage(manifest_file::AbstractString)
     close(io)
 end
 
-function read_project(io::IO)
-    project = TOML.parse(io)
-    if !haskey(project, "deps")
-        project["deps"] = Dict{String,Any}()
+function Project(raw::Dict)
+    project = Project()
+    project.raw = raw
+    # Name
+    project.name = get(raw, "name", nothing)
+    # UUID
+    uuid = get(raw, "uuid", nothing)
+    uuid !== nothing && (project.uuid = UUID(uuid))
+    # Version
+    version = get(raw, "version", nothing)
+    version !== nothing && (project.version = VersionNumber(version))
+    # Manifest
+    project.manifest = get(raw, "manifest", nothing)
+    # DEPS
+    deps = get(raw, "deps", nothing)
+    if deps !== nothing
+        for (name, uuid) in deps
+            project.deps[name] = UUID(uuid)
+        end
     end
+    # EXTRAS
+    extras = get(raw, "extras", nothing)
+    if extras !== nothing
+        for (name, uuid) in extras
+            project.extras[name] = UUID(uuid)
+        end
+    end
+    # COMPAT
+    compat = get(raw, "compat", nothing)
+    if compat !== nothing
+        for (name, version) in compat
+            project.compat[name] = version # TODO semver_spec(version)
+        end
+    end
+    # TARGETS
+    targets = get(raw, "targets", nothing)
+    if targets !== nothing
+        for (target, deps) in targets
+            project.targets[target] = deps
+            # TODO make sure names in `project.targets[target]` make sense
+        end
+    end
+    # TODO make sure all targets are listed in extras
+    # TODO any other validation
+    # validate(project)
     return project
 end
-function read_project(file::String)
-    isfile(file) ? open(read_project, file) : read_project(devnull)
+
+function read_project(filename::String)
+    !isfile(filename) && return Project()
+    raw = nothing
+    try
+        raw = TOML.parse(open(filename))
+    catch err
+        err isa TOML.ParserError || rethrow()
+        pkgerror("Could not parse project file at `$filename`: $(err.msg)")
+    end
+    return Project(raw)
 end
 
-_throw_package_err(x, f) = pkgerror("expected a `$x` entry in project file at $(abspath(f))")
 function read_package(f::String)
+    _throw_package_err(x) = pkgerror("expected a `$x` entry in project file at $(abspath(f))")
+
     project = read_project(f)
-    haskey(project, "name") || _throw_package_err("name", f)
-    haskey(project, "uuid") || _throw_package_err("uuid", f)
-    name = project["name"]
-    entry = joinpath(dirname(f), "src", "$name.jl")
-    if !isfile(entry)
+    project.name === nothing && _throw_package_err("name")
+    project.uuid === nothing && _throw_package_err("uuid")
+    name = project.name
+    if !isfile(joinpath(dirname(f), "src", "$name.jl"))
         pkgerror("expected the file `src/$name.jl` to exist for package $name at $(dirname(f))")
     end
     return project
@@ -690,6 +758,9 @@ function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec};
             if !folder_already_downloaded
                 version_path = Pkg.Operations.find_installed(pkg.name, pkg.uuid, pkg.repo.git_tree_sha1)
                 mkpath(version_path)
+                @static if Sys.iswindows()
+                    Base.GC.gc()
+                end
                 mv(project_path, version_path; force=true)
                 push!(new_uuids, pkg.uuid)
             end
@@ -707,8 +778,8 @@ function parse_package!(ctx, pkg, project_path)
     project_file = projectfile_path(project_path)
     if project_file !== nothing
         project_data = read_package(project_file)
-        pkg.uuid = UUID(project_data["uuid"])
-        pkg.name = project_data["name"]
+        pkg.uuid = project_data.uuid
+        pkg.name = project_data.name
     else
         if !isempty(ctx.old_pkg2_clone_name) # remove when legacy CI script support is removed
             pkg.name = ctx.old_pkg2_clone_name
@@ -792,14 +863,14 @@ end
 
 # Disambiguate name/uuid package specifications using project info.
 function project_deps_resolve!(env::EnvCache, pkgs::AbstractVector{PackageSpec})
-    uuids = env.project["deps"]
+    uuids = env.project.deps
     names = Dict(uuid => name for (name, uuid) in uuids)
     length(uuids) < length(names) && # TODO: handle this somehow?
         pkgerror("duplicate UUID found in project file's [deps] section")
     for pkg in pkgs
         pkg.mode == PKGMODE_PROJECT || continue
         if has_name(pkg) && !has_uuid(pkg) && pkg.name in keys(uuids)
-            pkg.uuid = UUID(uuids[pkg.name])
+            pkg.uuid = uuids[pkg.name]
         end
         if has_uuid(pkg) && !has_name(pkg) && pkg.uuid in keys(names)
             pkg.name = names[pkg.uuid]
@@ -1183,8 +1254,8 @@ function find_registered!(env::EnvCache,
         uuid in uuids || haskey(env.paths, uuid) || push!(uuids, uuid)
 
     # lookup any dependency in the project file
-    for (name, uuid) in env.project["deps"]
-        save(name); save(UUID(uuid))
+    for (name, uuid) in env.project.deps
+        save(name); save(uuid)
     end
     # lookup anything mentioned in the manifest file
     for (name, infos) in env.manifest, info in infos
@@ -1351,13 +1422,37 @@ function project_key_order(key::String)
     return 8
 end
 
+string(x::Vector{String}) = x
+
+function destructure(project::Project)::Dict
+    raw = project.raw
+    function entry!(key::String, src::Dict)
+        if isempty(src)
+            delete!(raw, key)
+        else
+            raw[key] = Dict(string(k) => string(v) for (k,v) in src)
+        end
+    end
+    entry!(key::String, src) = src === nothing ? delete!(raw, key) : (raw[key] = string(src))
+
+    entry!("name", project.name)
+    entry!("uuid", project.uuid)
+    entry!("version", project.version)
+    entry!("manifest", project.manifest)
+    entry!("deps", project.deps)
+    entry!("extras", project.extras)
+    entry!("compat", project.compat)
+    entry!("targets", project.targets)
+    return raw
+end
+
 function write_env(ctx::Context; display_diff=true)
     env = ctx.env
     # load old environment for comparison
     old_env = EnvCache(env.env)
     # update the project file
     project = deepcopy(env.project)
-    isempty(project["deps"]) && delete!(project, "deps")
+    project = destructure(project)
     if !isempty(project) || ispath(env.project_file)
         if display_diff && !(ctx.currently_running_target)
             printpkgstyle(ctx, :Updating, pathrepr(env.project_file))

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -512,15 +512,13 @@ temp_pkg_dir() do project_path
 end
 
 @testset "dependency of test dependency (#567)" begin
-    mktempdir() do tmpdir
-        temp_pkg_dir() do project_path; cd(tmpdir) do; with_temp_env() do
-            for x in ["x1", "x2", "x3"]
-                cp(joinpath(@__DIR__, "test_packages/$x"), joinpath(tmpdir, "$x"))
-                Pkg.develop(Pkg.PackageSpec(url = joinpath(tmpdir, x)))
-            end
-            Pkg.test("x3")
-        end end end
-    end
+    temp_pkg_dir() do project_path; cd_tempdir(;rm=false) do tmpdir; with_temp_env(;rm=false) do
+        for x in ["x1", "x2", "x3"]
+            cp(joinpath(@__DIR__, "test_packages/$x"), joinpath(tmpdir, "$x"))
+            Pkg.develop(Pkg.PackageSpec(url = joinpath(tmpdir, x)))
+        end
+        Pkg.test("x3")
+    end end end
 end
 
 @testset "printing of stdlib paths, issue #605" begin

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -14,6 +14,7 @@ include("utils.jl")
 function git_init_package(tmp, path)
     base = basename(path)
     pkgpath = joinpath(tmp, base)
+    println("git initing package at [$pkgpath]")
     cp(path, pkgpath)
     LibGit2.with(LibGit2.init(pkgpath)) do repo
         LibGit2.add!(repo, "*")
@@ -88,7 +89,9 @@ end
     @test statement.arguments[2] == "@0.5.0"
 end
 
-temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
+temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
+    tmp_pkg_path = mktempdir()
+
     pkg"activate ."
     pkg"add Example@0.5"
     @test isinstalled(TEST_PKG)
@@ -171,10 +174,8 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
         end # cd_tempdir
     end # withenv
     end # mktempdir
-end # mktempdir
 end # cd
 end # temp_pkg_dir
-
 
 temp_pkg_dir() do project_path; cd(project_path) do
     mktempdir() do tmp
@@ -367,7 +368,7 @@ end
 # Autocompletions
 temp_pkg_dir() do project_path; cd(project_path) do
     @testset "tab completion" begin
-        Pkg.Types.collect_registries()
+        pkg"registry add General" # instantiate the `General` registry to complete remote package names
         pkg"activate ."
         c, r = test_complete("add Exam")
         @test "Example" in c


### PR DESCRIPTION
Data flow:
`read_project`: file -> raw Dict 
`Project`: raw Dict -> Project struct
[Pkg Operations]
`destructure`: Project struct -> raw Dict
`write_env`: raw Dict -> file

A small step in the right direction I hope. It should at least be clear where we expect `String` data v typed data. And it should reduce the number of overall data conversions (e.g. no `UUID(uuid)` all over the place).

I left the `compat` as a `Dict{String,String}` (and not `Dict{String,VersionSpec}`) because `String` -> `VersionSpec` is a many-to-one mapping (I think).

