### PR TITLE
Fix `?` notation for REPL help

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -245,9 +245,13 @@ function core_parse(words::Vector{QString}; only_cmd=false)
         statement.preview = true
         next_word!() || return statement, word.raw
     end
-    word.raw[1]=='?' && !word.isquoted &&
-        (pushfirst!(words,QString(word.raw[2:end],false));(word=QString("?",false)))
-
+    # handle `?` alias for help
+    # It is special in that it requires no space between command and args
+    if word.raw[1]=='?' && !word.isquoted
+        length(word.raw) > 1 && pushfirst!(words, QString(word.raw[2:end],false))
+        word = QString("?", false)
+    end
+    # determine command
     super = get(super_specs, word.raw, nothing)
     if super !== nothing # explicit
         statement.super = word.raw

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -11,6 +11,16 @@ import LibGit2
 
 include("utils.jl")
 
+@testset "help" begin
+    pkg"?"
+    pkg"?  "
+    pkg"?add"
+    pkg"? add"
+    pkg"?    add"
+    pkg"help add"
+    @test_throws PkgError pkg"helpadd"
+end
+
 @testset "generate args" begin
     @test_throws PkgError pkg"generate"
 end


### PR DESCRIPTION
The broken implementation assumed `?` would be used with no spaces (e.g. `pkg> ?add`) but spaces are valid (e.g. `pkg> ? add`).

Fixes #1113 