### PR TITLE
Fix test isolation

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -792,20 +792,20 @@ end
 end
 
 @testset "create manifest file similar to project file" begin
-    cd_tempdir() do dir
+    temp_pkg_dir() do project_path; mktempdir() do dir
         touch(joinpath(dir, "Project.toml"))
-        Pkg.activate(".")
+        Pkg.activate(dir)
         Pkg.add("Example")
         @test isfile(joinpath(dir, "Manifest.toml"))
         @test !isfile(joinpath(dir, "JuliaManifest.toml"))
-    end
-    cd_tempdir() do dir
+    end end
+    temp_pkg_dir() do project_path; mktempdir() do dir
         touch(joinpath(dir, "JuliaProject.toml"))
-        Pkg.activate(".")
+        Pkg.activate(dir)
         Pkg.add("Example")
         @test !isfile(joinpath(dir, "Manifest.toml"))
         @test isfile(joinpath(dir, "JuliaManifest.toml"))
-    end
+    end end
 end
 
 @testset "query interface basic tests" begin


### PR DESCRIPTION
This was causing problems for me when testing locally. The tests would switch to using the built-in version of `Pkg` instead of the development one.

I don't understand exactly why this happens and why it does not cause problems on CI.