### PR TITLE
flush stdout before spawning new processes

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -827,6 +827,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
                       rpad(name * " ", max_name + 1, "─") * "→ " * Types.pathrepr(log_file))
 
         sandbox(ctx, pkg, source_path, builddir(source_path)) do
+            flush(stdout)
             ok = open(log_file, "w") do log
                 std = verbose ? ctx.io : log
                 success(pipeline(gen_build_code(buildfile(source_path)),
@@ -1363,6 +1364,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
             println(ctx.io, "Running sandbox")
             test_fn !== nothing && test_fn()
             Display.status(Context(), mode=PKGMODE_PROJECT)
+            flush(stdout)
             try
                 run(gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args))
                 printpkgstyle(ctx, :Testing, pkg.name * " tests passed ")

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -560,7 +560,7 @@ function backwards_compatibility_for_test(
         if !Types.is_project_uuid(ctx, pkg.uuid)
             Display.status(localctx, mode=PKGMODE_MANIFEST)
         end
-
+        flush(stdout)
         run_test()
     end
 end
@@ -603,6 +603,7 @@ function backwards_compat_for_build(ctx::Context, pkg::PackageSpec, build_file::
     end
     with_dependencies_loadable_at_toplevel(ctx, pkg;
                                            might_need_to_resolve=might_need_to_resolve) do localctx
+        flush(stdout)
         run_build()
     end
 end


### PR DESCRIPTION
One annoying thing that can happen when one runs a process that redirects stdin / stdout and that process runs Pkg.test is that output gets interleaved. The way that happens is that some output to stdout is still buffered (and haven't been commited to the redirected stdout), then Pkg.test runs, which starts a new process, and when the process finishes it flushes all its stdout to the redirected stream. Then we continue with the Pkg process which will at some point commit its buffered stuff to stdin. The stuff that was buffered before Pkg.test was called will thus come out in the wrong order.

Since we started directing much of our stuff to stderr, this is less important since stderr is (I think!) usually unbuffered but this makes sense to do anyway.