### PR TITLE
import Base.get

### DIFF
--- a/ext/TOML/src/parser.jl
+++ b/ext/TOML/src/parser.jl
@@ -1,4 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+import Base: get
+
 
 "TOML Table"
 struct Table


### PR DESCRIPTION
Enables parser to correctly parse floating point.