### PR TITLE
Change the docs to use PrintFileTree instead of `tree` command!

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -11,12 +11,12 @@ To generate files for a new package, use `pkg> generate`.
 (v1.0) pkg> generate HelloWorld
 ```
 
-This creates a new project `HelloWorld` with the following files (visualized with the external [`tree` command](https://linux.die.net/man/1/tree)):
+This creates a new project `HelloWorld` with the following files (visualized with the [PrintFileTree.jl package](https://github.com/NHDaly/PrintFileTree.jl)):
 
 ```jl
-shell> cd HelloWorld
+julia> cd("HelloWorld")
 
-shell> tree .
+julia> printfiletree(".")
 .
 ├── Project.toml
 └── src


### PR DESCRIPTION
This changes printing the directory from using the `tree` command to using the `PrintFileTree` package.

Mostly just because it's fun to use Julia stuff where we can, but also maybe because people might be less comfortable installing commandline tools than installing julia packages. :)


Feel free to just close this, though, if you think it's silly. :)