### PR TITLE
Add a more concise way to call the API functions

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -70,6 +70,11 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
                       version::Union{VersionNumber, String, VersionSpec, Nothing}=nothing,
                       url=nothing, rev=nothing, path=nothing, mode=PKGMODE_PROJECT, subdir=nothing, kwargs...)
             pkg = Package(name=name, uuid=uuid, version=version, url=url, rev=rev, path=path, mode=mode, subdir=subdir)
+            # Pkg.status takes a mode argument as well which is a bit ambiguous with the
+            # mode argument to the PackageSpec but probably not a problem in practice
+            if $f === status
+                kwargs = merge((;kwargs...), (:mode => mode,))
+            end
             # Handle $f() case
             if pkg == Package()
                 $f(PackageSpec[]; kwargs...)

--- a/src/API.jl
+++ b/src/API.jl
@@ -47,11 +47,16 @@ function check_package_name(x::AbstractString, mode=nothing)
         message = "`$x` is not a valid package name"
         if mode !== nothing && any(occursin.(['\\','/'], x)) # maybe a url or a path
             message *= "\nThe argument appears to be a URL or path, perhaps you meant " *
-                "`Pkg.$mode(PackageSpec(url=\"...\"))` or `Pkg.$mode(PackageSpec(path=\"...\"))`."
+                "`Pkg.$mode(url=\"...\")` or `Pkg.$mode(path=\"...\")`."
         end
         pkgerror(message)
     end
-    return PackageSpec(x)
+    return
+end
+check_package_name(::Nothing, ::Any) = nothing
+
+function require_not_empty(pkgs, f::Symbol)
+    isempty(pkgs) && pkgerror("$f requires at least one package")
 end
 
 # Provide some convenience calls
@@ -60,11 +65,27 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
         $f(pkg::Union{AbstractString, PackageSpec}; kwargs...) = $f([pkg]; kwargs...)
         $f(pkgs::Vector{<:AbstractString}; kwargs...)          = $f([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
         $f(pkgs::Vector{PackageSpec}; kwargs...)               = $f(Context(), pkgs; kwargs...)
+        $f(ctx::Context; kwargs...) = $f(ctx, PackageSpec[]; kwargs...)
+        function $f(; name::Union{Nothing,AbstractString}=nothing, uuid::Union{Nothing,String,UUID}=nothing,
+                      version::Union{VersionNumber, String, VersionSpec, Nothing}=nothing,
+                      url=nothing, rev=nothing, path=nothing, mode=PKGMODE_PROJECT, subdir=nothing, kwargs...)
+            pkg = Package(name=name, uuid=uuid, version=version, url=url, rev=rev, path=path, mode=mode, subdir=subdir)
+            # Handle $f() case
+            if pkg == Package()
+                $f(PackageSpec[]; kwargs...)
+            else
+                $f(pkg; kwargs...)
+            end
+        end
+        function $f(pkgs::Vector{<:NamedTuple}; kwargs...)
+            $f([Package(;pkg...) for pkg in pkgs]; kwargs...)
+        end
     end
 end
 
 function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
                  preserve::PreserveLevel=PRESERVE_TIERED, platform::Platform=platform_key_abi(), kwargs...)
+    require_not_empty(pkgs, :develop)
     foreach(pkg -> check_package_name(pkg.name, :develop), pkgs)
     pkgs = deepcopy(pkgs) # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
@@ -111,6 +132,7 @@ end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PRESERVE_TIERED,
              platform::Platform=platform_key_abi(), kwargs...)
+    require_not_empty(pkgs, :add)
     foreach(pkg -> check_package_name(pkg.name, :add), pkgs)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
@@ -164,6 +186,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
 end
 
 function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, kwargs...)
+    require_not_empty(pkgs, :rm)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     foreach(pkg -> pkg.mode = mode, pkgs)
 
@@ -188,7 +211,6 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, kwarg
     return
 end
 
-up(; kwargs...)                                        = up(PackageSpec[]; kwargs...)
 function up(ctx::Context, pkgs::Vector{PackageSpec};
             level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode=PKGMODE_PROJECT,
             update_registry::Bool=true, kwargs...)
