### PR TITLE
better error message when we cant find uuid in manifest

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -334,6 +334,9 @@ function _get_deps!(ctx::Context, pkgs::Vector{PackageSpec}, uuids::Vector{UUID}
             pkgs = [PackageSpec(name, uuid) for (name, uuid) in ctx.env.project.deps]
         else
             info = manifest_info(ctx.env, pkg.uuid)
+            if info === nothing
+                pkgerror("could not find manifest info for package with uuid: $(pkg.uuid)")
+            end
             pkgs = [PackageSpec(name, uuid) for (name, uuid) in info.deps]
         end
         _get_deps!(ctx, pkgs, uuids)


### PR DESCRIPTION
This should not really happen but it seems to happen anyway, so at least give a better error message for it.