### PR TITLE
Update default manifest file name

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -215,7 +215,7 @@ function manifestfile_path(env_path::String; strict=false)
         maybe_file = joinpath(env_path, name)
         isfile(maybe_file) && return maybe_file
     end
-    return strict ? nothing : joinpath(env_path, "Manifest.toml")
+    return strict ? nothing : replace(projectfile_path(env_path), r"Project\.toml$" => "Manifest.toml")
 end
 
 function find_project_file(env::Union{Nothing,String}=nothing)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -791,6 +791,23 @@ end
     end end
 end
 
+@testset "create manifest file similar to project file" begin
+    cd_tempdir() do dir
+        touch(joinpath(dir, "Project.toml"))
+        Pkg.activate(".")
+        Pkg.add("Example")
+        @test isfile(joinpath(dir, "Manifest.toml"))
+        @test !isfile(joinpath(dir, "JuliaManifest.toml"))
+    end
+    cd_tempdir() do dir
+        touch(joinpath(dir, "JuliaProject.toml"))
+        Pkg.activate(".")
+        Pkg.add("Example")
+        @test !isfile(joinpath(dir, "Manifest.toml"))
+        @test isfile(joinpath(dir, "JuliaManifest.toml"))
+    end
+end
+
 include("repl.jl")
 include("api.jl")
 include("registry.jl")


### PR DESCRIPTION
If a new project is created using "JuliaProject.toml" instead of
"Project.toml", the corresponding manifest file should be named
"JuliaManifest.toml" instead of "Manifest.toml".

Locally, even without my proposed changes, I get

```
  Got exception outside of a @test
  KeyError: key "uuid" not found
```

for

* [instantiate should respect tree hash](https://github.com/jonas-schulze/Pkg.jl/blob/default-manifest-name/test/pkg.jl#L753),
* [instantiate checks for consistent dependency graph](https://github.com/jonas-schulze/Pkg.jl/blob/default-manifest-name/test/pkg.jl#L771) and
* [up should prune manifest](https://github.com/jonas-schulze/Pkg.jl/blob/default-manifest-name/test/pkg.jl#L779)

Are those relevant/related?