### PR TITLE
Pkg should use it's own standard Project file order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,9 @@
-desc = "The next-generation Julia package manager."
+name = "Pkg"
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package", "management"]
 license = "MIT"
-name = "Pkg"
+desc = "The next-generation Julia package manager."
 version = "1.1.0"
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Sometimes I use Pkg to modify Pkg's project file. It ends up putting the project file's top-level entries in a different order. This puts them in the order that Pkg wants them in.