@@ -226,6 +248,7 @@ function resolve(ctx::Context; kwargs...)
 end
 
 function pin(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+    require_not_empty(pkgs, :pin)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
@@ -254,6 +277,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
 end
 
 function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+    require_not_empty(pkgs, :free)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
@@ -277,7 +301,6 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     return
 end
 
-test(;kwargs...)                                         = test(PackageSpec[]; kwargs...)
 function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, test_fn=nothing,
               julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
@@ -803,7 +826,6 @@ end
 
 @deprecate status(mode::PackageMode) status(mode=mode)
 
-status(; kwargs...) = status(PackageSpec[]; kwargs...)
 function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=PKGMODE_PROJECT,
                 io::IO=stdout, kwargs...)
     Context!(ctx; io=io, kwargs...)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -119,11 +119,11 @@ The following table describes the argument values for `preserve` (in order of st
 ```julia
 Pkg.add("Example") # Add a package from registry
 Pkg.add("Example"; preserve=Pkg.PRESERVE_ALL) # Add the `Example` package and preserve existing dependencies
-Pkg.add(PackageSpec(name="Example", version="0.3")) # Specify version; latest release in the 0.3 series
-Pkg.add(PackageSpec(name="Example", version="0.3.1")) # Specify version; exact release
-Pkg.add(PackageSpec(url="https://github.com/JuliaLang/Example.jl", rev="master")) # From url to remote gitrepo
-Pkg.add(PackageSpec(url="/remote/mycompany/juliapackages/OurPackage")) # From path to local gitrepo
-Pkg.add(PackageSpec(url="https://github.com/Company/MonoRepo", subdir="juliapkgs/Package.jl)")) # With subdir
+Pkg.add(name="Example", version="0.3") # Specify version; latest release in the 0.3 series
+Pkg.add(name="Example", version="0.3.1") # Specify version; exact release
+Pkg.add(url="https://github.com/JuliaLang/Example.jl", rev="master") # From url to remote gitrepo
+Pkg.add(url="/remote/mycompany/juliapackages/OurPackage") # From path to local gitrepo
+Pkg.add(url="https://github.com/Company/MonoRepo", subdir="juliapkgs/Package.jl)") # With subdir
 ```
 
 See also [`PackageSpec`](@ref).
@@ -245,7 +245,7 @@ git revision. A pinned package is never updated.
 # Examples
 ```julia
 Pkg.pin("Example")
-Pkg.pin(PackageSpec(name="Example", version="0.3.1"))
+Pkg.pin(name="Example", version="0.3.1")
 ```
 """
 const pin = API.pin
@@ -261,7 +261,6 @@ e.g. after [`Pkg.develop`](@ref), go back to tracking registered versions.
 # Examples
 ```julia
 Pkg.free("Package")
-Pkg.free(PackageSpec("Package"))
 ```
 """
 const free = API.free
@@ -284,10 +283,10 @@ If `pkg` is given as a local path, the package at that path will be tracked.
 Pkg.develop("Example")
 
 # By url
-Pkg.develop(PackageSpec(url="https://github.com/JuliaLang/Compat.jl"))
+Pkg.develop(url="https://github.com/JuliaLang/Compat.jl")
 
 # By path
-Pkg.develop(PackageSpec(path="MyJuliaPackages/Package.jl"))
+Pkg.develop(path="MyJuliaPackages/Package.jl")
 ```
 
 See also [`PackageSpec`](@ref)
@@ -433,6 +432,15 @@ This includes:
 Most functions in Pkg take a `Vector` of `PackageSpec` and do the operation on all the packages
 in the vector.
 
+!!! compat "Julia 1.5"
+    Many functions that take a `PackageSpec` or a `Vector{PackageSpec}` can be called with a more concise notation with `NamedTuple`s.
+    For example, `Pkg.add` can be called either as the explicit or concise versions as:
+    | Explicit                                                            | Concise
+    |:--------------------------------------------------------------------|:-----------------------------------------------|
+    | `Pkg.add(PackageSpec(name="Package))`                               | `Pkg.add(name = "Package")`                    |
+    | `Pkg.add(PackageSpec(url="www.myhost.com/MyPkg")))`                 | `Pkg.add(name = "Package")`                    |
+    |` Pkg.add([PackageSpec(name="Package"), PackageSpec(path="/MyPkg"])` | `Pkg.add([(;name="Package"), (;path="MyPkg")])`|
+
 Below is a comparison between the REPL version and the API version:
 
 | `REPL`               | `API`                                                 |
@@ -445,6 +453,7 @@ Below is a comparison between the REPL version and the API version:
 | `www.mypkg.com`      | `PackageSpec(url="www.mypkg.com")`                    |
 | `--manifest Package` | `PackageSpec(name="Package", mode=PKGSPEC_MANIFEST)`  |
 | `--major Package`    | `PackageSpec(name="Package", version=PKGLEVEL_MAJOR)` |
+
 """
 const PackageSpec = API.Package
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -32,7 +32,7 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
         # Now we double check we have a clean slate.
         @test isempty(Pkg.dependencies())
         # A simple `add` should set up some things for us:
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.3"))
+        Pkg.add(name="Example", version="0.5.3")
         # - `General` should be initiated by default.
         regs = Pkg.Registry.status(;as_api=true)
         @test length(regs) == 1
@@ -50,7 +50,7 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
         @test haskey(Pkg.project().dependencies, "Example")
         @test length(Pkg.project().dependencies) == 1
         # Now we install the same package at a different version:
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.1"))
+        Pkg.add(name="Example", version="0.5.1")
         # - Check that the package was installed correctly.
         Pkg.dependencies(exuuid) do pkg
             @test pkg.version == v"0.5.1"
@@ -59,10 +59,10 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
             @test pkg.source != source053
         end
         # Now a few more versions:
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.0"))
-        Pkg.add(Pkg.PackageSpec(;name="Example"))
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.3"))
+        Pkg.add(name="Example", version="0.5.0")
+        Pkg.add(name="Example")
+        Pkg.add(name="Example", version="0.3.0")
+        Pkg.add(name="Example", version="0.3.3")
         # With similar checks
         Pkg.dependencies(exuuid) do pkg
             @test pkg.version == v"0.3.3"
@@ -70,42 +70,42 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
         end
         # Now we try adding a second dependency.
         # We repeat the same class of tests.
-        Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"))
+        Pkg.add(name="JSON", version="0.18.0")
         sourcej018 = nothing
         Pkg.dependencies(json_uuid) do pkg
             @test pkg.version == v"0.18.0"
             @test isdir(pkg.source)
         end
-        Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.20.0"))
+        Pkg.add(name="JSON", version="0.20.0")
         Pkg.dependencies(json_uuid) do pkg
             @test isdir(pkg.source)
             @test pkg.source != sourcej018
         end
         # Now check packages which track repos instead of registered versions
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl", rev="v0.5.3"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl", rev="v0.5.3")
         Pkg.dependencies(exuuid) do pkg
             @test !pkg.is_tracking_registry
             @test isdir(pkg.source)
             @test isdir(Pkg.Types.add_repo_cache_path(pkg.git_source))
         end
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="master"))
+        Pkg.add(name="Example", rev="master")
         Pkg.dependencies(exuuid) do pkg
             @test !pkg.is_tracking_registry
             @test isdir(pkg.source)
             @test isdir(Pkg.Types.add_repo_cache_path(pkg.git_source))
         end
         # Also check that unregistered packages are installed properly.
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl")
         Pkg.dependencies(unregistered_uuid) do pkg
             @test isdir(pkg.source)
             @test isdir(Pkg.Types.add_repo_cache_path(pkg.git_source))
         end
         # Check `develop`
-        Pkg.develop(Pkg.PackageSpec(;name="Example"))
+        Pkg.develop(name="Example")
         Pkg.dependencies(exuuid) do pkg
             @test isdir(pkg.source) # TODO check for full git clone, have to implement saving original URL first
         end
-        Pkg.develop(Pkg.PackageSpec(;name="JSON"))
+        Pkg.develop(name="JSON")
         Pkg.dependencies(json_uuid) do pkg
             @test isdir(pkg.source) # TODO check for full git clone, have to implement saving original URL first
         end
@@ -147,7 +147,7 @@ inside_test_sandbox(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
         path = copy_test_package(tempdir, "BasicSandbox")
         # we set realonly here to simulate the premissions in the `$DEPOT/packages` directory
         Pkg.Types.set_readonly(path)
-        Pkg.develop(Pkg.PackageSpec(;path=path))
+        Pkg.develop(path=path)
         inside_test_sandbox("BasicSandbox") do
             Pkg.dependencies(foo_uuid) do pkg
                 @test length(pkg.dependencies) == 1
@@ -235,7 +235,7 @@ end
         path = copy_test_package(tempdir, "BasicTestTarget")
         # we set realonly here to simulate the premissions in the `$DEPOT/packages` directory
         Pkg.Types.set_readonly(path)
-        Pkg.develop(Pkg.PackageSpec(;path=path))
+        Pkg.develop(path=path)
         inside_test_sandbox("BasicTestTarget") do
             @test haskey(Pkg.project().dependencies, "Markdown")
             @test haskey(Pkg.project().dependencies, "Test")
@@ -278,20 +278,20 @@ end
 
 @testset "test: fallback when no project file exists" begin
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Permutations", version="0.3.2"))
+        Pkg.add(name="Permutations", version="0.3.2")
         Pkg.test("Permutations")
     end
 end
 
 @testset "build: fallback when no project file exists" begin
     isolate() do
-        Pkg.add(Pkg.PackageSpec(;name="ZMQ", version="0.6.3"))
+        Pkg.add(name="ZMQ", version="0.6.3")
     end
 end
 
 @testset "using a test/REQUIRE file" begin
     isolate() do
-        Pkg.add(Pkg.PackageSpec(;name="EnglishText", version="0.6.0"))
+        Pkg.add(name="EnglishText", version="0.6.0")
         Pkg.test("EnglishText")
     end
 end
@@ -340,17 +340,17 @@ end
 @testset "add: input checking" begin
     isolate(loaded_depot=true) do
         # Julia is not a valid package name.
-        @test_throws PkgError("`julia` is not a valid package name") Pkg.add(Pkg.PackageSpec(;name="julia"))
+        @test_throws PkgError("`julia` is not a valid package name") Pkg.add(name="julia")
         # Package names must be valid Julia identifiers.
-        @test_throws PkgError("`***` is not a valid package name") Pkg.add(Pkg.PackageSpec(;name="***"))
-        @test_throws PkgError("`Foo Bar` is not a valid package name") Pkg.add(Pkg.PackageSpec(;name="Foo Bar"))
+        @test_throws PkgError("`***` is not a valid package name") Pkg.add(name="***")
+        @test_throws PkgError("`Foo Bar` is not a valid package name") Pkg.add(name="Foo Bar")
         # Names which are invalid and are probably URLs or paths.
         @test_throws PkgError("""
         `https://github.com` is not a valid package name
-        The argument appears to be a URL or path, perhaps you meant `Pkg.add(PackageSpec(url="..."))` or `Pkg.add(PackageSpec(path="..."))`.""") Pkg.add("https://github.com")
+        The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.""") Pkg.add("https://github.com")
         @test_throws PkgError("""
         `./Foobar` is not a valid package name
-        The argument appears to be a URL or path, perhaps you meant `Pkg.add(PackageSpec(url="..."))` or `Pkg.add(PackageSpec(path="..."))`.""") Pkg.add("./Foobar")
+        The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.""") Pkg.add("./Foobar")
         # An empty spec is invalid.
         @test_throws PkgError(
             "name, UUID, URL, or filesystem path specification required when calling `add`"
@@ -358,7 +358,7 @@ end
         # Versions imply that we are tracking a registered version.
         @test_throws PkgError(
             "version specification invalid when tracking a repository: `0.5.0` specified for package `Example`"
-            ) Pkg.add(Pkg.PackageSpec(;name="Example", rev="master", version="0.5.0"))
+            ) Pkg.add(name="Example", rev="master", version="0.5.0")
         # Adding an unregistered package
         @test_throws PkgError Pkg.add("ThisIsHopefullyRandom012856014925701382")
         # Wrong UUID
@@ -368,7 +368,7 @@ end
         # Two packages with the same name
         @test_throws PkgError(
             "it is invalid to specify multiple packages with the same name: `Example`"
-            ) Pkg.add([Pkg.PackageSpec(;name="Example"), Pkg.PackageSpec(;name="Example",version="0.5.0")])
+            ) Pkg.add([(;name="Example"), (;name="Example",version="0.5.0")])
     end
     # Unregistered UUID in manifest
     isolate(loaded_depot=true) do; mktempdir() do tempdir
@@ -379,7 +379,7 @@ end
     # empty git repo (no commits)
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         close(LibGit2.init(tempdir))
-        try Pkg.add(Pkg.PackageSpec(;path=tempdir))
+        try Pkg.add(path=tempdir)
             @assert false
         catch err
             @test err isa PkgError
@@ -406,7 +406,7 @@ end
     end
     # Basic add by version
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.0"))
+        Pkg.add(name="Example", version="0.5.0")
         Pkg.dependencies(exuuid) do ex
             @test ex.is_tracking_registry
             @test ex.version == v"0.5.0"
@@ -428,7 +428,7 @@ end
     =#
     # Basic add by URL
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl", rev="v0.5.3"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl", rev="v0.5.3")
         Pkg.dependencies(exuuid) do ex
             @test !ex.is_tracking_registry
             @test ex.git_source == "https://github.com/JuliaLang/Example.jl"
@@ -438,7 +438,7 @@ end
     end
     # Basic add by git revision
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="master"))
+        Pkg.add(name="Example", rev="master")
         Pkg.dependencies(exuuid) do ex
             @test !ex.is_tracking_registry
             @test ex.git_source == "https://github.com/JuliaLang/Example.jl.git"
@@ -455,12 +455,12 @@ end
             @test pkg.name == "Markdown"
         end
         # - Adding a stdlib by UUID.
-        Pkg.add(Pkg.PackageSpec(;uuid=profile_uuid))
+        Pkg.add(uuid=profile_uuid)
         Pkg.dependencies(profile_uuid) do pkg
             @test pkg.name == "Profile"
         end
         # - Adding a stdlib by name/UUID.
-        Pkg.add(Pkg.PackageSpec(;name="Markdown", uuid=markdown_uuid))
+        Pkg.add(name="Markdown", uuid=markdown_uuid)
         Pkg.dependencies(markdown_uuid) do pkg
             @test pkg.name == "Markdown"
         end
@@ -468,7 +468,7 @@ end
     # Basic add by local path.
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "SimplePackage"))
-        Pkg.add(Pkg.PackageSpec(;path=path))
+        Pkg.add(path=path)
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.git_source == realpath(path)
             # We take care to check that the project file has been parsed correctly.
@@ -505,28 +505,28 @@ end
     end
     # Double add should not change state, this would be an unnecessary change.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add("Example")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
     end
     # Adding a new package should not alter the version of existing packages.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add("Test")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
     end
     # Add by version should not override pinned version.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         Pkg.pin("Example")
         Pkg.dependencies(exuuid) do ex
             @test ex.version == v"0.3.0"
             @test ex.is_tracking_registry
             @test ex.is_pinned
         end
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.0"))
+        Pkg.add(name="Example", version="0.5.0")
         # We check that the package state is left unchanged.
         Pkg.dependencies(exuuid) do ex
             @test ex.version == v"0.3.0"
@@ -536,13 +536,13 @@ end
     end
     # Add by version should override add by repo.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="master"))
+        Pkg.add(name="Example", rev="master")
         # First we check that we are not tracking a registered version.
         Pkg.dependencies(exuuid) do ex
             @test ex.git_revision == "master"
             @test !ex.is_tracking_registry
         end
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         # We should now be tracking a registered version.
         Pkg.dependencies(exuuid) do ex
             @test ex.version == v"0.3.0"
@@ -553,13 +553,13 @@ end
     # Add by version should override add by repo, even for indirect dependencies.
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "DependsOnExample"))
-        Pkg.add(Pkg.PackageSpec(;path=path))
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="master"))
+        Pkg.add(path=path)
+        Pkg.add(name="Example", rev="master")
         @test !Pkg.dependencies()[exuuid].is_tracking_registry
         # Now we remove the package as a direct dependency.
         # The package should still exist as an indirect dependency becuse `DependsOnExample` depends on it.
         Pkg.rm("Example")
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         # Now we check that we are tracking a registered version.
         Pkg.dependencies(exuuid) do ex
             @test ex.version == v"0.3.0"
@@ -568,14 +568,14 @@ end
     end end
     # Add by URL should not override pin.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
-        Pkg.pin(Pkg.PackageSpec(;name="Example"))
+        Pkg.add(name="Example", version="0.3.0")
+        Pkg.pin(name="Example")
         Pkg.dependencies(exuuid) do ex
             @test ex.is_pinned
             @test ex.is_tracking_registry
             @test ex.version == v"0.3.0"
         end
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl")
         Pkg.dependencies(exuuid) do ex
             @test ex.is_pinned
             @test ex.is_tracking_registry
@@ -584,7 +584,7 @@ end
     end
     # It should be possible to switch branches by reusing the URL.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl", rev="0.2.0"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl", rev="0.2.0")
         Pkg.dependencies(unregistered_uuid) do pkg
             @test pkg.git_source == "https://github.com/00vareladavid/Unregistered.jl"
             @test !pkg.is_tracking_registry
@@ -593,7 +593,7 @@ end
             @test haskey(pkg.dependencies, "Example")
         end
         # Now we refer to it by name so to check that we reuse the URL.
-        Pkg.add(Pkg.PackageSpec(;name="Unregistered", rev="0.1.0"))
+        Pkg.add(name="Unregistered", rev="0.1.0")
         Pkg.dependencies(unregistered_uuid) do pkg
             @test pkg.git_source == "https://github.com/00vareladavid/Unregistered.jl"
             @test !pkg.is_tracking_registry
@@ -614,15 +614,15 @@ end
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"))
+        Pkg.add(name="JSON", version="0.18.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
     end
     # - `tiered` is the default option.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_TIERED)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
@@ -630,7 +630,7 @@ end
     end
     # - `all` should succeed in the same way.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_ALL)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
@@ -638,7 +638,7 @@ end
     end
     # - `direct` should also succeed in the same way.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_DIRECT)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
@@ -646,7 +646,7 @@ end
     end
     # - `semver` should update `Example` to the highest semver compatible version.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_SEMVER)
         @test Pkg.dependencies()[exuuid].version == v"0.3.3"
@@ -654,7 +654,7 @@ end
     end
     #- `none` should update `Example` to the highest compatible version.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_NONE)
         @test Pkg.dependencies()[exuuid].version == v"0.5.3"
@@ -674,7 +674,7 @@ end
         empty_package = UUID("26187899-7657-4a90-a2f6-e79e0214bedc")
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "EmptyPackage"))
         path = abspath(path)
-        Pkg.add(Pkg.PackageSpec(;path=path))
+        Pkg.add(path=path)
         # Now we try to find the package.
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
         @test !isdir(Pkg.dependencies()[empty_package].source)
@@ -698,7 +698,7 @@ end
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "EmptyPackage"))
         # We add the package using a relative path.
         cd(path) do
-            Pkg.add(Pkg.PackageSpec(;path="."))
+            Pkg.add(path=".")
         end
         # Now we try to find the package.
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
@@ -718,7 +718,7 @@ end
     # Now we test packages added by URL.
     isolate(loaded_depot=true) do
         # Details: `master` is past `0.1.0`
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl", rev="0.1.0"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl", rev="0.1.0")
         Pkg.dependencies(unregistered_uuid) do pkg
             @test pkg.name == "Unregistered"
             @test isdir(pkg.source)
@@ -756,13 +756,13 @@ end
         Pkg.activate(joinpath(tmp, "ShouldPreserveAll"))
         parsers_uuid = UUID("69de0a69-1ddd-5017-9359-2bf0b02dc9f0")
         original_parsers_version = Pkg.dependencies()[parsers_uuid].version
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.0"))
+        Pkg.add(name="Example", version="0.5.0")
         @test Pkg.dependencies()[parsers_uuid].version == original_parsers_version
         # Direct
         copy_test_package(tmp, "ShouldPreserveDirect"; use_pkg=false)
         Pkg.activate(joinpath(tmp, "ShouldPreserveDirect"))
         ordered_collections = UUID("bac558e1-5e72-5ebc-8fee-abe8a469f55d")
-        Pkg.add(Pkg.PackageSpec(;uuid=ordered_collections, version="1.0.1"))
+        Pkg.add(uuid=ordered_collections, version="1.0.1")
         lazy_json = UUID("fc18253b-5e1b-504c-a4a2-9ece4944c004")
         data_structures = UUID("864edb3b-99cc-5e75-8d2d-829cb0a9cfe8")
         @test Pkg.dependencies()[lazy_json].version == v"0.1.0" # stayed the same
@@ -774,7 +774,7 @@ end
         light_graphs = UUID("093fc24a-ae57-5d10-9952-331d41423f4d")
         meta_graphs = UUID("626554b9-1ddb-594c-aa3c-2596fe9399a5")
         light_graphs_version = Pkg.dependencies()[light_graphs].version
-        Pkg.add(Pkg.PackageSpec(;uuid=meta_graphs, version="0.6.4"))
+        Pkg.add(uuid=meta_graphs, version="0.6.4")
         @test Pkg.dependencies()[meta_graphs].version == v"0.6.4" # sanity check
         # did not break semver
         @test Pkg.dependencies()[light_graphs].version in Pkg.Types.semver_spec("$(light_graphs_version)")
@@ -785,7 +785,7 @@ end
         Pkg.activate(joinpath(tmp, "ShouldPreserveNone"))
         array_interface = UUID("4fba245c-0d91-5ea0-9b3e-6abc04ee57a9")
         diff_eq_diff_tools = UUID("01453d9d-ee7c-5054-8395-0335cb756afa")
-        Pkg.add(Pkg.PackageSpec(;uuid=diff_eq_diff_tools, version="1.0.0"))
+        Pkg.add(uuid=diff_eq_diff_tools, version="1.0.0")
         @test Pkg.dependencies()[diff_eq_diff_tools].version == v"1.0.0" # sanity check
         @test Pkg.dependencies()[array_interface].version in Pkg.Types.semver_spec("1") # had to make breaking change
     end end
@@ -880,10 +880,10 @@ end
 @testset "develop: input checking" begin
     isolate(loaded_depot=true) do
         # Julia is not a valid package name.
-        @test_throws PkgError("`julia` is not a valid package name") Pkg.develop(Pkg.PackageSpec(;name="julia"))
+        @test_throws PkgError("`julia` is not a valid package name") Pkg.develop(name="julia")
         # Package names must be valid Julia identifiers.
-        @test_throws PkgError("`***` is not a valid package name") Pkg.develop(Pkg.PackageSpec(;name="***"))
-        @test_throws PkgError("`Foo Bar` is not a valid package name") Pkg.develop(Pkg.PackageSpec(;name="Foo Bar"))
+        @test_throws PkgError("`***` is not a valid package name") Pkg.develop(name="***")
+        @test_throws PkgError("`Foo Bar` is not a valid package name") Pkg.develop(name="Foo Bar")
         # Names which are invalid and are probably URLs or paths.
         @test_throws PkgError("""
         `https://github.com` is not a valid package name
@@ -898,7 +898,7 @@ end
         # git revisions imply that `develop` tracks a git repo.
         @test_throws PkgError(
             "git revision specification invalid when calling `develop`: `master` specified for package `Example`"
-            ) Pkg.develop(Pkg.PackageSpec(;name="Example", rev="master"))
+            ) Pkg.develop(name="Example", rev="master")
         # Adding an unregistered package by name.
         @test_throws PkgError Pkg.develop("ThisIsHopefullyRandom012856014925701382")
         # Wrong UUID
@@ -908,7 +908,7 @@ end
         # Two packages with the same name
         @test_throws PkgError(
             "it is invalid to specify multiple packages with the same UUID: `Example [7876af07]`"
-            ) Pkg.develop([Pkg.PackageSpec(;name="Example"), Pkg.PackageSpec(;uuid=exuuid)])
+            ) Pkg.develop([(;name="Example"), (;uuid=exuuid)])
     end
 end
 
