### PR TITLE
Deprecate the `Pkg.generate` function

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -2,6 +2,7 @@
 
 generate(path::String; kwargs...) = generate(Context(), path; kwargs...)
 function generate(ctx::Context, path::String; kwargs...)
+    Base.depwarn("Pkg.generate is deprecated. Please use PkgTemplates.jl instead.", Core.Typeof(generate).name.mt.name)
     Context!(ctx; kwargs...)
     dir, pkg = dirname(path), basename(path)
     Base.isidentifier(pkg) || pkgerror("$(repr(pkg)) is not a valid package name")


### PR DESCRIPTION
Now that https://github.com/invenia/PkgTemplates.jl/pull/61 has been merged, PkgTemplates.jl no longer uses `Pkg.generate`.

Therefore, I think that we should officially deprecate `Pkg.generate` and direct users to PkgTemplates.jl. This will allow us to remove `Pkg.generate` in Julia 2.0.

This pull request adds the deprecation warning to `Pkg.generate`.