### PR TITLE
Offload `PackageSpec` checking from REPL to API layer

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -56,6 +56,14 @@ function check_package_name(x::AbstractString, mode=nothing)
     return PackageSpec(x)
 end
 
+function err_rep(pkg::PackageSpec)
+    x = pkg.name !== nothing && pkg.uuid !== nothing ? x = "$name [$(string(pkg.uuid)[1:8])]" :
+        pkg.name !== nothing ? pkg.name :
+        pkg.uuid !== nothing ? string(pkg.uuid)[1:8] :
+        pkg.repo.url
+    return "`$x`"
+end
+
 develop(pkg::Union{AbstractString, PackageSpec}; kwargs...) = develop([pkg]; kwargs...)
 develop(pkgs::Vector{<:AbstractString}; kwargs...) =
     develop([check_package_name(pkg, :develop) for pkg in pkgs]; kwargs...)
@@ -67,12 +75,20 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
 
     for pkg in pkgs
         # if julia is passed as a package the solver gets tricked
-        pkg.name != "julia" || pkgerror("Trying to develop julia as a package")
-        pkg.repo.rev === nothing || pkgerror("git revision can not be given to `develop`")
-        pkg.name !== nothing || pkg.uuid !== nothing || pkg.repo.url !== nothing ||
-            pkgerror("A package must be specified by `name`, `uuid`, `url`, or `path`.")
-        pkg.version == VersionSpec() ||
-            pkgerror("Can not specify version when tracking a repo.")
+        if pkg.name == "julia"
+            pkgerror("`julia` is not a valid package name.")
+        end
+        if pkg.name === nothing && pkg.uuid === nothing && pkg.repo.url === nothing
+            pkgerror("When calling `develop`, packages must be specified by name, UUID, URL, or filesystem path.")
+        end
+        if pkg.repo.rev !== nothing
+            pkgerror("It is invalid to specify a git revision when calling `develop`:",
+                     " `$(pkg.repo.rev)` given for package $(err_rep(pkg)).")
+        end
+        if pkg.version != VersionSpec()
+            pkgerror("It is invalid to specify a version when calling `develop`:",
+                     " `$(pkg.version)` given for package $(err_rep(pkg)).")
+        end
     end
 
     preview_info(ctx)
@@ -98,9 +114,12 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; strict::Bool=false,
 
     for pkg in pkgs
         # if julia is passed as a package the solver gets tricked; this catches the error early on
-        pkg.name == "julia" && pkgerror("Trying to add julia as a package")
-        pkg.name !== nothing || pkg.uuid !== nothing || pkg.repo.url !== nothing ||
-            pkgerror("A package must be specified by `name`, `uuid`, `url`, or `path`.")
+        if pkg.name == "julia"
+            pkgerror("`julia` is not a valid package name.")
+        end
+        if pkg.name === nothing && pkg.uuid === nothing && pkg.repo.url === nothing
+            pkgerror("When calling `add`, packages must be specified by name, UUID, URL, or filesystem path.")
+        end
         if (pkg.repo.url !== nothing || pkg.repo.rev !== nothing)
             pkg.version == VersionSpec() ||
                 pkgerror("Can not specify version when tracking a repo.")
@@ -137,12 +156,13 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, kwarg
     foreach(pkg -> pkg.mode = mode, pkgs)
 
     for pkg in pkgs
-        pkg.name !== nothing || pkg.uuid !== nothing ||
-            pkgerror("Must specify package by either `name` or `uuid`.")
+        if pkg.name === nothing && pkg.uuid === nothing
+            pkgerror("When calling `rm`, packages must be specified by name or UUID.")
+        end
         if !(pkg.version == VersionSpec() && pkg.pinned == false &&
              pkg.tree_hash === nothing && pkg.repo.url === nothing &&
              pkg.repo.rev === nothing && pkg.path === nothing)
-            pkgerror("Package may only be specified by either `name` or `uuid`")
+            pkgerror("When calling `rm`, packages may only be specified by name or UUID.")
         end
     end
 
