### PR TITLE
Pkg.generate should set `1.0.0` as the initial version number for new packages

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -50,7 +50,7 @@ function project(ctx::Context, pkg::String, dir::String)
         toml = Dict("authors" => authors,
                     "name" => pkg,
                     "uuid" => string(uuid),
-                    "version" => "0.1.0",
+                    "version" => "1.0.0",
                     )
         TOML.print(io, toml, sorted=true, by=key -> (Types.project_key_order(key), key))
     end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -182,8 +182,8 @@ temp_pkg_dir() do project_path; cd(project_path) do
                     mkdir("tests")
                     cd("tests")
                     pkg"develop ../SubModule2"
-                    @test Pkg.dependencies()[uuid1].version == v"0.1.0"
-                    @test Pkg.dependencies()[uuid2].version == v"0.1.0"
+                    @test Pkg.dependencies()[uuid1].version == v"1.0.0"
+                    @test Pkg.dependencies()[uuid2].version == v"1.0.0"
                     # make sure paths to SubModule1 and SubModule2 are relative
                     manifest = Pkg.Types.Context().env.manifest
                     @test manifest[uuid1].path == "SubModule1"


### PR DESCRIPTION
I think that we should deprecate `Pkg.generate` (https://github.com/JuliaLang/Pkg.jl/pull/1496).

However, even if we do decide to deprecate `Pkg.generate`, we cannot remove it until Julia 2.0.

In the meantime, I think that `Pkg.generate` should set `1.0.0` as the initial version number for new packages.

## Rationale

There has been a great deal of confusion among Julia users regarding the behavior of semver in pre-`1.0` versions.

In particular, there is a strong habit to bump the minor version number (e.g. `0.2.0` to `0.3.0`) for non-breaking features. However, in Julia's implementation of semver, a nonbreaking feature addition in pre-`1.0` versions should only bump the patch version number (e.g. `0.2.0` to `0.2.1`).

These issues do not arise once we hit `1.0`. When the major version number is `>= 1`, we have the full benefit of using all three semver version components to their maximum potential.

I think that setting the default initial version number in `Pkg.generate` to `1.0.0` is an easy way to encourage users to feel comfortable starting their package versioning at `1.0.0`.