### PR TITLE
Continue precompiling even if some packages fail

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -450,7 +450,10 @@ function precompile(ctx::Context)
         end
         if stale
             printpkgstyle(ctx, :Precompiling, pkg.name)
-            Base.compilecache(pkg, sourcepath)
+            try
+                Base.compilecache(pkg, sourcepath)
+            catch
+            end
         end
     end
     nothing


### PR DESCRIPTION
If you copy your environment from one machine to another, and the target machine is, e.g., lacking necessary libs and therefore fails to precompile, there is little reason to stop trying to compile the remaining packages.

I'm not quite sure how to go about testing this; in particular, if I create `BrokenPkg` how do I ensure that `precompile` will try it before moving on to `WorkingPkg`?