@@ -938,7 +938,7 @@ end
     end
     # It is possible to develop by specifying a registered UUID.
     isolate(loaded_depot=true) do
-        Pkg.develop(Pkg.PackageSpec(;uuid=exuuid))
+        Pkg.develop(uuid=exuuid)
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
             @test pkg.source == joinpath(DEPOT_PATH[1], "dev", "Example")
@@ -948,7 +948,7 @@ end
     end
     # It is possible to develop by specifying a URL.
     isolate(loaded_depot=true) do
-        Pkg.develop(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
+        Pkg.develop(url="https://github.com/JuliaLang/Example.jl")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
             @test pkg.source == joinpath(DEPOT_PATH[1], "dev", "Example")
@@ -960,7 +960,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         copy_test_package(tempdir, "SimplePackage")
         path = joinpath(tempdir, "SimplePackage")
-        Pkg.develop(Pkg.PackageSpec(;path=path))
+        Pkg.develop(path=path)
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"
             @test realpath(pkg.source) == realpath(path)
@@ -972,7 +972,7 @@ end
     end end
     # recursive `dev`
     isolate(loaded_depot=true) do
-        Pkg.develop(Pkg.PackageSpec(;path=joinpath(@__DIR__, "test_packages", "A")))
+        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "A"))
         Pkg.dependencies(UUID("0829fd7c-1e7e-4927-9afa-b8c61d5e0e42")) do pkg # dep A
             @test haskey(pkg.dependencies, "B")
             @test haskey(pkg.dependencies, "C")
