### PR TITLE
 fix #711: multiple registries with the same package

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1251,6 +1251,7 @@ end
 function registered_uuid(env::EnvCache, name::String)::UUID
     uuids = registered_uuids(env, name)
     length(uuids) == 0 && return UUID(zero(UInt128))
+    length(uuids) == 1 && return uuids[1]
     choices::Vector{String} = []
     choices_cache::Vector{Tuple{UUID,String}} = []
     for uuid in uuids

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -236,6 +236,16 @@ end
         @test_throws PkgError Registry.add([RegistrySpec(url = Foo2.url)])
 
     end end
+
+    # issue #711
+    temp_pkg_dir() do depot; mktempdir() do depot2
+        insert!(Base.DEPOT_PATH, 2, depot2)
+        Registry.add("General")
+        with_depot2(() -> Registry.add("General"))
+        # This add should not error because depot/Example and depot2/Example have the same uuid
+        Pkg.add("Example")
+        @test isinstalled((name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")))
+    end end
 end
 
 end # module


### PR DESCRIPTION
Don't prompt the user for a choice when the same package name is found in multiple registries if they share the same uuid.

fix #711