### PR TITLE
[WIP] Allow `project` to dispatch on modules

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -25,6 +25,20 @@ end
 dependencies(fn::Function, uuid::UUID) = fn(dependencies()[uuid])
 
 project() = project(Context())
+function project(path::String)
+    projfile = projectfile_path(path; strict=true)
+    if projfile === nothing
+        pkgerror("no project file found at path `$path`")
+    end
+    return project(Context(env=EnvCache(projfile)))
+end
+function project(_module::Module)
+    path = pathof(Base.moduleroot(_module))
+    if path === nothing
+        pkgerror("module `$(nameof(_module))` does not belong to a package")
+    end
+    return project(dirname(dirname(path)))
+end
 function project(ctx::Context)::ProjectInfo
     return ProjectInfo(
         name         = ctx.env.pkg === nothing ? nothing : ctx.env.pkg.name,


### PR DESCRIPTION
This allows you to e.g. `Pkg.project(@__MODULE__).version` to get the version of the current package.
