### PR TITLE
Only clone default registries if there are no registries installed.

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1002,10 +1002,8 @@ const DEFAULT_REGISTRIES =
                               url = "https://github.com/JuliaRegistries/General.git")]
 
 function clone_default_registries()
-    user_regs = abspath(depots1(), "registries")
-    if !ispath(user_regs) || isempty(readdir(user_regs))
-        mkpath(user_regs)
-        printpkgstyle(stdout, :Cloning, "default registries into $user_regs")
+    if isempty(collect_registries()) # only clone if there are no installed registries
+        printpkgstyle(stdout, :Cloning, "default registries into $(pathrepr(depots1()))")
         clone_or_cp_registries(DEFAULT_REGISTRIES)
     end
 end

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -246,6 +246,18 @@ end
         Pkg.add("Example")
         @test isinstalled((name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")))
     end end
+
+    # only clone default registry if there are no registries installed at all
+    temp_pkg_dir() do depot1; mktempdir() do depot2
+        append!(empty!(DEPOT_PATH), [depot1, depot2])
+        @test length(Pkg.Types.collect_registries()) == 0
+        Pkg.add("Example")
+        @test length(Pkg.Types.collect_registries()) == 1
+        Pkg.rm("Example")
+        DEPOT_PATH[1:2] .= DEPOT_PATH[2:-1:1]
+        Pkg.add("Example") # should not trigger a clone of default registries
+        @test length(Pkg.Types.collect_registries()) == 1
+    end end
 end
 
 end # module


### PR DESCRIPTION
Possible "fix" for #892; if you don't want registries to update don't put them in `DEPOT_PATH[1]`.

bors try