### PR TITLE
Make sure we have found the registry path when developing

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1300,6 +1300,7 @@ end
 
 # Return most current package info for a registered UUID
 function registered_info(env::EnvCache, uuid::UUID, key::String)
+    haskey(env.paths, uuid) || find_registered!(env, [uuid])
     paths = env.paths[uuid]
     isempty(paths) && pkgerror("`$uuid` is not registered")
     values = []

--- a/test/api.jl
+++ b/test/api.jl
@@ -73,6 +73,7 @@ end
 
 @testset "Pkg.develop" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir;
+        exuuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # UUID of Example.jl
         entry = nothing
         # explicit relative path
         with_temp_env() do env_path
@@ -109,6 +110,16 @@ end
                     @test isdir(entry.path)
                 end
             end
+        end
+        # name + uuid
+        with_temp_env() do env_path
+            Pkg.develop(PackageSpec(name = "Example", uuid = exuuid))
+            @test Pkg.Types.Context().env.manifest[exuuid].version > v"0.5"
+        end
+        # uuid
+        with_temp_env() do env_path
+            Pkg.develop(PackageSpec(uuid = exuuid))
+            @test Pkg.Types.Context().env.manifest[exuuid].version > v"0.5"
         end
         # name + local
         with_temp_env() do env_path


### PR DESCRIPTION
Make sure we have found the registry path when developing packages, fixes #1206.