### PR TITLE
Check for composite exception before iterating (fix 1120)

### DIFF
--- a/src/project.jl
+++ b/src/project.jl
@@ -131,7 +131,7 @@ function read_project(io::IO; path=nothing)
     catch err
         if err isa TOML.ParserError
             pkgerror("Could not parse project $(something(path,"")): $(err.msg)")
-        elseif all(x -> x isa TOML.ParserError, err)
+        elseif err isa CompositeException && all(x -> x isa TOML.ParserError, err)
             pkgerror("Could not parse project $(something(path,"")): $err")
         else
             rethrow()


### PR DESCRIPTION
Fixes #1120 

Tested manually. Not really sure how to make the TOML parser fail in the right way to automate the test though :grimacing: 
