### PR TITLE
WIP: refactor some of the repo handling code

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -695,17 +695,13 @@ function precompile(ctx::Context)
     nothing
 end
 
-function tree_hash_exists(repo_path::String, tree_hash::String)
-    isdir(repo_path) || return false
-    LibGit2.with(LibGit2.GitRepo(repo_path)) do repo
-        try
-            LibGit2.GitObject(repo, tree_hash)
-            return true
-        catch err
-            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
-        end
-        return false
+function tree_hash(repo::LibGit2.GitRepo, tree_hash::String)
+    try
+        return LibGit2.GitObject(repo, tree_hash)
+    catch err
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
     end
+    return nothing
 end
 
 instantiate(; kwargs...) = instantiate(Context(); kwargs...)
@@ -761,21 +757,24 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
         else
             repo_source = normpath(joinpath(dirname(ctx.env.project_file), pkg.repo.source))
         end
-        clonepath = Types.clone_path(repo_source)
-        # We try to avoid updating the clone if the target already exists
-        if tree_hash_exists(clonepath, string(pkg.tree_hash))
-            tmp_source = Types.repo_checkout(ctx, clonepath, string(pkg.tree_hash))
-        else
-            if !isurl(repo_source) && !isdir(repo_source)
-                pkgerror("Expected $(err_rep(pkg)) to exist at `$(repo_source)`, but no such directory.")
-            end
-            Types.clone_path!(ctx, repo_source) # TODO a more direct way of updating a clone
-            tmp_source = Types.repo_checkout(ctx, clonepath, string(pkg.tree_hash))
+        if !isurl(repo_source) && !isdir(repo_source)
+            pkgerror("Did not find path `$(repo_source)` for $(err_rep(pkg))")
         end
-        # Finally move the checked out tree to the correct location
-        mkpath(sourcepath)
-        mv(tmp_source, sourcepath; force=true)
-        push!(new_git, pkg.uuid)
+        repo_path = Types.add_repo_cache_path(repo_source)
+        LibGit2.with(GitTools.ensure_clone(ctx, repo_path, pkg.repo.source; isbare=true)) do repo
+            # We only update the clone if the tree hash can't be found
+            tree_hash_object = tree_hash(repo, string(pkg.tree_hash))
+            if tree_hash_object === nothing
+                GitTools.fetch(ctx, repo, pkg.repo.source; refspecs=Types.refspecs)
+                tree_hash_object = tree_hash(repo, string(pkg.tree_hash))
+            end
+            if tree_hash_object === nothing
+                 pkgerror("Did not find tree_hash $(pkg.tree_hash) for $(err_rep(pkg))")
+            end
+            mkpath(sourcepath)
+            GitTools.checkout_tree_to_path(repo, tree_hash_object, sourcepath)
+            push!(new_git, pkg.uuid)
+        end
     end
 
     # Ensure artifacts are installed for the dependent packages, and finally this overall project

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -111,7 +111,17 @@ function ensure_clone(ctx, target_path, url; kwargs...)
     end
 end
 
-function clone(ctx, url, source_path; header=nothing, kwargs...)
+function checkout_tree_to_path(repo::LibGit2.GitRepo, tree::LibGit2.GitObject, path::String)
+    GC.@preserve path begin
+        opts = LibGit2.CheckoutOptions(
+            checkout_strategy = LibGit2.Consts.CHECKOUT_FORCE,
+            target_directory = Base.unsafe_convert(Cstring, path)
+        )
+        LibGit2.checkout_tree(repo, tree, options=opts)
+    end
+end
+
+function clone(ctx, url, source_path; header=nothing, credentials=nothing, kwargs...)
     @assert !isdir(source_path) || isempty(readdir(source_path))
     url = normalize_url(url)
     Pkg.Types.printpkgstyle(ctx, :Cloning, header == nothing ? "git-repo `$url`" : header)
@@ -123,8 +133,12 @@ function clone(ctx, url, source_path; header=nothing, kwargs...)
         )
     )
     print(stdout, "\e[?25l") # disable cursor
