### PR TITLE
small refactor of write_env functions

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -116,6 +116,18 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}=PackageSpec[];
     return mdiff
 end
 
+# Needs to be called before the environment have been written to disc
+function print_env_diff(ctx)
+    env = ctx.env
+    old_env = EnvCache(env.env) # load old environment for comparison
+    if !ctx.currently_running_target
+        printpkgstyle(ctx, :Updating, pathrepr(env.project_file))
+        print_project_diff(ctx, old_env, env)
+        printpkgstyle(ctx, :Updating, pathrepr(env.manifest_file))
+        print_manifest_diff(ctx, old_env, env)
+    end
+end
+
 function print_project_diff(ctx::Context, env0::EnvCache, env1::EnvCache)
     pm0 = Dict(uuid => entry for (uuid, entry) in env0.manifest if (uuid in values(env0.project.deps)))
     pm1 = Dict(uuid => entry for (uuid, entry) in env1.manifest if (uuid in values(env1.project.deps)))

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -908,7 +908,8 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     # only keep reachable manifest entires
     prune_manifest(ctx)
     # update project & manifest
-    write_env(ctx)
+    Display.print_env_diff(ctx)
+    write_env(ctx.env)
 end
 
 update_package_add(pkg::PackageSpec, ::Nothing, is_dep::Bool) = pkg
@@ -1025,7 +1026,8 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[];
     # and ensure they are all downloaded and unpacked as well:
     download_artifacts(ctx, pkgs; platform=platform)
 
-    write_env(ctx) # write env before building
+    Display.print_env_diff(ctx)
+    write_env(ctx.env) # write env before building
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1046,7 +1048,8 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Vector{UUID};
     new_apply = download_source(ctx, pkgs; readonly=false)
     download_artifacts(ctx, pkgs; platform=platform)
 
-    write_env(ctx) # write env before building
+    Display.print_env_diff(ctx)
+    write_env(ctx.env) # write env before building
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1110,7 +1113,9 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel)
     update_manifest!(ctx, pkgs)
     new_apply = download_source(ctx, pkgs)
     download_artifacts(ctx, pkgs)
-    write_env(ctx) # write env before building
+
+    Display.print_env_diff(ctx)
+    write_env(ctx.env) # write env before building
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
     # TODO what to do about repo packages?
 end
@@ -1160,7 +1165,9 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
 
     new = download_source(ctx, pkgs)
     download_artifacts(ctx, pkgs)
-    write_env(ctx) # write env before building
+
+    Display.print_env_diff(ctx)
+    write_env(ctx.env) # write env before building
     build_versions(ctx, UUID[pkg.uuid for pkg in new])
 end
 
@@ -1205,11 +1212,13 @@ function free(ctx::Context, pkgs::Vector{PackageSpec})
         update_manifest!(ctx, pkgs)
         new = download_source(ctx, pkgs)
         download_artifacts(ctx, new)
-        write_env(ctx) # write env before building
+        Display.print_env_diff(ctx)
+        write_env(ctx.env) # write env before building
         build_versions(ctx, UUID[pkg.uuid for pkg in new])
     else
         foreach(pkg -> manifest_info(ctx, pkg.uuid).pinned = false, pkgs)
-        write_env(ctx)
+        Display.print_env_diff(ctx)
+        write_env(ctx.env)
     end
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1354,11 +1354,9 @@ function pathrepr(path::String)
     return "`" * Base.contractuser(path) * "`"
 end
 
-function write_env(ctx::Context; display_diff=true)
-    env = ctx.env
-    old_env = EnvCache(env.env) # load old environment for comparison
-    write_project(env.project, env, old_env, ctx; display_diff=display_diff)
-    write_manifest(env.manifest, env, old_env, ctx; display_diff=display_diff)
+function write_env(env::EnvCache)
+    write_project(env)
+    write_manifest(env)
 end
 
 ###

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -314,7 +314,8 @@ function _add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID
     # resolve & apply package versions
     _resolve_versions!(ctx, pkgs)
     new_apply = apply_versions(ctx, pkgs; mode=mode)
