### PR TITLE
Only add undo snapshot in __init__ if we have a project to snapshot.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -907,7 +907,16 @@ UndoState() = UndoState(0, UndoState[])
 const undo_entries = Dict{String, UndoState}()
 const max_undo_limit = 50
 
-function add_snapshot_to_undo(env = EnvCache())
+function add_snapshot_to_undo(env=nothing)
+    # only attempt to take a snapshot if there is
+    # an active project to be found
+    if env === nothing
+        if Base.active_project() === nothing
+            return
+        else
+            env = EnvCache()
+        end
+    end
     state = get!(undo_entries, env.project_file) do
         UndoState()
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -625,7 +625,7 @@ end
         # Example
         Pkg.add(TEST_PKG.name)
         @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-        # 
+        #
         Pkg.undo()
         @test !haskey(Pkg.dependencies(), TEST_PKG.uuid)
         # Example
@@ -653,7 +653,7 @@ end
         # Example, Unicode
         Pkg.redo()
         @test haskey(Pkg.dependencies(), unicode_uuid)
-        
+
         # Example
         Pkg.undo()
 
@@ -670,6 +670,25 @@ end
         # Example, Unicode
         Pkg.redo()
         @test haskey(Pkg.dependencies(), unicode_uuid)
+
+        # add_snapshot_to_undo from __init__ should
+        # not throw in case of no active project
+        mktempdir() do tmp
+            # Copy just whats necessary from Pkg to a custom package directory
+            dir = joinpath(tmp, "Pkg"); mkdir(dir)
+            cp(joinpath(@__DIR__, "..", "Project.toml"), joinpath(dir, "Project.toml"))
+            cp(joinpath(@__DIR__, "..", "src"), joinpath(dir, "src"))
+            cp(joinpath(@__DIR__, "..", "ext"), joinpath(dir, "ext")) # for TOML
+            withenv("JULIA_LOAD_PATH" => tmp,
+                    "JULIA_PROJECT" => nothing) do
+                code = """
+                    @assert Base.active_project() === nothing
+                    using Pkg # should not error
+                    @assert isempty(Pkg.API.undo_entries)
+                    """
+                run(`$(Base.julia_cmd()) -e $(code)`)
+            end
+        end
 
     end end
 end


### PR DESCRIPTION
Fixes the precompilation problems in https://github.com/JuliaLang/julia/pull/33536.