### PR TITLE
Print contents of build.jl in the documentation

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -106,8 +106,8 @@ The build step is executed the first time a package is installed or when explici
 A package is built by executing the file `deps/build.jl`.
 
 ```
-shell> cat deps/build.log
-I am being built...
+shell> cat deps/build.jl
+println("I am being built...")
 
 (HelloWorld) pkg> build
   Building HelloWorld → `deps/build.log`


### PR DESCRIPTION
Both before and after the build step, the log file contents were displayed