### PR TITLE
generate: use uuid4() instead of uuid1()

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -49,7 +49,7 @@ function project(pkg::String, dir::String; preview::Bool)
 
     authors = ["$name " * (email == nothing ? "" : "<$email>")]
 
-    uuid = UUIDs.uuid1()
+    uuid = UUIDs.uuid4()
     genfile(pkg, dir, "Project.toml"; preview=preview) do io
         toml = Dict("authors" => authors,
                     "name" => pkg,


### PR DESCRIPTION
---
@StefanKarpinski suggested on slack that `uuid4` is the recommended function for generating packages' UUID, so let's follow this recommendation in `Pkg.generate()`.