### PR TITLE
Allow for multiple repo urls in Package.toml

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -433,7 +433,10 @@ function load_urls(ctx::Context, pkgs::Vector{PackageSpec})
         for path in registered_paths(ctx.env, uuid)
             info = parse_toml(path, "Package.toml")
             repo = info["repo"]
-            repo in urls[uuid] || push!(urls[uuid], repo)
+            repo isa String && (repo = [repo]) # the repo entry can be String or Vector{String}
+            for r in repo
+                repo in urls[uuid] || push!(urls[uuid], r)
+            end
         end
     end
     foreach(sort!, values(urls))


### PR DESCRIPTION
Allow for multiple repo urls in `Package.toml`, e.g `e.g repo = ["original-repo", "mirror-repo"]`.