### PR TITLE
Artifacts: fix porous platform support

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -555,8 +555,8 @@ to `true`, this will overwrite a pre-existant mapping, otherwise an error is rai
 `download_info` is an optional tuple that contains a vector of URLs and a hash.  These
 URLs will be listed as possible locations where this artifact can be obtained.  If `lazy`
 is set to `true`, even if download information is available, this artifact will not be
-downloaded until it is accessed via the `artifact"name"` syntax, or `ensure_installed()`
-is called upon it.
+downloaded until it is accessed via the `artifact"name"` syntax, or
+`ensure_artifact_installed()` is called upon it.
 """
 function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
                         platform::Union{Platform,Nothing} = nothing,

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -789,14 +789,18 @@ end
 """
     ensure_all_artifacts_installed(artifacts_toml::String;
                                    platform = platform_key_abi(),
-                                   package_uuid = nothing)
+                                   pkg_uuid = nothing,
+                                   include_lazy = false)
 
 Installs all non-lazy artifacts from a given `Artifacts.toml` file.  `package_uuid` must
 be provided to properly support overrides from `Overrides.toml` entries in depots.
+
+If `include_lazy` is set to `true`, then lazy packages will be installed as well.
 """
 function ensure_all_artifacts_installed(artifacts_toml::String;
                                         platform::Platform = platform_key_abi(),
-                                        pkg_uuid::Union{Nothing,Base.UUID} = nothing)
+                                        pkg_uuid::Union{Nothing,Base.UUID} = nothing,
+                                        include_lazy::Bool = false)
     if !isfile(artifacts_toml)
         return
     end
@@ -810,7 +814,7 @@ function ensure_all_artifacts_installed(artifacts_toml::String;
         meta === nothing && continue
 
         # If this mapping doesn't have a `download` stanza or is lazy, skip it
-        if !haskey(meta, "download") || get(meta, "lazy", false)
+        if !haskey(meta, "download") || (get(meta, "lazy", false) && !include_lazy)
             continue
         end
 

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -803,13 +803,18 @@ function ensure_all_artifacts_installed(artifacts_toml::String;
     artifact_dict = load_artifacts_toml(artifacts_toml; pkg_uuid=pkg_uuid)
 
     for name in keys(artifact_dict)
+        # Get the metadata about this name for the requested platform
         meta = artifact_meta(name, artifact_dict, artifacts_toml; platform=platform)
-        hash = SHA1(meta["git-tree-sha1"])
 
-        if artifact_exists(hash) || !haskey(meta, "download") || get(meta, "lazy", false)
+        # If there are no instances of this name for the desired platform, skip it
+        meta === nothing && continue
+
+        # If this mapping doesn't have a `download` stanza or is lazy, skip it
+        if !haskey(meta, "download") || get(meta, "lazy", false)
             continue
         end
 
+        # Otherwise, let's try and install it!
         ensure_artifact_installed(name, meta, artifacts_toml; platform=platform)
     end
 end

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -174,10 +174,10 @@ Base.string(mode::GitMode) = string(UInt32(mode); base=8)
 Base.print(io::IO, mode::GitMode) = print(io, string(mode))
 
 function gitmode(path::AbstractString)
-    if isdir(path)
-        return mode_dir
-    elseif islink(path)
+    if islink(path)
         return mode_symlink
+    elseif isdir(path)
+        return mode_dir
     # We cannot use `Sys.isexecutable()` because on Windows, that simply calls `isfile()`
     elseif filemode(path) & 0o010 == 0o010
         return mode_executable

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -230,7 +230,8 @@ end
 """
     tree_hash(root::AbstractString)
 