@@ -202,17 +222,23 @@ resolve(ctx::Context=Context()) =
 pin(pkg::Union{AbstractString, PackageSpec}; kwargs...) = pin([pkg]; kwargs...)
 pin(pkgs::Vector{<:AbstractString}; kwargs...)          = pin([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
 pin(pkgs::Vector{PackageSpec}; kwargs...)               = pin(Context(), pkgs; kwargs...)
-
 function pin(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
     preview_info(ctx)
 
     for pkg in pkgs
-        pkg.name !== nothing || pkg.uuid !== nothing ||
-            pkgerror("Must specify package by either `name` or `uuid`.")
-        pkg.repo.url === nothing || pkgerror("Can not specify `repo` url")
-        pkg.repo.rev === nothing || pkgerror("Can not specify `repo` rev")
+        if pkg.name === nothing && pkg.uuid === nothing
+            pkgerror("When calling `pin`, packages must be specified by name or UUID.")
+        end
+        if pkg.repo.url !== nothing
+            pkgerror("It is invalid to specify a repo location when calling `pin`:",
+                     " `$(pkg.repo.url)` given for package $(err_rep(pkg)).")
+        end
+        if pkg.repo.rev !== nothing
+            pkgerror("It is invalid to specify a git revision when calling `pin`:",
+                     " `$(pkg.repo.rev)` given for package $(err_rep(pkg)).")
+        end
     end
 
     foreach(pkg -> pkg.mode = PKGMODE_PROJECT, pkgs)
@@ -233,12 +259,13 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     preview_info(ctx)
 
     for pkg in pkgs
-        pkg.name !== nothing || pkg.uuid !== nothing ||
-            pkgerror("Must specify package by either `name` or `uuid`.")
+        if pkg.name === nothing && pkg.uuid === nothing
+            pkgerror("When calling `free`, packages must be specified by name or UUID.")
+        end
         if !(pkg.version == VersionSpec() && pkg.pinned == false &&
              pkg.tree_hash === nothing && pkg.repo.url === nothing &&
              pkg.repo.rev === nothing && pkg.path === nothing)
-            pkgerror("Package may only be specified by either `name` or `uuid`")
+            pkgerror("When calling `free`, packages may only be specified by name or UUID.")
         end
     end
 
@@ -855,10 +882,13 @@ function Package(;name::Union{Nothing,AbstractString} = nothing,
                  uuid::Union{Nothing,String,UUID} = nothing,
                  version::Union{VersionNumber, String, VersionSpec, Nothing} = nothing,
                  url = nothing, rev = nothing, path=nothing, mode::PackageMode = PKGMODE_PROJECT)
-    path !== nothing && url !== nothing &&
-        pkgerror("cannot specify both a path and url")
-    url !== nothing && version !== nothing &&
-        pkgerror("`version` can not be given with `url`, use `rev` instead")
+    if path !== nothing && url !== nothing
+        pkgerror("It is invalid to specify both `path` and `url`.")
+    end
+    if url !== nothing && version !== nothing
+        pkgerror("It is invalid to specify both `version` and `url`.",
+                 "Hint: `rev` may have been intended instead of `version.")
+    end
     repo = Types.GitRepo(rev = rev, url = url !== nothing ? url : path)
     version = version === nothing ? VersionSpec() : VersionSpec(version)
     uuid isa String && (uuid = UUID(uuid))

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -82,7 +82,7 @@ as any no-longer-necessary manifest packages due to project package removals.
 ],[ :name => "add",
     :handler => do_add!,
     :arg_count => 1 => Inf,
-    :arg_parser => (x -> parse_package(x; add_or_dev=true, valid=[VersionRange, Rev])),
+    :arg_parser => (x -> parse_package(x; add_or_dev=true)),
     :option_spec => OptionDeclaration[
         [:name => "strict", :api => :strict => true],
     ],
@@ -116,7 +116,7 @@ pkg> add Example=7876af07-990d-54b4-ab0e-23690620f79a
     :short_name => "dev",
     :handler => do_develop!,
     :arg_count => 1 => Inf,
-    :arg_parser => (x -> parse_package(x; add_or_dev=true, valid=[VersionRange])),
+    :arg_parser => (x -> parse_package(x; add_or_dev=true)),
     :option_spec => OptionDeclaration[
         [:name => "strict", :api => :strict => true],
         [:name => "local", :api => :shared => false],
@@ -157,7 +157,7 @@ makes the package no longer being checked out.
 ],[ :name => "pin",
     :handler => do_pin!,
     :arg_count => 1 => Inf,
-    :arg_parser => (x -> parse_package(x; valid=[VersionRange])),
+    :arg_parser => parse_package,
     :completions => complete_installed_packages,
     :description => "pins the version of packages",
     :help => md"""
@@ -221,7 +221,7 @@ it will be placed in the first depot of the stack.
     :short_name => "up",
     :handler => do_up!,
     :arg_count => 0 => Inf,
-    :arg_parser => (x -> parse_package(x; valid=[VersionRange])),
+    :arg_parser => parse_package,
     :option_spec => OptionDeclaration[
         [:name => "project",  :short_name => "p", :api => :mode => PKGMODE_PROJECT],
         [:name => "manifest", :short_name => "m", :api => :mode => PKGMODE_MANIFEST],

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -934,4 +934,62 @@ end
     end
 end
 
+@testset "REPL API: packagespec token order" begin
+    temp_pkg_dir() do project_path; with_temp_env() do;
+        @test_throws PkgError Pkg.REPLMode.pkgstr("add JSON Example#foobar#foobar LazyJSON")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up Example#foobar@0.0.0")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("pin Example@0.0.0@0.0.1")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up #foobar")
+        @test_throws PkgError Pkg.REPLMode.pkgstr("add @0.0.1")
+    end end
+end
+
+@testset "REPL API `develop`" begin
+    # errors
+    temp_pkg_dir() do project_path; with_temp_env() do;
+        @test_throws PkgError pkg"dev Example#master#master"
+        @test_throws PkgError pkg"develop Example#master"
+        @test_throws PkgError pkg"develop Example@0.5.0"
+        @test_throws PkgError pkg"develop JSON Example@0.5.0 LazyJSON"
+        @test_throws PkgError pkg"develop julia"
+        @test_throws PkgError pkg"develop julia#master"
+    end end
+end
+
+@testset "REPL API `remove`" begin
+    # errors
+    temp_pkg_dir() do project_path; with_temp_env() do;
+        Pkg.add("Example")
+        @test_throws PkgError pkg"remove Example#master"
+        @test_throws PkgError pkg"rm Example#master"
+        @test_throws PkgError pkg"remove Example@0.5.0"
+        @test_throws PkgError pkg"rm --project --manifest"
+    end end
+end
+
+@testset "REPL API `free`" begin
+    # errors
+    temp_pkg_dir() do project_path; with_temp_env() do;
+        Pkg.add("Example")
+        Pkg.pin("Example")
+        @test_throws PkgError pkg"free Example#master"
+        @test_throws PkgError pkg"free Example@0.5.0"
+    end end
+end
+
+@testset "REPL API `generate`" begin
+    # errors
+    temp_pkg_dir() do project_path; cd_tempdir() do tmpdir
+        @test_throws PkgError pkg"generate"
+        @test_throws PkgError pkg"generate Example Example2"
+    end end
+end
+
+@testset "REPL API `up`" begin
+    # errors
+    temp_pkg_dir() do project_path; with_temp_env() do;
+        @test_throws PkgError Pkg.REPLMode.pkgstr("up --major --minor")
+    end end
+end
+
 end # module


### PR DESCRIPTION
This checking is necessary in the API layer, so there is no need to duplicate it in the REPL layer. Also tweaked the API error handling to be a bit more clear/verbose.

---
fix #1257 
Example:
```
(foobar) pkg> dev JSON Example#master
ERROR: It is invalid to specify a git revision. git revision `master` was specified for package `Example`.
```

close #589
Example:
```
(v1.0) pkg> dev /tmp/idonotexist
[ Info: Resolving package identifier `/tmp/idonotexist` as a URL.
   Cloning git-repo `/tmp/idonotexist`
ERROR: failed to clone from /tmp/idonotexist, error: GitError(Code:ERROR, Class:Net, unsupported URL protocol)
```