### PR TITLE
semantic version compression & compat normalization script

### DIFF
--- a/bin/normalize.jl
+++ b/bin/normalize.jl
@@ -1,0 +1,36 @@
+import Pkg: TOML, Compress
+import Pkg.Types: VersionSpec, compress_versions
+
+const registry_path = joinpath(DEPOT_PATH[1], "registries", "General")
+const registry_file = joinpath(registry_path, "Registry.toml")
+const packages = TOML.parsefile(registry_file)["packages"]
+
+const julia_uuid = "1222c4b2-2114-5bfd-aeef-88e4692bbb3e"
+const version_map = Dict{String,Vector{VersionNumber}}()
+
+for (uuid, info) in packages
+	path = joinpath(registry_path, info["path"])
+	versions_file = joinpath(path, "Versions.toml")
+	versions = Compress.load(versions_file)
+	version_map[uuid] = sort!(collect(keys(versions)))
+end
+
+for (_, info) in packages
+	path = joinpath(registry_path, info["path"])
+	deps_file = joinpath(path, "Deps.toml")
+	isfile(deps_file) || continue
+	compat_file = joinpath(path, "Compat.toml")
+	isfile(compat_file) || continue
+	deps = Compress.load(deps_file)
+	compat = Compress.load(compat_file)
+	for (ver, data) in compat
+		for (dep, spec) in data
+			uuid = dep == "julia" ? julia_uuid : deps[ver][dep]
+			pool = version_map[uuid]
+			ranges = compress_versions(pool, VersionSpec(spec)).ranges
+			spec = length(ranges) == 1 ? string(ranges[1]) : map(string, ranges)
+			compat[ver][dep] = spec
+		end
+	end
+	Compress.save(compat_file, compat)
+end

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -266,10 +266,10 @@ function compress_versions(pool::Vector{VersionNumber}, subset::Vector{VersionNu
     isempty(subset) && return VersionSpec(ranges)
     a = first(subset)
     for b in reverse(subset)
-        is_breaking(a, b) && continue
-        for m = 1+leading_zeros(a):3
+        a.major == b.major || continue
+        for m = 1:3
             lo = VersionBound((a.major, a.minor, a.patch)[1:m]...)
-            for n = 1+leading_zeros(b):3
+            for n = 1:3
                 hi = VersionBound((b.major, b.minor, b.patch)[1:n]...)
                 r = VersionRange(lo, hi)
                 if !any(v in r for v in complement)
@@ -284,15 +284,6 @@ end
 function compress_versions(pool::Vector{VersionNumber}, subset)
     compress_versions(pool, filter(in(subset), pool))
 end
-
-is_breaking(a::VersionNumber, b::VersionNumber) =
-    a.major != b.major ||
-        a.major == b.major == 0 &&
-            (a.minor != b.minor ||
-                a.minor == b.minor == 0 && a.patch != b.patch)
-
-leading_zeros(v::VersionNumber) =
-    (v.major == 0) + (v.major == 0 && v.minor == 0)
 
 ###################
 # Semver notation #

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -97,10 +97,15 @@ struct VersionRange
     lower::VersionBound
     upper::VersionBound
     # NOTE: ranges are allowed to be empty; they are ignored by VersionSpec anyway
+    function VersionRange(lo::VersionBound, hi::VersionBound)
+        lo.n < hi.n && lo.t == hi.t && (lo = hi)
+        return new(lo, hi)
+    end
 end
 VersionRange(b::VersionBound=VersionBound()) = VersionRange(b, b)
 VersionRange(t::Integer...)                  = VersionRange(VersionBound(t...))
 VersionRange(v::VersionNumber)               = VersionRange(VersionBound(v))
+
 function VersionRange(s::AbstractString)
     m = match(r"^\s*v?((?:\d+(?:\.\d+)?(?:\.\d+)?)|\*)(?:\s*-\s*v?((?:\d+(?:\.\d+)?(?:\.\d+)?)|\*))?\s*$", s)
     m == nothing && throw(ArgumentError("invalid version range: $(repr(s))"))
@@ -254,36 +259,40 @@ subset of the pool of available versions, this function computes a `VersionSpec`
 includes all versions in `subset` and none of the versions in its complement.
 """
 function compress_versions(pool::Vector{VersionNumber}, subset::Vector{VersionNumber})
-    issorted(subset) || (subset = sort(subset))
-    compl = sort!(setdiff(pool, subset))
+    subset = sort(subset) # must copy, we mutate this
+    complement = sort!(setdiff(pool, subset))
     ranges = VersionRange[]
-    if isempty(compl)
-        lo, hi = first(subset), last(subset)
-        lower = VersionBound(lo.major, lo.minor)
-        upper = VersionBound(hi.major, hi.minor)
-        push!(ranges, VersionRange(lower, upper))
-    else
-        for v in subset
-            b = VersionBound(v.major, v.minor)
-            if any(b ≲ w ≲ b for w in compl)
-                b = VersionBound(v.major, v.minor, v.patch)
-            end
-            if isempty(ranges) || any(ranges[end].lower ≲ w ≲ b for w in compl)
-                # need a new interval
-                push!(ranges, VersionRange(b))
-            else
-                # merge with existing last range
-                ranges[end] = VersionRange(ranges[end].lower, b)
+    @label again
+    isempty(subset) && return VersionSpec(ranges)
+    a = first(subset)
+    for b in reverse(subset)
+        is_breaking(a, b) && continue
+        for m = 1+leading_zeros(a):3
+            lo = VersionBound((a.major, a.minor, a.patch)[1:m]...)
+            for n = 1+leading_zeros(b):3
+                hi = VersionBound((b.major, b.minor, b.patch)[1:n]...)
+                r = VersionRange(lo, hi)
+                if !any(v in r for v in complement)
+                    filter!(!in(r), subset)
+                    push!(ranges, r)
+                    @goto again
+                end
             end
         end
     end
-    @assert all(any(v in r for r in ranges) for v ∈ subset)
-    @assert all(!any(v in r for r in ranges) for v ∈ compl)
-    return VersionSpec(ranges)
 end
 function compress_versions(pool::Vector{VersionNumber}, subset)
     compress_versions(pool, filter(in(subset), pool))
 end
+
+is_breaking(a::VersionNumber, b::VersionNumber) =
+    a.major != b.major ||
+        a.major == b.major == 0 &&
+            (a.minor != b.minor ||
+                a.minor == b.minor == 0 && a.patch != b.patch)
+
+leading_zeros(v::VersionNumber) =
+    (v.major == 0) + (v.major == 0 && v.minor == 0)
 
 ###################
 # Semver notation #


### PR DESCRIPTION
This PR includes two things:

1. A script that normalizes all the `Compat.toml` files in `General` by loading then and then reapplying the version compression on both the keys and values en masse, thereby "normalizing" anything that's deviated for whatever reason from the standard way to express this.

2. A new version of `compress_versions` that is careful to produce a `VersionSpec` that respects gaps between versions that are considered "potentially breaking" according to semver. For example, if `A` claims compatibility with `B` versions `0.7.0`, `0.7.1`, `0.8.0`, `0.8.1` and `1.0.0` and those are the only versions that exist, then this will get compressed to `0.7-0.8, 1` whereas previously it would get compressed to `0.7-1` since there were no intervening incompatible versions.

We should merge this into Pkg and then deploy Registrator with this change after running the normalization script to update all the package `Compat.toml` files at once.

cc: @nkottary, @KristofferC, @fredrikekre 