### PR TITLE
clarify how new environments are activated

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -20,7 +20,7 @@ Upon entering the Pkg REPL, you should see a similar prompt:
 (v1.1) pkg>
 ```
 
-To add a package, use `add`:
+To add a package to the currently active environment (in this case `(v1.1)`, but more on environments later), use `add`:
 
 ```
 (v1.1) pkg> add Example
@@ -81,7 +81,12 @@ This lets us know `v1.1` is the **active environment**.
 The active environment is the environment that will be modified by Pkg commands such as `add`, `rm` and `update`.
 
 Let's set up a new environment so we may experiment.
-To set the active environment, use `activate`:
+To set the active environment, use `activate` and then the name of the environment, or the path to it
+if it's not in your current working directory.
+If the environment you want to activate doesn't exist yet, it will be created in your current working directory.
+If you want to change the working directory first, you can `cd` there after pressing `;` to get into shell mode.
+If you're not sure what the current working directory is you can run `pwd()` in the REPL.
+In our case, we are currently in the directory `/tmp/`, so the environment will be created there.
 
 ```
 (v1.1) pkg> activate tutorial
@@ -97,6 +102,11 @@ active environment:
 ```
 (tutorial) pkg>
 ```
+
+One thing to keep in mind is that the name `tutorial` is not exclusive to our environment.
+If we cd to a different folder like `/different/` and run `activate tutorial`, we might expect our old environment
+to be activated, but instead a new environment named tutorial will be created in `/different/`.
+To activate our original environment from anywhere, we can always run `activate /tmp/tutorial`.
 
 We can ask for information about the active environment by using `status`:
 


### PR DESCRIPTION
I had to find out by trial and error that a new environment is created if I try to activate an existing environment from a different working directory. This wasn't clear to me after reading the docs, so this PR is meant to clarify the process.