+    if credentials == nothing
+        credentials = LibGit2.CachedCredentials()
+    end
+    mkpath(source_path)
     try
-        return LibGit2.clone(url, source_path; callbacks=callbacks, kwargs...)
+        return LibGit2.clone(url, source_path; callbacks=callbacks, credentials=credentials, kwargs...)
     catch err
         rm(source_path; force=true, recursive=true)
         err isa LibGit2.GitError || rethrow()
@@ -135,12 +149,13 @@ function clone(ctx, url, source_path; header=nothing, kwargs...)
             Pkg.Types.pkgerror("failed to clone from $(url), error: $err")
         end
     finally
+        Base.shred!(credentials)
         print(stdout, "\033[2K") # clear line
         print(stdout, "\e[?25h") # put back cursor
     end
 end
 
-function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kwargs...)
+function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, credentials=nothing, kwargs...)
     if remoteurl === nothing
         remoteurl = LibGit2.with(LibGit2.get(LibGit2.GitRemote, repo, "origin")) do remote
             LibGit2.url(remote)
@@ -156,6 +171,9 @@ function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kw
         )
     )
     print(stdout, "\e[?25l") # disable cursor
+    if credentials == nothing
+        credentials = LibGit2.CachedCredentials()
+    end
     try
         return LibGit2.fetch(repo; remoteurl=remoteurl, callbacks=callbacks, kwargs...)
     catch err
@@ -166,6 +184,7 @@ function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kw
             Pkg.Types.pkgerror("failed to fetch from $(remoteurl), error: $err")
         end
     finally
+        Base.shred!(credentials)
         print(stdout, "\033[2K") # clear line
         print(stdout, "\e[?25h") # put back cursor
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -12,7 +12,7 @@ using REPL.TerminalMenus
 
 using ..TOML
 import ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION
-import Pkg: GitTools, depots, depots1, logdir, set_readonly
+import Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath
 import ..BinaryPlatforms: Platform
 
 import Base: SHA1
@@ -115,6 +115,7 @@ end
 
 has_name(pkg::PackageSpec) = pkg.name !== nothing
 has_uuid(pkg::PackageSpec) = pkg.uuid !== nothing
+isresolved(pkg::PackageSpec) = pkg.uuid !== nothing && pkg.name !== nothing
 
 function Base.show(io::IO, pkg::PackageSpec)
     vstr = repr(pkg.version)
@@ -451,123 +452,64 @@ function relative_project_path(ctx::Context, path::String)
                    Pkg.safe_realpath(dirname(ctx.env.project_file)))
 end
 
-function git_checkout_latest!(ctx::Context, repo_path::AbstractString)
-    LibGit2.with(LibGit2.GitRepo(repo_path)) do repo
-        rev = LibGit2.isattached(repo) ?
-            LibGit2.branch(repo) :
-            string(LibGit2.GitHash(LibGit2.head(repo)))
-        gitobject, isbranch = nothing, nothing
-        Base.shred!(LibGit2.CachedCredentials()) do creds
-            gitobject, isbranch = get_object_branch(ctx, repo, rev, creds)
-        end
-        try
-            LibGit2.transact(repo) do r
-                if isbranch
-                    LibGit2.branch!(r, rev, track=LibGit2.Consts.REMOTE_ORIGIN)
-                else
-                    LibGit2.checkout!(r, string(LibGit2.GitHash(gitobject)))
-                end
-            end
-        finally
-            close(gitobject)
-        end
-    end
-end
-
-function fresh_clone(ctx::Context, url::String)
-    clone_path = joinpath(depots1(), "clones")
-    mkpath(clone_path)
-    repo_path = joinpath(clone_path, string(hash(url), "_full"))
-    # make sure you have a fresh clone
-    repo = nothing
-    try
-        repo = GitTools.ensure_clone(ctx, repo_path, url)
-        Base.shred!(LibGit2.CachedCredentials()) do creds
-            GitTools.fetch(ctx, repo, url; refspecs=refspecs, credentials=creds)
-        end
-    finally
-        repo isa LibGit2.GitRepo && LibGit2.close(repo)
-    end
-    # Copy the repo to a temporary place and check out the rev
-    temp_repo = mktempdir()
-    cp(repo_path, temp_repo; force=true)
-    git_checkout_latest!(ctx, temp_repo)
-    return temp_repo
-end
-
 function devpath(ctx::Context, name::String, shared::Bool)
     dev_dir = shared ? Pkg.devdir() : joinpath(dirname(ctx.env.project_file), "dev")
     return joinpath(dev_dir, name)
 end
 
