### PR TITLE
Make `gen_project.jl` exit on finding Project.toml

### DIFF
--- a/bin/gen_project.jl
+++ b/bin/gen_project.jl
@@ -98,7 +98,7 @@ isempty(ARGS) && (push!(ARGS, pwd()))
 for arg in ARGS
     dir = abspath(expanduser(arg))
     isdir(dir) ||
-        @error "$arg does not appear to be a package (not a directory)"
+        error("$arg does not appear to be a package (not a directory)")
 
     name = basename(dir)
     if isempty(name)
@@ -109,11 +109,11 @@ for arg in ARGS
 
     project_file = joinpath(dir, "Project.toml")
     !force && isfile(project_file) &&
-        @error "$arg already has a project file" && exit(1)
+        error("$arg already has a project file")
 
     require_file = joinpath(dir, "REQUIRE")
     isfile(require_file) ||
-        @error "$arg does not appear to be a package (no REQUIRE file)"
+        error("$arg does not appear to be a package (no REQUIRE file)")
 
     project = Dict(
         "name" => name,

--- a/bin/gen_project.jl
+++ b/bin/gen_project.jl
@@ -109,7 +109,7 @@ for arg in ARGS
 
     project_file = joinpath(dir, "Project.toml")
     !force && isfile(project_file) &&
-        @error "$arg already has a project file"
+        @error "$arg already has a project file" && exit(1)
 
     require_file = joinpath(dir, "REQUIRE")
     isfile(require_file) ||


### PR DESCRIPTION
The 'defined behaviour' as far as I am aware is:

> You call it with ARGS as directories where packages live. If the first argument is `-f` then it will overwrite existing `Project.toml` files, otherwise it will refuse to do so. It generates a `[compat]` section that approximates the bounds in the REQUIRE file as closely as possible, but unfortunately since the `[compat]` section doesn’t support version ranges this translation can be a bit messy. It is strongly encouraged that you manually review the `[compat]` section and edit by hand as appropriate.

(from Stefan's comment on Discourse).