### PR TITLE
fix GitTools.tree_hash executableness criterion

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -202,7 +202,7 @@ function gitmode(path::AbstractString)
     elseif isdir(path)
         return mode_dir
     # We cannot use `Sys.isexecutable()` because on Windows, that simply calls `isfile()`
-    elseif filemode(path) & 0o010 == 0o010
+    elseif !iszero(filemode(path) & 0o100)
         return mode_executable
     else
         return mode_normal

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -256,7 +256,11 @@ end
 Calculate the git tree hash of a given path.  Note that attempting to take the
 tree hash of an empty directory will throw an error.
 """
-function tree_hash(root::AbstractString, HashType = SHA.SHA1_CTX)
+function tree_hash(
+    root::AbstractString,
+    names::Vector{String} = readdir(root);
+    HashType = SHA.SHA1_CTX,
+)
     entries = Tuple{String, Vector{UInt8}, GitMode}[]
     for f in readdir(root)
         # Skip `.git` directories
@@ -267,27 +271,22 @@ function tree_hash(root::AbstractString, HashType = SHA.SHA1_CTX)
         filepath = abspath(root, f)
         mode = gitmode(filepath)
         if mode == mode_dir
-            try
-                hash = tree_hash(filepath)
-            catch e
-                if isa(e, ArgumentError)
-                    continue
-                end
-                rethrow(e)
-            end
+            names = readdir(filepath)
+            isempty(names) && continue
+            hash = tree_hash(filepath, names)
         else
             hash = blob_hash(filepath)
         end
-        push!(entries, (f, hash, gitmode(filepath)))
+        push!(entries, (f, hash, mode))
     end
 
     # Sort entries by name (with trailing slashes for directories)
     sort!(entries, by = ((name, hash, mode),) -> mode == mode_dir ? name*"/" : name)
 
-    if isempty(entries)
-        ArgumentError("Invalid to calculate tree hash of empty directory")
+    content_size = 0
+    for (n, h, m) in entries
+        content_size += ndigits(UInt32(m); base=8) + 1 + sizeof(n) + 1 + 20
     end
-    content_size = sum(((n, h, m),) -> ndigits(UInt32(m); base=8) + 1 + sizeof(n) + 1 + 20, entries)
 
     # Return the hash of these entries
     ctx = HashType()
@@ -298,6 +297,5 @@ function tree_hash(root::AbstractString, HashType = SHA.SHA1_CTX)
     end
     return SHA.digest!(ctx)
 end
-
 
 end # module

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -90,7 +90,12 @@ end
 @testset "Artifact Creation" begin
     # We're going to ensure that our artifact creation does in fact give git-tree-sha1's.
     creators = [
-        # First we will test creating a single file
+        # First test the empty artifact
+        (path -> begin
+            # add no contents
+        end, "4b825dc642cb6eb9a060e54bf8d69288fbee4904"),
+
+        # Next test creating a single file
         (path -> begin
             open(joinpath(path, "foo"), "w") do io
                 print(io, "Hello, world!")
@@ -168,9 +173,6 @@ end
             @test verify_artifact(hash)
         end
     end
-
-    # Test that attempting to create an empty directory is an error:
-    @test_throws ArgumentError create_artifact(x -> nothing)
 end
 
 @testset "with_artifacts_directory()" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -1839,4 +1839,31 @@ end
     end
 end
 
+tree_hash(root::AbstractString) = bytes2hex(Pkg.GitTools.tree_hash(root))
+
+@testset "git tree hash computation" begin
+    mktempdir() do dir
+        # test "well known" empty tree hash
+        @test "4b825dc642cb6eb9a060e54bf8d69288fbee4904" == tree_hash(dir)
+        # create a text file
+        file = joinpath(dir, "hello.txt")
+        open(file, write=true) do io
+            println(io, "Hello, world.")
+        end
+        # reference hash generated with command-line git
+        @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
+        # test with various executable bits set
+        chmod(file, 0o645) # other x bit doesn't matter
+        @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
+        chmod(file, 0o654) # group x bit doesn't matter
+        @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
+        chmod(file, 0o744) # user x bit matters
+        if Sys.iswindows()
+            @test_broken "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
+        else
+            @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
+        end
+    end
+end
+
 end #module


### PR DESCRIPTION
Git only looks at the user's executable bit. This seems to be causing issues for users with strict umasks: https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/527.