### PR TITLE
Fully support JuliaArtifacts.toml filename everywhere.

### DIFF
--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -8,7 +8,13 @@ This mechanism is also used to provide the binary dependencies for packages buil
 
 `Pkg` provides an API for working with artifacts, as well as a TOML file format for recording artifact usage in your packages, and to automate downloading of artifacts at package install time.
 Artifacts can always be referred to by content hash, but are typically accessed by a name that is bound to a content hash in an `Artifacts.toml` file that lives in a project's source tree.
-An example `Artifacts.toml` file is shown here as an example:
+
+!!! note
+    It is possible to use the alternate name `JuliaArtifacts.toml`, similar
+    to how it is possible to use `JuliaProject.toml` and `JuliaManifest.toml`
+    instead of `Project.toml` and `Manifest.toml`, respectively.
+
+An example `Artifacts.toml` file is shown here:
 
 ```TOML
 # Example Artifacts.toml file

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -10,7 +10,7 @@ import REPL
 using REPL.TerminalMenus
 using ..Types, ..GraphType, ..Resolve, ..Pkg2, ..PlatformEngines, ..GitTools, ..Display
 import ..depots, ..depots1, ..devdir, ..Types.uuid_julia, ..Types.PackageEntry
-import ..Artifacts: ensure_all_artifacts_installed
+import ..Artifacts: ensure_all_artifacts_installed, artifact_names
 using ..BinaryPlatforms
 import ..Pkg
 
@@ -561,11 +561,14 @@ function download_artifacts(ctx::Context, pkgs::Vector{PackageSpec};
                             platform::Platform=platform_key_abi())
     for pkg in pkgs
         path = source_path(pkg)
-        # Check to see if this package has an Artifacts.toml
-        artifacts_toml = joinpath(path, "Artifacts.toml")
-        if isfile(artifacts_toml)
-            ensure_all_artifacts_installed(artifacts_toml; platform=platform)
-            write_env_usage(artifacts_toml, "artifact_usage.toml")
+        # Check to see if this package has an (Julia)Artifacts.toml
+        for f in artifact_names
+            artifacts_toml = joinpath(path, f)
+            if isfile(artifacts_toml)
+                ensure_all_artifacts_installed(artifacts_toml; platform=platform)
+                write_env_usage(artifacts_toml, "artifact_usage.toml")
+                break
+            end
         end
     end
 end
@@ -980,7 +983,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[];
     # TODO is it still necessary to prune? I don't think so..
     new_apply = download_source(ctx, pkgs)
 
-    # After downloading resolutionary packages, search for Artifacts.toml files
+    # After downloading resolutionary packages, search for (Julia)Artifacts.toml files
     # and ensure they are all downloaded and unpacked as well:
     download_artifacts(ctx, pkgs; platform=platform)
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -78,11 +78,11 @@ end
         # Test that some things raise warnings
         bad_meta = copy(meta)
         delete!(bad_meta, "os")
-        @test_logs (:error, r"Invalid Artifacts.toml") unpack_platform(bad_meta, "foo", "")
+        @test_logs (:error, r"Invalid artifacts file") unpack_platform(bad_meta, "foo", "")
 
         bad_meta = copy(meta)
         delete!(bad_meta, "arch")
-        @test_logs (:error, r"Invalid Artifacts.toml") unpack_platform(bad_meta, "foo", "")
+        @test_logs (:error, r"Invalid artifacts file") unpack_platform(bad_meta, "foo", "")
     end
 end
 
@@ -153,7 +153,7 @@ end
     for (creator, known_hash) in creators
         # Create artifact
         hash = create_artifact_chmod(creator)
-        
+
         # Ensure it hashes to the correct gitsha:
         @test hash.bytes == hex2bytes(known_hash)
 
@@ -405,7 +405,7 @@ end
         artifacts_toml = joinpath(tmpdir, "Artifacts.toml")
         bind_artifact!(artifacts_toml, "live", live_hash)
         bind_artifact!(artifacts_toml, "die", die_hash)
-        
+
         # Now test that the usage file exists, and contains our Artifacts.toml
         usage = Pkg.TOML.parse(String(read(usage_path)))
         @test any(x -> startswith(x, artifacts_toml), keys(usage))
@@ -485,7 +485,7 @@ end
             @test create_artifact_chmod(make_baz) == baz_hash
         end
 
-        # Next, set up our depot path, with `depot1` as the "innermost" depot. 
+        # Next, set up our depot path, with `depot1` as the "innermost" depot.
         old_depot_path = DEPOT_PATH
         empty!(DEPOT_PATH)
         append!(DEPOT_PATH, [depot1, depot2, depot3])
@@ -543,7 +543,7 @@ end
                 using ArtifactOverrideLoading
                 arty_path, barty_path
             end)
-        
+
             @test arty_path == artifact_path(bar_hash)
             @test barty_path == barty_override_path
         end


### PR DESCRIPTION
---

Currently, e.g. adding this fork of `JuliaBinaryWrappers/Zlib_jll.jl` with `Artifacts.toml` changed to `JuliaArtifacts.toml`
```
pkg> add https://github.com/fredrikekre/Zlib_jll.jl
```
doesn't download artifacts at install time.