-function is_tracking_repo(ctx::Context, name::String)::Bool
-    uuid = get(ctx.env.project.deps, name, nothing)
-    uuid === nothing && return false
-    entry = manifest_info(ctx, uuid)
-    entry === nothing && return false
-    return entry.repo.source !== nothing
-end
+function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
+    pkg.special_action = PKGSPEC_DEVELOPED
 
-# The return value says wether we are using a new clone
-function move_to_dev_path!(ctx::Context, pkg::PackageSpec, shared::Bool, temp_clone::String)::Bool
-    new = false
-    parse_package!(ctx, pkg, temp_clone)
+    # First, check if we can compute the path easily (which requires a given local path or name)
+    is_local_path = pkg.repo.source !== nothing && !isurl(pkg.repo.source)
+    if is_local_path || pkg.name !== nothing
+        dev_path = is_local_path ? pkg.repo.source : devpath(ctx, pkg.name, shared)
+        # If given an explicit local path, that needs to exist
+        if is_local_path && !isdir(dev_path)
+            pkgerror("Dev path `$(pkg.repo.source)` does not exist")
+        end
+        if isdir(dev_path)
+            resolve_projectfile!(ctx, pkg, dev_path)
+            println(ctx.io, "Path `$(dev_path)` exists and looks like the correct package. Using existing path.")
+            if is_local_path
+                pkg.path = isabspath(dev_path) ? dev_path : relative_project_path(ctx, dev_path)
+            else
+                pkg.path = shared ? dev_path : relative_project_path(ctx, dev_path)
+            end
+            return false
+        end
+    end
+    # If we dev by name and it is in the Project + tracking a repo in the source we can get the repo from the Manifest
+    if pkg.name !== nothing && pkg.uuid === nothing
+        uuid = get(ctx.env.project.deps, pkg.name, nothing)
+        if uuid !== nothing
+            entry = manifest_info(ctx, uuid)
+            if entry !== nothing 
+                pkg.repo.source = entry.repo.source
+            end
+        end
+    end
+    
+    # Still haven't found the source, try get it from the registry
+    if pkg.repo.source === nothing
+        set_repo_source_from_registry!(ctx, pkg)
+    end
+    @assert pkg.repo.source !== nothing
+
+    repo_path = dev_repo_cache_path(pkg.repo.source)
+    repo = GitTools.ensure_clone(ctx, repo_path, pkg.repo.source)
+    # TODO! Should reset --hard to latest commit here
+    resolve_projectfile!(ctx, pkg, repo_path)
     dev_path = devpath(ctx, pkg.name, shared)
     if isdir(dev_path)
-        parse_package!(ctx, pkg, dev_path)
         println(ctx.io, "Path `$(dev_path)` exists and looks like the correct package. Using existing path.")
-        rm(temp_clone; recursive=true)
+        new = false
     else
         mkpath(dirname(dev_path))
-        mv(temp_clone, dev_path)
+        cp(repo_path, dev_path)
         new = true
     end
     pkg.path = shared ? dev_path : relative_project_path(ctx, dev_path)
