### PR TITLE
Fix `gc`: `git_tree_sha` should be `repo.tree_sha`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -239,9 +239,9 @@ function gc(ctx::Context=Context(); kwargs...)
         manifest == nothing && continue
         new_usage[manifestfile] = [Dict("time" => date)]
         for (uuid, entry) in manifest
-            if entry.git_tree_sha !== nothing
+            if entry.repo.tree_sha !== nothing
                 push!(paths_to_keep,
-                      Operations.find_installed(entry.name, uuid, entry.git_tree_sha))
+                      Operations.find_installed(entry.name, uuid, entry.repo.tree_sha))
             end
         end
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -602,6 +602,16 @@ end
     end
 end
 
+#issue #975
+@testset "Pkg.gc" begin
+    temp_pkg_dir() do project_path
+        with_temp_env() do
+            Pkg.add("Example")
+            Pkg.gc()
+        end
+    end
+end
+
 include("repl.jl")
 include("api.jl")
 include("registry.jl")


### PR DESCRIPTION
Fixes #974 