### PR TITLE
fix #1077: handle stdlibs in update_package_add and friends

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -613,6 +613,16 @@ end
     end
 end
 
+@testset "issue #1077" begin
+    temp_pkg_dir() do project_path
+        Pkg.add("UUIDs")
+        # the following should not error
+        Pkg.add("UUIDs")
+        Pkg.test("UUIDs")
+        @test_throws PkgError("cannot `pin` stdlibs.") Pkg.pin("UUIDs")
+    end
+end
+
 #issue #975
 @testset "Pkg.gc" begin
     temp_pkg_dir() do project_path


### PR DESCRIPTION
Handle stdlibs explicitly in `update_package_add!`, `update_package_pin!`
and `update_package_test!`, since they are not versioned like other packages,
fixes #1077.

---
bors try