-    return new
-end
-
-function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
-    new = false
-    pkg.special_action = PKGSPEC_DEVELOPED
-    if pkg.repo.source !== nothing && !isurl(pkg.repo.source) # explicit path
-        given_abspath = isabspath(pkg.repo.source)
-        pkg.repo.source = try
-            realpath(pkg.repo.source)
-        catch
-            pkgerror("Dev path `$(pkg.repo.source)` does not exist")
-        end
-        parse_package!(ctx, pkg, pkg.repo.source)
-        pkg.path = given_abspath ? pkg.repo.source : relative_project_path(ctx, pkg.repo.source)
-    elseif pkg.name !== nothing && isdir(devpath(ctx, pkg.name, shared)) # existing dev path
-        dev_path = devpath(ctx, pkg.name, shared)
-        parse_package!(ctx, pkg, dev_path)
-        println(ctx.io, "Path `$(dev_path)` exists and looks like the correct package. Using existing path.")
-        pkg.path = shared ? dev_path : relative_project_path(ctx, dev_path)
-    elseif pkg.repo.source !== nothing # explicit URL
-        temp_clone = fresh_clone(ctx, pkg.repo.source)
-        new = move_to_dev_path!(ctx, pkg, shared, temp_clone)
-    elseif pkg.uuid === nothing && is_tracking_repo(ctx, pkg.name)
-        entry = manifest_info(ctx, ctx.env.project.deps[pkg.name])
-        dev_path = devpath(ctx, entry.name, shared)
-        if isdir(dev_path)
-            parse_package!(ctx, pkg, dev_path)
-            println(ctx.io, "Path `$(dev_path)` exists and looks like the correct package. Using existing path.")
-        end
-        # TODO check this, I might have deleted an else :|
-        temp_clone = fresh_clone(ctx, entry.repo.source)
-        new = move_to_dev_path!(ctx, pkg, shared, temp_clone)
-    else # resolve against registry
-        update_registries(ctx)
-        registry_resolve!(ctx, pkg)
-        if pkg.name === nothing || pkg.uuid === nothing
-            pkgerror("Package $(err_rep(pkg)) could not be found in a registry.") # TODO test this
-        end
-        paths = registered_paths(ctx, pkg.uuid)
-        isempty(paths) && pkgerror("Package $(err_rep(pkg)) could not be found in a registry.")
-        _, location = Types.registered_info(ctx, pkg.uuid, "repo")[1] #TODO look into [1]
-        temp_clone = fresh_clone(ctx, location)
-        new = move_to_dev_path!(ctx, pkg, shared, temp_clone)
-    end
     return new
 end
 
@@ -575,7 +517,7 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
     new_uuids = UUID[]
     for pkg in pkgs
         new = handle_repo_develop!(ctx, pkg, shared)
-        new  && push!(new_uuids, pkg.uuid)
+        new && push!(new_uuids, pkg.uuid)
         @assert pkg.path !== nothing
         @assert has_uuid(pkg)
         pkg.repo = GitRepo() # clear repo field, no longer needed
@@ -583,161 +525,111 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec}, 
     return new_uuids
 end
 
-clone_path(url::String) = joinpath(depots1(), "clones", string(hash(url)))
-function clone_path!(ctx::Context, url::String)
-    clone = clone_path(url)
-    mkpath(dirname(clone))
-    Base.shred!(LibGit2.CachedCredentials()) do creds
-        LibGit2.with(GitTools.ensure_clone(ctx, clone, url; isbare=true, credentials=creds)) do repo
-            GitTools.fetch(ctx, repo; refspecs=refspecs, credentials=creds)
-        end
+add_repo_cache_path(url::String) = joinpath(depots1(), "clones", string(hash(url)))
+dev_repo_cache_path(url::String) = add_repo_cache_path(url) * "_full"
+
+function set_repo_source_from_registry!(ctx, pkg)
+    registry_resolve!(ctx, pkg)
+    # Didn't find the package in the registry, but maybe it exists in the updated registry
+    if !isresolved(pkg)
+        update_registries(ctx)
+        registry_resolve!(ctx, pkg)
     end
-    return clone
+    ensure_resolved(ctx, [pkg]; registry=true)
+    # We might have been given a name / uuid combo that does not have an entry in the registry
+    repo_info = Types.registered_info(ctx, pkg.uuid, "repo")
+    if isempty(repo_info)
+        pkgerror("Repository for package with UUID `$(pkg.uuid)` could not be found in a registry.")
+    end
+    _, repo_source = repo_info[1] # Just take the first repo we found
+    pkg.repo.source = repo_source
 end
 
