### PR TITLE
Rework repo handling

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -3,7 +3,7 @@
 ## Adding packages
 
 There are two ways of adding packages, either using the `add` command or the `dev` command.
-The most frequently used one is `add` and its usage is described first.
+The most frequently used is `add` and its usage is described first.
 
 ### Adding registered packages
 
@@ -97,7 +97,7 @@ To go back to tracking the registry version of `Example`, the command `free` is 
 
 ### Adding unregistered packages
 
-If a package is not in a registry, it can still be added by instead of the package name giving the URL to the repository to `add`:
+If a package is not in a registry, it can be added by specifying a URL to the repository:
 
 ```
 (v1.0) pkg> add https://github.com/fredrikekre/ImportMacros.jl
@@ -118,9 +118,10 @@ For unregistered packages we could have given a branch name (or commit SHA1) to 
 ### Adding a local package
 
 Instead of giving a URL of a git repo to `add` we could instead have given a local path to a git repo.
-This works similarly to adding a URL. The local repository will be tracked (at some branch) and updates
+This works similar to adding a URL. The local repository will be tracked (at some branch) and updates
 from that local repo are pulled when packages are updated.
-Note that changes to files in the local package repository will not immediately be reflected when loading that package.
+Note tracking a package through `add` is distinct from `develop`:
+changes to files in the local package repository will not immediately be reflected when loading that package.
 The changes would have to be committed and the packages updated in order to pull in the changes.
 
 In addition, it is possible to add packages relatively to the `Manifest.toml` file, see [Developing Packages](@ref) for an example.
@@ -147,7 +148,7 @@ Let's try to `dev` a registered package:
 The `dev` command fetches a full clone of the package to `~/.julia/dev/` (the path can be changed by setting the environment variable `JULIA_PKG_DEVDIR`).
 When importing `Example` julia will now import it from `~/.julia/dev/Example` and whatever local changes have been made to the files in that path are consequently
 reflected in the code loaded. When we used `add` we said that we tracked the package repository, we here say that we track the path itself.
-Note that the package manager will never touch any of the files at a tracked path. It is therefore up to you to pull updates, change branches etc.
+Note the package manager will never touch any of the files at a tracked path. It is therefore up to you to pull updates, change branches etc.
 If we try to `dev` a package at some branch that already exists at `~/.julia/dev/` the package manager we will simply use the existing path.
 For example:
 
@@ -157,8 +158,8 @@ For example:
 [ Info: Path `/Users/kristoffer/.julia/dev/Example` exists and looks like the correct package, using existing path instead of cloning
 ```
 
-Note the info message saying that it is using the existing path. As a general rule, the package manager will
-never touch files that are tracking a path.
+Note the info message saying that it is using the existing path.
+When tracking a path, the package manager will never modify the files at that path.
 
 If `dev` is used on a local path, that path to that package is recorded and used when loading that package.
 The path will be recorded relative to the project file, unless it is given as an absolute path.
@@ -182,15 +183,12 @@ Note that if you add a dependency to a package that tracks a local path, the Man
 out of sync with the actual dependency graph. This means that the package will not be able to load that dependency since it is not recorded
 in the Manifest. To synchronize the Manifest, use the REPL command `resolve`.
 
-Similarly with `add`, `dev` can track packages with a path relative to the `Manifest.toml` file. This is done by giving a relative path to `add` or `dev`. Notice that due to the way Julia handles relative paths, when you *give* the path, it is always assumed to be with respect to the current working directory, `pwd()`. However, when the package is loaded its path is indeed resolved with respect to the `Manifest.toml` file. To be on the safe side, you can always change path to the `Manifest.toml` file before adding the relative path. For example:
-```
-julia> cd("path/to/manifest"); # This is the project's folder
-
-(v1.0) pkg> activate .
-
-(SomeProject) pkg> dev src/ExamplePackage # similarly for add
-```
-
+In addition to absolute paths, `add` and `dev` can accept relative paths to packages.
+In this case, the relative path from the active project to the package is stored.
+This approach is useful when the relative location of tracked dependencies is more important than their absolute location.
+For example, the tracked dependencies can be stored inside of the active project directory.
+The whole directory can be moved and `Pkg` will still be able to find the dependencies
+because their path relative to the active project is preserved even though their absolute path has changed.
 
 ## Removing packages
 

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -156,7 +156,7 @@ vstring(ctx::Context, a::VerInfo) =
     string((a.ver == nothing && a.hash != nothing) ? "[$(string(a.hash)[1:16])]" : "",
            a.ver != nothing ? "v$(a.ver)" : "",
            a.path != nothing ? " [$(pathrepr(a.path))]" : "",
-           a.repo != nothing ? " #$(revstring(a.repo.rev)) ($(a.repo.url))" : "",
+           a.repo != nothing ? " #$(revstring(a.repo.rev)) ($(a.repo.source))" : "",
            a.pinned == true ? " ⚲" : "",
            )
 
