### PR TITLE
Introduce env navigation syntax

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -498,6 +498,10 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT)
 end
 
 
+function _activate_info()
+    p = Base.active_project()
+    p === nothing || @info("activating$(ispath(p) ? "" : " new") environment at $(pathrepr(p)).")
+end
 function activate()
     Base.ACTIVE_PROJECT[] = nothing
     p = Base.active_project()
@@ -536,25 +540,20 @@ function activate(path::AbstractString; shared::Bool=false)
             end
         end
     else
+        !isempty(path) || pkgerror("Not a valid name for a shared environment")
         # initialize `fullpath` in case of empty `Pkg.depots()`
         fullpath = ""
-        # loop over all depots to check if the shared environment already exists
         for depot in Pkg.depots()
             fullpath = joinpath(Pkg.envdir(depot), path)
             isdir(fullpath) && break
         end
+        isdir(fullpath) || (fullpath = joinpath(Pkg.envdir(Pkg.depots1()), path))
         # this disallows names such as "Foo/bar", ".", "..", etc
-        if basename(abspath(fullpath)) != path
-            pkgerror("not a valid name for a shared environment: $(path)")
-        end
-        # unless the shared environment already exists, place it in the first depots
-        if !isdir(fullpath)
-            fullpath = joinpath(Pkg.envdir(Pkg.depots1()), path)
-        end
+        basename(abspath(fullpath)) == path ||
+            pkgerror("Not a valid name for a shared environment: `$path`")
     end
     Base.ACTIVE_PROJECT[] = Base.load_path_expand(fullpath)
-    p = Base.active_project()
-    p === nothing || @info("activating$(ispath(p) ? "" : " new") environment at $(pathrepr(p)).")
+    _activate_info()
     return nothing
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -924,4 +924,25 @@ end
     end end end
 end
 
+@testset "Env navigation" begin
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        mkdir(joinpath(tmp, "test"))
+        Pkg.activate(tmp)
+        Pkg.add("Random")
+        pkg"activate +test"
+        Pkg.add("Example")
+        pkg"activate -"
+        @test Pkg.Types.Context().env.project.deps ==
+            Dict("Random" => UUID("9a3f8284-a2c9-5f02-9a11-845980a1fd5c"))
+        Pkg.activate(joinpath(tmp, "test"))
+        @test Pkg.Types.Context().env.project.deps ==
+            Dict("Example" => UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
+        pkg"activate @foo"
+        Pkg.add("Example")
+        Pkg.activate(joinpath(Pkg.envdir(), "foo"))
+        @test Pkg.Types.Context().env.project.deps ==
+            Dict("Example" => UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
+    end end
+end
+
 end # module


### PR DESCRIPTION
Changes:
- introduce `activate` sandbox support e.g. `activate +test`
- introduce `activate` "backjump" support e.g. `activate -`
- introduce `activate` shared env "@" syntax e.g. `activate @foo`