### PR TITLE
Properly handle Manifest dependencies (Fix #894)

### DIFF
--- a/test/manifest/not_unique_names.toml
+++ b/test/manifest/not_unique_names.toml
@@ -1,0 +1,103 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+git-tree-sha1 = "a016e0bfe98a748c4488e2248c2ef4c67d6fdd35"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.5.0"
+
+    [DocStringExtensions.deps]
+    LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+    Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+    Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Documenter]]
+git-tree-sha1 = "9f2135e0e7ecb63f9c3ef73ea15a31d8cdb79bb7"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.20.0"
+
+    [Documenter.deps]
+    Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+    DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+    InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+    LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+    Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+    Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+    Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+path = ".."
+uuid = "748391e3-3ea3-41aa-8037-d96b5d03e7c6"
+version = "1.0.0"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/manifest/simple.toml
+++ b/test/manifest/simple.toml
@@ -1,0 +1,46 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Example]]
+deps = ["Test"]
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.1"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -542,6 +542,37 @@ temp_pkg_dir() do project_path
     end
 end
 
+@testset "manifest read/write unit tests" begin
+    manifestdir = joinpath(@__DIR__, "manifest")
+    temp = joinpath(mktempdir(), "x.toml")
+    for testfile in joinpath.(manifestdir, readdir(manifestdir))
+        a = Types.read_manifest(testfile)
+        Types.write_manifest(a, temp)
+        b = Types.read_manifest(temp)
+        for (uuid, x) in a
+            y = b[uuid]
+            for property in propertynames(x)
+                @test getproperty(x, property) == getproperty(y, property)
+            end
+        end
+    end
+    rm(dirname(temp); recursive = true, force = true)
+end
+
+@testset "project read/write unit tests" begin
+    projectdir = joinpath(@__DIR__, "project")
+    temp = joinpath(mktempdir(), "x.toml")
+    for testfile in joinpath.(projectdir, readdir(projectdir))
+        a = Types.read_project(testfile)
+        Types.write_project(a, temp)
+        b = Types.read_project(temp)
+        for property in propertynames(a)
+            @test getproperty(a, property) == getproperty(b, property)
+        end
+    end
+    rm(dirname(temp); recursive = true, force = true)
+end
+
 include("repl.jl")
 include("api.jl")
 include("registry.jl")

--- a/test/project/pkg.toml
+++ b/test/project/pkg.toml
@@ -1,0 +1,21 @@
+name = "Pkg"
+keywords = ["package", "management"]
+license = "MIT"
+desc = "The next-generation Julia package manager."
+version = "1.0.0"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project/simple.toml
+++ b/test/project/simple.toml
@@ -1,0 +1,6 @@
+name = "FooBar"
+uuid = "3644d252-e973-11e8-2189-c5f41ab12867"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"


### PR DESCRIPTION
I broke `Pkg` by merging #894 last night. I hadn't realized that we save the `deps` section differently depending on whether all the dependencies have unique names.

I added tests to ensure that `write_manifest(read_manifest(x)) == x`. Also added the equivalent tests for `Project.toml`.