### PR TITLE
Use Cmd for {julia,test}_args keyword arguments

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -230,10 +230,8 @@ test(pkgs::Vector{<:AbstractString}; kwargs...)          = test([PackageSpec(pkg
 test(pkgs::Vector{PackageSpec}; kwargs...)               = test(Context(), pkgs; kwargs...)
 function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, test_fn=nothing,
-              julia_args::AbstractVector{<:Base.AbstractCmd}=Cmd[],
-              test_args::AbstractVector{<:AbstractString}=String[], kwargs...)
-    julia_args = convert(Vector{Cmd}, julia_args)
-    test_args = convert(Vector{String}, test_args)
+              julia_args::Cmd=``,
+              test_args::Cmd=``, kwargs...)
     pkgs = deepcopy(pkgs) # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1144,13 +1144,12 @@ end
 
 function gen_test_code(testfile::String;
         coverage=false,
-        julia_args::Vector{Cmd}=Cmd[],
-        test_args::Vector{String}=String[])
-    julia_args_str::Vector{String} = vcat([x.exec for x in julia_args]...)
+        julia_args::Cmd=``,
+        test_args::Cmd=``)
     code = """
         $(Base.load_path_setup_code(false))
         cd($(repr(dirname(testfile))))
-        append!(empty!(ARGS), $(repr(test_args)))
+        append!(empty!(ARGS), $(repr(test_args.exec)))
         include($(repr(testfile)))
         """
     return ```
@@ -1162,7 +1161,7 @@ function gen_test_code(testfile::String;
         --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
         --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])
-        $(julia_args_str)
+        $(julia_args)
         --eval $(code)
     ```
 end
@@ -1248,8 +1247,8 @@ testdir(source_path::String) = joinpath(source_path, "test")
 testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 function test(ctx::Context, pkgs::Vector{PackageSpec};
         coverage=false, test_fn=nothing,
-        julia_args::Vector{Cmd}=Cmd[],
-        test_args::Vector{String}=String[])
+        julia_args::Cmd=``,
+        test_args::Cmd=``)
     ctx.preview || Pkg.instantiate(ctx)
 
     # load manifest data

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -144,8 +144,8 @@ const update = API.up
 
 **Keyword arguments:**
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
-  - `julia_args`: vector of `Cmd` passed to the test process.
-  - `test_args`: vector of test arguments (`ARGS`) available in the test process.
+  - `julia_args::Cmd`: options to be passed the test process.
+  - `test_args::Cmd`: test arguments (`ARGS`) available in the test process.
 
 !!! compat "Julia 1.3"
     `julia_args` and `test_args` requires at least Julia 1.3.

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -572,7 +572,7 @@ end
 
 function backwards_compatibility_for_test(
     ctx::Context, pkg::PackageSpec, testfile::String, pkgs_errored::Vector{String},
-    coverage; julia_args=Cmd[], test_args=String[]
+    coverage; julia_args=``, test_args=``
 )
     printpkgstyle(ctx, :Testing, pkg.name)
     if ctx.preview
@@ -582,10 +582,9 @@ function backwards_compatibility_for_test(
     code = """
         $(Base.load_path_setup_code(false))
         cd($(repr(dirname(testfile))))
-        append!(empty!(ARGS), $(repr(test_args)))
+        append!(empty!(ARGS), $(repr(test_args.exec)))
         include($(repr(testfile)))
         """
-    julia_args_str = vcat([x.exec for x in julia_args]...)
     cmd = ```
         $(Base.julia_cmd())
         --code-coverage=$(coverage ? "user" : "none")
@@ -595,7 +594,7 @@ function backwards_compatibility_for_test(
         --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
         --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])
-        $(julia_args_str)
+        $(julia_args)
         --eval $code
     ```
     run_test = () -> begin

--- a/test/api.jl
+++ b/test/api.jl
@@ -261,10 +261,10 @@ end
         copy_test_package(tmp, "TestArguments")
         Pkg.activate(joinpath(tmp, "TestArguments"))
         # test the old code path (no test/Project.toml)
-        Pkg.test("TestArguments"; test_args=["a", "b"], julia_args = [`--quiet --check-bounds=no`])
+        Pkg.test("TestArguments"; test_args=`a b`, julia_args=`--quiet --check-bounds=no`)
         # test new code path
         touch(joinpath(tmp, "TestArguments", "test", "Project.toml"))
-        Pkg.test("TestArguments"; test_args=["a", "b"], julia_args = [`--quiet --check-bounds=no`])
+        Pkg.test("TestArguments"; test_args=`a b`, julia_args=`--quiet --check-bounds=no`)
     end
 end
 


### PR DESCRIPTION
Before:

```julia
Pkg.test(julia_args=[`--compiled-modules=no`, `--compile=min`], test_args=["foo", "bar"])
```

After:

```julia
Pkg.test(julia_args=`--compiled-modules=no --compile=min`, test_args=`foo bar`)
```

close #1278 