### PR TITLE
Refactor types

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -216,11 +216,11 @@ print_diff(ctx::Context, diff::Vector{DiffEntry}, status=false) = print_diff(std
 
 function name_ver_info(entry::PackageEntry)
     entry.name, VerInfo(
-        entry.git_tree_sha,
+        entry.repo.tree_sha,
         entry.path,
         entry.version === nothing ? nothing : VersionNumber(entry.version),
         entry.pinned,
-        entry.repo_url === nothing ? nothing : Types.GitRepo(entry.repo_url, entry.repo_rev),
+        entry.repo.url === nothing ? nothing : entry.repo,
         )
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -105,13 +105,13 @@ function collect_fixed!(ctx::Context, pkgs::Vector{PackageSpec}, uuid_to_name::D
             @assert pkg.path !== nothing
             path = pkg.path
         elseif pkg.special_action == PKGSPEC_REPO_ADDED
-            @assert pkg.repo !== nothing && pkg.repo.git_tree_sha1 !== nothing
-            path = find_installed(pkg.name, pkg.uuid, pkg.repo.git_tree_sha1)
+            @assert pkg.repo !== nothing && pkg.repo.tree_sha !== nothing
+            path = find_installed(pkg.name, pkg.uuid, pkg.repo.tree_sha)
         elseif entry !== nothing && entry.path !== nothing
             path = pkg.path = entry.path
-        elseif entry !== nothing && entry.repo_url !== nothing
-            path = find_installed(pkg.name, pkg.uuid, entry.git_tree_sha)
-            pkg.repo = Types.GitRepo(entry.repo_url, entry.repo_rev, entry.git_tree_sha)
+        elseif entry !== nothing && entry.repo.url !== nothing
+            path = find_installed(pkg.name, pkg.uuid, entry.repo.tree_sha)
+            pkg.repo = entry.repo
         else
             continue
         end
@@ -197,8 +197,8 @@ function collect_require!(ctx::Context, pkg::PackageSpec, path::String, fix_deps
 
     # And collect the stdlibs
     stdlibs = find_stdlib_deps(ctx, path)
-    for (uuid, stdlib) in stdlibs
-        deppkg = PackageSpec(stdlib, uuid, VersionSpec())
+    for (uuid, name) in stdlibs
+        deppkg = PackageSpec(name, uuid)
         push!(fix_deps_map[pkg.uuid], deppkg)
         push!(fix_deps, deppkg)
     end
@@ -645,7 +645,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
         if pkg.path !== nothing || uuid in keys(ctx.stdlibs)
             hash = nothing
         elseif pkg.repo != nothing
-            hash = pkg.repo.git_tree_sha1
+            hash = pkg.repo.tree_sha
         else
             hash = hashes[uuid]
         end
@@ -692,27 +692,27 @@ function update_manifest(ctx::Context, pkg::PackageSpec, hash::Union{SHA1, Nothi
     is_stdlib = uuid in keys(ctx.stdlibs)
     if !is_stdlib
         entry.version = string(version)
-        entry.git_tree_sha = hash
+        entry.repo.tree_sha = hash
         entry.path = path
         if special_action == PKGSPEC_DEVELOPED
             entry.pinned = false
-            entry.repo_url = nothing
-            entry.repo_rev = nothing
+            entry.repo.url = nothing
+            entry.repo.rev = nothing
         elseif special_action == PKGSPEC_FREED
             if entry.pinned
                 entry.pinned = false
             else
-                entry.repo_url = nothing
-                entry.repo_rev = nothing
+                entry.repo.url = nothing
+                entry.repo.rev = nothing
             end
         elseif special_action == PKGSPEC_PINNED
             entry.pinned = true
         elseif special_action == PKGSPEC_REPO_ADDED
-            entry.repo_url = repo.url
-            entry.repo_rev = repo.rev
+            entry.repo.url = repo.url
+            entry.repo.rev = repo.rev
             path = find_installed(name, uuid, hash)
         end
-        if entry.repo_url !== nothing
+        if entry.repo.url !== nothing
             path = find_installed(name, uuid, hash)
         end
     end
@@ -737,14 +737,14 @@ function update_manifest(ctx::Context, pkg::PackageSpec, hash::Union{SHA1, Nothi
             # Remove when packages uses Project files properly
             dep_pkgs = PackageSpec[]
             stdlib_deps = find_stdlib_deps(ctx, path)
-            for (stdlib_uuid, stdlib) in stdlib_deps
-                push!(dep_pkgs, PackageSpec(stdlib, stdlib_uuid))
+            for (uuid, name) in stdlib_deps
+                push!(dep_pkgs, PackageSpec(name, uuid))
             end
             reqfile = joinpath(path, "REQUIRE")
             if isfile(reqfile)
                 for r in Pkg2.Reqs.read(reqfile)
                     r isa Pkg2.Reqs.Requirement || continue
-                    push!(dep_pkgs, PackageSpec(r.package))
+                    push!(dep_pkgs, PackageSpec(name=r.package))
                 end
                 registry_resolve!(env, dep_pkgs)
                 project_deps_resolve!(ctx.env, dep_pkgs)
@@ -812,8 +812,8 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         entry === nothing && return
         need_to_resolve |= (entry.path !== nothing)
         localctx.env.project.deps[pkg.name] = pkg.uuid
-        for (dpkg, uuid) in entry.deps
-            collect_deps!(seen, PackageSpec(dpkg, uuid))
+        for (name, uuid) in entry.deps
+            collect_deps!(seen, PackageSpec(name, uuid))
         end
     end
 
@@ -915,7 +915,7 @@ function collect_target_deps!(
         entry = manifest_info(ctx.env, pkg.uuid)
         path = (entry.path !== nothing) ?
             project_rel_path(ctx, entry.path) :
-            find_installed(pkg.name, pkg.uuid, entry.git_tree_sha)
+            find_installed(pkg.name, pkg.uuid, entry.repo.tree_sha)
     end
 
     project_path = nothing
@@ -1021,8 +1021,8 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
         else
             entry = manifest_info(ctx.env, uuid)
             name = entry.name
-            if entry.git_tree_sha !== nothing
-                hash_or_path = entry.git_tree_sha
+            if entry.repo.tree_sha !== nothing
+                hash_or_path = entry.repo.tree_sha
                 path = find_installed(name, uuid, hash_or_path)
             elseif entry.path !== nothing
                 path = project_rel_path(ctx, entry.path)
@@ -1186,8 +1186,8 @@ function up(ctx::Context, pkgs::Vector{PackageSpec})
             pkg.version isa UpgradeLevel || continue
             level = pkg.version
             entry = manifest_info(ctx.env, pkg.uuid)
-            if entry !== nothing && entry.repo_url !== nothing
-                pkg.repo = Types.GitRepo(entry.repo_url, entry.repo_rev)
+            if entry !== nothing && entry.repo.url !== nothing
+                pkg.repo = entry.repo
                 new = handle_repos_add!(ctx, [pkg]; credentials=creds,
                                         upgrade_or_add = (level == UPLEVEL_MAJOR))
                 append!(new_git, new)
@@ -1237,7 +1237,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec})
     for pkg in pkgs
         pkg.special_action = PKGSPEC_FREED
         entry = manifest_info(ctx.env, pkg.uuid)
-        if entry.path !== nothing || entry.repo_url !== nothing
+        if entry.path !== nothing || entry.repo.url !== nothing
             need_to_resolve = true
         else
             pkg.version = VersionNumber(entry.version)
@@ -1261,8 +1261,8 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
             version_path = dirname(ctx.env.project_file)
         else
             entry = manifest_info(ctx.env, pkg.uuid)
-            if entry.git_tree_sha !== nothing
-                version_path = find_installed(pkg.name, pkg.uuid, entry.git_tree_sha)
+            if entry.repo.tree_sha !== nothing
+                version_path = find_installed(pkg.name, pkg.uuid, entry.repo.tree_sha)
             elseif entry.path !== nothing
                 version_path =  project_rel_path(ctx, entry.path)
             elseif pkg.uuid in keys(ctx.stdlibs)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -334,7 +334,7 @@ Below is a comparison between the REPL version and the `PackageSpec` version:
 | `--manifest Package` | `PackageSpec(name="Package", mode=PKGSPEC_MANIFEST)`  |
 | `--major Package`    | `PackageSpec(name="Package", version=PKGLEVEL_MAJOR)` |
 """
-const PackageSpec = Types.PackageSpec
+const PackageSpec = API.Package
 
 """
     Pkg.setprotocol!(proto::Union{Nothing, AbstractString}=nothing)

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -162,9 +162,9 @@ function parse_package(word::AbstractString; add_or_develop=false)::PackageSpec
         if !occursin(Base.Filesystem.path_separator_re, word)
             @info "resolving package specifier `$word` as a directory at `$(Base.contractuser(abspath(word)))`."
         end
-        return PackageSpec(Types.GitRepo(expanduser(word)))
+        return PackageSpec(repo=Types.GitRepo(url=expanduser(word)))
     elseif occursin(uuid_re, word)
-        return PackageSpec(UUID(word))
+        return PackageSpec(uuid=UUID(word))
     elseif occursin(name_re, word)
         return PackageSpec(String(match(name_re, word).captures[1]))
     elseif occursin(name_uuid_re, word)
@@ -172,7 +172,7 @@ function parse_package(word::AbstractString; add_or_develop=false)::PackageSpec
         return PackageSpec(String(m.captures[1]), UUID(m.captures[2]))
     elseif add_or_develop
         # Guess it is a url then
-        return PackageSpec(Types.GitRepo(word))
+        return PackageSpec(repo=Types.GitRepo(url=word))
     else
         pkgerror("`$word` cannot be parsed as a package")
     end
@@ -219,7 +219,7 @@ end
 mutable struct Statement
     super::Union{Nothing, String}
     spec::Union{Nothing, CommandSpec}
-    options::Union{Vector{Option}, Vector{String}} # TODO clean up this state
+    options::Union{Vector{Option}, Vector{String}}
     arguments::Vector{String}
     preview::Bool
     Statement() = new(nothing, nothing, String[], [], false)
@@ -416,7 +416,7 @@ function package_args(args::Vector{PackageToken}; add_or_dev=false)::Vector{Pack
                 pkg.version = VersionSpec(modifier)
             else # modifier isa Rev
                 if pkg.repo === nothing
-                    pkg.repo = Types.GitRepo("", modifier.rev)
+                    pkg.repo = Types.GitRepo(rev=modifier.rev)
                 else
                     pkg.repo.rev = modifier.rev
                 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -25,7 +25,7 @@ end
             cd(mkdir("modules")) do
                 Pkg.generate("Foo")
             end
-            Pkg.develop(Pkg.Types.PackageSpec(path="modules/Foo")) # to avoid issue #542
+            Pkg.develop(Pkg.PackageSpec(path="modules/Foo")) # to avoid issue #542
             Pkg.activate("Foo") # activate path Foo over deps Foo
             @test Base.active_project() == joinpath(path, "Foo", "Project.toml")
             Pkg.activate(".")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -16,6 +16,7 @@ import LibGit2
 include("utils.jl")
 
 const TEST_PKG = (name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
+const PackageSpec = Pkg.Types.PackageSpec
 
 import Pkg.Types: semver_spec, VersionSpec
 @testset "semver notation" begin
@@ -193,7 +194,7 @@ temp_pkg_dir() do project_path
         Pkg.rm(TEST_PKG.name)
         mktempdir() do devdir
             withenv("JULIA_PKG_DEVDIR" => devdir) do
-                @test_throws PkgError Pkg.develop(PackageSpec(url="bleh", rev="blurg"))
+                @test_throws PkgError Pkg.develop(Pkg.PackageSpec(url="bleh", rev="blurg"))
                 Pkg.develop(TEST_PKG.name)
                 @test isinstalled(TEST_PKG)
                 @test Pkg.API.__installed()[TEST_PKG.name] > old_v
@@ -437,7 +438,7 @@ temp_pkg_dir() do project_path
         @testset "inconsistent repo state" begin
             package_path = joinpath(project_path, "Example")
             LibGit2.with(LibGit2.clone("https://github.com/JuliaLang/Example.jl", package_path)) do repo
-                Pkg.add(PackageSpec(path=package_path))
+                Pkg.add(Pkg.PackageSpec(path=package_path))
             end
             rm(joinpath(package_path, ".git"); force=true, recursive=true)
             @test_throws PkgError Pkg.update()
@@ -456,7 +457,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
         mkdir("machine1")
         cd("machine1")
         Pkg.activate(".")
-        Pkg.add(PackageSpec(path="../Example.jl"))
+        Pkg.add(Pkg.PackageSpec(path="../Example.jl"))
         cd("..")
         cp("machine1", "machine2")
         empty!(DEPOT_PATH)
@@ -593,10 +594,10 @@ end
 @testset "issue #913" begin
     temp_pkg_dir() do project_path
         Pkg.activate(project_path)
-        Pkg.add(PackageSpec(name="Example", rev = "master"))
+        Pkg.add(Pkg.PackageSpec(name="Example", rev = "master"))
         @test isinstalled(TEST_PKG)
         rm.(joinpath.(project_path, ["Project.toml","Manifest.toml"]))
-        Pkg.add(PackageSpec(name="Example", rev = "master")) # should not fail
+        Pkg.add(Pkg.PackageSpec(name="Example", rev = "master")) # should not fail
         @test isinstalled(TEST_PKG)
     end
 end

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -3,7 +3,7 @@ module RegistryTests
 using Pkg, UUIDs, LibGit2, Test
 using Pkg: depots1
 using Pkg.REPLMode: pkgstr
-using Pkg.Types: PkgError, EnvCache, manifest_info
+using Pkg.Types: PkgError, EnvCache, manifest_info, PackageSpec
 
 include("utils.jl")
 
@@ -86,9 +86,9 @@ end
             url = joinpath(regdir, "RegistryFoo2"))
 
         # Packages in registries
-        Example  = PackageSpec(name = "Example",  uuid = "7876af07-990d-54b4-ab0e-23690620f79a")
-        Example1 = PackageSpec(name = "Example1", uuid = "c5f1542f-b8aa-45da-ab42-05303d706c66")
-        Example2 = PackageSpec(name = "Example2", uuid = "d7897d3a-8e65-4b65-bdc8-28ce4e859565")
+        Example  = PackageSpec(name = "Example",  uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
+        Example1 = PackageSpec(name = "Example1", uuid = UUID("c5f1542f-b8aa-45da-ab42-05303d706c66"))
+        Example2 = PackageSpec(name = "Example2", uuid = UUID("d7897d3a-8e65-4b65-bdc8-28ce4e859565"))
 
 
         # Add General registry
@@ -268,7 +268,7 @@ end
             @test manifest_info(EnvCache(), uuid).version == "0.5.0"
             Pkg.update() # should not update Example
             @test manifest_info(EnvCache(), uuid).version == "0.5.0"
-            @test_throws Pkg.Types.ResolverError Pkg.add(PackageSpec(name="Example", version="0.5.1"))
+            @test_throws Pkg.Types.ResolverError Pkg.add(PackageSpec(name="Example", version=v"0.5.1"))
             Pkg.rm("Example")
             Pkg.add("JSON") # depends on Example
             @test manifest_info(EnvCache(), uuid).version == "0.5.0"

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -100,11 +100,10 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
 
     # Test upgrade --fixed doesn't change the tracking (https://github.com/JuliaLang/Pkg.jl/issues/434)
     entry = Pkg.Types.manifest_info(Pkg.Types.EnvCache(), TEST_PKG.uuid)
-    @test entry.repo_rev == "master"
+    @test entry.repo.rev == "master"
     pkg"up --fixed"
     entry = Pkg.Types.manifest_info(Pkg.Types.EnvCache(), TEST_PKG.uuid)
-    @test entry.repo_rev == "master"
-
+    @test entry.repo.rev == "master"
 
     pkg"test Example"
     @test isinstalled(TEST_PKG)
@@ -354,16 +353,17 @@ temp_pkg_dir() do depot; cd_tempdir() do tmp
     @test manifest[uuid].path == joinpath("..", "Foo")
 end end
 
-# develop with --shared and --local
-cd_tempdir() do tmp
-    uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # Example
-    pkg"activate ."
-    pkg"develop Example" # test default
-    @test manifest_info(EnvCache(), uuid).path == joinpath(Pkg.devdir(), "Example")
-    pkg"develop --shared Example"
-    @test manifest_info(EnvCache(), uuid).path == joinpath(Pkg.devdir(), "Example")
-    pkg"develop --local Example"
-    @test manifest_info(EnvCache(), uuid).path == joinpath("dev", "Example")
+@testset "develop with `--shared` and `--local" begin
+    temp_pkg_dir() do project_path; cd_tempdir() do tmp
+        uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # Example
+        pkg"activate ."
+        pkg"develop Example" # test default
+        @test manifest_info(EnvCache(), uuid).path == joinpath(Pkg.devdir(), "Example")
+        pkg"develop --shared Example"
+        @test manifest_info(EnvCache(), uuid).path == joinpath(Pkg.devdir(), "Example")
+        pkg"develop --local Example"
+        @test manifest_info(EnvCache(), uuid).path == joinpath("dev", "Example")
+    end end
 end
 
 test_complete(s) = Pkg.REPLMode.completions(s, lastindex(s))


### PR DESCRIPTION
1. Refactor types for consistency across codebase (e.g. sometimes we do `isempty(name)` and other times we do `name === nothing`, `PackageEntry` should have a `GitRepo` field, ...)
2. Split `PackageSpec` constructor into an internal constructor and a user-facing constructor (inspired by #872). It really is two different use cases: one is "create this object and set these fields", the other needs to do hand holding and error checking.

It was difficult to do one without the other, so that's why I included them together.