### PR TITLE
Replace trivial uses of rethrow(exc) with rethrow()

### DIFF
--- a/bin/gitmeta.jl
+++ b/bin/gitmeta.jl
@@ -85,7 +85,7 @@ function gitmeta(pkgs::Dict{String,Package})
             if !updated
                 try LibGit2.GitObject(repo, git_commit_hash)
                 catch err
-                    err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+                    err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
                     @info "Updating $pkg from $(p.url)"
                     LibGit2.fetch(repo, remoteurl=p.url, refspecs=["+refs/*:refs/remotes/cache/*"])
                 end
@@ -94,7 +94,7 @@ function gitmeta(pkgs::Dict{String,Package})
             git_commit = try LibGit2.GitObject(repo, git_commit_hash)
             catch err
                 failed = true
-                err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+                err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
                 @error("$pkg: git object $(v.sha1) could not be found")
             end
             failed && continue

--- a/src/API.jl
+++ b/src/API.jl
@@ -122,14 +122,14 @@ function update_registry(ctx)
                     try
                         GitTools.fetch(repo; refspecs=["+refs/heads/$branch:refs/remotes/origin/$branch"])
                     catch e
-                        e isa PkgError || rethrow(e)
+                        e isa PkgError || rethrow()
                         push!(errors, (reg, "failed to fetch from repo"))
                         @goto done
                     end
                     ff_succeeded = try
                         LibGit2.merge!(repo; branch="refs/remotes/origin/$branch", fastforward=true)
                     catch e
-                        e isa LibGit2.GitError && e.code == LibGit2.Error.ENOTFOUND || rethrow(e)
+                        e isa LibGit2.GitError && e.code == LibGit2.Error.ENOTFOUND || rethrow()
                         push!(errors, (reg, "branch origin/$branch not found"))
                         @goto done
                     end
@@ -137,7 +137,7 @@ function update_registry(ctx)
                     if !ff_succeeded
                         try LibGit2.rebase!(repo, "origin/$branch")
                         catch e
-                            e isa LibGit2.GitError || rethrow(e)
+                            e isa LibGit2.GitError || rethrow()
                             push!(errors, (reg, "registry failed to rebase on origin/$branch"))
                             @goto done
                         end

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -21,7 +21,7 @@ const color_dark = :light_black
 function git_file_stream(repo::LibGit2.GitRepo, spec::String; fakeit::Bool=false)::IO
     blob = try LibGit2.GitBlob(repo, spec)
     catch err
-        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
         fakeit && return devnull
     end
     iob = IOBuffer(LibGit2.content(blob))

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -99,7 +99,7 @@ function clone(url, source_path; header=nothing, kwargs...)
         return LibGit2.clone(url, source_path; callbacks=callbacks, kwargs...)
     catch err
         rm(source_path; force=true, recursive=true)
-        err isa LibGit2.GitError || rethrow(err)
+        err isa LibGit2.GitError || rethrow()
         if (err.class == LibGit2.Error.Net && err.code == LibGit2.Error.EINVALIDSPEC) ||
            (err.class == LibGit2.Error.Repository && err.code == LibGit2.Error.ENOTFOUND)
             Pkg.Types.pkgerror("Git repository not found at '$(url)'")
