### PR TITLE
Fix generation of stdlib test targets in gen_project.jl.

### DIFF
--- a/bin/gen_project.jl
+++ b/bin/gen_project.jl
@@ -139,9 +139,11 @@ for arg in ARGS
                 project["compat"][dep] = semver(req.versions.intervals)
             end
         end
+    end
 
+    for (srcdir, section) in (("src" => "deps"), ("test", "extras"))
         for stdlib in STDLIBS
-            if uses(dirname(file), stdlib)
+            if uses(joinpath(dir, srcdir), stdlib)
                 project[section][stdlib] = uuid(stdlib)
             end
         end


### PR DESCRIPTION
Before this change, there were two issues:

* `dirname(file)` for the main `REQUIRE` is the root of the package, so stdlib dependencies found in the `test` directory would also be added to `deps`
* if there was no `test/REQUIRE`, the `test` directory would never be separately searched for stdlib dependencies.