### PR TITLE
Check for consistent toml files before `instantiate`ing

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -467,6 +467,13 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
         pkgerror("manifest at $(ctx.env.manifest_file) does not exist")
     end
     Operations.prune_manifest(ctx.env)
+    for (name, uuid) in ctx.env.project.deps
+        get(ctx.env.manifest, uuid, nothing) === nothing || continue
+        pkgerror("`$name` is a direct dependency, but does not appear in the manifest.",
+                 " If you intend `$name` to be a direct dependency, run `Pkg.resolve()` to populate the manifest.",
+                 " Otherwise, remove `$name` with `Pkg.rm(\"$name\")`.",
+                 " Finally, run `Pkg.instantiate()` again.")
+    end
     Types.update_registries(ctx)
     pkgs = PackageSpec[]
     Operations.load_all_deps!(ctx, pkgs)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -768,6 +768,14 @@ end
     end end
 end
 
+@testset "instantiate checks for consistent dependency graph" begin
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        copy_test_package(tmp, "ExtraDirectDep")
+        Pkg.activate(joinpath(tmp, "ExtraDirectDep"))
+        @test_throws PkgError Pkg.instantiate()
+    end end
+end
+
 @testset "up should prune manifest" begin
     example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
     unicode_uuid = UUID("4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5")

--- a/test/test_packages/ExtraDirectDep/Manifest.toml
+++ b/test/test_packages/ExtraDirectDep/Manifest.toml
@@ -1,0 +1,6 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Example]]
+git-tree-sha1 = "686e1ac14b35cce47f90c91200f904c603ace29e"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.4.0"

--- a/test/test_packages/ExtraDirectDep/Project.toml
+++ b/test/test_packages/ExtraDirectDep/Project.toml
@@ -1,0 +1,7 @@
+name = "ExtraDirectDep"
+uuid = "3df6871a-8032-11e9-14c7-ef1c42524041"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"


### PR DESCRIPTION
So #1106 occurred because of an inconsistency between the toml files. This just explicitly checks for this case.