### PR TITLE
Some small test improvements

### DIFF
--- a/test/api.jl
+++ b/test/api.jl
@@ -1,11 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module APITests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Pkg, Test
 import Pkg.Types.PkgError, Pkg.Types.ResolverError
+using UUIDs
 
-include("utils.jl")
+using ..Utils
 
 @testset "API should accept `AbstractString` arguments" begin
     temp_pkg_dir() do project_path
@@ -263,7 +265,7 @@ end
         Pkg.add(Pkg.PackageSpec(;uuid=meta_graphs, version="0.6.4"))
         @test Pkg.dependencies()[meta_graphs].version == v"0.6.4" # sanity check
         # did not break semver
-        @test Pkg.dependencies()[light_graphs].version in Pkg.Types.semver_spec("$(light_graphs_version)") 
+        @test Pkg.dependencies()[light_graphs].version in Pkg.Types.semver_spec("$(light_graphs_version)")
         # did change version
         @test Pkg.dependencies()[light_graphs].version != light_graphs_version
         # NONE

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1,11 +1,12 @@
 module ArtifactTests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Test, Random, Pkg.Artifacts, Pkg.BinaryPlatforms, Pkg.PlatformEngines
 import Pkg.Artifacts: pack_platform!, unpack_platform, with_artifacts_directory, ensure_all_artifacts_installed
 using Pkg.TOML, Dates
 import Base: SHA1
 
-include("utils.jl")
+using ..Utils
 
 # Helper function to create an artifact, then chmod() the whole thing to 0o755.  This is
 # important to keep hashes stable across platforms that have different umasks, changing

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -1,4 +1,5 @@
 module BinaryPlatformTests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Test, Pkg.BinaryPlatforms
 import Pkg.BinaryPlatforms: gcc_version, platform_name

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module OperationsTest
+import ..Pkg # ensure we are using the correct Pkg
 
 import Random: randstring
 import LibGit2
@@ -14,7 +15,7 @@ using Pkg.Types
 import Random: randstring
 import LibGit2
 
-include("utils.jl")
+using ..Utils
 
 const TEST_PKG = (name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
 const PackageSpec = Pkg.Types.PackageSpec
@@ -813,10 +814,5 @@ end
         @test xs[TEST_PKG.uuid].ispinned == false
     end end
 end
-
-include("repl.jl")
-include("api.jl")
-include("registry.jl")
-include("artifacts.jl")
 
 end # module

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -1,4 +1,5 @@
 module PlatformEngineTests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Test, Pkg.PlatformEngines, Pkg.BinaryPlatforms, SHA
 

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -1,11 +1,12 @@
 module RegistryTests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Pkg, UUIDs, LibGit2, Test
 using Pkg: depots1
 using Pkg.REPLMode: pkgstr
 using Pkg.Types: PkgError, Context, manifest_info, PackageSpec
 
-include("utils.jl")
+using ..Utils
 
 
 function setup_test_registries(dir = pwd())

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module REPLTests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Pkg
 using Pkg.Types: manifest_info, EnvCache, Context
@@ -9,7 +10,7 @@ using UUIDs
 using Test
 import LibGit2
 
-include("utils.jl")
+using ..Utils
 
 @testset "help" begin
     pkg"?"

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module ResolveTest
+import ..Pkg # ensure we are using the correct Pkg
 
 using Test
 using Pkg.Types

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,15 @@
 
 module PkgTests
 
+import Pkg
+
 include("utils.jl")
+
 include("pkg.jl")
+include("repl.jl")
+include("api.jl")
+include("registry.jl")
+include("artifacts.jl")
 include("binaryplatforms.jl")
 include("platformengines.jl")
 include("sandbox.jl")

--- a/test/sandbox.jl
+++ b/test/sandbox.jl
@@ -1,10 +1,11 @@
 module SandboxTests
+import ..Pkg # ensure we are using the correct Pkg
 
 using Test
 using UUIDs
 using Pkg
 
-include("utils.jl")
+using ..Utils
 test_test(fn, name; kwargs...) = Pkg.test(name; test_fn=fn, kwargs...)
 test_test(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,16 +1,21 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
-import Pkg
+
+module Utils
+
+import ..Pkg
+
+export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
+       with_temp_env, with_pkg_env, git_init_and_commit, copy_test_package,
+       git_init_package, add_test_package, add_this_pkg, TEST_SIG, TEST_PKG
 
 function temp_pkg_dir(fn::Function;rm=true)
-    local env_dir
-    local old_load_path
-    local old_depot_path
-    local old_home_project
-    local old_active_project
-    local old_general_registry_url
+    old_load_path = copy(LOAD_PATH)
+    old_depot_path = copy(DEPOT_PATH)
+    old_home_project = Base.HOME_PROJECT[]
+    old_active_project = Base.ACTIVE_PROJECT[]
+    old_general_registry_url = Pkg.Types.DEFAULT_REGISTRIES[1].url
     try
         # Clone the registry only once
-        old_general_registry_url = Pkg.Types.DEFAULT_REGISTRIES[1].url
         generaldir = joinpath(@__DIR__, "registries", "General")
         if !isdir(generaldir)
             mkpath(generaldir)
@@ -21,11 +26,6 @@ function temp_pkg_dir(fn::Function;rm=true)
                 end
             end
         end
-
-        old_load_path = copy(LOAD_PATH)
-        old_depot_path = copy(DEPOT_PATH)
-        old_home_project = Base.HOME_PROJECT[]
-        old_active_project = Base.ACTIVE_PROJECT[]
         empty!(LOAD_PATH)
         empty!(DEPOT_PATH)
         Base.HOME_PROJECT[] = nothing
@@ -179,4 +179,6 @@ function add_this_pkg()
         path=pkg_dir,
     )
     Pkg.develop(spec)
+end
+
 end


### PR DESCRIPTION
- Be more careful about not importing a "global" Pkg in modules. If our project is messed up we will use the stdlib Pkg which is bad. Instead, only `import Pkg` in the `runtests.jl` and refer everything to that Pkg with `import ..Pkg`.
- Make `Utils` a module so that we don't need to include (and recompile it) in all submodules.
- Move some test files that were included in the end of `pkg.jl` out into `runtests.jl`.
- Define some of the variables in `temp_pkg_dir` outside the try block.