@@ -131,7 +131,7 @@ function fetch(repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kwargs.
     try
         return LibGit2.fetch(repo; remoteurl=remoteurl, callbacks=callbacks, kwargs...)
     catch err
-        err isa LibGit2.GitError || rethrow(err)
+        err isa LibGit2.GitError || rethrow()
         if (err.class == LibGit2.Error.Repository && err.code == LibGit2.Error.ERROR)
             Pkg.Types.pkgerror("Git repository not found at '$(remoteurl)'")
         else

--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -1079,7 +1079,7 @@ function deep_clean!(graph::Graph)
             try
                 propagate_constraints!(graph, Set{Int}([p0]), log_events = false)
             catch err
-                err isa ResolverError || rethrow(err)
+                err isa ResolverError || rethrow()
                 gconstr_msk[p0][v0] = false
             end
             pop_snapshot!(graph)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -462,7 +462,7 @@ function install_archive(
             try
                 run(cmd, (devnull, devnull, devnull))
             catch e
-                e isa InterruptException && rethrow(e)
+                e isa InterruptException && rethrow()
                 url_success = false
             end
             url_success || continue
@@ -473,7 +473,7 @@ function install_archive(
             try
                 run(cmd, (devnull, devnull, devnull))
             catch e
-                e isa InterruptException && rethrow(e)
+                e isa InterruptException && rethrow()
                 @warn "failed to extract archive downloaded from $(archive_url)"
                 url_success = false
             end
@@ -518,7 +518,7 @@ function install_git(
                     end
                     break # object was found, we can stop
                 catch err
-                    err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+                    err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
                 end
                 GitTools.fetch(repo, url, refspecs=refspecs, credentials=creds)
             end
@@ -527,7 +527,7 @@ function install_git(
         tree = try
             LibGit2.GitObject(repo, git_hash)
         catch err
-            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
             error("$name: git object $(string(hash)) could not be found")
         end
         tree isa LibGit2.GitTree ||
@@ -667,7 +667,7 @@ function find_stdlib_deps(ctx::Context, path::String)
             endswith(file, ".jl") || continue
             filecontent = try read(joinpath(root, file), String)
                 catch e
-                    e isa SystemError || rethrow(e)
+                    e isa SystemError || rethrow()
                     ""
                 end
             for ((uuid, stdlib), r) in zip(ctx.stdlibs, regexps)

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -533,7 +533,7 @@ function do_cmd(repl::REPL.AbstractREPL, input::String; do_rethrow=false)
         end
     catch err
         if do_rethrow
-            rethrow(err)
+            rethrow()
         end
         if err isa PkgError || err isa ResolverError
             Base.display_error(repl.t.err_stream, ErrorException(sprint(showerror, err)), Ptr{Nothing}[])

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -122,7 +122,7 @@ function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}(), verbose::B
         try
             simplify_graph_soft!(graph, Set{Int}([p0]), log_events = false)
         catch err
-            isa(err, ResolverError) || rethrow(err)
+            isa(err, ResolverError) || rethrow()
             @goto done
         end
 
@@ -220,7 +220,7 @@ function greedysolver(graph::Graph)
     try
         simplify_graph_soft!(graph, req_inds, log_events = false)
     catch err
-        err isa ResolverError || rethrow(err)
+        err isa ResolverError || rethrow()
         pop_snapshot!(graph)
         return (false, Int[])
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -476,7 +476,7 @@ end
 function read_manifest(file::String)
     try isfile(file) ? open(read_manifest, file) : read_manifest(devnull)
     catch err
-        err isa ErrorException && startswith(err.msg, "ambiguious dependency") || rethrow(err)
+        err isa ErrorException && startswith(err.msg, "ambiguious dependency") || rethrow()
         err.msg *= "In manifest file: $file"
         rethrow(err)
     end
@@ -755,18 +755,18 @@ function get_object_branch(repo, rev, creds)
         gitobject = LibGit2.GitObject(repo, "remotes/cache/heads/" * rev)
         isbranch = true
     catch err
-        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
     end
     if gitobject == nothing
         try
             gitobject = LibGit2.GitObject(repo, rev)
         catch err
-            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
             GitTools.fetch(repo; refspecs=refspecs, credentials=creds)
             try
                 gitobject = LibGit2.GitObject(repo, rev)
             catch err
-                err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
+                err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
                 pkgerror("git object $(rev) could not be found")
             end
         end

--- a/src/resolve/MaxSum.jl
+++ b/src/resolve/MaxSum.jl
@@ -350,7 +350,7 @@ function try_simplify_graph_soft!(graph, sources)
     try
         simplify_graph_soft!(graph, sources, log_events = false)
     catch err
-        err isa ResolverError || rethrow(err)
+        err isa ResolverError || rethrow()
         return false
     end
     return true
@@ -373,7 +373,7 @@ function converge!(graph::Graph, msgs::Messages, strace::SolutionTrace, perm::No
         try
             maxdiff = iterate!(graph, msgs, perm)
         catch err
-            err isa UnsatError || rethrow(err)
+            err isa UnsatError || rethrow()
             if is_best_sofar
                 p0 = err.p0
                 s0 = findlast(graph.gconstr[p0])


### PR DESCRIPTION
In all these cases we're merely rethrowing the existing exception, so it
seems simpler and clearer just to use `rethrow()` without arguments.

Companion to https://github.com/JuliaLang/julia/pull/29794