### PR TITLE
Add `--strict` option to `add` and `dev`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -35,7 +35,7 @@ develop(pkgs::Vector{<:AbstractString}; kwargs...) =
     develop([check_package_name(pkg, :develop) for pkg in pkgs]; kwargs...)
 develop(pkgs::Vector{PackageSpec}; kwargs...)      = develop(Context(), pkgs; kwargs...)
 function develop(ctx::Context, pkgs::Vector{PackageSpec};
-                 shared::Bool=true, keep_manifest::Bool=false, kwargs...)
+                 shared::Bool=true, strict::Bool=false, kwargs...)
     pkgs = deepcopy(pkgs) # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
@@ -56,7 +56,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec};
     any(pkg -> Types.collides_with_project(ctx.env, pkg), pkgs) &&
         pkgerror("Cannot `develop` package with the same name or uuid as the project")
 
-    Operations.develop(ctx, pkgs, new_git; keep_manifest=keep_manifest)
+    Operations.develop(ctx, pkgs, new_git; strict=strict)
     ctx.preview && preview_info()
     return
 end
@@ -65,7 +65,7 @@ add(pkg::Union{AbstractString, PackageSpec}; kwargs...) = add([pkg]; kwargs...)
 add(pkgs::Vector{<:AbstractString}; kwargs...) =
     add([check_package_name(pkg, :add) for pkg in pkgs]; kwargs...)
 add(pkgs::Vector{PackageSpec}; kwargs...)      = add(Context(), pkgs; kwargs...)
-function add(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+function add(ctx::Context, pkgs::Vector{PackageSpec}; strict::Bool=false, kwargs...)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
@@ -96,7 +96,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     any(pkg -> Types.collides_with_project(ctx.env, pkg), pkgs) &&
         pkgerror("Cannot $mode package with the same name or uuid as the project")
 
-    Operations.add(ctx, pkgs, new_git)
+    Operations.add(ctx, pkgs, new_git; strict=strict)
     ctx.preview && preview_info()
     return
 end

--- a/src/REPL/command_declarations.jl
+++ b/src/REPL/command_declarations.jl
@@ -92,6 +92,9 @@ as any no-longer-necessary manifest packages due to project package removals.
     :handler => do_add!,
     :arg_count => 1 => Inf,
     :arg_parser => (x -> parse_package(x; add_or_dev=true, valid=[VersionRange, Rev])),
+    :option_spec => OptionDeclaration[
+        [:name => "strict", :api => :strict => true],
+    ],
     :completions => complete_add_dev,
     :description => "add packages to project",
     :help => md"""
@@ -126,6 +129,7 @@ pkg> add Example=7876af07-990d-54b4-ab0e-23690620f79a
     :arg_count => 1 => Inf,
     :arg_parser => (x -> parse_package(x; add_or_dev=true, valid=[VersionRange])),
     :option_spec => OptionDeclaration[
+        [:name => "strict", :api => :strict => true],
         [:name => "local", :api => :shared => false],
         [:name => "shared", :api => :shared => true],
     ],


### PR DESCRIPTION
Adds API and REPL support for a `--strict` option, which simply preserves the whole, existing dependency graph.

Resolves #1107 