### PR TITLE
Add verbose option to Pkg.instantiate

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -457,7 +457,7 @@ end
 
 instantiate(; kwargs...) = instantiate(Context(); kwargs...)
 function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
-                     update_registry::Bool=true, kwargs...)
+                     update_registry::Bool=true, verbose::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     if (!isfile(ctx.env.manifest_file) && manifest == nothing) || manifest == false
         up(ctx; update_registry=update_registry)
@@ -484,7 +484,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
         mv(tmp_source, sourcepath; force=true)
     end
     new_apply = Operations.download_source(ctx, pkgs)
-    Operations.build_versions(ctx, union(new_apply, new_git))
+    Operations.build_versions(ctx, union(new_apply, new_git); verbose=verbose)
 end
 
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -265,12 +265,14 @@ const develop = API.develop
 const generate = API.generate
 
 """
-    Pkg.instantiate()
+    Pkg.instantiate(; verbose = false)
 
 If a `Manifest.toml` file exists in the current project, download all
 the packages declared in that manifest.
 Otherwise, resolve a set of feasible packages from the `Project.toml` files
 and install them.
+`verbose = true` prints the build output to `stdout`/`stderr` instead of
+redirecting to the `build.log` file.
 """
 const instantiate = API.instantiate
 

--- a/src/REPL/command_declarations.jl
+++ b/src/REPL/command_declarations.jl
@@ -43,12 +43,13 @@ If `cmd` is a full command, display help for `cmd`.
     :option_spec => OptionDeclaration[
         [:name => "project", :short_name => "p", :api => :manifest => false],
         [:name => "manifest", :short_name => "m", :api => :manifest => true],
+        [:name => "verbose", :short_name => "v", :api => :verbose => true],
     ],
     :description => "downloads all the dependencies for the project",
     :help => md"""
-    instantiate
-    instantiate [-m|--manifest]
-    instantiate [-p|--project]
+    instantiate [-v|--verbose]
+    instantiate [-v|--verbose] [-m|--manifest]
+    instantiate [-v|--verbose] [-p|--project]
 
 Download all the dependencies for the current project at the version given by the project's manifest.
 If no manifest exists or the `--project` option is given, resolve and download the dependencies compatible with the project.

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -747,6 +747,13 @@ end
     end end
 end
 
+@testset "smoke test instantiate(verbose=true)" begin
+    temp_pkg_dir() do project_path
+        Pkg.activate(project_path)
+        Pkg.instantiate(verbose=true)
+    end
+end
+
 include("repl.jl")
 include("api.jl")
 include("registry.jl")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -747,13 +747,6 @@ end
     end end
 end
 
-@testset "smoke test instantiate(verbose=true)" begin
-    temp_pkg_dir() do project_path
-        Pkg.activate(project_path)
-        Pkg.instantiate(verbose=true)
-    end
-end
-
 include("repl.jl")
 include("api.jl")
 include("registry.jl")

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -936,4 +936,11 @@ end
     end end end
 end
 
+@testset "smoke test `instantiate --verbose`" begin
+    temp_pkg_dir() do project_path
+        Pkg.activate(project_path)
+        pkg"instantiate --verbose"
+    end
+end
+
 end # module

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -939,6 +939,7 @@ end
 @testset "smoke test `instantiate --verbose`" begin
     temp_pkg_dir() do project_path
         Pkg.activate(project_path)
+        Pkg.instantiate(verbose=true)
         pkg"instantiate --verbose"
         pkg"instantiate -v"
     end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -940,6 +940,7 @@ end
     temp_pkg_dir() do project_path
         Pkg.activate(project_path)
         pkg"instantiate --verbose"
+        pkg"instantiate -v"
     end
 end
 


### PR DESCRIPTION
This PR adds `verbose` option to `Pkg.instantiate`.  This is useful, for example,if you want to set up multiple projects in installation step of CI.  Using `Pkg.build(verbose=true)` would invoke unnecessary redundant builds while `Pkg.instantiate()` prints only very minimum log.  It can be fixed by supporting `verbose` in `Pkg.instantiate`.
