### PR TITLE
fix not returning to project in artifact test

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -334,7 +334,7 @@ end
     # Don't use `temp_pkg_dir()` here because we need `Pkg.test()` to run in the
     # same package context as the one we're running in right now.  Yes, this pollutes
     # the global artifact namespace and package list, but it should be harmless.
-    mktempdir() do project_path
+    temp_pkg_dir() do project_path
         copy_test_package(project_path, "ArtifactInstallation")
         Pkg.activate(joinpath(project_path))
         add_this_pkg()


### PR DESCRIPTION
This causes us to have the wrong Project file when exiting the Artifact tests. This means that in latter test modules it is possible that we load the sysimg baked Pkg instead of the one we are testing.