### PR TITLE
[WIP/RFC] Conditional dependencies and package features

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ keywords = ["package", "management"]
 license = "MIT"
 name = "Pkg"
 version = "1.1.0"
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/API.jl
+++ b/src/API.jl
@@ -546,6 +546,7 @@ setprotocol!(proto::Union{Nothing, AbstractString}=nothing) = GitTools.setprotoc
 function Package(;name::Union{Nothing,AbstractString} = nothing,
                  uuid::Union{Nothing,String,UUID} = nothing,
                  version::Union{VersionNumber, String, VersionSpec, Nothing} = nothing,
+                 features::Union{Nothing, String, Vector{String}} = String[],
                  url = nothing, rev = nothing, path=nothing, mode::PackageMode = PKGMODE_PROJECT)
     path !== nothing && url !== nothing &&
         pkgerror("cannot specify both a path and url")
@@ -555,8 +556,13 @@ function Package(;name::Union{Nothing,AbstractString} = nothing,
         nothing :
         Types.GitRepo(rev = rev, url = url !== nothing ? url : path)
     version = version === nothing ? VersionSpec() : VersionSpec(version)
+
+    features = features === nothing ? String[] :
+               features isa String  ? [features] :
+               features
+
     uuid isa String && (uuid = UUID(uuid))
-    PackageSpec(name, uuid, version, mode, nothing, PKGSPEC_NOTHING, repo)
+    PackageSpec(name, uuid, version, features, mode, nothing, PKGSPEC_NOTHING, repo)
 end
 Package(name::AbstractString) = PackageSpec(name)
 Package(name::AbstractString, uuid::UUID) = PackageSpec(name, uuid)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -145,6 +145,7 @@ Base.@kwdef mutable struct PackageSpec
     name::Union{Nothing,String} = nothing
     uuid::Union{Nothing,UUID} = nothing
     version::VersionTypes = VersionSpec()
+    features::Vector{String} = String[]
     mode::PackageMode = PKGMODE_PROJECT
     path::Union{Nothing,String} = nothing
     special_action::PackageSpecialAction = PKGSPEC_NOTHING # If the package is currently being pinned, freed etc
@@ -160,7 +161,9 @@ has_uuid(pkg::PackageSpec) = pkg.uuid !== nothing
 
 function Base.show(io::IO, pkg::PackageSpec)
     vstr = repr(pkg.version)
-    f = ["name" => pkg.name, "uuid" => has_uuid(pkg) ? pkg.uuid : "", "v" => (vstr == "VersionSpec(\"*\")" ? "" : vstr)]
+    f = ["name" => pkg.name, "uuid" => has_uuid(pkg) ? pkg.uuid : "",
+        "v" => (vstr == "VersionSpec(\"*\")" ? "" : vstr),
+        "features" => pkg.features]
     if pkg.repo !== nothing
         if pkg.repo.url !== nothing
             push!(f, "url/path" => string("\"", pkg.repo.url, "\""))

--- a/test/test_packages/CUDA/Project.toml
+++ b/test/test_packages/CUDA/Project.toml
@@ -1,0 +1,6 @@
+authors = ["Roger-luo <hiroger@qq.com>"]
+name = "CUDA"
+uuid = "11d27378-0a18-11e9-0a59-4ba122bf6828"
+version = "0.1.0"
+
+[deps]

--- a/test/test_packages/CUDA/src/CUDA.jl
+++ b/test/test_packages/CUDA/src/CUDA.jl
@@ -1,0 +1,5 @@
+module CUDA
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/ConditionalDependency/Project.toml
+++ b/test/test_packages/ConditionalDependency/Project.toml
@@ -1,0 +1,18 @@
+authors = ["Roger-luo <hiroger@qq.com>"]
+name = "ConditionalDependency"
+uuid = "09c64820-0a14-11e9-376f-03eff1a9e926"
+version = "0.1.0"
+
+[extras]
+x2 = "52baf49e-96b1-11e8-23dd-2d073a3a6758"
+
+[extras.CUDA]
+uuid = "11d27378-0a18-11e9-0a59-4ba122bf6828"
+features = ["cuda"]
+version = "0.2.0"
+
+[features]
+cuda = ["CUDA"]
+
+[targets]
+test = ["x2"]

--- a/test/test_packages/ConditionalDependency/src/ConditionalDependency.jl
+++ b/test/test_packages/ConditionalDependency/src/ConditionalDependency.jl
@@ -1,0 +1,5 @@
+module ConditionalDependency
+
+greet() = print("Hello World!")
+
+end # module


### PR DESCRIPTION
### Backgrond

Conditional dependency is useful when a package provides optional enhancement based on other packages, e.g [Flux.jl](https://github.com/FluxML/Flux.jl/) allows to use CuArray to accelerate the calculation with CUDA. And in the future, there may be package depends on [MKL.jl](https://github.com/JuliaComputing/MKL.jl) (MKL has some non-BLAS/LAPACK routines, like `batched_gemm`).

However, current solution, the [Requires](https://github.com/MikeInnes/Requires.jl) package, can not provide explicit dependency in `Project.toml`, and it does not support multiple package at the moment: https://github.com/MikeInnes/Requires.jl/issues/54 thus I believe this can just be a temporary work around.

And it is not convenient and does not make sense to enable the feature by explicitly using several package:

A package `Foo` depends on `CUDAnative` and `CuArrays` when cuda is available, but neither of the following make sense

```julia
using Foo, CUDAnative, CuArrays
using Foo, CuArrays
using Foo, CUDAnative
```

We found this is very in-convenient while developing [CuYao.jl](https://github.com/QuantumBFS/CuYao.jl) and [BatchedRoutines.jl](https://github.com/Roger-luo/BatchedRoutines.jl), since part of the implementation is implemented with `CUDAnative`/`GPUArray`/`CuArray`, but actually just requires to enable the `cuda` feature.

This is because `Foo` may wrap types in `CuArrays`/`CUDAnative`, or it will just use `CuArray`. And what we actually want to do here, is just to precompile and build the CUDA related part of Foo when the feature CUDA is enabled.

### Proposal

The proposal here is inspired by [rust-cargo](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html). It will add a new field `[features]` in `Project.toml` and for each package in `Manifest.toml`, and also for `PackageSpec` type.

#### TOML changes

```toml
authors = ["Roger-luo <hiroger@qq.com>"]
name = "ConditionalDependency"
uuid = "09c64820-0a14-11e9-376f-03eff1a9e926"
version = "0.1.0"

[extras]
x2 = "52baf49e-96b1-11e8-23dd-2d073a3a6758"
CUDA = "11d27378-0a18-11e9-0a59-4ba122bf6828"

[features]
cuda = ["CUDA"]

[targets]
test = ["x2"]
```

Since there is a new field for each package, in order to allow developer use a package with specific feature, more detailed information about dependencies in `Project.toml` will be allowed

```toml
authors = ["Roger-luo <hiroger@qq.com>"]
name = "ConditionalDependency"
uuid = "09c64820-0a14-11e9-376f-03eff1a9e926"
version = "0.1.0"

[extras]
x2 = "52baf49e-96b1-11e8-23dd-2d073a3a6758"

[extras.CUDA]
uuid = "11d27378-0a18-11e9-0a59-4ba122bf6828"
version = "0.2.0"
features = ["feature1", "feature2"]

[features]
cuda = ["CUDA"]

[targets]
test = ["x2"]
```

here

```toml
CUDA = "11d27378-0a18-11e9-0a59-4ba122bf6828"
```

will be equivalent to 

```toml
[extras.CUDA]
uuid = "11d27378-0a18-11e9-0a59-4ba122bf6828"
```

#### CLI changes

And a new key word argument for `add`

```sh
(pkg) > add Foo --features cuda mkl

(pkg) > add Foo --all-features
```

#### How to know which feature is enabled in the scripts?

A new environment macro `@__FEATURES__` will be add to `Pkg` and it can be used to decide whether to precompile/use part of the code, e.g

```julia
module Foo

import Pkg

@static if "cuda" in Pkg.@__FEATURES__
     include("cuda.jl")
end

end
```

This macro contains code that looks up current environment and returns a vector of string. e.g

If this package is developed in env `v1.0`, then it will look up `v1.0/Manifest.toml` which contains the enabled features and put that to `@__FEATURES__`.

### Cases

If this is implemented, we can install Flux in the following syntax to choose different platform.

```sh
add Flux --features cuda
add Flux --features tpu
add Flux --all-features # enable them all 
add Flux # default is cpu only
```

similar for many other packages, it will become more explicit and elegant.

### Potential Problems

The extra key word `--features` in `add` will need to be the last argument, or the CLI cannot recognize multiple features. 