### PR TITLE
Properly escape TOML fields in `generate`

### DIFF
--- a/ext/TOML/src/parser.jl
+++ b/ext/TOML/src/parser.jl
@@ -585,7 +585,8 @@ function escape(p::Parser, st::Int, multiline::Bool)
                 NONE()
             end
         else
-            error(p, st, position(p), "unknown string escape: `$("\\x"*hex(ch,2))`")
+            escape_str = "\\x"*string(UInt32(ch), base=16, pad=2)
+            error(p, st, position(p), "unknown string escape: `$escape_str`")
             NONE()
         end
     end

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -46,20 +46,16 @@ function project(pkg::String, dir::String; preview::Bool)
         end
     end
 
-    authorstr = "[\"$name " * (email == nothing ? "" : "<$email>") * "\"]"
+    authors = ["$name " * (email == nothing ? "" : "<$email>")]
 
     uuid = UUIDs.uuid1()
     genfile(pkg, dir, "Project.toml"; preview=preview) do io
-        print(io,
-            """
-            authors = $authorstr
-            name = "$pkg"
-            uuid = "$uuid"
-            version = "0.1.0"
-
-            [deps]
-            """
-        )
+        toml = Dict("authors" => authors,
+                    "name" => pkg,
+                    "uuid" => string(uuid),
+                    "version" => "0.1.0",
+                    )
+        TOML.print(io, toml, sorted=true, by=key -> (Types.project_key_order(key), key))
     end
     return uuid
 end


### PR DESCRIPTION
Someone on slack hit a call to `hex` which was supposed to be deprecated.
Root cause of the issue was that `generate` did not properly escape the `authors` field.

I think just piping through `TOML.print` should do the trick.

Note I couldn't figure out how to keep the empty `deps` field when generating a project, so I just avoid printing it. Is it just there for aesthetic purposes? We don't care to preserve it when `rm`ing all dependencies...