### PR TITLE
Fix tree hashing with nested empty directories

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -126,8 +126,11 @@ end
             end
 
             # Empty directories do nothing to effect the hash, so we create one with a
-            # random name to prove that it does not get hashed into the rest.
-            mkpath(joinpath(path, Random.randstring(8)))
+            # random name to prove that it does not get hashed into the rest.  Also, it
+            # turns out that life is cxomplex enough that we need to test the nested
+            # empty directories case as well.
+            rand_dir = joinpath(path, Random.randstring(8), "inner")
+            mkpath(rand_dir)
 
             # Symlinks are not followed, even if they point to directories
             symlink("foo3", joinpath(path, "foo3_link"))
@@ -148,7 +151,7 @@ end
                 cd(path) do
                     read(`git init .`)
                     read(`git add . `)
-                    read(`git commit -m "foo"`)
+                    read(`git commit --allow-empty -m "foo"`)
                     hash = chomp(String(read(`git log -1 --pretty='%T' HEAD`)))
                     println(hash)
                 end


### PR DESCRIPTION
When testing for directories to exclude from hashing, we must exclude
not only empty directories, but also directories that themselves contain
nothing but empty directories; in essence, we suppress adding
directories that have no files contained within their entire subtree.

While fixing this, it seemed prudent to eliminate the `names` argument
to `tree_hash()`, especially as it was not actually used to iterate
over.

This will fix the error reported in https://github.com/JuliaLang/julia/pull/33979#issuecomment-561041847