### PR TITLE
Require --diff for diff output in status

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -490,12 +490,12 @@ end
 
 @deprecate status(mode::PackageMode) status(mode=mode)
 
-status(; mode=PKGMODE_PROJECT) = status(PackageSpec[]; mode=mode)
-status(pkg::Union{AbstractString,PackageSpec}; mode=PKGMODE_PROJECT) = status([pkg]; mode=mode)
-status(pkgs::Vector{<:AbstractString}; mode=PKGMODE_PROJECT) =
-    status([check_package_name(pkg) for pkg in pkgs]; mode=mode)
-status(pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT) = status(Context(), pkgs; mode=mode)
-function status(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT)
+status(; kwargs...) = status(PackageSpec[]; kwargs...)
+status(pkg::Union{AbstractString,PackageSpec}; kwargs...) = status([pkg]; kwargs...)
+status(pkgs::Vector{<:AbstractString}; kwargs...) =
+    status([check_package_name(pkg) for pkg in pkgs]; kwargs...)
+status(pkgs::Vector{PackageSpec}; kwargs...) = status(Context(), pkgs; kwargs...)
+function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=PKGMODE_PROJECT)
     project_resolve!(ctx.env, pkgs)
     project_deps_resolve!(ctx.env, pkgs)
     if mode === PKGMODE_MANIFEST
@@ -503,7 +503,7 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT)
     end
     manifest_resolve!(ctx.env, pkgs)
     ensure_resolved(ctx.env, pkgs)
-    Pkg.Display.status(ctx, pkgs, mode=mode)
+    Pkg.Display.status(ctx, pkgs, diff=diff, mode=mode)
     return nothing
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -283,16 +283,22 @@ from packages that are tracking a path.
 const resolve = API.resolve
 
 """
-    Pkg.status([pkgs...]; mode::PackageMode=PKGMODE_PROJECT)
+    Pkg.status([pkgs...]; mode::PackageMode=PKGMODE_PROJECT, diff::Bool=false)
 
 Print out the status of the project/manifest.
 If `mode` is `PKGMODE_PROJECT`, print out status only about the packages
 that are in the project (explicitly added). If `mode` is `PKGMODE_MANIFEST`,
 print status also about those in the manifest (recursive dependencies). If there are
 any packages listed as arguments, the output will be limited to those packages.
+Setting `diff=true` will, if the environment is in a git repository, limit
+the output to the difference as compared to the last git commit.
 
 !!! compat "Julia 1.1"
     `Pkg.status` with package arguments requires at least Julia 1.1.
+
+!!! compat "Julia 1.3"
+    The `diff` keyword argument requires Julia 1.3. In earlier versions `diff=true`
+    is the default for environments in git repositories.
 """
 const status = API.status
 

