### PR TITLE
Make files read only more often

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1045,7 +1045,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Vector{UUID};
     # resolve & apply package versions
     resolve_versions!(ctx, pkgs)
     update_manifest!(ctx, pkgs)
-    new_apply = download_source(ctx, pkgs; readonly=false)
+    new_apply = download_source(ctx, pkgs; readonly=true)
     download_artifacts(ctx, pkgs; platform=platform)
 
     Display.print_env_diff(ctx)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -12,7 +12,7 @@ using REPL.TerminalMenus
 
 using ..TOML
 import ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION
-import Pkg: GitTools, depots, depots1, logdir
+import Pkg: GitTools, depots, depots1, logdir, set_readonly
 import ..BinaryPlatforms: Platform
 
 import Base: SHA1
@@ -725,6 +725,7 @@ function instantiate_pkg_repo!(ctx::Context, pkg::PackageSpec, cached_repo::Unio
     isdir(version_path) && return false
     mkpath(version_path)
     mv(cached_repo, version_path; force=true)
+    set_readonly(version_path)
     return true
 end
 


### PR DESCRIPTION
Make files read only when installing a given git revision, and when installing a package because of a dependency from a Pkg.develop'd package, fixes #729, fixes #1313, fixes #1382.