### PR TITLE
Turn of inlining when computing coverage (WIP)

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -254,7 +254,7 @@ test(pkg::Union{String, PackageSpec}; kwargs...)  = test([pkg]; kwargs...)
 test(pkgs::Vector{String}; kwargs...)             = test([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
 test(pkgs::Vector{PackageSpec}; kwargs...)        = test(Context(), pkgs; kwargs...)
 
-function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...)
+function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, inline=nothing, kwargs...)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
@@ -270,7 +270,11 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...
     if !ctx.preview && (Operations.any_package_not_installed(ctx) || !isfile(ctx.env.manifest_file))
         Pkg.instantiate(ctx)
     end
-    Operations.test(ctx, pkgs; coverage=coverage)
+    if inline == nothing
+        # by default, allow inline for normal tests, and forbid it for coverage tests
+        inline = !coverage
+    end
+    Operations.test(ctx, pkgs; coverage=coverage, inline=inline)
     return
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1280,7 +1280,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec})
     need_to_resolve && build_versions(ctx, new)
 end
 
-function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
+function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, inline=true)
     # See if we can find the test files for all packages
     missing_runtests = String[]
     testfiles        = String[]
@@ -1333,6 +1333,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
             --color=$(Base.have_color ? "yes" : "no")
             --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
             --check-bounds=yes
+            --inline=$(inline ? "yes" : "no")
             --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
             --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])
             --eval $code

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -148,6 +148,10 @@ passing `coverage=true`. The default behavior is not to run coverage.
 
 The tests are executed in a new process with `check-bounds=yes` and by default `startup-file=no`.
 If using the startup file (`~/.julia/config/startup.jl`) is desired, start julia with `--startup-file=yes`.
+
+If computing coverage has been requested, by default the new process is given
+the option `--inline=no` to improve coverage computations. If that is not
+desired, it can be avoided by passing `inline=true` to `test`.
 """
 const test = API.test
 


### PR DESCRIPTION
It can also be explicitly turned on or off via the new keyword argument
`inline` for Pkg.test.

This is meant to resolve issue #865. I marked it as WIP as clearly this new option should be documented; but before spending time on that, I wanted to see if this approach was deemed acceptable at all.