### PR TITLE
Add precompile section for `@artifact_str`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [extras]

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -537,6 +537,12 @@ const precompile_script = """
     ] add Te\t\t$CTRL_C
     ] st
     $CTRL_C
+    # Create simple artifact, bind it, then use it:
+    foo_hash = Pkg.Artifacts.create_artifact(dir -> touch(joinpath(dir, "foo")))
+    Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo", foo_hash)
+    # Because @artifact_str doesn't work at REPL-level, we JIT out a file that we can include()
+    open(io -> println(io, "Pkg.Artifacts.artifact\\\"foo\\\""), "load_artifact.jl", "w")
+    foo_path = include("load_artifact.jl")
     rm(tmp; recursive=true)"""
 
 end # module

--- a/test/FakeTerminals.jl
+++ b/test/FakeTerminals.jl
@@ -1,0 +1,19 @@
+module FakeTerminals
+
+import REPL
+
+mutable struct FakeTerminal <: REPL.Terminals.UnixTerminal
+    in_stream::Base.IO
+    out_stream::Base.IO
+    err_stream::Base.IO
+    hascolor::Bool
+    raw::Bool
+    FakeTerminal(stdin,stdout,stderr,hascolor=true) =
+        new(stdin,stdout,stderr,hascolor,false)
+end
+
+REPL.Terminals.hascolor(t::FakeTerminal) = t.hascolor
+REPL.Terminals.raw!(t::FakeTerminal, raw::Bool) = t.raw = raw
+REPL.Terminals.size(t::FakeTerminal) = (24, 80)
+
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -3,7 +3,7 @@
 module APITests
 import ..Pkg # ensure we are using the correct Pkg
 
-using Pkg, Test
+using Pkg, Test, REPL
 import Pkg.Types.PkgError, Pkg.Resolve.ResolverError
 using UUIDs
 
@@ -80,6 +80,62 @@ end
         touch(joinpath(tmp, "TestArguments", "test", "Project.toml"))
         Pkg.test("TestArguments"; test_args=`a b`, julia_args=`--quiet --check-bounds=no`)
         Pkg.test("TestArguments"; test_args=["a", "b"], julia_args=["--quiet", "--check-bounds=no"])
+    end
+end
+
+
+include("FakeTerminals.jl")
+import .FakeTerminals.FakeTerminal
+
+@testset "Pkg.precompile_script" begin
+    function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_exit=false))
+        # Use pipes so we can easily do blocking reads
+        # In the future if we want we can add a test that the right object
+        # gets displayed by intercepting the display
+        input = Pipe()
+        output = Pipe()
+        err = Pipe()
+        Base.link_pipe!(input, reader_supports_async=true, writer_supports_async=true)
+        Base.link_pipe!(output, reader_supports_async=true, writer_supports_async=true)
+        Base.link_pipe!(err, reader_supports_async=true, writer_supports_async=true)
+
+        repl = REPL.LineEditREPL(FakeTerminal(input.out, output.in, err.in), true)
+        repl.options = options
+
+        f(input.in, output.out, repl)
+        t = @async begin
+            close(input.in)
+            close(output.in)
+            close(err.in)
+        end
+        @test read(err.out, String) == ""
+        #display(read(output.out, String))
+        Base.wait(t)
+        nothing
+    end
+
+    fake_repl() do stdin_write, stdout_read, repl
+        repltask = @async REPL.run_repl(repl)
+
+        for line in split(Pkg.precompile_script, "\n"; keepempty=false)
+            sleep(0.1)
+            # Consume any extra output
+            if bytesavailable(stdout_read) > 0
+                copyback = readavailable(stdout_read)
+                #@info(copyback)
+            end
+
+            # Write the line
+            write(stdin_write, line, "\n")
+
+            # Read until some kind of prompt
+            readuntil(stdout_read, "\n")
+            readuntil(stdout_read, ">")
+            #@info(line)
+        end
+
+        write(stdin_write, "\x04")
+        wait(repltask)
     end
 end
 


### PR DESCRIPTION
This adds a precompile section so that we can avoid precompiling `@artifact_str` so much.
We generate a simple artifact, bind it out to an `Artifacts.toml` file, then read it in
again with an `include()`. :P