### PR TITLE
Change direct path to `7z` to point toward `libexec`, not `bin`

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -384,8 +384,8 @@ function probe_platform_engines!(;verbose::Bool = false)
         # We greatly prefer `7z` as a compression engine on Windows
         prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
 
-        # On windows, we bundle 7z with Julia, so try invoking that directly
-        exe7z = joinpath(Sys.BINDIR, "7z.exe")
+        # We bundle 7z with Julia, so try invoking that directly as well
+        exe7z = joinpath(Sys.BINDIR, "..", "libexec", "7z.exe")
         prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
     end
 


### PR DESCRIPTION
This was accidentally dropped when I abandoned my previous 7z rework PR.  This needs to be merged into 1.3 to complete the fixes for https://github.com/JuliaLang/julia/pull/33505