### PR TITLE
Properly Plumb Platform kwarg for `ensure_artifact_installed()`

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -778,7 +778,7 @@ Ensures an artifact is installed, downloading it via the download information st
 function ensure_artifact_installed(name::String, artifacts_toml::String;
                                    platform::Platform = platform_key_abi(),
                                    pkg_uuid::Union{Base.UUID,Nothing}=nothing)
-    meta = artifact_meta(name, artifacts_toml; pkg_uuid=pkg_uuid)
+    meta = artifact_meta(name, artifacts_toml; pkg_uuid=pkg_uuid, platform=platform)
     if meta === nothing
         error("Cannot locate artifact '$(name)' in '$(artifacts_toml)'")
     end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -272,6 +272,8 @@ end
         bind_artifact!(artifacts_toml, "foo_txt", hash; download_info=download_info, platform=Windows(:i686))
         @test artifact_hash("foo_txt", artifacts_toml; platform=Linux(:x86_64)) == hash2
         @test artifact_hash("foo_txt", artifacts_toml; platform=Windows(:i686)) == hash
+        @test ensure_artifact_installed("foo_txt", artifacts_toml; platform=Linux(:x86_64)) == artifact_path(hash2)
+        @test ensure_artifact_installed("foo_txt", artifacts_toml; platform=Windows(:i686)) == artifact_path(hash)
 
         # Next, check that we can get the download_info properly:
         meta = artifact_meta("foo_txt", artifacts_toml; platform=Windows(:i686))


### PR DESCRIPTION
Otherwise, it ignores your selection of `platform` when testing to see if the artifact even exists.