@@ -1061,7 +1061,7 @@ end
         copy_test_package(tempdir, "SimplePackage")
         package_path = joinpath(tempdir, "SimplePackage")
         Pkg.activate(tempdir)
-        Pkg.develop(Pkg.PackageSpec(;path=package_path))
+        Pkg.develop(path=package_path)
         original_source = nothing
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"
@@ -1133,7 +1133,7 @@ end
     end
     # Developing an existing package which is tracking a repo should just override.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="master"))
+        Pkg.add(name="Example", rev="master")
         Pkg.develop("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
@@ -1220,7 +1220,7 @@ end
 @testset "instantiate: changes to the active project" begin
     # Instantiate should preserve tree hash for regularly versioned packages.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         th = nothing
         Pkg.dependencies(exuuid) do pkg
             th = pkg.tree_hash
@@ -1240,7 +1240,7 @@ end
     end
     # `instantiate` should preserve tree hash for packages tracking repos.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="v0.5.3"))
+        Pkg.add(name="Example", rev="v0.5.3")
         th = nothing
         Pkg.dependencies(exuuid) do pkg
             th = pkg.tree_hash
@@ -1289,8 +1289,8 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         simple_package_path = copy_test_package(tempdir, "SimplePackage")
         unregistered_example_path = copy_test_package(tempdir, "Example")
-        Pkg.develop(Pkg.PackageSpec(;path=simple_package_path))
-        Pkg.develop(Pkg.PackageSpec(;path=unregistered_example_path))
+        Pkg.develop(path=simple_package_path)
+        Pkg.develop(path=unregistered_example_path)
         rm(Pkg.project().path)
         @test_throws PkgError Pkg.instantiate()
     end end
@@ -1303,7 +1303,7 @@ end
 @testset "instantiate: caching" begin
     # Instantiate should not override existing source.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         th, t1 = nothing, nothing
         Pkg.dependencies(exuuid) do pkg
             th = pkg.tree_hash
@@ -1358,7 +1358,7 @@ end
 @testset "update: changes to the active project" begin
     # Basic testing of UPLEVEL
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         Pkg.update(; level = Pkg.UPLEVEL_FIXED)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
@@ -1395,7 +1395,7 @@ end
 @testset "update: package state changes" begin
     # basic update on old registered package
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
+        Pkg.add(name="Example", version="0.3.0")
         Pkg.update()
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
@@ -1404,7 +1404,7 @@ end
     end
     # `update` should not update `pin`ed packages
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example",version="0.3.0"))
+        Pkg.add(name="Example",version="0.3.0")
         Pkg.pin("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
@@ -1429,7 +1429,7 @@ end
     # up should not affect `dev` packages
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = copy_test_package(tempdir, "SimplePackage")
-        Pkg.develop(Pkg.PackageSpec(;path=path))
+        Pkg.develop(path=path)
         state = Pkg.dependencies()[simple_package_uuid]
         Pkg.update()
         @test Pkg.dependencies()[simple_package_uuid] == state
@@ -1437,7 +1437,7 @@ end
     # up and packages tracking repos
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "SimplePackage"))
-        Pkg.add(Pkg.PackageSpec(;path=path))
+        Pkg.add(path=path)
         # test everything went ok
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"
@@ -1480,9 +1480,9 @@ end
     end end
     # make sure that we preserve the state of packages which are not the target
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl")
         Pkg.develop("Example")
