### PR TITLE
filter out unreachable registries when collecting.

### DIFF
--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -73,13 +73,12 @@ Display information about available registries.
 """
 function status()
     regs = Types.collect_registries()
-    regs = unique(r -> r.uuid, regs) # Maybe not?
     Types.printpkgstyle(stdout, Symbol("Registry Status"), "")
     if isempty(regs)
         println("  (no registries found)")
     else
         for reg in regs
-            printstyled(" [$(string(reg.uuid)[1:8])]"; color = :light_black)
+            printstyled("  [$(string(reg.uuid)[1:8])]"; color = :light_black)
             print(" $(reg.name)")
             reg.url === nothing || print(" ($(reg.url))")
             println()

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -931,7 +931,7 @@ function clone_default_registries()
     end
 end
 
-# Return `RegistrySpec`s of each registry in a depot
+# Return `RegistrySpec`s of each unique registry in a depot, sorted by name
 function collect_registries(depot::String)
     d = joinpath(depot, "registries")
     regs = RegistrySpec[]
@@ -948,12 +948,17 @@ function collect_registries(depot::String)
             push!(regs, spec)
         end
     end
+    # filter out only unique registries
+    sort!(regs; by = r -> r.name)
+    regs = unique(r -> r.uuid, regs)
     return regs
 end
-# Return `RegistrySpec`s of all registries in all depots
+# Return `RegistrySpec`s of all unique registries in all depots
 function collect_registries()
     isempty(depots()) && return RegistrySpec[]
-    return RegistrySpec[r for d in depots() for r in collect_registries(d)]
+    regs = RegistrySpec[r for d in depots() for r in collect_registries(d)]
+    regs = unique(r -> r.uuid, regs)
+    return regs
 end
 
 # Hacky way to make e.g. `registry add General` work.

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -245,6 +245,17 @@ end
         # This add should not error because depot/Example and depot2/Example have the same uuid
         Pkg.add("Example")
         @test isinstalled((name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")))
+        Pkg.rm("Example")
+        @test !isinstalled((name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")))
+        # test filtering if the same package uuid is found in different registries
+        registry2 = joinpath(Base.DEPOT_PATH[2], "registries", "General", "Registry.toml")
+        str = read(registry2, String)
+        str = replace(str, "name = \"General\"" => "name = \"General2\"", count = 1)
+        str = replace(str, "uuid = \"23338594-aafe-5451-b93e-139f81909106\"" =>
+                           "uuid = \"2759d7ed-3a0f-4efa-9123-a918602b9842\"", count = 1)
+        write(registry2, str)
+        Pkg.add("Example")
+        @test isinstalled((name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")))
     end end
 end
 


### PR DESCRIPTION
This filters out identical registries when collecting them. A registry is unreachable if there exist another registry with the same uuid higher up in DEPOT_PATH.

WIP mostly because I don't know how to print this to make sense, some alternatives unreachable ones are greyed out, but not visible here):

1.
```
pkg> registry st
Registry Status 
  [23338594] General (https://github.com/JuliaRegistries/General.git)
             installed in [`~/.julia/registries/General`]
 Unreachable registries:
  [23338594] General (https://github.com/JuliaRegistries/General.git)
             installed in [`~/sandbox/registries/General`]
```
2. 
```
pkg> registry st
Registry Status 
  [23338594] General (https://github.com/JuliaRegistries/General.git)
 Unreachable registries:
  [23338594] General (https://github.com/JuliaRegistries/General.git)
```
3. 
```
pkg> registry st
Registry Status 
  [23338594] General (https://github.com/JuliaRegistries/General.git)
 Unreachable registries:
  [23338594] General (https://github.com/JuliaRegistries/General.git)
             installed in [`~/sandbox/registries/General`]
```

IMO 1. looks kinda messy, but 2. does not give any information about why it is unreachable. 3. is some kind of combination