### PR TITLE
Generate dummy output during `Pkg.test` to keep Travis from failing

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -229,7 +229,7 @@ test(pkg::Union{AbstractString, PackageSpec}; kwargs...) = test([pkg]; kwargs...
 test(pkgs::Vector{<:AbstractString}; kwargs...)          = test([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
 test(pkgs::Vector{PackageSpec}; kwargs...)               = test(Context(), pkgs; kwargs...)
 function test(ctx::Context, pkgs::Vector{PackageSpec};
-              coverage=false, test_fn=nothing, kwargs...)
+              coverage=false, test_fn=nothing, output_seconds::Integer = 0, kwargs...)
     pkgs = deepcopy(pkgs) # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
@@ -242,7 +242,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env, pkgs)
         ensure_resolved(ctx.env, pkgs)
     end
-    Operations.test(ctx, pkgs; coverage=coverage, test_fn=test_fn)
+    Operations.test(ctx, pkgs; coverage=coverage, test_fn=test_fn, output_seconds=output_seconds)
     return
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -139,9 +139,9 @@ const update = API.up
 
 
 """
-    Pkg.test(; coverage::Bool=false)
-    Pkg.test(pkg::Union{String, Vector{String}; coverage::Bool=false)
-    Pkg.test(pkgs::Union{PackageSpec, Vector{PackageSpec}}; coverage::Bool=false)
+    Pkg.test(; coverage::Bool=false, output_seconds::Integer = 0)
+    Pkg.test(pkg::Union{String, Vector{String}; coverage::Bool=false, output_seconds::Integer = 0)
+    Pkg.test(pkgs::Union{PackageSpec, Vector{PackageSpec}}; coverage::Bool=false, output_seconds::Integer = 0)
 
 Run the tests for package `pkg`, or for the current project (which thus needs to be a package) if no
 positional argument is given to `Pkg.test`. A package is tested by running its
@@ -169,6 +169,9 @@ The tests are executed in a new process with `check-bounds=yes` and by default `
 If using the startup file (`~/.julia/config/startup.jl`) is desired, start julia with `--startup-file=yes`.
 Inlining of functions during testing can be disabled (for better coverage accuracy)
 by starting julia with `--inline=no`.
+
+If `output_seconds` is greater than 0, then a dummy line of output will be written
+every `output_seconds` seconds until the tests finish.
 """
 const test = API.test
 

--- a/test/sandbox.jl
+++ b/test/sandbox.jl
@@ -17,6 +17,27 @@ test_test(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
             @test true
         end
     end end
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        copy_test_package(tmp, "BasicSandbox")
+        Pkg.activate(joinpath(tmp, "BasicSandbox"))
+        test_test(; output_seconds = -1) do
+            @test true
+        end
+    end end
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        copy_test_package(tmp, "BasicSandbox")
+        Pkg.activate(joinpath(tmp, "BasicSandbox"))
+        test_test(; output_seconds = 0) do
+            @test true
+        end
+    end end
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        copy_test_package(tmp, "BasicSandbox")
+        Pkg.activate(joinpath(tmp, "BasicSandbox"))
+        test_test(; output_seconds = 1) do
+            @test true
+        end
+    end end
     # try to use subgraph from active env
     temp_pkg_dir() do project_path; mktempdir() do tmp
         copy_test_package(tmp, "TransferSubgraph")


### PR DESCRIPTION
## Summary

This pull request adds the `output_seconds` keyword argument to `Pkg.test`. The default value of `output_seconds` is `0.`

If `output_seconds` is greater than `0`, then a line of output will be printed every `output_seconds` seconds until the test suite finishes.

If `output_seconds` is less than or equal to `0`, then you get the current behavior.

## Example usage
```julia
julia> Pkg.test("Foo") # preserves the current behavior
julia> Pkg.test("Foo"; output_seconds = -1) # preserves the current behavior
julia> Pkg.test("Foo"; output_seconds = 0) # preserves the current behavior
julia> Pkg.test("Foo"; output_seconds = 1) # prints a line of output every 1 second
julia> Pkg.test("Foo"; output_seconds = 300) # prints a line of output every 300 seconds
```

## Motivation

If `Pkg.test` runs for more than 10 minutes without generating any output, Travis will fail the job. The functionality in this pull request allows you to generate output to satisfy Travis while you wait for your jobs to finish.

One way to get around this is the `travis_wait` function. However, `travis_wait` is not defined in subshells, so if you use a custom `script` file, then `travis_wait` is not defined.

Additionally, if you use `travis_wait`, then you'll need to find a different solution for `AppVeyor`, `CircleCI`, etc. In contrast, if we can add support directly to `Pkg.test`, then you can have the same solution for all CI platforms.

## Questions

Is this the best way to implement this feature? I don't love relying on `kill` to end the dummy output generating process. Is there a better way to accomplish the same outcome?