-        Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"))
+        Pkg.add(name="JSON", version="0.18.0")
         Pkg.add("Markdown")
         Pkg.add("Unicode")
         Pkg.update("Unicode")
@@ -1504,8 +1504,8 @@ end
     end
     # `--fixed` should prevent the target package from being updated, but update other dependencies
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"))
-        Pkg.add(Pkg.PackageSpec(; name="JSON", version="0.18.0"))
+        Pkg.add( name="Example", version="0.3.0")
+        Pkg.add( name="JSON", version="0.18.0")
         Pkg.update("JSON"; level=Pkg.UPLEVEL_FIXED)
         Pkg.dependencies(json_uuid) do pkg
             @test pkg.version == v"0.18.0"
@@ -1529,7 +1529,7 @@ end
     # `up` should detect broken local packages
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "SimplePackage"))
-        Pkg.add(Pkg.PackageSpec(;path=path))
+        Pkg.add(path=path)
         rm(joinpath(path, ".git"); force=true, recursive=true)
         @test_throws PkgError Pkg.update()
     end end
@@ -1545,21 +1545,21 @@ end
     end
     # pinning to an arbritrary version should check for unregistered packages
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl")
         @test_throws PkgError("unable to pin unregistered package `Unregistered [dcb67f36]` to an arbritrary version"
-                              ) Pkg.pin(Pkg.PackageSpec(;name="Unregistered", version="0.1.0"))
+                              ) Pkg.pin(name="Unregistered", version="0.1.0")
     end
     # pinning to an abritrary version should check version exists
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example",rev="master"))
-        @test_throws ResolverError Pkg.pin(Pkg.PackageSpec(;name="Example",version="100.0.0"))
+        Pkg.add(name="Example",rev="master")
+        @test_throws ResolverError Pkg.pin(name="Example",version="100.0.0")
     end
 end
 
 @testset "pin: package state changes" begin
     # regular registered package
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.3"))
+        Pkg.add( name="Example", version="0.3.3")
         Pkg.pin("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
@@ -1568,7 +1568,7 @@ end
     end
     # packge tracking repo
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl")
         Pkg.pin("Unregistered")
         Pkg.dependencies(unregistered_uuid) do pkg
             @test !pkg.is_tracking_registry
@@ -1577,8 +1577,8 @@ end
     end
     # versioned pin
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.3"))
-        Pkg.pin(Pkg.PackageSpec(; name="Example", version="0.5.1"))
+        Pkg.add( name="Example", version="0.3.3")
+        Pkg.pin( name="Example", version="0.5.1")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
             @test pkg.is_pinned
@@ -1586,8 +1586,8 @@ end
     end
     # pin should check for a valid version number
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;name="Example", rev="master"))
-        @test_throws ResolverError Pkg.pin(Pkg.PackageSpec(;name="Example",version="100.0.0")) # TODO maybe make a PkgError
+        Pkg.add(name="Example", rev="master")
+        @test_throws ResolverError Pkg.pin(name="Example",version="100.0.0") # TODO maybe make a PkgError
     end
 end
 
