### PR TITLE
RFC: Generate stubs for `tests/runtests.jl`

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -19,16 +19,13 @@ shell> cd HelloWorld
 shell> tree .
 .
 ├── Project.toml
-├── docs
-│   └── src
-│       └── index.md
 ├── src
 │   └── HelloWorld.jl
 └── test
     ├── Project.toml
     └── runtests.jl
 
-4 directories, 5 files
+2 directories, 4 files
 ```
 
 The `Project.toml` file contains the name of the package, its unique UUID, its version, the author and potential dependencies:
@@ -64,13 +61,6 @@ using HelloWorld
 using Test
 
 @test 1 == 1
-```
-
-The content of `docs/src/index.md` is:
-```markdown
-# Introduction
-
-Welcome to the documentation for HelloWorld.jl.
 ```
 
 We can now activate the project and load the package:

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -19,10 +19,16 @@ shell> cd HelloWorld
 shell> tree .
 .
 ├── Project.toml
-└── src
-    └── HelloWorld.jl
+├── docs
+│   └── src
+│       └── index.md
+├── src
+│   └── HelloWorld.jl
+└── test
+    ├── Project.toml
+    └── runtests.jl
 
-1 directory, 2 files
+4 directories, 5 files
 ```
 
 The `Project.toml` file contains the name of the package, its unique UUID, its version, the author and potential dependencies:
@@ -44,6 +50,27 @@ module HelloWorld
 greet() = print("Hello World!")
 
 end # module
+```
+
+The content of `test/Project.toml` is:
+```toml
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+```
+
+The content of `test/runtests.jl` is:
+```jl
+using HelloWorld
+using Test
+
+@test 1 == 1
+```
+
+The content of `docs/src/index.md` is:
+```markdown
+# Introduction
+
+Welcome to the documentation for HelloWorld.jl.
 ```
 
 We can now activate the project and load the package:

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -60,7 +60,9 @@ The content of `test/runtests.jl` is:
 using HelloWorld
 using Test
 
-@test 1 == 1
+@testset "HelloWorld.jl" begin
+    @test 1 == 2
+end
 ```
 
 We can now activate the project and load the package:

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -13,7 +13,6 @@ function generate(ctx::Context, path::String; kwargs...)
     entrypoint(pkg, dir; preview=ctx.preview)
     gentestproject(pkg, dir; preview=ctx.preview)
     genruntests(pkg, dir; preview=ctx.preview)
-    gendocsindex(pkg, dir; preview=ctx.preview)
     ctx.preview && preview_info()
     return Dict(pkg => uuid)
 end
@@ -100,14 +99,3 @@ function genruntests(pkg::String, dir; preview::Bool)
     end
 end
 
-function gendocsindex(pkg::String, dir; preview::Bool)
-    genfile(pkg, dir, "docs/src/index.md"; preview=preview) do io
-        print(io,
-           """
-            # Introduction
-
-            Welcome to the documentation for $pkg.jl.
-            """
-        )
-    end
-end

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -98,4 +98,3 @@ function genruntests(pkg::String, dir; preview::Bool)
         )
     end
 end
-

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -93,7 +93,9 @@ function genruntests(pkg::String, dir; preview::Bool)
             using $pkg
             using Test
 
-            @test 1 == 1
+            @testset "$pkg.jl" begin
+                @test 1 == 2
+            end
             """
         )
     end

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -11,6 +11,9 @@ function generate(ctx::Context, path::String; kwargs...)
     print(" project $pkg:\n")
     uuid = project(pkg, dir; preview=ctx.preview)
     entrypoint(pkg, dir; preview=ctx.preview)
+    gentestproject(pkg, dir; preview=ctx.preview)
+    genruntests(pkg, dir; preview=ctx.preview)
+    gendocsindex(pkg, dir; preview=ctx.preview)
     ctx.preview && preview_info()
     return Dict(pkg => uuid)
 end
@@ -70,6 +73,40 @@ function entrypoint(pkg::String, dir; preview::Bool)
             greet() = print("Hello World!")
 
             end # module
+            """
+        )
+    end
+end
+
+function gentestproject(pkg::String, dir; preview::Bool)
+    genfile(pkg, dir, "test/Project.toml"; preview=preview) do io
+        toml = Dict(
+            "deps" => Dict("Test" => "8dfed614-e22c-5e08-85e1-65c5234f0b40")
+            )
+        TOML.print(io, toml, sorted=true, by=key -> (Types.project_key_order(key), key))
+    end
+end
+
+function genruntests(pkg::String, dir; preview::Bool)
+    genfile(pkg, dir, "test/runtests.jl"; preview=preview) do io
+        print(io,
+           """
+            using $pkg
+            using Test
+
+            @test 1 == 1
+            """
+        )
+    end
+end
+
+function gendocsindex(pkg::String, dir; preview::Bool)
+    genfile(pkg, dir, "docs/src/index.md"; preview=preview) do io
+        print(io,
+           """
+            # Introduction
+
+            Welcome to the documentation for $pkg.jl.
             """
         )
     end


### PR DESCRIPTION
Currently, `Pkg.generate` creates the following files:
- `Project.toml`
- `src/$pkg.jl`

This pull request modifies `Pkg.generate` to also create the following files:
- `test/Project.toml`
- `test/runtests.jl`