### PR TITLE
Use relative import everywhere (to use latest Pkg.jl without rebuilding julia)

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -11,7 +11,7 @@ import LibGit2
 import ..depots, ..depots1, ..logdir, ..devdir
 import ..Operations, ..Display, ..GitTools, ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION
 using ..Types, ..TOML
-using Pkg.Types: VersionTypes
+using ..Types: VersionTypes
 using ..BinaryPlatforms
 using ..Artifacts: artifact_paths
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -12,7 +12,7 @@ using REPL.TerminalMenus
 
 using ..TOML
 import ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION, ..DEFAULT_IO
-import Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath
+import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath
 import ..BinaryPlatforms: Platform
 
 import Base: SHA1


### PR DESCRIPTION
I'm experimenting if I can use the latest Pkg.jl without rebuilding `julia`.  The idea is to have a "shim" package like this:

```julia
module LatestPkg

include("PATH/TO/Pkg/src/Pkg.jl")
using .Pkg

end
```

For full code, see: https://github.com/tkf/LatestPkg.jl

It turned out this works once I fixed a few non-relative imports in Pkg.jl.  I'm not sure how much usable it is yet.  But I guess it still makes sense, even just for consistency reason?
