### PR TITLE
`registered_name` should return `nothing` when UUID is not registered

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -380,7 +380,7 @@ function resolve_versions!(
     for (uuid, ver) in vers
         uuid in uuids && continue
         name = registered_name(ctx.env, uuid)
-        push!(pkgs, PackageSpec(name, uuid, ver))
+        push!(pkgs, PackageSpec(;name=name, uuid=uuid, version=ver))
     end
     return vers
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1384,9 +1384,9 @@ function registered_uuid(env::EnvCache, name::String)::Union{Nothing,UUID}
 end
 
 # Determine current name for a given package UUID
-function registered_name(env::EnvCache, uuid::UUID)::String
+function registered_name(env::EnvCache, uuid::UUID)::Union{Nothing,String}
     names = registered_names(env, uuid)
-    length(names) == 0 && return ""
+    length(names) == 0 && return nothing
     length(names) == 1 && return names[1]
     values = registered_info(env, uuid, "name")
     name = nothing


### PR DESCRIPTION
I missed this in #857. `nothing`, not the empty string, represents the absence of a value.