### PR TITLE
Allow packages to easily retrieve their version

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -8,7 +8,7 @@ import Random
 using Dates
 import LibGit2
 
-import ..depots, ..depots1, ..logdir, ..devdir
+import ..depots, ..depots1, ..logdir, ..devdir, ..pkgdir
 import ..Operations, ..Display, ..GitTools, ..Pkg, ..UPDATED_REGISTRY_THIS_SESSION
 using ..Types, ..TOML
 using ..Types: VersionTypes
@@ -985,7 +985,7 @@ Get the `VersionNumber` of the package which expands this macro. If executed out
 package `nothing` will be returned.
 """
 macro __VERSION__()
-    pkg_dir = Base.pkgdir(__module__)
+    pkg_dir = pkgdir(__module__)
 
     if pkg_dir !== nothing
         project_data = TOML.parsefile(Types.projectfile_path(pkg_dir))

--- a/src/API.jl
+++ b/src/API.jl
@@ -985,17 +985,14 @@ Get the `VersionNumber` of the package which expands this macro. If executed out
 package `nothing` will be returned.
 """
 macro __VERSION__()
-    ctx = Types.Context()
-    pkg_id = Base.PkgId(__module__)
-    pkg_id.uuid === nothing && return nothing
+    pkg_dir = Base.pkgdir(__module__)
 
-    pkg_info = if ctx.env.project.name == pkg_id.name
-        ctx.env.project
+    if pkg_dir !== nothing
+        project_data = TOML.parsefile(joinpath(pkg_dir, "Project.toml"))
+        return VersionNumber(project_data["version"])
     else
-        Pkg.Types.manifest_info(ctx, pkg_id.uuid)
+        return nothing
     end
-
-    return pkg_info.version
 end
 
 end # module

--- a/src/API.jl
+++ b/src/API.jl
@@ -988,7 +988,7 @@ macro __VERSION__()
     pkg_dir = Base.pkgdir(__module__)
 
     if pkg_dir !== nothing
-        project_data = TOML.parsefile(joinpath(pkg_dir, "Project.toml"))
+        project_data = TOML.parsefile(Types.projectfile_path(pkg_dir))
         return VersionNumber(project_data["version"])
     else
         return nothing

--- a/src/API.jl
+++ b/src/API.jl
@@ -977,4 +977,25 @@ Package(name::AbstractString) = PackageSpec(name)
 Package(name::AbstractString, uuid::UUID) = PackageSpec(name, uuid)
 Package(name::AbstractString, uuid::UUID, version::VersionTypes) = PackageSpec(name, uuid, version)
 
+
+"""
+    @__VERSION__ -> Union{VersionNumber, Nothing}
+
+Get the `VersionNumber` of the package which expands this macro. If executed outside of a
+package `nothing` will be returned.
+"""
+macro __VERSION__()
+    ctx = Types.Context()
+    pkg_id = Base.PkgId(__module__)
+    pkg_id.uuid === nothing && return nothing
+
+    pkg_info = if ctx.env.project.name == pkg_id.name
+        ctx.env.project
+    else
+        Pkg.Types.manifest_info(ctx, pkg_id.uuid)
+    end
+
+    return pkg_info.version
+end
+
 end # module

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -5,7 +5,7 @@ module Pkg
 import Random
 import REPL
 
-export @pkg_str
+export @pkg_str, @__VERSION__
 export PackageSpec
 export PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT
 export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
@@ -41,6 +41,7 @@ include("API.jl")
 include("Registry.jl")
 include("REPLMode/REPLMode.jl")
 
+import .API: @__VERSION__
 import .REPLMode: @pkg_str
 import .Types: UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH, UPLEVEL_FIXED
 import .Types: PKGMODE_MANIFEST, PKGMODE_PROJECT

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,3 +34,12 @@ casesensitive_isdir(dir::String) =
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value
 end
+
+if VERSION < v"1.4.0-DEV.397"  # Defined in Base as of #33128
+    function pkgdir(m::Module)
+        rootmodule = Base.moduleroot(m)
+        path = pathof(rootmodule)
+        path === nothing && return nothing
+        return dirname(dirname(path))
+    end
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -86,7 +86,6 @@ end
 @testset "@__VERSION__" begin
     @test @__VERSION__() === nothing
     @test Pkg.eval(:(@__VERSION__())) == Pkg.Types.read_project("../Project.toml").version
-    # TODO: Add test for package that depends on Pkg
 end
 
 end # module APITests

--- a/test/api.jl
+++ b/test/api.jl
@@ -83,4 +83,10 @@ end
     end
 end
 
+@testset "@__VERSION__" begin
+    @test @__VERSION__() === nothing
+    @test Pkg.eval(:(@__VERSION__())) == Pkg.Types.read_project("../Project.toml").version
+    # TODO: Add test for package that depends on Pkg
+end
+
 end # module APITests


### PR DESCRIPTION
Allows for packages to codify their own deprecations for future revisions. I example of deprecating the return type of a function:
```julia
if @__VERSION__() < v"1.4"
    """
        f() -> String
    """
    function f(; classic_return::Bool=true)
        if classic_return
            Base.depwarn("`f` will return `nothing` in version 1.4")
            return ""
        else
            return nothing
        end
    end
elseif v"1.4" <= @__VERSION__ < v"1.5"
    """
        f() -> Nothing
    """
    function f(; classic_return=nothing)
        if classic_return !== nothing
            Base.depwarn("`f` will no drop support for the `class_return` keyword in version 1.5")
        end
        return nothing
    end
else
    """
        f() -> Nothing
    """
    f() = nothing
end
```