### PR TITLE
Add basedocs for the base julia manual.

### DIFF
--- a/docs/src/basedocs.md
+++ b/docs/src/basedocs.md
@@ -1,0 +1,17 @@
+# Pkg
+
+Pkg is Julia's builtin package manager, and handles operations
+such as installing, updating and removing packages.
+
+!!! note
+    What follows is a very brief introduction to Pkg. It is highly
+    recommended to read the full manual, which is available here:
+    [https://julialang.github.io/Pkg.jl/v1/](https://julialang.github.io/Pkg.jl/v1/).
+
+```@eval
+import Markdown
+file = joinpath(Sys.STDLIB, "Pkg", "docs", "src", "getting-started.md")
+str = read(file, String)
+str = replace(str, r"^#.*$"m => "")
+Markdown.parse(str)
+```


### PR DESCRIPTION
This snippet will be included in Julia's manual, essentially just the getting started section, and a pointer to the full manual.