@@ -1621,7 +1621,7 @@ end
     end
     # free package tracking repo
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(; name="Example", rev="master"))
+        Pkg.add( name="Example", rev="master")
         Pkg.free("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
@@ -1639,11 +1639,11 @@ end
     end
     # free should error when called on packages tracking unregistered packages
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl")
         @test_throws PkgError("unable to free unregistered package `Unregistered [dcb67f36]`") Pkg.free("Unregistered")
     end
     isolate(loaded_depot=true) do
-        Pkg.develop(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.develop(url="https://github.com/00vareladavid/Unregistered.jl")
         @test_throws PkgError("unable to free unregistered package `Unregistered [dcb67f36]`") Pkg.free("Unregistered")
     end
 end
@@ -1711,8 +1711,8 @@ end
     end
     # remove should not alter other dependencies
     isolate(loaded_depot=true) do
-        Pkg.add([Pkg.PackageSpec(;name="Example"),
-                 Pkg.PackageSpec(;name="JSON", version="0.18.0"),])
+        Pkg.add([(;name="Example"),
+                 (;name="JSON", version="0.18.0"),])
         json = Pkg.dependencies()[json_uuid]
         Pkg.rm("Example")
         @test Pkg.dependencies()[json_uuid] == json
@@ -1732,8 +1732,8 @@ end
     # rm removes unused recursive depdencies
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = copy_test_package(tempdir, "SimplePackage")
-        Pkg.develop(Pkg.PackageSpec(;path=path))
-        Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"))
+        Pkg.develop(path=path)
+        Pkg.add(name="JSON", version="0.18.0")
         Pkg.rm("SimplePackage")
         @test haskey(Pkg.dependencies(), markdown_uuid)
         @test !haskey(Pkg.dependencies(), simple_package_uuid)
@@ -1904,9 +1904,9 @@ end
         @test occursin(r"Status `.+Project.toml` \(empty project\)", readline(io))
         ## loaded project
         Pkg.add("Markdown")
-        Pkg.add(Pkg.PackageSpec(; name="JSON", version="0.18.0"))
+        Pkg.add( name="JSON", version="0.18.0")
         Pkg.develop("Example")
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
+        Pkg.add(url="https://github.com/00vareladavid/Unregistered.jl")
         Pkg.status(; io = io)
         @test occursin(r"Status `.+Project\.toml`", readline(io))
         @test occursin(r"\[7876af07\] Example v\d\.\d\.\d `.+`", readline(io))
@@ -1937,7 +1937,7 @@ end
         Pkg.status(;io=io, mode=Pkg.PKGMODE_MANIFEST)
         @test occursin(r"Status `.+Manifest\.toml` \(empty manifest\)", readline(io))
         # loaded manifest
-        Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"))
+        Pkg.add( name="Example", version="0.3.0")
         Pkg.add("Markdown")
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST)
         @test occursin(r"Status `.+Manifest.toml`", readline(io))
@@ -1971,7 +1971,7 @@ end
         @test occursin(r"No Changes to `.+Project\.toml`", readline(io))
         ## non-empty project + non-empty diff
         Pkg.rm("Markdown")
-        Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"))
+        Pkg.add( name="Example", version="0.3.0")
         ## diff project
         Pkg.status(; io=io, diff=true)
         @test occursin(r"Diff `.+Project\.toml`", readline(io))
@@ -2006,7 +2006,7 @@ end
 @testset "Repo caching" begin
     # Add by URL should not overwrite files.
     isolate(loaded_depot=true) do
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl")
         s1, t1, c1 = 0, 0, 0
         Pkg.dependencies(exuuid) do pkg
             @test isdir(pkg.source)
@@ -2015,7 +2015,7 @@ end
             @test isdir(Pkg.Types.add_repo_cache_path(pkg.git_source))
             t1 = mtime(pkg.source)
         end
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl")
         Pkg.dependencies(exuuid) do pkg
             @test isdir(pkg.source)
             @test pkg.source == s1
@@ -2027,7 +2027,7 @@ end
     # Add by URL should not overwrite files, even across projects
     isolate(loaded_depot=true) do
         # Make sure we have everything downloaded
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl")
         s1, t1, c1 = 0, 0, 0
         Pkg.dependencies(exuuid) do pkg
             @test isdir(pkg.source)
@@ -2041,7 +2041,7 @@ end
         @test isempty(Pkg.project().dependencies)
         @test isempty(Pkg.dependencies())
         # Finally, add the same URL, we should reuse the existing directories.
-        Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
+        Pkg.add(url="https://github.com/JuliaLang/Example.jl")
         Pkg.dependencies(exuuid) do pkg
             @test isdir(pkg.source)
             @test pkg.source == s1
@@ -2053,7 +2053,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         empty_package = UUID("26187899-7657-4a90-a2f6-e79e0214bedc")
         path = git_init_package(tempdir, joinpath(@__DIR__, "test_packages", "EmptyPackage"))
-        Pkg.add(Pkg.PackageSpec(;path=path))
+        Pkg.add(path=path)
         # We check that the package was installed correctly.
         cache, original_master = 0, 0
         Pkg.dependencies(empty_package) do pkg
@@ -2240,7 +2240,7 @@ end
 @testset "package name in resolver errors" begin
     isolate(loaded_depot=true) do
         try
-            Pkg.add(Pkg.PackageSpec(;name="Example", version = v"55"))
+            Pkg.add(name="Example", version = v"55")
         catch e
             @test occursin(TEST_PKG.name, sprint(showerror, e))
         end

--- a/test/new.jl
+++ b/test/new.jl
@@ -887,10 +887,10 @@ end
         # Names which are invalid and are probably URLs or paths.
         @test_throws PkgError("""
         `https://github.com` is not a valid package name
-        The argument appears to be a URL or path, perhaps you meant `Pkg.develop(PackageSpec(url="..."))` or `Pkg.develop(PackageSpec(path="..."))`.""") Pkg.develop("https://github.com")
+        The argument appears to be a URL or path, perhaps you meant `Pkg.develop(url="...")` or `Pkg.develop(path="...")`.""") Pkg.develop("https://github.com")
         @test_throws PkgError("""
         `./Foobar` is not a valid package name
-        The argument appears to be a URL or path, perhaps you meant `Pkg.develop(PackageSpec(url="..."))` or `Pkg.develop(PackageSpec(path="..."))`.""") Pkg.develop("./Foobar")
+        The argument appears to be a URL or path, perhaps you meant `Pkg.develop(url="...")` or `Pkg.develop(path="...")`.""") Pkg.develop("./Foobar")
         # An empty spec is invalid.
         @test_throws PkgError(
             "name, UUID, URL, or filesystem path specification required when calling `develop`"

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -725,7 +725,7 @@ end
             repodir = git_init_package(tmp, "test_packages/MainRepo")
             # Add with subdir
             subdir_uuid = UUID("6fe4e069-dcb0-448a-be67-3a8bf3404c58")
-            Pkg.add(Pkg.PackageSpec(url = repodir, subdir = "SubDir"))
+            Pkg.add(url = repodir, subdir = "SubDir")
             pkgdir = abspath(joinpath(dirname(Base.find_package("SubDir")), ".."))
 
             # Update with subdir in manifest
@@ -737,7 +737,7 @@ end
             Pkg.rm("SubDir")
 
             # Dev of local path with subdir
-            Pkg.develop(Pkg.PackageSpec(path=repodir, subdir = "SubDir"))
+            Pkg.develop(path=repodir, subdir="SubDir")
             @test Pkg.dependencies()[subdir_uuid].source == joinpath(repodir, "SubDir")
         end
     end end


### PR DESCRIPTION
When using the `Pkg.API` calls and wanting to e.g. add something by URL, it is a bit verbose to have to write

```jl
Pkg.add(PackageSpec(url = "..."))
```

Now it is possible to write

```jl
Pkg.add(url = "...")
```

in other words, relevant keyword arguments gets passed directly to the PackageSpec constructor. For multiple packages we can use a Vector of NamedTuples where each named tuple gets passed:

```jl
Pkg.add([(url = "...",), (url = "...",)])
```

Previously, all keyword arguments were passed directly to the `Context!` modifier but that is a real waste because no one uses that.

I need to expand the docs a bit and ideally this should be added for the `Pkg.Registry` module as well but that might be a later project...