-    write_env(ctx) # write env before building
+    Display.print_env_diff(ctx)
+    write_env(ctx.env) # write env before building
     build_versions(ctx, union(new_apply, new_git))
 end
 # Find repos and hashes for each package UUID & version
@@ -516,7 +517,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         not_loadable = setdiff(should_be_in_manifest, should_be_in_project)
         Pkg.API.rm(localctx, [PackageSpec(uuid = uuid) for uuid in not_loadable])
 
-        write_env(localctx, display_diff = false)
+        write_env(localctx.env)
         will_resolve && build_versions(localctx, new)
 
         sep = Sys.iswindows() ? ';' : ':'

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -220,20 +220,15 @@ function destructure(manifest::Manifest)::Dict
     return raw
 end
 
-function write_manifest(manifest::Manifest, manifest_file::AbstractString)
-    raw = destructure(manifest)
+function write_manifest(env)
+    mkpath(dirname(env.manifest_file))
+    write_manifest(env.manifest, env.manifest_file)
+end
+write_manifest(manifest::Manifest, manifest_file::AbstractString) =
+    write_manifest(destructure(manifest), manifest_file)
+function write_manifest(manifest::Dict, manifest_file::AbstractString)
     io = IOBuffer()
     print(io, "# This file is machine-generated - editing it directly is not advised\n\n")
-    TOML.print(io, raw, sorted=true)
+    TOML.print(io, manifest, sorted=true)
     open(f -> write(f, seekstart(io)), manifest_file; truncate=true)
-end
-
-function write_manifest(manifest::Manifest, env, old_env, ctx::Context; display_diff=true)
-    isempty(manifest) && !ispath(env.manifest_file) && return
-
-    if display_diff && !(ctx.currently_running_target)
-        printpkgstyle(ctx, :Updating, pathrepr(env.manifest_file))
-        Pkg.Display.print_manifest_diff(ctx, old_env, env)
-    end
-    write_manifest(manifest, env.manifest_file)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -168,6 +168,10 @@ _project_key_order = ["name", "uuid", "keywords", "license", "desc", "deps", "co
 project_key_order(key::String) =
     something(findfirst(x -> x == key, _project_key_order), length(_project_key_order) + 1)
 
+function write_project(env)
+    mkpath(dirname(env.project_file))
+    write_project(env.project, env.project_file)
+end
 write_project(project::Project, project_file::AbstractString) =
     write_project(destructure(project), project_file)
 function write_project(project::Dict, project_file::AbstractString)
@@ -175,14 +179,4 @@ function write_project(project::Dict, project_file::AbstractString)
     TOML.print(io, project, sorted=true, by=key -> (project_key_order(key), key))
     open(f -> write(f, seekstart(io)), project_file; truncate=true)
 end
-function write_project(project::Project, env, old_env, ctx::Context; display_diff=true)
-    project = destructure(ctx.env.project)
-    if !isempty(project) || ispath(env.project_file)
-        if display_diff && !(ctx.currently_running_target)
-            printpkgstyle(ctx, :Updating, pathrepr(env.project_file))
-            Pkg.Display.print_project_diff(ctx, old_env, env)
-        end
-        mkpath(dirname(env.project_file))
-        write_project(project, env.project_file)
-    end
-end
+


### PR DESCRIPTION
I didn't like how we passed in `env.project, env, old_env, ctx` to one function (all of this can be gotten from `ctx` and the first argument `project` was immediately overwritten etc) and also options like `display_diff = true` seems to indicate that that part should just be in its own function. Therefore, factor out the project diff printing into a new function into `Display` and call that function.


Also, slight refactoring to the `write_manifest` and `write_project` to make them look more similar to each other.