### PR TITLE
Fix printing when installing from git.

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -641,7 +641,7 @@ function download_source(ctx::Context, pkgs::Vector{PackageSpec},
             readonly && set_readonly(path)
         end
         vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
-        @info "Installed $(rpad(pkg.name * " ", max_name + 2, "─")) $vstr"
+        printpkgstyle(ctx, :Installed, string(rpad(pkg.name * " ", max_name + 2, "─"), " ", vstr))
     end
 
     return new_versions

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -304,7 +304,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
             end
         end
         vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
-        @info "Installed $(rpad(pkg.name * " ", max_name + 2, "─")) $vstr"
+        printpkgstyle(ctx, :Installed, string(rpad(pkg.name * " ", max_name + 2, "─"), " ", vstr))
     end
 
     ##########################################


### PR DESCRIPTION
---
We were using `@info` when installing from git and `printpkgstyle` when installing from a tarball.

bors r+