@@ -246,7 +246,7 @@ function name_ver_info(entry::PackageEntry)
         entry.path,
         entry.version,
         entry.pinned,
-        entry.repo.url === nothing ? nothing : entry.repo, # TODO
+        entry.repo.source === nothing ? nothing : entry.repo, # TODO
         )
 end
 

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -103,8 +103,13 @@ function normalize_url(url::AbstractString)
     end
 end
 
-ensure_clone(ctx, target_path, url; kwargs...) =
-    ispath(target_path) ? LibGit2.GitRepo(target_path) : GitTools.clone(ctx, url, target_path; kwargs...)
+function ensure_clone(ctx, target_path, url; kwargs...)
+    if ispath(target_path)
+        return LibGit2.GitRepo(target_path)
+    else
+        return GitTools.clone(ctx, url, target_path; kwargs...)
+    end
+end
 
 function clone(ctx, url, source_path; header=nothing, kwargs...)
     @assert !isdir(source_path) || isempty(readdir(source_path))

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -33,13 +33,13 @@ end
 # more accurate name is `should_be_tracking_registered_version`
 # the only way to know for sure is to key into the registries
 tracking_registered_version(pkg) =
-    !is_stdlib(pkg.uuid) && pkg.path === nothing && pkg.repo.url === nothing
+    !is_stdlib(pkg.uuid) && pkg.path === nothing && pkg.repo.source === nothing
 
 function source_path(pkg::PackageSpec)
     return is_stdlib(pkg.uuid)    ? Types.stdlib_path(pkg.name) :
-        pkg.path      !== nothing ? pkg.path :
-        pkg.repo.url  !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
-        pkg.tree_hash !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
+        pkg.path        !== nothing ? pkg.path :
+        pkg.repo.source !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
+        pkg.tree_hash   !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
         nothing
 end
 
