### PR TITLE
Add completion support for `activate`

### DIFF
--- a/test/repl.jl
+++ b/test/repl.jl
@@ -451,6 +451,13 @@ temp_pkg_dir() do project_path; cd(project_path) do
         touch("README.md")
         c, r = test_complete("add RE")
         @test !("README.md" in c)
+
+        # activate
+        pkg"activate --shared FooBar"
+        pkg"add Example"
+        pkg"activate ."
+        c, r = test_complete("activate --shared ")
+        @test "FooBar" in c
     end # testset
 end end
 


### PR DESCRIPTION
Iterative path completion for `activate`. Also includes support for `activate --shared`.

Examples:
```
(Pkg) pkg> activate --shared 
foobar v1.0
(Pkg) pkg> activate /
sys/      opt/       root/      lib64/     lib/       mnt/       bin/       run/       var/       tmp/
nix/      boot/      usr/       proc/      home/      dev/       etc/       srv/       .emacs.d/  sbin/
```

Includes a small fix for #839.
Should resolve #834. 