### PR TITLE
7z improvements

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -488,7 +488,9 @@ function install_archive(
         url_success || continue
         dirs = readdir(dir)
         # 7z on Win might create this spurious file
+        @show dirs
         filter!(x -> x != "pax_global_header", dirs)
+        @show dirs
         @assert length(dirs) == 1
         # Assert that the tarball unpacked to the tree sha we wanted
         # TODO: Enable on Windows when tree_hash handles

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -197,13 +197,14 @@ function probe_platform_engines!(;verbose::Bool = false)
     # the correct 7z given the path to the executable:
     unpack_7z = (exe7z) -> begin
         return (tarball_path, out_path, excludelist = nothing) ->
-        pipeline(`$exe7z x $(tarball_path) -y -so`,
-                 `$exe7z x -si -y -ttar -o$(out_path) $(excludelist == nothing ? [] : "-x@$(excludelist)")`)
+        pipeline(pipeline(`$exe7z x $(tarball_path) -y -so`,
+                 `$exe7z x -si -y -ttar -o$(out_path) $(excludelist == nothing ? [] : "-x@$(excludelist)")`);
+                 stdout=devnull, stderr=devnull)
     end
     package_7z = (exe7z) -> begin
         return (in_path, tarball_path) ->
-            pipeline(`$exe7z a -ttar -so a.tar "$(joinpath(".",in_path,"*"))"`,
-                     `$exe7z a -si $(tarball_path)`)
+            pipeline(pipeline(`$exe7z a -ttar -so a.tar "$(joinpath(".",in_path,"*"))"`,
+                     `$exe7z a -si $(tarball_path)`); stdout=devnull, stderr=devnull)
     end
     list_7z = (exe7z) -> begin
         return (path; verbose = false) ->


### PR DESCRIPTION
This silences verbose `7z` output, and prefers `7z` on all platforms.