### PR TITLE
Make sandbox isolation more flexible

### DIFF
--- a/test/sandbox.jl
+++ b/test/sandbox.jl
@@ -37,6 +37,16 @@ test_test(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
             @test json.version == v"0.20.0"
         end
     end end
+    # test dependencies should be preserved, when possible
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        copy_test_package(tmp, "Sandbox_PreserveTestDeps")
+        Pkg.activate(joinpath(tmp, "Sandbox_PreserveTestDeps"))
+        test_test("Foo") do
+            x = get(Pkg.Types.Context().env.manifest, UUID("7876af07-990d-54b4-ab0e-23690620f79a"), nothing)
+            @test x !== nothing
+            @test x.version == v"0.4.0"
+        end
+    end end
 end
 
 @testset "Basic `build` sandbox" begin

--- a/test/test_packages/Sandbox_PreserveTestDeps/Manifest.toml
+++ b/test/test_packages/Sandbox_PreserveTestDeps/Manifest.toml
@@ -1,0 +1,11 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Example]]
+git-tree-sha1 = "686e1ac14b35cce47f90c91200f904c603ace29e"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.4.0"
+
+[[Foo]]
+path = "dev/Foo"
+uuid = "48898bec-3adb-11e9-02a6-a164ba74aeae"
+version = "0.1.0"

--- a/test/test_packages/Sandbox_PreserveTestDeps/Project.toml
+++ b/test/test_packages/Sandbox_PreserveTestDeps/Project.toml
@@ -1,0 +1,8 @@
+name = "Sandbox_PreserveTestDeps"
+uuid = "3872bf94-3adb-11e9-01dc-bf80c7641364"
+authors = ["David Varela <00.varela.david@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Foo = "48898bec-3adb-11e9-02a6-a164ba74aeae"

--- a/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/Project.toml
+++ b/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/Project.toml
@@ -1,0 +1,3 @@
+name = "Foo"
+uuid = "48898bec-3adb-11e9-02a6-a164ba74aeae"
+version = "0.1.0"

--- a/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/src/Foo.jl
+++ b/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/src/Foo.jl
@@ -1,0 +1,5 @@
+module Foo
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/test/Manifest.toml
+++ b/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/test/Manifest.toml
@@ -1,0 +1,59 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Example]]
+deps = ["Test"]
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/test/Project.toml
+++ b/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/test/runtests.jl
+++ b/test/test_packages/Sandbox_PreserveTestDeps/dev/Foo/test/runtests.jl
@@ -1,0 +1,9 @@
+module FooTests
+
+import Foo
+import Example
+
+Foo.greet()
+Example.hello("human")
+
+end

--- a/test/test_packages/Sandbox_PreserveTestDeps/src/Sandbox_PreserveTestDeps.jl
+++ b/test/test_packages/Sandbox_PreserveTestDeps/src/Sandbox_PreserveTestDeps.jl
@@ -1,0 +1,5 @@
+module Sandbox_PreserveTestDeps
+
+greet() = print("Hello World!")
+
+end # module


### PR DESCRIPTION
After much discussion(#1030), we agreed to make the sandbox mechanism more flexible; specifically when it comes to testing. 

This change simply collects the test environment direct dependencies and tries to preserve them. This is in addition to the dependencies which are specified by `Pkg.test("SomeDep")`

---
I still believe there is merit to a more structured workflow, but that requires more reflection and feedback from users. It will be interesting to see how the relationship between `Pkg` and testing develops. But refining the technical aspects of the sandbox is more important at this point.