### PR TITLE
fix rm: `project.extras` also contains dependency names

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1139,7 +1139,8 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
         @info "No changes"
         return
     end
-    deps_names = collect(keys(ctx.env.project.deps))
+    deps_names = append!(collect(keys(ctx.env.project.deps)),
+                         collect(keys(ctx.env.project.extras)))
     filter!(ctx.env.project.targets) do (target, deps)
         !isempty(filter!(in(deps_names), deps))
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -615,6 +615,18 @@ end
     end
 end
 
+#issue #876
+@testset "targets should survive add/rm" begin
+    temp_pkg_dir() do project_path; cd_tempdir() do tmpdir
+        cp(joinpath(@__DIR__, "project", "good", "pkg.toml"), "Project.toml")
+        targets = deepcopy(Pkg.Types.read_project("Project.toml").targets)
+        Pkg.activate(".")
+        Pkg.add("Example")
+        Pkg.rm("Example")
+        @test targets == Pkg.Types.read_project("Project.toml").targets
+    end end
+end
+
 @testset "reading corrupted project files" begin
     dir = joinpath(@__DIR__, "project", "bad")
     for bad_project in joinpath.(dir, readdir(dir))


### PR DESCRIPTION
fixes #876 

Thanks @fredrikekre for getting it down to a minimal repro.