-function guess_rev(ctx::Context, repo_path)::String
-    rev = nothing
-    LibGit2.with(LibGit2.GitRepo(repo_path)) do repo
-        rev = LibGit2.isattached(repo) ?
-            LibGit2.branch(repo) :
-            string(LibGit2.GitHash(LibGit2.head(repo)))
-        gitobject, isbranch = nothing, nothing
-        Base.shred!(LibGit2.CachedCredentials()) do creds
-            gitobject, isbranch = get_object_branch(ctx, repo, rev, creds)
-        end
-        LibGit2.with(gitobject) do object
-            rev = isbranch ? rev : string(LibGit2.GitHash(gitobject))
-        end
-    end
-    return rev
-end
-
-function with_git_tree(fn, ctx::Context, repo_path::String, rev::String)
-    gitobject = nothing
-    Base.shred!(LibGit2.CachedCredentials()) do creds
-        LibGit2.with(LibGit2.GitRepo(repo_path)) do repo
-            gitobject, isbranch = get_object_branch(ctx, repo, rev, creds)
-            LibGit2.with(LibGit2.peel(LibGit2.GitTree, gitobject)) do git_tree
-                @assert git_tree isa LibGit2.GitTree
-                return applicable(fn, repo, git_tree) ?
-                    fn(repo, git_tree) :
-                    fn(git_tree)
-            end
-        end
-    end
-end
-
-function repo_checkout(ctx::Context, repo_path, rev)
-    project_path = mktempdir()
-    with_git_tree(ctx, repo_path, rev) do repo, git_tree
-        _project_path = project_path # https://github.com/JuliaLang/julia/issues/30048
-        GC.@preserve _project_path begin
-            opts = LibGit2.CheckoutOptions(
-                checkout_strategy = LibGit2.Consts.CHECKOUT_FORCE,
-                target_directory = Base.unsafe_convert(Cstring, _project_path),
-            )
-            LibGit2.checkout_tree(repo, git_tree, options=opts)
-        end
-    end
-    return project_path
-end
-
-function tree_hash(ctx::Context, repo_path, rev)
-    with_git_tree(ctx, repo_path, rev) do git_tree
-        return SHA1(string(LibGit2.GitHash(git_tree))) # TODO can it be just SHA1?
-    end
-end
-
-function instantiate_pkg_repo!(ctx::Context, pkg::PackageSpec, cached_repo::Union{Nothing,String}=nothing)
-    pkg.special_action = PKGSPEC_REPO_ADDED
-    clone = clone_path!(ctx, pkg.repo.source)
-    pkg.tree_hash = tree_hash(ctx, clone, pkg.repo.rev)
-    version_path = Pkg.Operations.find_installed(pkg.name, pkg.uuid, pkg.tree_hash)
-    if cached_repo === nothing
-        cached_repo = repo_checkout(ctx, clone, string(pkg.tree_hash))
-    end
-    isdir(version_path) && return false
-    mkpath(version_path)
-    mv(cached_repo, version_path; force=true)
-    set_readonly(version_path)
-    return true
-end
 
 function handle_repo_add!(ctx::Context, pkg::PackageSpec)
-    given_abspath = nothing
+    pkg.special_action = PKGSPEC_REPO_ADDED
+    # The first goal is to populate pkg.repo.source if that wasn't given explicitly
     if pkg.repo.source === nothing
         @assert pkg.repo.rev !== nothing
-        # First, we try resolving against the manifest to avoid updating registries if at all possible.
+        # First, we try resolving against the manifest and current registry to avoid updating registries if at all possible.
         # This also handles the case where we _only_ wish to switch the tracking branch for a package.
         manifest_resolve!(ctx, [pkg]; force=true)
