### PR TITLE
Introduce `temp` option for `activate`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -837,7 +837,9 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=
 end
 
 
-function activate()
+function activate(;temp=false,shared=false)
+    shared && pkgerror("Must give a name for a shared environment")
+    temp && return activate(mktempdir())
     Base.ACTIVE_PROJECT[] = nothing
     p = Base.active_project()
     p === nothing || printpkgstyle(Context(), :Activating, "environment at $(pathrepr(p))")
@@ -861,7 +863,8 @@ function _activate_dep(dep_name::AbstractString)
         end
     end
 end
-function activate(path::AbstractString; shared::Bool=false)
+function activate(path::AbstractString; shared::Bool=false, temp::Bool=false)
+    temp && pkgerror("Can not give `path` argument when creating a temporary environment")
     if !shared
         # `pkg> activate path`/`Pkg.activate(path)` does the following
         # 1. if path exists, activate that

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -227,18 +227,20 @@ packages have changed causing the current Manifest to be out of sync.
     :arg_parser => parse_activate,
     :option_spec => OptionDeclaration[
         [:name => "shared", :api => :shared => true],
+        [:name => "temp", :api => :temp => true],
     ],
     :completions => complete_activate,
     :description => "set the primary environment the package manager manipulates",
     :help => md"""
     activate
-    activate [--shared] path
+    activate [--shared|--temp] [path]
 
 Activate the environment at the given `path`, or the home project environment if no `path` is specified.
 The active environment is the environment that is modified by executing package commands.
 When the option `--shared` is given, `path` will be assumed to be a directory name and searched for in the
 `environments` folders of the depots in the depot stack. In case no such environment exists in any of the depots,
 it will be placed in the first depot of the stack.
+Use the `temp` option to create temporary environments. This should be useful for experimenting with packages.
 """ ,
 ],[ :name => "update",
     :short_name => "up",

--- a/test/new.jl
+++ b/test/new.jl
@@ -320,6 +320,10 @@ end
         @test api == Pkg.activate
         @test args == "FooBar"
         @test isempty(opts)
+        # - activating a temporary project
+        api, opts = first(Pkg.pkg"activate --temp")
+        @test api == Pkg.activate
+        @test opts == Dict(:temp => true)
     end
 end
 


### PR DESCRIPTION
Resolve #1201 

I find myself needing this often as well.

Example:
```
(Pkg) pkg> activate --temp
Activating new environment at `/tmp/tmpVtb1OR/Project.toml`
```