### PR TITLE
Fix `compress_versions()` confusion with build number VersionNumber's

### DIFF
--- a/src/versions.jl
+++ b/src/versions.jl
@@ -262,7 +262,12 @@ subset of the pool of available versions, this function computes a `VersionSpec`
 includes all versions in `subset` and none of the versions in its complement.
 """
 function compress_versions(pool::Vector{VersionNumber}, subset::Vector{VersionNumber})
-    subset = sort(subset) # must copy, we mutate this
+    # Explicitly drop prerelease/build numbers, as those can confuse this.
+    # TODO: Rewrite all this to use VersionNumbers instead of VersionBounds
+    drop_build_prerelease(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch)
+    pool = drop_build_prerelease.(pool)
+    subset = sort!(drop_build_prerelease.(subset))
+
     complement = sort!(setdiff(pool, subset))
     ranges = VersionRange[]
     @label again

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -95,6 +95,32 @@ import Pkg.Types: semver_spec, VersionSpec
     @test !(Pkg.Types.isjoinable(Pkg.Types.VersionBound((1,5)), Pkg.Types.VersionBound((1,6,0))))
 end
 
+@testset "compress_versions()" begin
+    # Test exact version matching
+    vs = [v"1.1.0", v"1.1.1", v"1.1.2"]
+    @test Pkg.Types.compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1.1.1")
+    
+    # Test holes
+    vs = [v"1.1.0", v"1.1.1", v"1.1.4"]
+    @test Pkg.Types.compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1.1.1")
+    
+    # Test patch variation with length(subset) > 1
+    vs = [v"1.1.0", v"1.1.1", v"1.1.2", v"1.1.3", v"1.2.0"]
+    @test Pkg.Types.compress_versions(vs, [vs[2], vs[3]]) == Pkg.Types.VersionSpec("1.1.1-1.1.2")
+    
+    # Test minor variation
+    vs = [v"1.1.0", v"1.1.1", v"1.2.0"]
+    @test Pkg.Types.compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1.1.1-1.1")
+   
+    # Test major variation
+    vs = [v"1.1.0", v"1.1.1", v"1.2.0", v"2.0.0"]
+    @test Pkg.Types.compress_versions(vs, [vs[2], vs[3]]) == Pkg.Types.VersionSpec("1.1.1-1")
+
+    # Test build numbers and prerelease values are ignored
+    vs = [v"1.1.0-alpha", v"1.1.0+0", v"1.1.0+1"]
+    @test Pkg.Types.compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1")
+end
+
 # TODO: Should rewrite these tests not to rely on internals like field names
 @testset "union, isjoinable" begin
     @test sprint(print, VersionRange("0-0.3.2")) == "0-0.3.2"


### PR DESCRIPTION
This is not a permanent fix, it's to paper over the fact that we have
two, slightly incompatible concepts of a `VersionNumber` within `Pkg`;
the `VersionNumber` and the `VersionBound`.  The latter does not support
`build` or `prerelease` specifiers, which causes much confusion within
`compress_versions()` when it attempts to compare equality of
`VersionNumber` objects with their supposedly-equivalent `VersionBound`
objects.  To fix this, we explcitly strip those pieces of information
before doing any comparisons.