### PR TITLE
Safer Project.toml and Manifest.toml printing

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -202,13 +202,12 @@ function destructure(manifest::Manifest)::Dict
     return raw
 end
 
-write_manifest(manifest::Manifest, manifest_file::AbstractString) =
-    open(io -> write_manifest(manifest, io), manifest_file; truncate=true)
-
-function write_manifest(manifest::Manifest,io::IO)
+function write_manifest(manifest::Manifest, manifest_file::AbstractString)
     raw = destructure(manifest)
+    io = IOBuffer()
     print(io, "# This file is machine-generated - editing it directly is not advised\n\n")
     TOML.print(io, raw, sorted=true)
+    open(f -> write(f, seekstart(io)), manifest_file; truncate=true)
 end
 
 function write_manifest(manifest::Manifest, env, old_env, ctx::Context; display_diff=true)

--- a/src/project.jl
+++ b/src/project.jl
@@ -170,12 +170,11 @@ project_key_order(key::String) =
 
 write_project(project::Project, project_file::AbstractString) =
     write_project(destructure(project), project_file)
-write_project(project::Project, io::IO) =
-    write_project(destructure(project), io)
-write_project(project::Dict, project_file::AbstractString) =
-    open(io -> write_project(project, io), project_file; truncate=true)
-write_project(project::Dict, io::IO) =
+function write_project(project::Dict, project_file::AbstractString)
+    io = IOBuffer()
     TOML.print(io, project, sorted=true, by=key -> (project_key_order(key), key))
+    open(f -> write(f, seekstart(io)), project_file; truncate=true)
+end
 function write_project(project::Project, env, old_env, ctx::Context; display_diff=true)
     project = destructure(ctx.env.project)
     if !isempty(project) || ispath(env.project_file)


### PR DESCRIPTION
Write out `Project.toml` and `Manifest.toml` to a temporary
`IOBuffer`, before modifying the file on disk, fixes #1202.