### PR TITLE
Adjustments to `pin` API

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -624,7 +624,7 @@ end
         # the following should not error
         Pkg.add("UUIDs")
         Pkg.test("UUIDs")
-        @test_throws PkgError("cannot `pin` stdlibs.") Pkg.pin("UUIDs")
+        @test_throws PkgError("`pin` can not be applied to `UUIDs` because it is a stdlib.") Pkg.pin("UUIDs")
     end
 end
 


### PR DESCRIPTION
#1217 suggests there is some confusing behavior in `pin`.

More consistent behavior would be:
- `pkg> pin Example@x` means "Try to pin the package to the given registered version, if it exists"
    - error out when either the package or the version is unregistered
- `pkg> pin Example` means "Preserve the package at whatever state it happens to be in"
    - error out for stdlibs since stdlibs can not really be mutated in the way other packages can

---
close #1217
