### PR TITLE
Bring back package naming guidelines, fix #945.

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -187,3 +187,45 @@ using Test
   [d8327f2a] + HelloWorld v0.1.0 [`~/.julia/dev/Pkg/HelloWorld`]
    Testing HelloWorld tests passed```
 ```
+
+### Package naming guidelines
+
+Package names should be sensible to most Julia users, *even to those who are not domain experts*.
+The following guidelines applies to the `General` registry, but may be useful for other package
+registries as well.
+
+Since the `General` registry belongs to the entire community people may have opinions about
+your package name when you publish it, especially if it's ambiguous or can be confused with
+something other than what it is. Usually you will then get suggestions for a new name that
+may fit your package better.
+
+1. Avoid jargon. In particular, avoid acronyms unless there is minimal possibility of confusion.
+
+     * It's ok to say `USA` if you're talking about the USA.
+     * It's not ok to say `PMA`, even if you're talking about positive mental attitude.
+2. Avoid using `Julia` in your package name.
+
+     * It is usually clear from context and to your users that the package is a Julia package.
+     * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors
+       to the Julia language itself.
+3. Packages that provide most of their functionality in association with a new type should have pluralized
+   names.
+
+     * `DataFrames` provides the `DataFrame` type.
+     * `BloomFilters` provides the `BloomFilter` type.
+     * In contrast, `JuliaParser` provides no new type, but instead new functionality in the `JuliaParser.parse()`
+       function.
+4. Err on the side of clarity, even if clarity seems long-winded to you.
+
+     * `RandomMatrices` is a less ambiguous name than `RndMat` or `RMT`, even though the latter are shorter.
+5. A less systematic name may suit a package that implements one of several possible approaches to
+   its domain.
+
+     * Julia does not have a single comprehensive plotting package. Instead, `Gadfly`, `PyPlot`, `Winston`
+       and other packages each implement a unique approach based on a particular design philosophy.
+     * In contrast, `SortingAlgorithms` provides a consistent interface to use many well-established
+       sorting algorithms.
+6. Packages that wrap external libraries or programs should be named after those libraries or programs.
+
+     * `CPLEX.jl` wraps the `CPLEX` library, which can be identified easily in a web search.
+     * `MATLAB.jl` provides an interface to call the MATLAB engine from within Julia.


### PR DESCRIPTION
cc @tpapp