### PR TITLE
Automatically detect unregistered dependencies

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -29,6 +29,7 @@ export UUID, pkgID, SHA1, VersionRange, VersionSpec, empty_versionspec,
     PackageSpecialAction, PKGSPEC_NOTHING, PKGSPEC_PINNED, PKGSPEC_FREED, PKGSPEC_DEVELOPED, PKGSPEC_TESTED, PKGSPEC_REPO_ADDED,
     printpkgstyle,
     projectfile_path, manifestfile_path,
+    is_unregistered,
     RegistrySpec
 
 include("versions.jl")
@@ -251,6 +252,7 @@ Base.@kwdef mutable struct PackageEntry
     other::Union{Dict,Nothing} = nothing
 end
 const Manifest = Dict{UUID,PackageEntry}
+is_unregistered(pkg) = pkg.path !== nothing || pkg.repo.url !== nothing
 
 function Base.show(io::IO, pkg::PackageEntry)
     f = []

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -12,7 +12,7 @@ function generate(ctx::Context, path::String; kwargs...)
     uuid = project(pkg, dir; preview=ctx.preview)
     entrypoint(pkg, dir; preview=ctx.preview)
     ctx.preview && preview_info()
-    return Dict(pkg => uuid)
+    return uuid
 end
 
 function genfile(f::Function, pkg::String, dir::String, file::String; preview::Bool)

--- a/src/project.jl
+++ b/src/project.jl
@@ -36,7 +36,7 @@ function read_project_deps(raw::Dict{String,Any}, section_name::String)
             uuid = UUID(uuid)
         catch err
             err isa ArgumentError || rethrow()
-            pkgerror("Malfomed value for `$name` in `$(section_name)` section.")
+            pkgerror("Malformed value for `$name` in `$(section_name)` section.")
         end
         deps[name] = uuid
     end

--- a/test/api.jl
+++ b/test/api.jl
@@ -73,10 +73,10 @@ end
         # explicit relative path
         with_temp_env() do env_path
             cd(env_path) do
-                uuids = Pkg.generate("Foo")
+                foo_uuid = Pkg.generate("Foo")
                 Pkg.develop(PackageSpec(;path="Foo"))
                 manifest = Pkg.Types.read_manifest(joinpath(env_path, "Manifest.toml"))
-                entry = manifest[uuids["Foo"]]
+                entry = manifest[foo_uuid]
             end
             @test entry.path == "Foo"
             @test entry.name == "Foo"
@@ -85,11 +85,11 @@ end
         # explicit absolute path
         with_temp_env() do env_path
             cd_tempdir() do temp_dir
-                uuids = Pkg.generate("Foo")
+                foo_uuid = Pkg.generate("Foo")
                 absolute_path = abspath(joinpath(temp_dir, "Foo"))
                 Pkg.develop(PackageSpec(;path=absolute_path))
                 manifest = Pkg.Types.read_manifest(joinpath(env_path, "Manifest.toml"))
-                entry = manifest[uuids["Foo"]]
+                entry = manifest[foo_uuid]
                 @test entry.name == "Foo"
                 @test entry.path == absolute_path
                 @test isdir(entry.path)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -194,8 +194,8 @@ temp_pkg_dir() do project_path; cd(project_path) do
             pkg"generate HelloWorld"
             cd("HelloWorld") do
                 with_current_env() do
-                    uuid1 = Pkg.generate("SubModule1")["SubModule1"]
-                    uuid2 = Pkg.generate("SubModule2")["SubModule2"]
+                    uuid1 = Pkg.generate("SubModule1")
+                    uuid2 = Pkg.generate("SubModule2")
                     pkg"develop SubModule1"
                     mkdir("tests")
                     cd("tests")
@@ -280,9 +280,9 @@ end
 
 # test relative dev paths (#490)
 cd_tempdir() do tmp
-    uuid1 = Pkg.generate("HelloWorld")["HelloWorld"]
+    uuid1 = Pkg.generate("HelloWorld")
     cd("HelloWorld")
-    uuid2 = Pkg.generate("SubModule")["SubModule"]
+    uuid2 = Pkg.generate("SubModule")
     cd(mkdir("tests"))
     pkg"activate ."
     pkg"develop .." # HelloWorld
@@ -314,9 +314,9 @@ end
 # test relative dev paths (#490) without existing Project.toml
 temp_pkg_dir() do depot; cd_tempdir() do tmp
     pkg"activate NonExistent"
-    uuid= nothing
+    uuid = nothing
     withenv("USER" => "Test User") do
-        uuid = Pkg.generate("Foo")["Foo"]
+        uuid = Pkg.generate("Foo")
     end
     # this dev should not error even if NonExistent/Project.toml file is non-existent
     @test !isdir("NonExistent")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -127,11 +127,15 @@ function git_init_package(tmp, path)
     base = basename(path)
     pkgpath = joinpath(tmp, base)
     cp(path, pkgpath)
-    LibGit2.with(LibGit2.init(pkgpath)) do repo
+    git_init_package(pkgpath)
+    return pkgpath
+end
+
+function git_init_package(path)
+    LibGit2.with(LibGit2.init(path)) do repo
         LibGit2.add!(repo, "*")
         LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
     end
-    return pkgpath
 end
 
 copy_test_package(tmpdir::String, name::String) =


### PR DESCRIPTION
- [x] support `develop`ed packages
- [x] support packages which are tracking repos

resolves #1005 

---
Let us banish this issue to the past

Example:
```
(B) pkg> status
Project B v0.1.0
    Status `/tmp/B/Project.toml`
  (empty environment)

(B) pkg> dev /tmp/C
 Resolving package versions...
  Updating `/tmp/B/Project.toml`
  [3c22e19c] + C v0.1.0 [`/tmp/C`]
  Updating `/tmp/B/Manifest.toml`
  [3c22e19c] + C v0.1.0 [`/tmp/C`]

(B) pkg> activate A
[ Info: activating environment at `/tmp/A/Project.toml`.

(A) pkg> dev /tmp/B
 Resolving package versions...
  Updating `/tmp/A/Project.toml`
  [391d23c0] + B v0.1.0 [`/tmp/B`]
  Updating `/tmp/A/Manifest.toml`
  [391d23c0] + B v0.1.0 [`/tmp/B`]
  [3c22e19c] + C v0.1.0 [`/tmp/C`]
```