### PR TITLE
Transfer can_inline to subprocess

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1333,6 +1333,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
             --color=$(Base.have_color ? "yes" : "no")
             --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
             --check-bounds=yes
+            --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
             --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
             --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])
             --eval $code

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -148,9 +148,8 @@ passing `coverage=true`. The default behavior is not to run coverage.
 
 The tests are executed in a new process with `check-bounds=yes` and by default `startup-file=no`.
 If using the startup file (`~/.julia/config/startup.jl`) is desired, start julia with `--startup-file=yes`.
-Note that the option `--inline=no` is passed  to the new process if that
-option was also given to the currently running Julia, i.e., if
-`Base.JLOptions().can_inline` is false.
+Inlining of functions during testing can be disabled (for better coverage accuracy)
+by starting julia with `--inline=no`.
 """
 const test = API.test
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -148,6 +148,9 @@ passing `coverage=true`. The default behavior is not to run coverage.
 
 The tests are executed in a new process with `check-bounds=yes` and by default `startup-file=no`.
 If using the startup file (`~/.julia/config/startup.jl`) is desired, start julia with `--startup-file=yes`.
+Note that the option `--inline=no` is passed  to the new process if that
+option was also given to the currently running Julia, i.e., if
+`Base.JLOptions().can_inline` is false.
 """
 const test = API.test
 


### PR DESCRIPTION
This is meant as an alternative to PR #866 for resolving issue #865