### PR TITLE
fix #915: status -m Package prints status of Package's deps

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -476,6 +476,10 @@ status(pkgs::Vector{<:AbstractString}; mode=PKGMODE_PROJECT) =
     status([check_package_name(pkg) for pkg in pkgs]; mode=mode)
 status(pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT) = status(Context(), pkgs; mode=mode)
 function status(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT)
+    project_resolve!(ctx.env, pkgs)
+    project_deps_resolve!(ctx.env, pkgs)
+    manifest_resolve!(ctx.env, pkgs)
+    ensure_resolved(ctx.env, pkgs)
     Pkg.Display.status(ctx, pkgs, mode=mode)
     return nothing
 end

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -601,7 +601,7 @@ end
 
 # TODO set default Display.status keyword: mode = PKGMODE_COMBINED
 do_status!(ctx::APIOptions, args::PkgArguments, api_opts::APIOptions) =
-    Display.status(Context!(ctx), args, mode=get(api_opts, :mode, PKGMODE_COMBINED))
+    API.status(Context!(ctx), args, mode=get(api_opts, :mode, PKGMODE_COMBINED))
 
 # TODO , test recursive dependencies as on option.
 function do_test!(ctx::APIOptions, args::PkgArguments, api_opts::APIOptions)


### PR DESCRIPTION
Print the status of pkg's deps in manifest/combined mode, i.e.

    pkg> st -m pkg

fix #915 