### PR TITLE
remove preview command

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -123,7 +123,7 @@ from that local repo are pulled when packages are updated.
 Note that changes to files in the local package repository will not immediately be reflected when loading that package.
 The changes would have to be committed and the packages updated in order to pull in the changes.
 
-In addition, it is possible to add packages relatively to the `Manifest.toml` file, see [Developing Packages](@ref) for an example. 
+In addition, it is possible to add packages relatively to the `Manifest.toml` file, see [Developing Packages](@ref) for an example.
 
 ### Developing packages
 
@@ -300,22 +300,3 @@ To run a typical garbage collection with default arguments, simply use the `gc` 
 ```
 
 Note that only packages in `~/.julia/packages` are deleted.
-
-
-## Preview mode
-
-If you just want to see the effects of running a command, but not change your state you can `preview` a command.
-For example:
-
-```
-(HelloWorld) pkg> preview add Plots
-```
-
-or
-
-```
-(HelloWorld) pkg> preview up
-```
-
-will show you the effects that `add Plots`, or `up`, respectively, would have on your project.
-However, nothing will be installed and your `Project.toml` and `Manifest.toml` files will remain untouched.

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -304,17 +304,6 @@ the output to the difference as compared to the last git commit.
 
 Deletes packages that cannot be reached from any existing environment.
 """,
-],[ # preview is not a regular command.
-    # this is here so that preview appears as a registered command to users
-    :name => "preview",
-    :description => "previews a subsequent command without affecting the current state",
-    :help => md"""
-    preview cmd
-
-Runs the command `cmd` in preview mode. This is defined such that no side effects
-will take place i.e. no packages are downloaded and neither the project nor manifest
-is modified.
-""",
 ],
 ], #package
 "registry" => CommandDeclaration[

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -131,12 +131,12 @@ function _completions(input, final, offset, index)
     statement, partial = core_parse(words)
     final && (partial = "") # last token is finalized -> no partial
     # number of tokens which specify the command
-    command_size = count([statement.preview, statement.super !== nothing, true])
+    command_size = count([statement.super !== nothing, true])
     command_is_focused() = !((word_count == command_size && final) || word_count > command_size)
 
     if statement.spec === nothing # spec not determined -> complete command
         !command_is_focused() && return String[], 0:-1, false
-        x = complete_command(statement, final, word_count == (statement.preview ? 3 : 2))
+        x = complete_command(statement, final, word_count == 2)
     else
         command_is_focused() && return String[], 0:-1, false
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -317,7 +317,6 @@ end
 Base.@kwdef mutable struct Context
     env::EnvCache = EnvCache()
     io::IO = stderr
-    preview::Bool = false
     use_libgit2_for_all_downloads::Bool = false
     use_only_tarballs_for_downloads::Bool = false
     # NOTE: The JULIA_PKG_CONCURRENCY environment variable is likely to be removed in
@@ -1004,10 +1003,6 @@ end
 clone_or_cp_registries(regs::Vector{RegistrySpec}, depot::String=depots1()) =
     clone_or_cp_registries(Context(), regs, depot)
 function clone_or_cp_registries(ctx::Context, regs::Vector{RegistrySpec}, depot::String=depots1())
-    if ctx.preview
-        println(ctx.io, "Skipping adding registries in preview mode")
-        return nothing
-    end
     populate_known_registries_with_urls!(regs)
     for reg in regs
         if reg.path !== nothing && reg.url !== nothing
@@ -1119,10 +1114,6 @@ end
 
 # entry point for `registry rm`
 function remove_registries(ctx::Context, regs::Vector{RegistrySpec})
-    if ctx.preview
-        println(ctx.io, "skipping removing registries in preview mode")
-        return nothing
-    end
     for registry in find_installed_registries(ctx, regs)
         printpkgstyle(ctx, :Removing, "registry `$(registry.name)` from $(Base.contractuser(registry.path))")
         rm(registry.path; force=true, recursive=true)
@@ -1135,10 +1126,6 @@ function update_registries(ctx::Context, regs::Vector{RegistrySpec} = collect_re
                            force::Bool=false)
     !force && UPDATED_REGISTRY_THIS_SESSION[] && return
     errors = Tuple{String, String}[]
-    if ctx.preview
-        println(ctx.io, "skipping updating registries in preview mode")
-        return nothing
-    end
     for reg in unique(r -> r.uuid, find_installed_registries(ctx, regs))
         if isdir(joinpath(reg.path, ".git"))
             regpath = pathrepr(reg.path)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -3,21 +3,18 @@
 generate(path::String; kwargs...) = generate(Context(), path; kwargs...)
 function generate(ctx::Context, path::String; kwargs...)
     Context!(ctx; kwargs...)
-    preview_info(ctx)
     dir, pkg = dirname(path), basename(path)
     Base.isidentifier(pkg) || pkgerror("$(repr(pkg)) is not a valid package name")
     isdir(path) && pkgerror("$(abspath(path)) already exists")
     printpkgstyle(ctx, :Generating, " project $pkg:")
     uuid = project(ctx, pkg, dir)
     entrypoint(ctx, pkg, dir)
-    preview_info(ctx)
     return Dict(pkg => uuid)
 end
 
 function genfile(f::Function, ctx::Context, pkg::String, dir::String, file::String)
     path = joinpath(dir, pkg, file)
     println(ctx.io, "    $path")
-    ctx.preview && return
     mkpath(dirname(path))
     open(f, path, "w")
     return

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -235,5 +235,5 @@ function write_manifest(manifest::Manifest, env, old_env, ctx::Context; display_
         printpkgstyle(ctx, :Updating, pathrepr(env.manifest_file))
         Pkg.Display.print_manifest_diff(ctx, old_env, env)
     end
-    !ctx.preview && write_manifest(manifest, env.manifest_file)
+    write_manifest(manifest, env.manifest_file)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -182,9 +182,7 @@ function write_project(project::Project, env, old_env, ctx::Context; display_dif
             printpkgstyle(ctx, :Updating, pathrepr(env.project_file))
             Pkg.Display.print_project_diff(ctx, old_env, env)
         end
-        if !ctx.preview
-            mkpath(dirname(env.project_file))
-            write_project(project, env.project_file)
-        end
+        mkpath(dirname(env.project_file))
+        write_project(project, env.project_file)
     end
 end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -380,12 +380,6 @@ temp_pkg_dir() do project_path; cd(project_path) do
         @test apply_completion("rm E") == "rm Example"
         @test apply_completion("add Exampl") == "add Example"
 
-        c, r = test_complete("preview r")
-        @test "remove" in c
-        c, r = test_complete("help r")
-        @test "remove" in c
-        @test !("rm" in c)
-
         # stdlibs
         c, r = test_complete("add Stat")
         @test "Statistics" in c
@@ -661,55 +655,42 @@ end
     @test statement.spec == Pkg.REPLMode.SPECS[]["package"]["up"]
     @test isempty(statement.options)
     @test isempty(statement.arguments)
-    @test statement.preview == false
 
     statement = Pkg.REPLMode.parse("dev Example")[1]
     @test statement.spec == Pkg.REPLMode.SPECS[]["package"]["develop"]
     @test isempty(statement.options)
     @test statement.arguments == [QString("Example", false)]
-    @test statement.preview == false
 
     statement = Pkg.REPLMode.parse("dev Example#foo #bar")[1]
     @test statement.spec == Pkg.REPLMode.SPECS[]["package"]["develop"]
     @test isempty(statement.options)
     @test statement.arguments == [QString("Example#foo", false),
                                   QString("#bar", false)]
-    @test statement.preview == false
 
     statement = Pkg.REPLMode.parse("dev Example#foo Example@v0.0.1")[1]
     @test statement.spec == Pkg.REPLMode.SPECS[]["package"]["develop"]
     @test isempty(statement.options)
     @test statement.arguments == [QString("Example#foo", false),
                                   QString("Example@v0.0.1", false)]
-    @test statement.preview == false
 
     statement = Pkg.REPLMode.parse("add --first --second arg1")[1]
     @test statement.spec == Pkg.REPLMode.SPECS[]["package"]["add"]
     @test statement.options == map(Pkg.REPLMode.parse_option, ["--first", "--second"])
     @test statement.arguments == [QString("arg1", false)]
-    @test statement.preview == false
 
-    statements = Pkg.REPLMode.parse("preview add --first -o arg1; pin -x -a arg0 Example")
-    @test statements[1].spec == Pkg.REPLMode.SPECS[]["package"]["add"]
-    @test statements[1].preview == true
-    @test statements[1].options == map(Pkg.REPLMode.parse_option, ["--first", "-o"])
-    @test statements[1].arguments == [QString("arg1", false)]
-    @test statements[2].spec == Pkg.REPLMode.SPECS[]["package"]["pin"]
-    @test statements[2].preview == false
-    @test statements[2].options == map(Pkg.REPLMode.parse_option, ["-x", "-a"])
-    @test statements[2].arguments == [QString("arg0", false), QString("Example", false)]
+    statement = Pkg.REPLMode.parse("pin -x -a arg0 Example")[1]
+    @test statement.spec == Pkg.REPLMode.SPECS[]["package"]["pin"]
+    @test statement.options == map(Pkg.REPLMode.parse_option, ["-x", "-a"])
+    @test statement.arguments == [QString("arg0", false), QString("Example", false)]
 
     statements = Pkg.REPLMode.parse("up; pin --first; dev")
     @test statements[1].spec == Pkg.REPLMode.SPECS[]["package"]["up"]
-    @test statements[1].preview == false
     @test isempty(statements[1].options)
     @test isempty(statements[1].arguments)
     @test statements[2].spec == Pkg.REPLMode.SPECS[]["package"]["pin"]
-    @test statements[2].preview == false
     @test statements[2].options == map(Pkg.REPLMode.parse_option, ["--first"])
     @test isempty(statements[2].arguments)
     @test statements[3].spec == Pkg.REPLMode.SPECS[]["package"]["develop"]
-    @test statements[3].preview == false
     @test isempty(statements[3].options)
     @test isempty(statements[3].arguments)
 end
@@ -888,17 +869,6 @@ end
         Pkg.REPLMode.pkg"package add Example"
         @test isinstalled(TEST_PKG)
         Pkg.REPLMode.pkg"package rm Example"
-        @test !isinstalled(TEST_PKG)
-    end end end
-end
-
-@testset "preview" begin
-    temp_pkg_dir() do project_path; cd_tempdir() do tmpdir; with_temp_env() do;
-        pkg"add Example"
-        pkg"preview rm Example"
-        @test isinstalled(TEST_PKG)
-        pkg"rm Example"
-        pkg"preview add Example"
         @test !isinstalled(TEST_PKG)
     end end end
 end


### PR DESCRIPTION
`preview` had good intentions. By allowing to check what happened when executing a command without it taking effect, it was intended for the user to avoid pkg commands that mess up their project. However, in practice, no one think they will do a mistake so no one uses preview. It is also quite invasive in the code base. You constantly need to think if you are running things in preview mode and in that case try to emulate the normal usage but at the same time don't do any persistent mutations.

What is needed is instead `undo` + `redo`. This just removes `preview` and I will implement `undo` + `redo` to replace it (unless someone beats me to it)