-        # If we could not resolve against manifest, resolve against the registry.
-        if pkg.name === nothing || pkg.uuid === nothing
-            @goto reg_resolve
+        if isresolved(pkg)
+            entry = manifest_info(ctx, pkg.uuid)
+            if entry !== nothing && entry.repo.source !== nothing # reuse source in manifest
+                pkg.repo.source = entry.repo.source
+            end
         end
-        entry = manifest_info(ctx, pkg.uuid)
-        # We still have to check this case, recall that name and UUID could both be given explicitly.
-        entry !== nothing || @goto reg_resolve 
-        if entry.pinned
-            pkg.tree_hash = entry.tree_hash # TODO why do we need this?
-            return false
-        elseif entry.repo.source !== nothing # reuse source in manifest
-            # TODO check consistency with entry
-            pkg.repo.source = entry.repo.source
-            @goto do_clone
+        if pkg.repo.source === nothing
+            set_repo_source_from_registry!(ctx, pkg)
         end
-        @label reg_resolve
-        update_registries(ctx) # If the information not in manifest, we have no choice but to update the registry.
-        registry_resolve!(ctx, pkg)
-        if pkg.name === nothing || pkg.uuid === nothing
-            pkgerror("Package $(err_rep(pkg)) could not be found in a registry or a manifest.")
-        end
-        paths = registered_paths(ctx, pkg.uuid)
-        # We still have to check this case, both name/UUID can be given explicitly.
-        if isempty(paths)
-            pkgerror("Package with UUID `$(pkg.uuid)` could not be found in a registry.")
-        end
-        _, pkg.repo.source = Types.registered_info(ctx, pkg.uuid, "repo")[1]
     end
-    @label do_clone
     @assert pkg.repo.source !== nothing
+
+    # We now have the source of the package repo, check if it is a local path and if that exists
     if !isurl(pkg.repo.source)
-        given_abspath = isabspath(pkg.repo.source)
-        pkg.repo.source = try
-            realpath(pkg.repo.source)
-        catch
+        if isdir(pkg.repo.source)
+            if !isdir(joinpath(pkg.repo.source, ".git"))
+                pkgerror("Did not find a git repository at `$(pkg.repo.source)`")
+            end
+            pkg.repo.source = safe_realpath(pkg.repo.source)
+        else
             pkgerror("Path `$(pkg.repo.source)` does not exist.")
         end
     end
-    clone_path   = clone_path!(ctx, pkg.repo.source)
-    pkg.repo.rev = something(pkg.repo.rev, guess_rev(ctx, clone_path))
-    cached_repo  = repo_checkout(ctx, clone_path, pkg.repo.rev)
-    package      = parse_package!(ctx, pkg, cached_repo)
-    if given_abspath !== nothing && !given_abspath
-        pkg.repo.source = relative_project_path(ctx, pkg.repo.source)
+    LibGit2.with(GitTools.ensure_clone(ctx, add_repo_cache_path(pkg.repo.source), pkg.repo.source; isbare=true)) do repo
+        # If the user didn't specify rev, assume they want the default (master) branch if on a branch, otherwise the current commit
+        if pkg.repo.rev == nothing
+            pkg.repo.rev = LibGit2.isattached(repo) ? LibGit2.branch(repo) : string(LibGit2.GitHash(LibGit2.head(repo)))
+        end
+
+        obj_branch = get_object_or_branch(repo, pkg.repo.rev)
+        fetched = false
+        if obj_branch === nothing
+            fetched = true
+            GitTools.fetch(ctx, repo, pkg.repo.source; refspecs=refspecs)
+            obj_branch = get_object_or_branch(repo, pkg.repo.rev)
+            if obj_branch === nothing
+                pkgerror("Did not find rev $(pkg.repo.rev) in repository")
+            end
+        end
+        gitobject, isbranch = obj_branch
+
+        # If we are tracking a branch and are not pinned we want to update the repo if we haven't done that yet
+        entry = manifest_info(ctx, pkg.uuid)
+        ispinned = entry !== nothing && entry.pinned
+        if isbranch && !fetched && !ispinned
+            GitTools.fetch(ctx, repo, pkg.repo.source; refspecs=refspecs)
+            gitobject, isbranch = get_object_or_branch(repo, pkg.repo.rev)
+        end
+
+        # Now we have the gitobject for our ref, time to find the tree hash for it
+        tree_hash_object = LibGit2.peel(LibGit2.GitTree, gitobject)
+        pkg.tree_hash = SHA1(string(LibGit2.GitHash(tree_hash_object)))
+
+        # If we already resolved a uuid, we can bail early if this package is already installed at the current tree_hash
+        if has_uuid(pkg)
+            version_path = Pkg.Operations.source_path(pkg)
+            isdir(version_path) && return false
+        end
+
+        temp_path = mktempdir()
+        GitTools.checkout_tree_to_path(repo, tree_hash_object, temp_path)
+        package = resolve_projectfile!(ctx, pkg, temp_path)
+
+        # Now that we are fully resolved (name, UUID, tree_hash, repo.source, repo.rev), we can finally
+        # check to see if the package exists at its canonical path.
+        version_path = Pkg.Operations.source_path(pkg)
+        isdir(version_path) && return false
+        
+        # Otherwise, move the temporary path into its correct place and set read only
+        mkpath(version_path)
+        mv(temp_path, version_path; force=true)
+        set_readonly(version_path)
+        return true
     end
