### PR TITLE
Improve "No changes" message for rm() & behavior during build

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -903,7 +903,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
         uuid ∉ drop
     end
     if length(ctx.env.project.deps) == n
-        println(ctx.io, "No changes to package dependencies")
+        println(ctx.io, "No dependencies have been removed")
         return
     end
     # only declare `compat` for direct dependencies

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -903,7 +903,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
         uuid ∉ drop
     end
     if length(ctx.env.project.deps) == n
-        println(ctx.io, "No changes")
+        println(ctx.io, "No changes to package dependencies")
         return
     end
     # only declare `compat` for direct dependencies

--- a/src/backwards_compatible_isolation.jl
+++ b/src/backwards_compatible_isolation.jl
@@ -513,7 +513,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         # a trivial modification of the project file only.
         # See issue https://github.com/JuliaLang/Pkg.jl/issues/1144
         not_loadable = setdiff(should_be_in_manifest, should_be_in_project)
-        Pkg.API.rm(localctx, [PackageSpec(uuid = uuid) for uuid in not_loadable])
+        length(not_loadable) > 0 && Pkg.API.rm(localctx, [PackageSpec(uuid = uuid) for uuid in not_loadable])
 
         write_env(localctx.env)
         will_resolve && build_versions(localctx, new)


### PR DESCRIPTION
The message `Info: No changes` is confusing in some cases. For instance,  when you know that `build.jl` has actually changed the package build state. This is designed to make it clearer that it's referring to dependencies