### PR TITLE
Make `develop` resolve more flexible

### DIFF
--- a/test/api.jl
+++ b/test/api.jl
@@ -77,6 +77,11 @@ end
 end
 
 @testset "Pkg.develop" begin
+    # develop tries to resolve from the manifest
+    temp_pkg_dir() do project_path; with_temp_env() do env_path;
+        Pkg.add(Pkg.PackageSpec(url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.develop("Unregistered")
+    end end
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir;
         exuuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # UUID of Example.jl
         entry = nothing


### PR DESCRIPTION
The behavior that a user expected in #1098 is reasonable. Basically they want to resolve the pkg against the manifest, which already has all the necessary information. This also adds an error message for `Pkg.develop(PackageSpec(uuid=unregistered_uuid))`.

Note that we can't go from `add`->`dev` in the same way until we merge something like #492.

---
resolve #1098
resolve #328

Example:
```
(afdasf) pkg> add https://github.com/00vareladavid/Unregistered.jl
  Updating git-repo `https://github.com/00vareladavid/Unregistered.jl`
  Updating git-repo `https://github.com/00vareladavid/Unregistered.jl`
 Resolving package versions...
  Updating `/tmp/afdasf/Project.toml`
  [dcb67f36] + Unregistered v0.1.0 #master (https://github.com/00vareladavid/Unregistered.jl)
  Updating `/tmp/afdasf/Manifest.toml`
  [dcb67f36] + Unregistered v0.1.0 #master (https://github.com/00vareladavid/Unregistered.jl)

(afdasf) pkg> dev Unregistered
  Updating git-repo `https://github.com/00vareladavid/Unregistered.jl`
 Resolving package versions...
  Updating `/tmp/afdasf/Project.toml`
  [dcb67f36] ~ Unregistered v0.1.0 #master (https://github.com/00vareladavid/Unregistered.jl) ⇒ v0.1.0 [`~/.julia/dev/Unregistered`]
  Updating `/tmp/afdasf/Manifest.toml`
  [dcb67f36] ~ Unregistered v0.1.0 #master (https://github.com/00vareladavid/Unregistered.jl) ⇒ v0.1.0 [`~/.julia/dev/Unregistered`]
```