### PR TITLE
Move save of initial snapshot to EnvCache constructor

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -906,6 +906,7 @@ end
 UndoState() = UndoState(0, UndoState[])
 const undo_entries = Dict{String, UndoState}()
 const max_undo_limit = 50
+const saved_initial_snapshot = Ref(false)
 
 function add_snapshot_to_undo(env=nothing)
     # only attempt to take a snapshot if there is

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -507,7 +507,6 @@ function __init__()
             end
         end
     end
-    API.add_snapshot_to_undo()
 end
 
 ##################

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -671,25 +671,6 @@ end
         Pkg.redo()
         @test haskey(Pkg.dependencies(), unicode_uuid)
 
-        # add_snapshot_to_undo from __init__ should
-        # not throw in case of no active project
-        mktempdir() do tmp
-            # Copy just whats necessary from Pkg to a custom package directory
-            dir = joinpath(tmp, "Pkg"); mkdir(dir)
-            cp(joinpath(@__DIR__, "..", "Project.toml"), joinpath(dir, "Project.toml"))
-            cp(joinpath(@__DIR__, "..", "src"), joinpath(dir, "src"))
-            cp(joinpath(@__DIR__, "..", "ext"), joinpath(dir, "ext")) # for TOML
-            withenv("JULIA_LOAD_PATH" => tmp,
-                    "JULIA_PROJECT" => nothing) do
-                code = """
-                    @assert Base.active_project() === nothing
-                    using Pkg # should not error
-                    @assert isempty(Pkg.API.undo_entries)
-                    """
-                run(`$(Base.julia_cmd()) -e $(code)`)
-            end
-        end
-
     end end
 end
 


### PR DESCRIPTION
Move save of initial snapshot to `EnvCache` constructor instead of doing it from `__init__`.

Should fix the remaining problems of https://github.com/JuliaLang/julia/pull/33536