### PR TITLE
stop lower/upper bounding packages in Project in add / develop

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -969,7 +969,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[]; strict::Bo
     end
     foreach(pkg -> ctx.env.project.deps[pkg.name] = pkg.uuid, pkgs) # update set of deps
     # load dep graph
-    strict ? load_all_deps!(ctx, pkgs) : load_direct_deps!(ctx, pkgs)
+    strict ? load_all_deps!(ctx, pkgs) : load_direct_deps!(ctx, pkgs; version=false)
     check_registered(ctx, pkgs)
     resolve_versions!(ctx, pkgs)
     update_manifest!(ctx, pkgs)
@@ -987,7 +987,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Vector{UUID};
     for pkg in pkgs
         ctx.env.project.deps[pkg.name] = pkg.uuid
     end
-    strict ? load_all_deps!(ctx, pkgs) : load_direct_deps!(ctx, pkgs)
+    strict ? load_all_deps!(ctx, pkgs) : load_direct_deps!(ctx, pkgs; version=false)
     check_registered(ctx, pkgs)
 
     # resolve & apply package versions


### PR DESCRIPTION
Currently, packages in the Project file gets semver restricted (actually, reading the code they might get restricted to exact versions) when a user adds or devs a new package. This introduces some "hysteresis" in the resolver in the sense that what you already happened to have installed will affect the version bounds that gets entered into the resolver.

This has caused quite a lot of confusion when e.g. `add A; add B` gives different results than `add B; add A` or `add A B`. I think it is better to try to have the inputs to the resolver be as stateless as possible by default. We still have the `strict` option if one wants to use that (and of course `[compat]`).

People might complain that a bunch of unrelated stuff gets updated but that is already true for recursive deps and again, there is `--strict`.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/110

TODO: Add test.