### PR TITLE
Tweak API docs for `dependencies` and `project`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,6 +33,7 @@ Pkg.status
 Pkg.precompile
 Pkg.setprotocol!
 Pkg.dependencies
+Pkg.project
 ```
 
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -271,43 +271,44 @@ const develop = API.develop
 const generate = API.generate
 
 """
-!!! note
-    This feature is experimental.
-
     Pkg.dependencies()::Dict{UUID, PackageInfo}
+
+!!! compat "Julia 1.4"
+    This feature requires Julia 1.4, and is considered experimental.
 
 Query the dependecy graph.
 The result is a `Dict` that maps a package UUID to a `PackageInfo` struct representing the dependency (a package).
 
-PackageInfo fields:
+# `PackageInfo` fields
 
-| `field`        | `Description`                                              |
-|:---------------|:-----------------------------------------------------------|
-| `name`         | The name of the package                                    |
-| `version`      | The version of the package (this is `Nothing` for stdlibs) |
-| `isdeveloped`  | Whether a package is directly tracking a directory         |
-| `ispinned`     | Whether a package is pinned                                |
-| `source`       | The directory containing the source code for that package  |
-| `dependencies` | The dependencies of that package as a vector of UUIDs      |
+| Field        | Description                                                |
+|:-------------|:-----------------------------------------------------------|
+| name         | The name of the package                                    |
+| version      | The version of the package (this is `Nothing` for stdlibs) |
+| isdeveloped  | Whether a package is directly tracking a directory         |
+| ispinned     | Whether a package is pinned                                |
+| source       | The directory containing the source code for that package  |
+| dependencies | The dependencies of that package as a vector of UUIDs      |
 """
 const dependencies = API.dependencies
 
 """
-!!! note
-    This feature is experimental.
-
     Pkg.project()::ProjectInfo
+
+!!! compat "Julia 1.4"
+    This feature requires Julia 1.4, and is considered experimental.
 
 Request a `ProjectInfo` struct which contains information about the active project.
 
-ProjectInfo fields:
-| `field`        | `Description`                                                                               |
-|:---------------|:--------------------------------------------------------------------------------------------|
-| `name`         | The project's name                                                                          |
-| `uuid`         | The project's UUID                                                                          |
-| `version`      | The project's version                                                                       |
-| `dependencies` | The project's direct dependencies as a `Dict` which maps dependency name to dependency UUID |
-| `path`         | The location of the project file which defines the active project                           |
+# `ProjectInfo` fields
+
+| Field        | Description                                                                                 |
+|:-------------|:--------------------------------------------------------------------------------------------|
+| name         | The project's name                                                                          |
+| uuid         | The project's UUID                                                                          |
+| version      | The project's version                                                                       |
+| dependencies | The project's direct dependencies as a `Dict` which maps dependency name to dependency UUID |
+| path         | The location of the project file which defines the active project                           |
 """
 const project = API.project
 


### PR DESCRIPTION
---

So I noticed just after merging that the formatting was a little weird :sweat_smile:.

@fredrikekre would you happen to know why `Pkg.project` doesn't appear in the API docs? I admit that I'm not clear on how the docs are generated, I just tried following the same format as the other API functions.