### PR TITLE
`rm` should also remove from `compat`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -870,11 +870,10 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
         pkg.mode == PKGMODE_PROJECT || continue
         found = false
         for (name::String, uuid::UUID) in ctx.env.project.deps
-            has_name(pkg) && pkg.name == name ||
-            has_uuid(pkg) && pkg.uuid == uuid || continue
-            !has_name(pkg) || pkg.name == name ||
+            pkg.name == name || pkg.uuid == uuid || continue
+            pkg.name == name ||
                 error("project file name mismatch for `$uuid`: $(pkg.name) ≠ $name")
-            !has_uuid(pkg) || pkg.uuid == uuid ||
+            pkg.uuid == uuid ||
                 error("project file UUID mismatch for `$name`: $(pkg.uuid) ≠ $uuid")
             uuid in drop || push!(drop, uuid)
             found = true
@@ -892,6 +891,9 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     if length(ctx.env.project.deps) == n
         println(ctx.io, "No changes")
         return
+    end
+    filter!(ctx.env.project.compat) do (name, _)
+        name in keys(ctx.env.project.deps)
     end
     deps_names = append!(collect(keys(ctx.env.project.deps)),
                          collect(keys(ctx.env.project.extras)))

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -558,7 +558,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         # a trivial modification of the project file only.
         # See issue https://github.com/JuliaLang/Pkg.jl/issues/1144
         not_loadable = setdiff(should_be_in_manifest, should_be_in_project)
-        Operations.rm(localctx, [PackageSpec(uuid = uuid) for uuid in not_loadable])
+        Pkg.API.rm(localctx, [PackageSpec(uuid = uuid) for uuid in not_loadable])
 
         write_env(localctx, display_diff = false)
         will_resolve && build_versions(localctx, new)

--- a/test/api.jl
+++ b/test/api.jl
@@ -16,6 +16,17 @@ include("utils.jl")
     end
 end
 
+@testset "Pkg.rm" begin
+    # rm should remove compat entries
+    temp_pkg_dir() do tmp
+        copy_test_package(tmp, "BasicCompat")
+        Pkg.activate(joinpath(tmp, "BasicCompat"))
+        @test haskey(Pkg.Types.Context().env.project.compat, "Example")
+        Pkg.rm("Example")
+        @test !haskey(Pkg.Types.Context().env.project.compat, "Example")
+    end
+end
+
 @testset "Pkg.activate" begin
     temp_pkg_dir() do project_path
         cd_tempdir() do tmp

--- a/test/test_packages/BasicCompat/Project.toml
+++ b/test/test_packages/BasicCompat/Project.toml
@@ -1,0 +1,9 @@
+name = "BasicCompat"
+uuid = "02d2db24-ca84-11e9-2b8f-0dc1ce28a7da"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "= 0.5.2"

--- a/test/test_packages/BasicCompat/src/BasicCompat.jl
+++ b/test/test_packages/BasicCompat/src/BasicCompat.jl
@@ -1,0 +1,5 @@
+module BasicCompat
+
+greet() = print("Hello World!")
+
+end # module


### PR DESCRIPTION
Fix #1323