-Calculate the git tree hash of a given path.
+Calculate the git tree hash of a given path.  Note that attempting to take the
+tree hash of an empty directory will throw an error.
 """
 function tree_hash(root::AbstractString, HashType = SHA.SHA1_CTX)
     entries = Tuple{String, Vector{UInt8}, GitMode}[]
@@ -243,7 +244,14 @@ function tree_hash(root::AbstractString, HashType = SHA.SHA1_CTX)
         filepath = abspath(root, f)
         mode = gitmode(filepath)
         if mode == mode_dir
-            hash = tree_hash(filepath)
+            try
+                hash = tree_hash(filepath)
+            catch e
+                if isa(e, ArgumentError)
+                    continue
+                end
+                rethrow(e)
+            end
         else
             hash = blob_hash(filepath)
         end
@@ -253,9 +261,12 @@ function tree_hash(root::AbstractString, HashType = SHA.SHA1_CTX)
     # Sort entries by name (with trailing slashes for directories)
     sort!(entries, by = ((name, hash, mode),) -> mode == mode_dir ? name*"/" : name)
 
-    # Return the hash of these entries
+    if isempty(entries)
+        ArgumentError("Invalid to calculate tree hash of empty directory")
+    end
     content_size = sum(((n, h, m),) -> ndigits(UInt32(m); base=8) + 1 + sizeof(n) + 1 + 20, entries)
 
+    # Return the hash of these entries
     ctx = HashType()
     SHA.update!(ctx, Vector{UInt8}("tree $(content_size)\0"))
     for (name, hash, mode) in entries

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -984,9 +984,19 @@ function verify(path::AbstractString, hash::AbstractString; verbose::Bool = fals
         end
     end
 
-    # Save a hash cache if everything worked out fine
-    open(hash_path, "w") do file
-        write(file, hash)
+    # Try to save a hash cache if everything worked out fine
+    try
+        open(hash_path, "w") do file
+            write(file, hash)
+        end
+    catch e
+        if isa(e, InterruptException)
+            rethrow(e)
+        end
+
+        if verbose
+            @warn("Unable to create hash cache file $(hash_path)")
+        end
     end
 
     if report_cache_status

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -116,7 +116,11 @@ end
             # Empty directories do nothing to effect the hash, so we create one with a
             # random name to prove that it does not get hashed into the rest.
             mkpath(joinpath(path, Random.randstring(8)))
-        end, "82d49cf70690ea5cab519986313828eb03ba8358"),
+
+            # Symlinks are not followed, even if they point to directories
+            symlink("foo3", joinpath(path, "foo3_link"))
+            symlink("../bar", joinpath(path, "bar", "infinite_link"))
+        end, "64c11f7121bc55c520dbfd47e900c8aa4a5b7a42"),
     ]
 
     # Enable the following code snippet to figure out the correct gitsha's:
@@ -124,6 +128,7 @@ end
         for (creator, blah) in creators
             mktempdir() do path
                 creator(path)
+                chmod(path, 0o755; recursive=true)
                 cd(path) do
                     read(`git init .`)
                     read(`git add . `)

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1,6 +1,6 @@
 module ArtifactTests
 
-using Test, Pkg.Artifacts, Pkg.BinaryPlatforms, Pkg.PlatformEngines
+using Test, Random, Pkg.Artifacts, Pkg.BinaryPlatforms, Pkg.PlatformEngines
 import Pkg.Artifacts: pack_platform!, unpack_platform, with_artifacts_directory, ensure_all_artifacts_installed
 using Pkg.TOML, Dates
 import Base: SHA1
@@ -112,6 +112,10 @@ end
             open(joinpath(path, "foo3"), "w") do io
                 print(io, "baz!")
             end
+
+            # Empty directories do nothing to effect the hash, so we create one with a
+            # random name to prove that it does not get hashed into the rest.
+            mkpath(joinpath(path, Random.randstring(8)))
         end, "82d49cf70690ea5cab519986313828eb03ba8358"),
     ]
 
@@ -146,6 +150,9 @@ end
         # Test that the artifact verifies
         @test verify_artifact(hash)
     end
+
+    # Test that attempting to create an empty directory is an error:
+    @test_throws ArgumentError create_artifact(x -> nothing)
 end
 
 @testset "with_artifacts_directory()" begin

--- a/test/artifacts/bad/incorrect_gitsha.toml
+++ b/test/artifacts/bad/incorrect_gitsha.toml
@@ -1,0 +1,6 @@
+[broken_artifact]
+git-tree-sha1 = "0000000000000000000000000000000000000000"
+
+[[broken_artifact.download]]
+url = "https://github.com/staticfloat/small_bin/raw/master/socrates.tar.gz"
+sha256 = "e65d2f13f2085f2c279830e863292312a72930fee5ba3c792b14c33ce5c5cc58"

--- a/test/artifacts/bad/incorrect_sha256.toml
+++ b/test/artifacts/bad/incorrect_sha256.toml
@@ -1,0 +1,6 @@
+[broken_artifact]
+git-tree-sha1 = "43563e7631a7eafae1f9f8d9d332e3de44ad7239"
+
+[[broken_artifact.download]]
+url = "https://github.com/staticfloat/small_bin/raw/master/socrates.tar.gz"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"

--- a/test/test_packages/ArtifactInstallation/Artifacts.toml
+++ b/test/test_packages/ArtifactInstallation/Artifacts.toml
@@ -23,15 +23,18 @@ os = "macos"
     [[c_simple.download]]
     sha256 = "e88816a1492eecb4569bb24b3e52b757e59c87419dba962e99148b338369f326"
     url = "https://github.com/JuliaBinaryWrappers/c_simple_jll.jl/releases/download/c_simple+v1.2.3-pkgtest/c_simple.v1.2.3.x86_64-apple-darwin14.tar.gz"
-[[c_simple]]
-arch = "powerpc64le"
-git-tree-sha1 = "dc9f84891c8215f90095b619533e141179b6cc06"
-libc = "glibc"
-os = "linux"
 
-    [[c_simple.download]]
-    sha256 = "715af8f0405cff35feef5ad5e93836bb1bb0f93c77218bfdad411c8a4368ab4b"
-    url = "https://github.com/JuliaBinaryWrappers/c_simple_jll.jl/releases/download/c_simple+v1.2.3-pkgtest/c_simple.v1.2.3.powerpc64le-linux-gnu.tar.gz"
+# NOTE: We explicitly comment this out, to test porous platform support.  Don't un-comment this!
+#[[c_simple]]
+#arch = "powerpc64le"
+#git-tree-sha1 = "dc9f84891c8215f90095b619533e141179b6cc06"
+#libc = "glibc"
+#os = "linux"
+#
+#    [[c_simple.download]]
+#    sha256 = "715af8f0405cff35feef5ad5e93836bb1bb0f93c77218bfdad411c8a4368ab4b"
+#    url = "https://github.com/JuliaBinaryWrappers/c_simple_jll.jl/releases/download/c_simple+v1.2.3-pkgtest/c_simple.v1.2.3.powerpc64le-linux-gnu.tar.gz"
+
 [[c_simple]]
 arch = "i686"
 git-tree-sha1 = "78e282b79c16febc54a56ed244088ff92a55533f"

--- a/test/test_packages/ArtifactInstallation/Artifacts.toml
+++ b/test/test_packages/ArtifactInstallation/Artifacts.toml
@@ -128,7 +128,7 @@ url = "https://github.com/staticfloat/small_bin/raw/master/socrates.tar.bz2"
 sha256 = "13fc17b97be41763b02cbb80e9d048302cec3bd3d446c2ed6e8210bddcd3ac76"
 
 [collapse_the_symlink]
-git-tree-sha1 = "634bd3979e06385661f40d7ec1596ba94fd1c16d"
+git-tree-sha1 = "69a468bd51751f4ed7eda31c240e775df06d6ee6"
 
 [[collapse_the_symlink.download]]
 url = "https://github.com/staticfloat/small_bin/raw/master/collapse_the_symlink/collapse_the_symlink.tar.gz"

--- a/test/test_packages/ArtifactInstallation/Artifacts.toml
+++ b/test/test_packages/ArtifactInstallation/Artifacts.toml
@@ -124,3 +124,9 @@ sha256 = "e65d2f13f2085f2c279830e863292312a72930fee5ba3c792b14c33ce5c5cc58"
 url = "https://github.com/staticfloat/small_bin/raw/master/socrates.tar.bz2"
 sha256 = "13fc17b97be41763b02cbb80e9d048302cec3bd3d446c2ed6e8210bddcd3ac76"
 
+[collapse_the_symlink]
+git-tree-sha1 = "634bd3979e06385661f40d7ec1596ba94fd1c16d"
+
+[[collapse_the_symlink.download]]
+url = "https://github.com/staticfloat/small_bin/raw/master/collapse_the_symlink/collapse_the_symlink.tar.gz"
+sha256 = "956c1201405f64d3465cc28cb0dec9d63c11a08cad28c381e13bb22e1fc469d3"


### PR DESCRIPTION
This branch contains a set of improvements to Artifacts/PlatformEngines:

* Fix "porous" platform support; there is one method (`ensure_all_artifacts_installed()`) that will break if a multi-platform artifact doesn't have support for the current platform.  Oops.

* Fix artifact verification; when downloading, I was not verifying that the artifact's git tree sha actually was what the `Artifact.toml` advertised; there's an issue here where one package could list the incorrect tree hash, then put something completely different in that location (because the download happened directly, rather than to a temporary directory, verified, then moved into place).  This plugs that hole, so there is now one fewer ways we can get the wrong thing in the right place.

* Fix broken symlink support; As part of implementing the above verification, I discovered that broken symlinks can break things.  Fixed to be resilient to them in all places it matters, especially across windows.

* Improve testing of error messages; some of the error messaging methods were a little ad-hoc; this makes things a little more uniform, and tests them more thoroughly.