### PR TITLE
More printing updates

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -726,7 +726,6 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}, verbose::Bool)
     uuids = UUID[]
     _get_deps!(ctx, pkgs, uuids)
     build_versions(ctx, uuids; might_need_to_resolve=true, verbose=verbose)
-    ctx.preview && preview_info()
 end
 
 function dependency_order_uuids(ctx::Context, uuids::Vector{UUID})::Dict{UUID,Int}
@@ -816,9 +815,9 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
 
         sandbox(ctx, pkg, source_path, builddir(source_path)) do
             ok = open(log_file, "w") do log
+                std = verbose ? ctx.io : log
                 success(pipeline(gen_build_code(buildfile(source_path)),
-                                 stdout = verbose ? stdout : log,
-                                 stderr = verbose ? stderr : log))
+                                 stdout=std, stderr=std))
             end
             ok && return
             n_lines = isinteractive() ? 100 : 5000

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -95,8 +95,8 @@ Pkg.Registry.status()
 ```
 """
 status(; kwargs...) = status(Context(); kwargs...)
-function status(ctx::Context; kwargs...)
-    Context!(ctx; kwargs...)
+function status(ctx::Context; io::IO=stdout, kwargs...)
+    Context!(ctx; io=io, kwargs...)
     regs = Types.collect_registries()
     regs = unique(r -> r.uuid, regs) # Maybe not?
     Types.printpkgstyle(ctx, Symbol("Registry Status"), "")

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -309,7 +309,7 @@ end
 # ENV variables to set some of these defaults?
 Base.@kwdef mutable struct Context
     env::EnvCache = EnvCache()
-    io::IO = stdout
+    io::IO = stderr
     preview::Bool = false
     use_libgit2_for_all_downloads::Bool = false
     use_only_tarballs_for_downloads::Bool = false
@@ -1352,17 +1352,11 @@ function manifest_info(ctx::Context, uuid::UUID)::Union{PackageEntry,Nothing}
     return get(ctx.env.manifest, uuid, nothing)
 end
 
-# TODO: redirect to ctx stream
-function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false)
+function printpkgstyle(ctx::Context, cmd::Symbol, text::String, ignore_indent::Bool=false)
     indent = textwidth(string(:Downloaded))
     ignore_indent && (indent = 0)
-    printstyled(io, lpad(string(cmd), indent), color=:green, bold=true)
-    println(io, " ", text)
-end
-
-# TODO: use ctx specific context
-function printpkgstyle(ctx::Context, cmd::Symbol, text::String, ignore_indent::Bool=false)
-    printpkgstyle(ctx.io, cmd, text)
+    printstyled(ctx.io, lpad(string(cmd), indent), color=:green, bold=true)
+    println(ctx.io, " ", text)
 end
 
 

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -632,7 +632,8 @@ function backwards_compat_for_build(ctx::Context, pkg::PackageSpec, build_file::
         ```
     run_build = () -> begin
         ok = open(log_file, "w") do log
-            success(pipeline(cmd, stdout = verbose ? stdout : log, stderr = verbose ? stderr : log))
+            std = verbose ? ctx.io : log
+            success(pipeline(cmd, stdout=std, stderr=std))
         end
         if !ok
             n_lines = isinteractive() ? 100 : 5000


### PR DESCRIPTION
Print more stuff to `ctx.io`, which now defaults to `stderr` except when the user has explicitly asked for the output (e.g. `pkg> status`, `pkg> registry status` and `pkg> help`).