--- a/src/REPL/command_declarations.jl
+++ b/src/REPL/command_declarations.jl
@@ -287,24 +287,28 @@ The `startup.jl` file is disabled during precompilation unless julia is started 
     :option_spec => OptionDeclaration[
         [:name => "project",  :short_name => "p", :api => :mode => PKGMODE_PROJECT],
         [:name => "manifest", :short_name => "m", :api => :mode => PKGMODE_MANIFEST],
+        [:name => "diff", :short_name => "d", :api => :diff => true],
     ],
     :completions => complete_installed_packages,
     :description => "summarize contents of and changes to environment",
     :help => md"""
-    status [pkgs...]
-    status [-p|--project] [pkgs...]
-    status [-m|--manifest] [pkgs...]
+    status [-d|--diff] [pkgs...]
+    status [-d|--diff] [-p|--project] [pkgs...]
+    status [-d|--diff] [-m|--manifest] [pkgs...]
 
-Show the status of the current environment. By default, the full contents of
-the project file is summarized, showing what version each package is on and
-how it has changed since the last git commit (if in a git repository), as well as
-any changes to manifest packages not already listed. In `--project` mode, the
+Show the status of the current environment. In `--project` mode (default), the
 status of the project file is summarized. In `--manifest` mode the output also
-includes the recursive dependencies of added packages. If there are any
-packages listed as arguments the output will be limited to those packages.
+includes the recursive dependencies of added packages given in the manifest.
+If there are any packages listed as arguments the output will be limited to those packages.
+The `--diff` option will, if the environment is in a git repository, limit
+the output to the difference as compared to the last git commit.
 
 !!! compat "Julia 1.1"
     `pkg> status` with package arguments requires at least Julia 1.1.
+
+!!! compat "Julia 1.3"
+    The `--diff` option requires Julia 1.3. In earlier versions `--diff`
+    is the default for environments in git repositories.
 """,
 ],[ :kind => CMD_GC,
     :name => "gc",

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -448,7 +448,7 @@ end
 
 # TODO set default Display.status keyword: mode = PKGMODE_COMBINED
 do_status!(ctx::APIOptions, args::Vector, api_opts::APIOptions) =
-    API.status(Context!(ctx), args, mode=get(api_opts, :mode, PKGMODE_COMBINED))
+    API.status(Context!(ctx), args, diff=get(api_opts, :diff, false), mode=get(api_opts, :mode, PKGMODE_COMBINED))
 
 # TODO , test recursive dependencies as on option.
 function do_test!(ctx::APIOptions, args::Vector, api_opts::APIOptions)

--- a/test/api.jl
+++ b/test/api.jl
@@ -68,6 +68,10 @@ end
         Pkg.status("Test"; mode=PKGMODE_MANIFEST)
         @test_throws PkgError Pkg.status("Test"; mode=Pkg.Types.PKGMODE_COMBINED)
         @test_throws PkgError Pkg.status("Test"; mode=PKGMODE_PROJECT)
+        # diff option
+        @test_logs (:warn, r"diff option only available") Pkg.status(diff=true)
+        git_init_and_commit(project_path)
+        @test_logs () Pkg.status(diff=true)
     end
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -737,7 +737,7 @@ end
         end
         write("Project.toml", "[deps]\nExample = \"7876af07-990d-54b4-ab0e-23690620f79a\"\n")
         Pkg.activate(dir)
-        @test_logs (:warn, r"Could not read project from HEAD") Pkg.status()
+        @test_logs (:warn, r"could not read project from HEAD") Pkg.status(diff=true)
     end end
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -705,19 +705,13 @@ end
         Pkg.generate("A")
         cd(mkdir("packages")) do
             Pkg.generate("A")
-            LibGit2.with(LibGit2.init("A")) do repo
-                LibGit2.add!(repo, "*")
-                LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
-            end
+            git_init_and_commit("A")
         end
         Pkg.generate("B")
         project = Pkg.Types.read_project("A/Project.toml")
         project.name = "B"
         Pkg.Types.write_project(project, "B/Project.toml")
-        LibGit2.with(LibGit2.init("B")) do repo
-            LibGit2.add!(repo, "*")
-            LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
-        end
+        git_init_and_commit("B")
         Pkg.develop(Pkg.PackageSpec(path = abspath("A")))
         # package with same name but different uuid exist in project
         @test_throws PkgError Pkg.develop(Pkg.PackageSpec(path = abspath("packages", "A")))
@@ -731,10 +725,7 @@ end
 @testset "issue #1180: broken toml-files in HEAD" begin
     temp_pkg_dir() do dir; cd(dir) do
         write("Project.toml", "[deps]\nExample = \n")
-        LibGit2.with(LibGit2.init(dir)) do repo
-            LibGit2.add!(repo, "*")
-            LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
-        end
+        git_init_and_commit(dir)
         write("Project.toml", "[deps]\nExample = \"7876af07-990d-54b4-ab0e-23690620f79a\"\n")
         Pkg.activate(dir)
         @test_logs (:warn, r"could not read project from HEAD") Pkg.status(diff=true)

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -39,10 +39,7 @@ function setup_test_registries(dir = pwd())
             ["0.5"]
             julia = "0.6-1.0"
             """)
-        LibGit2.with(LibGit2.init(regpath)) do repo
-            LibGit2.add!(repo, "*")
-            LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
-        end
+        git_init_and_commit(regpath)
     end
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -497,10 +497,7 @@ temp_pkg_dir() do project_path
                         Pkg.generate(pkg_name)
                     end
                     cd(pkg_name) do
-                        LibGit2.with(LibGit2.init(joinpath(project_path, parent_dir, pkg_name))) do repo
-                            LibGit2.add!(repo, "*")
-                            LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
-                        end
+                        git_init_and_commit(joinpath(project_path, parent_dir, pkg_name))
                     end #cd pkg_name
                 end # cd parent_dir
             end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -891,6 +891,12 @@ end
         status Example Random
         status -m Example
         """
+        # --diff option
+        @test_logs (:warn, r"diff option only available") pkg"status --diff"
+        @test_logs (:warn, r"diff option only available") pkg"status -d"
+        git_init_and_commit(project_path)
+        @test_logs () pkg"status --diff"
+        @test_logs () pkg"status -d"
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -123,14 +123,18 @@ using UUIDs
 const TEST_SIG = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time()), 0)
 const TEST_PKG = (name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
 
+function git_init_and_commit(path; msg = "initial commit")
+    LibGit2.with(LibGit2.init(path)) do repo
+        LibGit2.add!(repo, "*")
+        LibGit2.commit(repo, msg; author=TEST_SIG, committer=TEST_SIG)
+    end
+end
+
 function git_init_package(tmp, path)
     base = basename(path)
     pkgpath = joinpath(tmp, base)
     cp(path, pkgpath)
-    LibGit2.with(LibGit2.init(pkgpath)) do repo
-        LibGit2.add!(repo, "*")
-        LibGit2.commit(repo, "initial commit"; author=TEST_SIG, committer=TEST_SIG)
-    end
+    git_init_and_commit(pkgpath)
     return pkgpath
 end
 


### PR DESCRIPTION
---
I think the current behaviour causes too much confusion, and you often just want to see the absolute status anyway. See e.g. https://discourse.julialang.org/t/pkg-status-and-project-toml-out-of-sync/24473, https://stackoverflow.com/questions/56050364/how-to-prevent-pkg-jl-to-hold-state-beyond-project-toml-and-manifest-toml etc.

Edit: https://github.com/JuliaLang/Pkg.jl/pull/1205/files?w=1 for easier review.