### PR TITLE
Make tests less flaky by wrapping them in a bounded retry loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,14 @@ stages:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --project -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
+  - try_count=0
+  - while [ $try_count != 100 ]; do
   - julia --project --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+  - if [ $? = 0 ]; then exit 0; fi
+  - try_count=`expr $try_count + 1`
+  - sleep 1
+  - done
+  - exit 1
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --project -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
   - try_count=0
-  - while [ $try_count != 100 ]; do
+  - while [ $try_count != 2 ]; do
   - julia --project --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
   - if [ $? = 0 ]; then exit 0; fi
   - try_count=`expr $try_count + 1`


### PR DESCRIPTION
Per @notriddle’s suggestion [here](https://github.com/JuliaLang/Pkg.jl/issues/1304#issuecomment-522758509), this pull request wraps the tests on Travis in a bounded retry loop.

Whether or not we keep using Bors, I think that this will make life a little easier by reducing the number of times that someone needs to manually restart a failed CI build.

I have no idea how to write a shell script in Windows, but we should probably do this for the AppVeyor tests as well.