### PR TITLE
Introduce special REPL syntax for shared environments

### DIFF
--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -6,7 +6,7 @@ import ..isdir_windows_workaround
 """
 Parser for PackageSpec objects.
 """
-function parse_package(args::Vector{QString}; add_or_dev=false)::Vector{PackageSpec}
+function parse_package(args::Vector{QString}, options; add_or_dev=false)::Vector{PackageSpec}
     args::Vector{PackageToken} = map(PackageToken, package_lex(args))
     return parse_package_args(args; add_or_dev=add_or_dev)
 end
@@ -95,7 +95,7 @@ end
 ################
 # RegistrySpec #
 ################
-function parse_registry(raw_args::Vector{QString}; add=false)
+function parse_registry(raw_args::Vector{QString}, options; add=false)
     regs = RegistrySpec[]
     foreach(x -> push!(regs, parse_registry(x; add=add)), unwrap(raw_args))
     return regs
@@ -132,8 +132,22 @@ end
 #
 # # Other
 #
-function parse_activate(args::Vector{QString})::Vector{String}
-    return [(x.isquoted ? x.raw : expanduser(x.raw)) for x in args]
+function parse_activate(args::Vector{QString}, options)
+    isempty(args) && return [] # nothing to do
+    if length(args) == 1
+        x = first(args)
+        if x.isquoted
+            return [x.raw]
+        end
+        x = x.raw
+        if first(x) == '@'
+            options[:shared] = true
+            return [x[2:end]]
+        else
+            return [expanduser(x)]
+        end
+    end
+    return args # this is currently invalid input for "activate"
 end
 
 #

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -22,7 +22,7 @@ julia is started with `--startup-file=yes`.
     :short_name => "?",
     :api => identity, # dummy API function
     :arg_count => 0 => Inf,
-    :arg_parser => identity,
+    :arg_parser => ((x,y) -> x),
     :completions => complete_help,
     :description => "show this message",
     :help => md"""
@@ -86,7 +86,7 @@ as any no-longer-necessary manifest packages due to project package removals.
     :api => API.add,
     :should_splat => false,
     :arg_count => 1 => Inf,
-    :arg_parser => (x -> parse_package(x; add_or_dev=true)),
+    :arg_parser => ((x,y) -> parse_package(x,y; add_or_dev=true)),
     :option_spec => OptionDeclaration[
         [:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
@@ -135,7 +135,7 @@ pkg> add Example=7876af07-990d-54b4-ab0e-23690620f79a
     :api => API.develop,
     :should_splat => false,
     :arg_count => 1 => Inf,
-    :arg_parser => (x -> parse_package(x; add_or_dev=true)),
+    :arg_parser => ((x,y) -> parse_package(x,y; add_or_dev=true)),
     :option_spec => OptionDeclaration[
         [:name => "strict", :api => :strict => true],
         [:name => "local", :api => :shared => false],
@@ -274,7 +274,7 @@ packages will not be upgraded at all.
 ],[ :name => "generate",
     :api => API.generate,
     :arg_count => 1 => 1,
-    :arg_parser => x -> map(expanduser, unwrap(x)),
+    :arg_parser => ((x,y) -> map(expanduser, unwrap(x))),
     :description => "generate files for a new project",
     :help => md"""
     generate pkgname
@@ -356,7 +356,7 @@ Redoes the changes from the latest [`undo`](@ref).
     :api => Registry.add,
     :should_splat => false,
     :arg_count => 1 => Inf,
-    :arg_parser => (x -> parse_registry(x; add = true)),
+    :arg_parser => ((x,y) -> parse_registry(x,y; add = true)),
     :description => "add package registries",
     :help => md"""
     registry add reg...

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -1,16 +1,22 @@
 ########################
 # Completion Functions #
 ########################
-function complete_activate(options, partial, i1, i2)
+function _shared_envs()
     possible = String[]
+    for depot in Base.DEPOT_PATH
+        envdir = joinpath(depot, "environments")
+        isdir(envdir) || continue
+        append!(possible, readdir(envdir))
+    end
+    return possible
+end
+
+function complete_activate(options, partial, i1, i2)
     shared = get(options, :shared, false)
     if shared
-        for depot in Base.DEPOT_PATH
-            envdir = joinpath(depot, "environments")
-            isdir(envdir) || continue
-            append!(possible, readdir(envdir))
-        end
-        return possible
+        return _shared_envs()
+    elseif !isempty(partial) && first(partial) == '@'
+        return "@" .* _shared_envs()
     else
         return complete_local_dir(partial, i1, i2)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -266,6 +266,34 @@ end
 end
 
 #
+# # Activate
+#
+@testset "activate: repl" begin
+    isolate(loaded_depot=true) do
+        Pkg.REPLMode.TEST_MODE[] = true
+        # - activate shared env
+        api, args, opts = first(Pkg.pkg"activate --shared Foo")
+        @test api == Pkg.activate
+        @test args == "Foo"
+        @test opts == Dict(:shared => true)
+        # - activate shared env using special syntax
+        api, args, opts = first(Pkg.pkg"activate @Foo")
+        @test api == Pkg.activate
+        @test args == "Foo"
+        @test opts == Dict(:shared => true)
+        # - no arg activate
+        api, opts = first(Pkg.pkg"activate")
+        @test api == Pkg.activate
+        @test isempty(opts)
+        # - regular activate
+        api, args, opts = first(Pkg.pkg"activate FooBar")
+        @test api == Pkg.activate
+        @test args == "FooBar"
+        @test isempty(opts)
+    end
+end
+
+#
 # # Add
 #
 


### PR DESCRIPTION
Introduces a new syntax for shared/named environments. Includes autocompletion support and the nicer printing Stefan mentioned in #930.

Example:
```
(Pkg) pkg> activate @
@Example   @Profiling  @SomeEnv    @v1.0       @v1.1       @v1.2       @v1.3
(Pkg) pkg> activate @Profiling
Activating environment at `~/.julia/environments/Profiling/Project.toml`

(@Profiling) pkg> 
```

Close #930