@@ -243,7 +243,7 @@ function collect_project!(ctx::Context, pkg::PackageSpec, path::String, fix_deps
     return
 end
 
-istracking(pkg) = pkg.path !== nothing || pkg.repo.url !== nothing
+istracking(pkg) = pkg.path !== nothing || pkg.repo.source !== nothing
 isfixed(pkg) = istracking(pkg) || pkg.pinned
 
 function collect_fixed!(ctx::Context, pkgs::Vector{PackageSpec}, names::Dict{UUID, String})
@@ -940,7 +940,7 @@ function update_package_add(pkg::PackageSpec, entry::PackageEntry, is_dep::Bool)
         return PackageSpec(; uuid=pkg.uuid, name=pkg.name, pinned=true,
                            version=entry.version, tree_hash=entry.tree_hash)
     end
-    if entry.path !== nothing || entry.repo.url !== nothing || pkg.repo.url !== nothing
+    if entry.path !== nothing || entry.repo.source !== nothing || pkg.repo.source !== nothing
         return pkg # overwrite everything, nothing to copy over
     end
     if is_stdlib(pkg.uuid)
@@ -1078,7 +1078,10 @@ end
 up_load_versions!(ctx::Context, pkg::PackageSpec, ::Nothing, level::UpgradeLevel) = false
 function up_load_versions!(ctx::Context, pkg::PackageSpec, entry::PackageEntry, level::UpgradeLevel)
     entry.version !== nothing || return false # no version to set
-    if entry.repo.url !== nothing # repo packages have a version but are treated special
+    if entry.pinned || level == UPLEVEL_FIXED
+        pkg.version = entry.version
+        pkg.tree_hash = entry.tree_hash
+    elseif entry.repo.source !== nothing # repo packages have a version but are treated special
         pkg.repo = entry.repo
         if level == UPLEVEL_MAJOR
             new = instantiate_pkg_repo!(ctx, pkg)
@@ -1091,9 +1094,6 @@ function up_load_versions!(ctx::Context, pkg::PackageSpec, entry::PackageEntry, 
             pkg.version = entry.version
             pkg.tree_hash = entry.tree_hash
         end
-    elseif entry.pinned || level == UPLEVEL_FIXED
-        pkg.version = entry.version
-        pkg.tree_hash = entry.tree_hash
     else
         ver = entry.version
         r = level == UPLEVEL_PATCH ? VersionRange(ver.major, ver.minor) :
@@ -1165,7 +1165,7 @@ function update_package_pin!(ctx::Context, pkg::PackageSpec, entry::PackageEntry
         pkg.tree_hash = entry.tree_hash
         pkg.path = entry.path
     else # given explicit registered version
-        if entry.repo.url !== nothing || entry.path !== nothing
+        if entry.repo.source !== nothing || entry.path !== nothing
             # A pin in this case includes an implicit `free` to switch to tracking registered versions
             # First, make sure the package is registered so we have something to free to
             if isempty(registered_paths(ctx, pkg.uuid))
@@ -1204,7 +1204,7 @@ function update_package_free!(ctx::Context, pkg::PackageSpec, entry::PackageEntr
     if entry.path !== nothing # deved
         return # -> name, uuid
     end
-    if entry.repo !== nothing # tracking a repo
+    if entry.repo.source !== nothing # tracking a repo
         # make sure the package is registered so we have something to free to
         if isempty(registered_paths(ctx, pkg.uuid))
             pkgerror("cannot free package $(something(pkg.name, "")) since it is not found in a registry")
@@ -1320,11 +1320,12 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
         end
         with_temp_env(tmp) do
             try
-                Pkg.API.develop(PackageSpec(;repo=GitRepo(;url=target_path)); strict=true)
+                Pkg.API.develop(PackageSpec(;repo=GitRepo(;source=target_path)); strict=true)
                 @debug "Using _parent_ dep graph"
-            catch # TODO
-                Base.rm(tmp_manifest) # retry with a clean dependency graph
-                Pkg.API.develop(PackageSpec(;repo=GitRepo(;url=target_path)))
+            catch err# TODO
+                @error err
+                isfile(tmp_manifest) && Base.rm(tmp_manifest) # retry with a clean dependency graph
+                Pkg.API.develop(PackageSpec(;repo=GitRepo(;source=target_path)))
                 @debug "Using _clean_ dep graph"
             end
             # Run sandboxed code

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -73,11 +73,11 @@ end
 # packages can be identified through: uuid, name, or name+uuid
 # additionally valid for add/develop are: local path, url
 function parse_package_identifier(word::AbstractString; add_or_develop=false)::PackageSpec
-    if add_or_develop && casesensitive_isdir(expanduser(word))
+    if add_or_develop && isdir_windows_workaround(expanduser(word))
         if !occursin(Base.Filesystem.path_separator_re, word)
             @info "Resolving package identifier `$word` as a directory at `$(Base.contractuser(abspath(word)))`."
         end
-        return PackageSpec(repo=Types.GitRepo(url=expanduser(word)))
+        return PackageSpec(repo=Types.GitRepo(source=expanduser(word)))
     elseif occursin(uuid_re, word)
         return PackageSpec(uuid=UUID(word))
     elseif occursin(name_re, word)
@@ -85,10 +85,8 @@ function parse_package_identifier(word::AbstractString; add_or_develop=false)::P
     elseif occursin(name_uuid_re, word)
         m = match(name_uuid_re, word)
         return PackageSpec(String(m.captures[1]), UUID(m.captures[2]))
-    elseif add_or_develop
-        @info "Resolving package identifier `$word` as a URL."
-        # Guess it is a url then
-        return PackageSpec(repo=Types.GitRepo(url=word))
+    elseif add_or_develop && isurl(word)
+        return PackageSpec(repo=Types.GitRepo(source=word))
     else
         pkgerror("Unable to parse `$word` as a package.")
     end

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -1,7 +1,7 @@
 function _update_manifest(ctx::Context, pkg::PackageSpec, hash::Union{SHA1, Nothing})
     env = ctx.env
     uuid, name, version, path, special_action, repo = pkg.uuid, pkg.name, pkg.version, pkg.path, pkg.special_action, pkg.repo
-    hash === nothing && @assert (path != nothing || pkg.uuid in keys(ctx.stdlibs) || pkg.repo.url != nothing)
+    hash === nothing && @assert (path != nothing || pkg.uuid in keys(ctx.stdlibs) || pkg.repo.source != nothing)
     # TODO I think ^ assertion is wrong, add-repo should have a hash
     entry = get!(env.manifest, uuid, Types.PackageEntry())
     entry.name = name
@@ -12,23 +12,23 @@ function _update_manifest(ctx::Context, pkg::PackageSpec, hash::Union{SHA1, Noth
         entry.path = path
         if special_action == PKGSPEC_DEVELOPED
             entry.pinned = false
-            entry.repo.url = nothing
+            entry.repo.source = nothing
             entry.repo.rev = nothing
         elseif special_action == PKGSPEC_FREED
             if entry.pinned
                 entry.pinned = false
             else
-                entry.repo.url = nothing
+                entry.repo.source = nothing
                 entry.repo.rev = nothing
             end
         elseif special_action == PKGSPEC_PINNED
             entry.pinned = true
         elseif special_action == PKGSPEC_REPO_ADDED
-            entry.repo.url = repo.url
+            entry.repo.source = repo.source
             entry.repo.rev = repo.rev
             path = find_installed(name, uuid, hash)
         end
-        if entry.repo.url !== nothing
+        if entry.repo.source !== nothing
             path = find_installed(name, uuid, hash)
         end
     end
@@ -153,7 +153,7 @@ function _collect_fixed!(ctx::Context, pkgs::Vector{PackageSpec}, uuid_to_name::
             path = find_installed(pkg.name, pkg.uuid, pkg.tree_hash)
         elseif entry !== nothing && entry.path !== nothing
             path = pkg.path = entry.path
-        elseif entry !== nothing && entry.repo.url !== nothing
+        elseif entry !== nothing && entry.repo.source !== nothing
             path = find_installed(pkg.name, pkg.uuid, entry.tree_hash)
             pkg.repo = entry.repo
             pkg.tree_hash = entry.tree_hash
@@ -200,7 +200,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
     for pkg in pkgs
         !is_stdlib(ctx, pkg.uuid) || continue
         pkg.path === nothing || continue
-        pkg.repo.url === nothing || continue
+        pkg.repo.source === nothing || continue
         path = find_installed(pkg.name, pkg.uuid, hashes[pkg.uuid])
         if !ispath(path)
             push!(pkgs_to_install, (pkg, path))
@@ -280,7 +280,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
             uuid = pkg.uuid
             if pkg.path !== nothing || uuid in keys(ctx.stdlibs)
                 hash = nothing
-            elseif pkg.repo.url !== nothing
+            elseif pkg.repo.source !== nothing
                 hash = pkg.tree_hash
             else
                 hash = hashes[uuid]
@@ -322,7 +322,7 @@ function _version_data!(ctx::Context, pkgs::Vector{PackageSpec})
     clones = Dict{UUID,Vector{String}}()
     for pkg in pkgs
         !is_stdlib(pkg.uuid) || continue
-        pkg.repo.url === nothing || continue
+        pkg.repo.source === nothing || continue
         pkg.path === nothing || continue
         uuid = pkg.uuid
         ver = pkg.version::VersionNumber

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -133,13 +133,13 @@ function Manifest(raw::Dict)::Manifest
         uuid = nothing
         deps = nothing
         try
-            uuid           = read_field("uuid",          nothing, info, safe_uuid)
-            entry.pinned   = read_pinned(get(info, "pinned", nothing))
-            entry.version  = read_field("version",       nothing, info, safe_version)
-            entry.path     = read_field("path",          nothing, info, safe_path)
-            entry.repo.url = read_field("repo-url",      nothing, info, identity)
-            entry.repo.rev = read_field("repo-rev",      nothing, info, identity)
-            entry.tree_hash = read_field("git-tree-sha1", nothing, info, safe_SHA1)
+            entry.pinned      = read_pinned(get(info, "pinned", nothing))
+            uuid              = read_field("uuid",          nothing, info, safe_uuid)
+            entry.version     = read_field("version",       nothing, info, safe_version)
+            entry.path        = read_field("path",          nothing, info, safe_path)
+            entry.repo.source = read_field("repo-url",      nothing, info, identity)
+            entry.repo.rev    = read_field("repo-rev",      nothing, info, identity)
+            entry.tree_hash   = read_field("git-tree-sha1", nothing, info, safe_SHA1)
             deps = read_deps(get(info, "deps", nothing))
         catch
             @error "Could not parse entry for `$name`"
@@ -201,7 +201,7 @@ function destructure(manifest::Manifest)::Dict
             path = join(splitpath(path), "/")
         end
         entry!(new_entry, "path", path)
-        entry!(new_entry, "repo-url", entry.repo.url)
+        entry!(new_entry, "repo-url", entry.repo.source)
         entry!(new_entry, "repo-rev", entry.repo.rev)
         if isempty(entry.deps)
             delete!(new_entry, "deps")

--- a/test/api.jl
+++ b/test/api.jl
@@ -121,7 +121,7 @@ end
                 manifest = Pkg.Types.read_manifest(joinpath(env_path, "Manifest.toml"))
                 entry = manifest[uuids["Foo"]]
                 @test entry.name == "Foo"
-                @test entry.path == absolute_path
+                @test realpath(entry.path) == realpath(absolute_path)
                 @test isdir(entry.path)
             end
         end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -136,7 +136,7 @@ temp_pkg_dir() do project_path
         Pkg.gc(;collect_delay=Day(1000))
         @test !isempty(readdir(pkgdir))
 
-        # Setting collect_delay to zero causes it to be reaped immediately, howeveage
+        # Setting collect_delay to zero causes it to be reaped immediately, however
         Pkg.gc(;collect_delay=Second(0))
         @test isempty(readdir(pkgdir))
     end
@@ -506,7 +506,7 @@ end
     temp_pkg_dir() do project_path; cd_tempdir(;rm=false) do tmpdir; with_temp_env(;rm=false) do
         for x in ["x1", "x2", "x3"]
             cp(joinpath(@__DIR__, "test_packages/$x"), joinpath(tmpdir, "$x"))
-            Pkg.develop(Pkg.PackageSpec(url = joinpath(tmpdir, x)))
+            Pkg.develop(Pkg.PackageSpec(path = joinpath(tmpdir, x)))
         end
         Pkg.test("x3")
     end end end
@@ -787,19 +787,21 @@ end
 end
 
 @testset "create manifest file similar to project file" begin
-    cd_tempdir() do dir
-        touch(joinpath(dir, "Project.toml"))
-        Pkg.activate(".")
-        Pkg.add("Example")
-        @test isfile(joinpath(dir, "Manifest.toml"))
-        @test !isfile(joinpath(dir, "JuliaManifest.toml"))
-    end
-    cd_tempdir() do dir
-        touch(joinpath(dir, "JuliaProject.toml"))
-        Pkg.activate(".")
-        Pkg.add("Example")
-        @test !isfile(joinpath(dir, "Manifest.toml"))
-        @test isfile(joinpath(dir, "JuliaManifest.toml"))
+    temp_pkg_dir() do project_path
+        cd_tempdir() do dir
+            touch(joinpath(dir, "Project.toml"))
+            Pkg.activate(".")
+            Pkg.add("Example")
+            @test isfile(joinpath(dir, "Manifest.toml"))
+            @test !isfile(joinpath(dir, "JuliaManifest.toml"))
+        end
+        cd_tempdir() do dir
+            touch(joinpath(dir, "JuliaProject.toml"))
+            Pkg.activate(".")
+            Pkg.add("Example")
+            @test !isfile(joinpath(dir, "Manifest.toml"))
+            @test isfile(joinpath(dir, "JuliaManifest.toml"))
+        end
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,7 +6,7 @@ import ..Pkg
 
 export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
        with_temp_env, with_pkg_env, git_init_and_commit, copy_test_package,
-       git_init_package, add_test_package, add_this_pkg, TEST_SIG, TEST_PKG
+       git_init_package, add_this_pkg, TEST_SIG, TEST_PKG
 
 function temp_pkg_dir(fn::Function;rm=true)
     old_load_path = copy(LOAD_PATH)
@@ -160,20 +160,11 @@ function copy_test_package(tmpdir::String, name::String; use_pkg=true)
         end
     end
 end
-function add_test_package(name::String, uuid::UUID)
-    test_pkg_dir = joinpath(@__DIR__, "test_packages", name)
-    spec = Pkg.Types.PackageSpec(
-        name=name,
-        uuid=uuid,
-        path=test_pkg_dir,
-    )
-    Pkg.add(spec)
-end
 
 function add_this_pkg()
     pkg_dir = dirname(@__DIR__)
     pkg_uuid = Pkg.TOML.parsefile(joinpath(pkg_dir, "Project.toml"))["uuid"]
-    spec = Pkg.Types.PackageSpec(
+    spec = Pkg.PackageSpec(
         name="Pkg",
         uuid=UUID(pkg_uuid),
         path=pkg_dir,


### PR DESCRIPTION
Goals:
- Treat relative paths consistently for `dev` and `add`. `dev` does this correctly, but the behavior for `add` is confusing (see #1215).
- Refactor `handle_repos_*` in hopes of making the internal structure more clear.
- Prevent an unnecessary cache update on `add` (fix #1343).
- Prevent an unnecessary update of cached clone on instantiate. We should only fetch if the tree does not already exist in the clone.

---
close #709