### PR TITLE
`bin/recompress.jl`: Don't try to parse version numbers for JLL packages

### DIFF
--- a/bin/recompress.jl
+++ b/bin/recompress.jl
@@ -10,10 +10,13 @@ const packages = TOML.parsefile(registry_file)["packages"]
 const version_map = Dict{String,Vector{VersionNumber}}()
 
 for (uuid, info) in packages
-    path = joinpath(registry_path, info["path"])
-    versions_file = joinpath(path, "Versions.toml")
-    versions = Compress.load(versions_file)
-    version_map[uuid] = sort!(collect(keys(versions)))
+    name = info["name"]
+    if !endswith(name, "_jll")
+        path = joinpath(registry_path, info["path"])
+        versions_file = joinpath(path, "Versions.toml")
+        versions = Compress.load(versions_file)
+        version_map[uuid] = sort!(collect(keys(versions)))
+    end
 end
 
 for (_, info) in packages


### PR DESCRIPTION
Currently, if you try to run the `bin/recompress.jl` script on the General registry, you will quickly encounter an error similar to the following:
```
ERROR: LoadError: ArgumentError: invalid version range: "4.1.0+1"
```

This happens because JLL packages use version numbers like `4.1.0+1`, which the compress script does not like.

The solution is: do not try to parse version numbers for JLL packages.

This pull request implements that solution.

cc: @KristofferC since I think he's the last person to look at this code.