### PR TITLE
Clarify backward-compatible feature additions require only minor bump in pre-1.0 packages

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -56,8 +56,8 @@ Example = "0.2.1"
 
 results in a versionbound on Example as `[0.2.1, 0.3.0)`.
 
-In particular, the depended package (`Example` in above example) may set `version = "0.2.4"` when it has feature additions
-compared to 0.2.3 as long as it remains backward compatible with 0.2.0.  See also [The `version` field](@ref).
+In particular, a package may set `version = "0.2.4"` when it has feature additions compared to 0.2.3 as long as it
+remains backward compatible with 0.2.0.  See also [The `version` field](@ref).
 
 ### Caret specifiers
 

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -56,8 +56,8 @@ Example = "0.2.1"
 
 results in a versionbound on Example as `[0.2.1, 0.3.0)`.
 
-In particular, it is valid to register a package with version 0.2.4 when it has feature additions compared to 0.2.3 as
-long as it remains backward compatible with 0.2.0.
+In particular, the depended package (`Example` in above example) may set `version = "0.2.4"` when it has feature additions
+compared to 0.2.3 as long as it remains backward compatible with 0.2.0.  See also [The `version` field](@ref).
 
 ### Caret specifiers
 

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -56,6 +56,9 @@ Example = "0.2.1"
 
 results in a versionbound on Example as `[0.2.1, 0.3.0)`.
 
+In particular, it is valid to register a package with version 0.2.4 when it has feature additions compared to 0.2.3 as
+long as it remains backward compatible with 0.2.0.
+
 ### Caret specifiers
 
 A caret specifier allows upgrade that would be compatible according to semver.

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -59,7 +59,7 @@ should follow SemVer. The basic rules are:
   `Base` or other packages.
 See also the section on [Compatibility](@ref).
 
-Note that pre-1.0.0 rule is where Pkg.jl deviates from SemVer specification.  See
+Note that Pkg.jl deviates from the SemVer specification when it comes to versions pre-1.0.0. See
 [Pre-1.0 behavior](@ref) for more details.
 
 

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -59,6 +59,9 @@ should follow SemVer. The basic rules are:
   `Base` or other packages.
 See also the section on [Compatibility](@ref).
 
+Note that pre-1.0.0 rule is where Pkg.jl deviates from SemVer specification.  See
+[Pre-1.0 behavior](@ref) for more details.
+
 
 ### The `[deps]` section
 


### PR DESCRIPTION
... as discussed in #1417.

close #1417