### PR TITLE
store the initial manifest and project in the envcache

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -220,7 +220,7 @@ function destructure(manifest::Manifest)::Dict
     return raw
 end
 
-function write_manifest(env)
+function write_manifest(env::EnvCache)
     mkpath(dirname(env.manifest_file))
     write_manifest(env.manifest, env.manifest_file)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -168,7 +168,7 @@ _project_key_order = ["name", "uuid", "keywords", "license", "desc", "deps", "co
 project_key_order(key::String) =
     something(findfirst(x -> x == key, _project_key_order), length(_project_key_order) + 1)
 
-function write_project(env)
+function write_project(env::EnvCache)
     mkpath(dirname(env.project_file))
     write_project(env.project, env.project_file)
 end


### PR DESCRIPTION
Instead of having to reparse Project + Manifest again just before we write out the new ones. I think this makes more sense (avoids reparsing the manifest + project and is not sensitive for writing the diff before the files update). I wanted this for the undo/redo stuff but factored out this change here.