### PR TITLE
Allow path starting with ~/ to be used as a repo-url

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -83,6 +83,9 @@ function setprotocol!(;
 end
 
 function normalize_url(url::AbstractString)
+    if !Sys.iswindows() && startswith(url, "~/")
+        url = expanduser(url)
+    end
     m = match(GIT_REGEX, url)
     m === nothing && return url
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -791,6 +791,23 @@ end
     end end
 end
 
+if !Sys.iswindows()
+    @testset "resolve ~/ in repo-url" begin
+        temp_pkg_dir() do env_path; with_pkg_env(env_path) do; mktempdir() do tmp; withenv("HOME" => tmp) do
+            pkgname = "DependsOnExample"
+            repo_url = "~/mypackage/$pkgname"
+            repo_parent = dirname(expanduser(repo_url))
+            mkpath(repo_parent)
+            git_init_package(repo_parent, joinpath(@__DIR__, "test_packages", pkgname))
+            Pkg.add(Pkg.PackageSpec(path=repo_url))
+            manifest = read(joinpath(env_path, "Manifest.toml"), String)
+            @test occursin(repo_url, manifest)
+            Pkg.update(pkgname)
+            @test occursin(repo_url, manifest)
+        end end end end
+    end
+end
+
 include("repl.jl")
 include("api.jl")
 include("registry.jl")


### PR DESCRIPTION
This PR lets you specify a directory under `$HOME` using `~/` for `repo-url`. It would be useful when sending `Manifest.toml` containing local paths to different users and when such repository does not have a stable public URL. Git CLI also lets you use a path starting with `~/` as `remote.$name.url` so I suppose this is not so crazy idea?
