### PR TITLE
Fix manifest iteration

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -116,9 +116,8 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
                 push!(pkgs, PackageSpec(name, uuid, level))
             end
         elseif mode == PKGMODE_MANIFEST
-            for (name, infos) in ctx.env.manifest, info in infos
-                uuid = UUID(info["uuid"])
-                push!(pkgs, PackageSpec(name, uuid, level))
+            for (uuid, entry) in ctx.env.manifest
+                push!(pkgs, PackageSpec(entry.name, uuid, level))
             end
         end
     else
@@ -249,12 +248,10 @@ function gc(ctx::Context=Context(); kwargs...)
         end
         manifest == nothing && continue
         new_usage[manifestfile] = [Dict("time" => date)]
-        for (name, infos) in manifest
-            for info in infos
-                if haskey(info, "uuid") && haskey(info, "git-tree-sha1")
-                    push!(paths_to_keep,
-                          Operations.find_installed(name, UUID(info["uuid"]), SHA1(info["git-tree-sha1"])))
-                end
+        for (uuid, entry) in manifest
+            if entry.git_tree_sha !== nothing
+                push!(paths_to_keep,
+                      Operations.find_installed(entry.name, uuid, entry.git_tree_sha))
             end
         end
     end


### PR DESCRIPTION
I missed two more from #894.

I was going to add tests for `up --manifest` (seems we are not testing that at all), but I don't understand its purpose. Docs say that `up --project` updates both the project and manifest while `up --manifest` only updates the manifest. But isn't the project a subset of the manifest?

I ran some manual tests: I add a dependency at a version that can be updated and I manually edit the manifest so that a package which is not in `Project.toml` can also be updated. AFAICT there is no difference between `--manifest` and `--project`. Am I missing something?
```
(xadsf) pkg> add Example@0.3.0
 Resolving package versions...
  Updating `/tmp/xadsf/Project.toml`
  [7876af07] ↓ Example v0.5.1 ⇒ v0.3.0
  Updating `/tmp/xadsf/Manifest.toml`
  [7876af07] ↓ Example v0.5.1 ⇒ v0.3.0

# manually edit `Manifest.toml` here

(xadsf) pkg> up --manifest
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
  Updating `/tmp/xadsf/Project.toml`
  [7876af07] ↑ Example v0.3.0 ⇒ v0.5.1
  Updating `/tmp/xadsf/Manifest.toml`
  [7876af07] ↑ Example v0.3.0 ⇒ v0.5.1
  [682c06a0] ? JSON v0.18.0 ⇒ v0.20.0

(xadsf) pkg> add Example@0.3.0
 Resolving package versions...
 Installed Example ─ v0.3.0
  Updating `/tmp/xadsf/Project.toml`
  [7876af07] ↓ Example v0.5.1 ⇒ v0.3.0
  Updating `/tmp/xadsf/Manifest.toml`
  [7876af07] ↓ Example v0.5.1 ⇒ v0.3.0

# manually edit `Manifest.toml` here

(xadsf) pkg> up --project
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
  Updating `/tmp/xadsf/Project.toml`
  [7876af07] ↑ Example v0.3.0 ⇒ v0.5.1
  Updating `/tmp/xadsf/Manifest.toml`
  [7876af07] ↑ Example v0.3.0 ⇒ v0.5.1
  [682c06a0] ? JSON v0.18.0 ⇒ v0.20.0
```