### PR TITLE
Make the link to the Pkg docs more searchable

### DIFF
--- a/docs/src/basedocs.md
+++ b/docs/src/basedocs.md
@@ -4,8 +4,10 @@ Pkg is Julia's builtin package manager, and handles operations
 such as installing, updating and removing packages.
 
 !!! note
-    What follows is a very brief introduction to Pkg. It is highly
-    recommended to read the full manual, which is available here:
+    What follows is a very brief introduction to Pkg. For more
+    information on `Project.toml` files, `Manifest.toml` files, package
+    version compatibility (`[compat]`), environments, registries, etc.,
+    it is highly recommended to read the full manual, which is available here:
     [https://julialang.github.io/Pkg.jl/v1/](https://julialang.github.io/Pkg.jl/v1/).
 
 ```@eval


### PR DESCRIPTION
If you try and search the Julia documentation for Project.toml, you only get https://docs.julialang.org/en/v1/manual/code-loading/#Project-environments-1 . If you search compat, you get https://docs.julialang.org/en/v1/search/?q=compat , which is really just showing results like https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Creating-C-Compatible-Julia-Function-Pointers-1 . This makes it very difficult to find out where to learn about Pkg. Thus I threw a bunch of keywords in there to make the search mechanism lead people to this link.