### PR TITLE
Don't throw for missing Versions.toml in the registry

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -24,7 +24,7 @@ function find_installed(name::String, uuid::UUID, sha1::SHA1)
 end
 
 function load_versions(path::String; include_yanked = false)
-    toml = parse_toml(path, "Versions.toml")
+    toml = parse_toml(path, "Versions.toml"; fakeit=true)
     d = Dict{VersionNumber, SHA1}(
             VersionNumber(ver) => SHA1(info["git-tree-sha1"]) for (ver, info) in toml
                 if !get(info, "yanked", false) || include_yanked)


### PR DESCRIPTION
Don't throw for missing Versions.toml in the registry, instead consider that the same as no versions, i.e. an empty existing file.