### PR TITLE
TOML.print: remove unnecessary ::Function restriction on by kwarg.

### DIFF
--- a/ext/TOML/src/print.jl
+++ b/ext/TOML/src/print.jl
@@ -55,7 +55,7 @@ function _print(io::IO, a::AbstractDict,
     indent::Int = 0,
     first_block::Bool = true,
     sorted::Bool = false,
-    by::Function = identity,
+    by = identity,
 )
     akeys = keys(a)
     if sorted

--- a/ext/TOML/test/runtests.jl
+++ b/ext/TOML/test/runtests.jl
@@ -668,5 +668,11 @@ data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers supp
     res2 = TOML.parse(io)
     @test res1 == res2
 
+    # sorting with non-Function by
+    io = IOBuffer()
+    d = Dict("1.10" => 10, "1.1" => 1)
+    TOML.print(io, d; sorted=true, by = VersionNumber)
+    @test String(take!(io)) == "\"1.1\" = 1\n\"1.10\" = 10\n"
+
 end
 end


### PR DESCRIPTION
Wanted to use `by = VersionNumber` in https://github.com/JuliaComputing/Registrator.jl/pull/95, but had to workaround it with `by = x -> VersionNumber(x)`.