-    @assert pkg.name !== nothing && pkg.uuid !== nothing &&
-        pkg.repo.source !== nothing && pkg.repo.rev !== nothing
-    # Check for pinned entry again.
-    entry = manifest_info(ctx, pkg.uuid)
-    if entry !== nothing && entry.pinned
-        rm(cached_repo; recursive=true, force=true)
-        pkg.tree_hash = entry.tree_hash
-        return false
-    end
-    pkg.tree_hash = tree_hash(ctx, clone_path, pkg.repo.rev)
-    # Now that we are fully resolved (name, UUID, tree_hash, repo.source, repo.rev), we can finally
-    # check to see if the package exists at its canonical path.
-    version_path = Pkg.Operations.source_path(pkg)
-    isdir(version_path) && return false
-    mkpath(version_path)
-    mv(cached_repo, version_path; force=true)
-    return true
 end
 
-"""
-Ensure repo specified by `repo` exists at version path for package
-Set tree_hash
-"""
 function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec})
     new_uuids = UUID[]
     for pkg in pkgs
@@ -747,45 +639,40 @@ function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec})
     return new_uuids
 end
 
-function parse_package!(ctx, pkg, project_path)
+function resolve_projectfile!(ctx, pkg, project_path)
     env = ctx.env
     project_file = projectfile_path(project_path; strict=true)
