### PR TITLE
Add cut_body_after to bors.toml.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,3 +4,4 @@ status = [
 ]
 delete-merged-branches = true
 timeout-sec = 7200
+cut_body_after = "---"


### PR DESCRIPTION
`cut_body_after` lets us control what ends up in the merge commit message, whats before `---` will be in there, and whats after will be removed.

---

This should thus not go in the commit message, but maybe bors uses the toml file on master so this might not work for this PR.

bors try