### PR TITLE
Set quiet_download to true by default.

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -603,15 +603,15 @@ if `force` is not set and the already-existent file fails verification, or if
 `force` is set, verification fails, and then verification fails again after
 redownloading the file.
 
-If `quiet_download` is set to `false` (the default), this method will print to
-stdout when downloading a new file.  If it is set to `true` (and `verbose` is
+If `quiet_download` is set to `false`, this method will print to
+stdout when downloading a new file.  If it is set to `true` (default, and `verbose` is
 set to `false`) the downloading process will be completely silent.  If
 `verbose` is set to `true`, messages about integrity verification will be
 printed in addition to messages regarding downloading.
 """
 function download_verify(url::AbstractString, hash::AbstractString,
                          dest::AbstractString; verbose::Bool = false,
-                         force::Bool = false, quiet_download::Bool = false)
+                         force::Bool = false, quiet_download::Bool = true)
     # Whether the file existed in the first place
     file_existed = false
 


### PR DESCRIPTION
Messages like
```
[ Info: Downloading https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl/releases/download/Bzip2-v1.0.6+0/Bzip2.v1.0.6.x86_64-linux-gnu.tar.gz to /tmp/jl_QkNkzY-download.gz...
```
does not seem very useful to users.