-    project_file === nothing && pkgerror(string("could not find project file in pacakge at ",
+    project_file === nothing && pkgerror(string("could not find project file in package at ",
                                                 pkg.repo.source !== nothing ? pkg.repo.source : (pkg.path)))
-    if project_file !== nothing
-        project_data = read_package(project_file)
-        pkg.uuid = project_data.uuid # TODO check no overwrite
-        pkg.name = project_data.name # TODO check no overwrite
-    end
+    project_data = read_package(project_file)
+    pkg.uuid = project_data.uuid # TODO check no overwrite
+    pkg.name = project_data.name # TODO check no overwrite
 end
 
-get_object_branch(ctx::Context, repo, rev::SHA1, creds) =
-    get_object_branch(ctx, repo, string(rev), creds)
+get_object_or_branch(repo, rev::SHA1) =
+    get_object_or_branch(repo, string(rev))
 
-function get_object_branch(ctx::Context, repo, rev, creds)
-    gitobject = nothing
-    isbranch = false
+# Returns nothing if rev could not be found in repo
+function get_object_or_branch(repo, rev)
     try
         gitobject = LibGit2.GitObject(repo, "remotes/cache/heads/" * rev)
-        isbranch = true
+        return gitobject, true
     catch err
         err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
     end
-    if gitobject == nothing
-        try
-            gitobject = LibGit2.GitObject(repo, rev)
-        catch err
-            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
-            GitTools.fetch(ctx, repo; refspecs=refspecs, credentials=creds)
-            try
-                gitobject = LibGit2.GitObject(repo, rev)
-            catch err
-                err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
-                pkgerror("git object $(rev) could not be found")
-            end
-        end
+    try
+        gitobject = LibGit2.GitObject(repo, "remotes/origin/" * rev)
+        return gitobject, true
+    catch err
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
     end
-    return gitobject, isbranch
+    try
+        gitobject = LibGit2.GitObject(repo, rev)
+        return gitobject, false
+    catch err
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
+    end
+    return nothing
 end
 
 ########################################
@@ -1003,10 +890,7 @@ function clone_or_cp_registries(ctx::Context, regs::Vector{RegistrySpec}, depot:
             printpkgstyle(ctx, :Copying, "registry from `$(Base.contractuser(reg.path))`")
             cp(reg.path, tmp; force=true)
         elseif reg.url !== nothing # clone from url
-            Base.shred!(LibGit2.CachedCredentials()) do creds
-                LibGit2.with(GitTools.clone(ctx, reg.url, tmp; header = "registry from $(repr(reg.url))",
-                    credentials = creds)) do repo
-                end
+            LibGit2.with(GitTools.clone(ctx, reg.url, tmp; header = "registry from $(repr(reg.url))")) do repo
             end
         else
             pkgerror("no path or url specified for registry")

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -572,11 +572,12 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
             if !isdir(joinpath(pkg.repo.source, ".git"))
                 pkgerror("Did not find a git repository at `$(pkg.repo.source)`")
             end
-            pkg.repo.source = safe_realpath(pkg.repo.source)
+            pkg.repo.source = isabspath(pkg.repo.source) ? abspath(pkg.repo.source) : safe_realpath(pkg.repo.source)
         else
             pkgerror("Path `$(pkg.repo.source)` does not exist.")
         end
     end
+
     LibGit2.with(GitTools.ensure_clone(ctx, add_repo_cache_path(pkg.repo.source), pkg.repo.source; isbare=true)) do repo
         # If the user didn't specify rev, assume they want the default (master) branch if on a branch, otherwise the current commit
         if pkg.repo.rev == nothing

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -19,11 +19,9 @@ function temp_pkg_dir(fn::Function;rm=true)
         generaldir = joinpath(@__DIR__, "registries", "General")
         if !isdir(generaldir)
             mkpath(generaldir)
-            Base.shred!(LibGit2.CachedCredentials()) do creds
-                LibGit2.with(Pkg.GitTools.clone(Pkg.Types.Context(),
-                                                "https://github.com/JuliaRegistries/General.git",
-                    generaldir, credentials = creds)) do repo
-                end
+            LibGit2.with(Pkg.GitTools.clone(Pkg.Types.Context(),
+                                            "https://github.com/JuliaRegistries/General.git",
+                generaldir)) do repo
             end
         end
         empty!(LOAD_PATH)


### PR DESCRIPTION
I was working on adding subdir support (multiple packages in the same repo) but even with https://github.com/JuliaLang/Pkg.jl/pull/1372 I found the repo handling code a bit tricky to follow.

This is an attempt to go through the code, add some comments, and arguably clean up some things when going through the code again.
It ended up with about -100 lines which I think is a good indication that it is arguably a bit simpler now.

Some things I did in no particular order:

- Push the `GitRepo` uses "up the stack" so we don't open and close it in all small helper functions.
- Move uses of `CredentialsCache` inside `GitTools.fetch` and `GitTools.clone` instead of creating them all over the place
- Rename some things to be a bit more precise / consistent with other uses, for example:
    - `resolve_projectfile!` instead of `parse_package!`, we are setting `uuid` and `name`, that is `resolve`.
    - `dev_repo_cache_path` / `add_repo_cache_path` instead of `clone_path`
- Sometimes inlined small helper functions that were used in one place when their name was confusing (for the uninitiated) and it was hard to context swap to the other function instead of reading it inline.