### PR TITLE
pkg> status SomePackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ New features
 ------------
 
 * Pkg now implements an interface for working with registries ([#588]).
+* `Pkg.status` and `pkg> status` now accept package arguments for
+  filtering of the output ([#881]).
 
 Bug fixes
 ----------
@@ -25,3 +27,4 @@ Deprecated or removed
 [#639]: https://github.com/JuliaLang/Pkg.jl/pull/639
 [#642]: https://github.com/JuliaLang/Pkg.jl/pull/642
 [#588]: https://github.com/JuliaLang/Pkg.jl/pull/588
+[#881]: https://github.com/JuliaLang/Pkg.jl/pull/881

--- a/src/API.jl
+++ b/src/API.jl
@@ -209,7 +209,7 @@ end
 
 installed() = __installed(PKGMODE_PROJECT)
 function __installed(mode::PackageMode=PKGMODE_MANIFEST)
-    diffs = Display.status(Context(), mode, #=use_as_api=# true)
+    diffs = Display.status(Context(), PackageSpec[], mode=mode, use_as_api=true)
     version_status = Dict{String, Union{VersionNumber,Nothing}}()
     diffs == nothing && return version_status
     for entry in diffs
@@ -500,11 +500,17 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing, kwarg
 end
 
 
-status(mode=PKGMODE_PROJECT) = status(Context(), mode)
-function status(ctx::Context, mode=PKGMODE_PROJECT)
-    Pkg.Display.status(ctx, mode)
-    return
+@deprecate status(mode::PackageMode) status(mode=mode)
+
+status(; mode=PKGMODE_PROJECT) = status(PackageSpec[]; mode=mode)
+status(pkg::Union{String,PackageSpec}; mode=PKGMODE_PROJECT) = status([pkg]; mode=mode)
+status(pkgs::Vector{String}; mode=PKGMODE_PROJECT) = status([check_package_name(pkg) for pkg in pkgs]; mode=mode)
+status(pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT) = status(Context(), pkgs; mode=mode)
+function status(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT)
+    Pkg.Display.status(ctx, pkgs, mode=mode)
+    return nothing
 end
+
 
 activate() = (Base.ACTIVE_PROJECT[] = nothing)
 function activate(path::String; shared::Bool=false)

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -29,11 +29,23 @@ function git_file_stream(repo::LibGit2.GitRepo, spec::String; fakeit::Bool=false
     return iob
 end
 
-function status(ctx::Context, mode::PackageMode, use_as_api=false)
+function status(ctx::Context, args::Vector{PackageSpec}=PackageSpec[];
+                mode::PackageMode=PKGMODE_PROJECT, use_as_api=false)
     env = ctx.env
     project₀ = project₁ = env.project
     manifest₀ = manifest₁ = env.manifest
     diff = nothing
+
+    pkgfilter = (diff) -> begin
+        for pkg in args
+            if has_uuid(pkg) ? pkg.uuid == diff.uuid : pkg.name == diff.name
+                return true
+            end
+        end
+        return false
+    end
+    filter_pkgs = length(args) > 0
+
     if !use_as_api
         pkg = ctx.env.pkg
         if pkg !== nothing
@@ -55,6 +67,7 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
         m₀ = filter_manifest(in_project(project₀["deps"]), manifest₀)
         m₁ = filter_manifest(in_project(project₁["deps"]), manifest₁)
         diff = manifest_diff(ctx, m₀, m₁)
+        filter_pkgs && filter!(pkgfilter, diff)
         if !use_as_api
             printpkgstyle(ctx, :Status, pathrepr(env.project_file), #=ignore_indent=# true)
             print_diff(ctx, diff, #=status=# true)
@@ -62,6 +75,7 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
     end
     if mode == PKGMODE_MANIFEST
         diff = manifest_diff(ctx, manifest₀, manifest₁)
+        filter_pkgs && filter!(pkgfilter, diff)
         if !use_as_api
             printpkgstyle(ctx, :Status, pathrepr(env.manifest_file), #=ignore_indent=# true)
             print_diff(ctx, diff, #=status=# true)
@@ -71,6 +85,7 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
         m₀ = filter_manifest(p, manifest₀)
         m₁ = filter_manifest(p, manifest₁)
         c_diff = filter!(x->x.old != x.new, manifest_diff(ctx, m₀, m₁))
+        filter_pkgs && filter!(pkgfilter, c_diff)
         if !isempty(c_diff)
             if !use_as_api
                 printpkgstyle(ctx, :Status, pathrepr(env.manifest_file), #=ignore_indent=# true)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1347,7 +1347,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
         end
         with_dependencies_loadable_at_toplevel(ctx, pkg; might_need_to_resolve=true) do localctx
             if !Types.is_project_uuid(ctx.env, pkg.uuid)
-                Display.status(localctx, PKGMODE_MANIFEST)
+                Display.status(localctx, mode=PKGMODE_MANIFEST)
             end
 
             run_test()

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -257,12 +257,13 @@ from packages that are tracking a path.
 const resolve = API.resolve
 
 """
-    Pkg.status(mode::PackageMode=PKGMODE_PROJECT)
+    Pkg.status([pkgs...]; mode::PackageMode=PKGMODE_PROJECT)
 
 Print out the status of the project/manifest.
 If `mode` is `PKGMODE_PROJECT` prints out status about only those packages
 that are in the project (explicitly added). If `mode` is `PKGMODE_MANIFEST`
-also print for those in the manifest (recursive dependencies).
+also print for those in the manifest (recursive dependencies). If there are
+any packages listed as arguments the output will be limited to those packages.
 """
 const status = API.status
 

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -601,7 +601,7 @@ end
 
 # TODO set default Display.status keyword: mode = PKGMODE_COMBINED
 do_status!(ctx::APIOptions, args::PkgArguments, api_opts::APIOptions) =
-    Display.status(Context!(ctx), get(api_opts, :mode, PKGMODE_COMBINED))
+    Display.status(Context!(ctx), args, mode=get(api_opts, :mode, PKGMODE_COMBINED))
 
 # TODO , test recursive dependencies as on option.
 function do_test!(ctx::APIOptions, args::PkgArguments, api_opts::APIOptions)
@@ -1305,6 +1305,8 @@ The `startup.jl` file is disabled during precompilation unless julia is started 
     :name => "status",
     :short_name => "st",
     :handler => do_status!,
+    :arg_count => 0 => Inf,
+    :arg_parser => (x -> parse_pkg(x)),
     :option_spec => OptionDeclaration[
         [:name => "project", :short_name => "p", :api => :mode => PKGMODE_PROJECT],
         [:name => "manifest", :short_name => "m", :api => :mode => PKGMODE_MANIFEST],
@@ -1313,16 +1315,17 @@ The `startup.jl` file is disabled during precompilation unless julia is started 
     :description => "summarize contents of and changes to environment",
     :help => md"""
 
-    status
-    status [-p|--project]
-    status [-m|--manifest]
+    status [pkgs...]
+    status [-p|--project] [pkgs...]
+    status [-m|--manifest] [pkgs...]
 
 Show the status of the current environment. By default, the full contents of
 the project file is summarized, showing what version each package is on and
 how it has changed since the last git commit (if in a git repo), as well as
 any changes to manifest packages not already listed. In `--project` mode, the
 status of the project file is summarized. In `--manifest` mode the output also
-includes the dependencies of explicitly added packages.
+includes the dependencies of explicitly added packages. If there are any 
+packages listed as arguments the output will be limited to those packages.
     """,
 ],[ :kind => CMD_GC,
     :name => "gc",

--- a/test/api.jl
+++ b/test/api.jl
@@ -42,4 +42,19 @@ include("utils.jl")
     end
 end
 
+@testset "Pkg.status" begin
+    temp_pkg_dir() do project_path
+        Pkg.add(["Example", "Random"])
+        Pkg.status()
+        Pkg.status("Example")
+        Pkg.status(["Example", "Random"])
+        Pkg.status(PackageSpec("Example"))
+        Pkg.status(PackageSpec(uuid = "7876af07-990d-54b4-ab0e-23690620f79a"))
+        Pkg.status(PackageSpec.(["Example", "Random"]))
+        Pkg.status(; mode=PKGMODE_MANIFEST)
+        Pkg.status("Example"; mode=PKGMODE_MANIFEST)
+        @test_deprecated Pkg.status(PKGMODE_MANIFEST)
+    end
+end
+
 end # module APITests

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -909,6 +909,21 @@ end
     end end end
 end
 
+@testset "status" begin
+    temp_pkg_dir() do project_path
+        pkg"""
+        add Example Random
+        status
+        status -m
+        status Example
+        status Example=7876af07-990d-54b4-ab0e-23690620f79a
+        status 7876af07-990d-54b4-ab0e-23690620f79a
+        status Example Random
+        status -m Example
+        """
+    end
+end
+
 @testset "subcommands" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do
         Pkg.REPLMode.pkg"package add Example"


### PR DESCRIPTION
I gave #575 a try. There is also this related [discourse thread](https://discourse.julialang.org/t/pkg-repl-mode-filter-status-list/17087).

This PR adds `pkg> status [pkg]`, where `pkg` can be one or multiple package names. It will actually just filter the full `status` list for the given package names.

It's my first Pkg.jl PR. Looking forward to comments!

WIP because I (at least) have to add some tests.