### PR TITLE
Disable needless specialization in Artifacts code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [extras]

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -407,16 +407,7 @@ function unpack_platform(entry::Dict, name::String, artifacts_toml::String)
     nover(x::Nothing) = nothing
     nover(x) = VersionNumber(x)
 
-    # First, extract OS; we need to build a mapping here
-    os_map = Dict(
-        "windows" => Windows,
-        "macos" => MacOS,
-        "freebsd" => FreeBSD,
-        "linux" => Linux,
-    )
-    P = get(os_map, lowercase(entry["os"]), UnknownPlatform)
-
-    # Next, architecture, libc, libgfortran version and cxxabi (if given)
+    # Extract architecture, libc, libgfortran version and cxxabi (if given)
     arch = nosym(get(entry, "arch", nothing))
     libc = nosym(get(entry, "libc", nothing))
     libgfortran_version = nover(get(entry, "libgfortran_version", nothing))
@@ -424,17 +415,27 @@ function unpack_platform(entry::Dict, name::String, artifacts_toml::String)
     cxxstring_abi = nosym(get(entry, "cxxstring_abi", nothing))
 
     # Construct the actual Platform object
-    return P(arch;
-        libc=libc,
-        compiler_abi=CompilerABI(
-            libgfortran_version=libgfortran_version,
-            libstdcxx_version=libstdcxx_version,
-            cxxstring_abi=cxxstring_abi
-        ),
+    os = lowercase(entry["os"])
+    compiler_abi=CompilerABI(
+        libgfortran_version=libgfortran_version,
+        libstdcxx_version=libstdcxx_version,
+        cxxstring_abi=cxxstring_abi
     )
+    if os == "linux"
+        return Linux(arch; libc=libc, compiler_abi=compiler_abi)
+    elseif os == "windows"
+        return Windows(arch; libc=libc, compiler_abi=compiler_abi)
+    elseif os == "macos"
+        return MacOS(arch; libc=libc, compiler_abi=compiler_abi)
+    elseif os == "freebsd"
+        return FreeBSD(arch; libc=libc, compiler_abi=compiler_abi)
+    else
+        return UnknownPlatform()
+    end
 end
 
 function pack_platform!(meta::Dict, p::Platform)
+    @nospecialize meta p
     os_map = Dict(
         Windows => "windows",
         MacOS => "macos",
@@ -529,6 +530,7 @@ most appropriate mapping.  If none is found, return `nothing`.
 function artifact_meta(name::String, artifacts_toml::String;
                        platform::Platform = platform_key_abi(),
                        pkg_uuid::Union{Base.UUID,Nothing}=nothing)
+    @nospecialize platform
     if !isfile(artifacts_toml)
         return nothing
     end
@@ -540,6 +542,7 @@ end
 
 function artifact_meta(name::String, artifact_dict::Dict, artifacts_toml::String;
                        platform::Platform = platform_key_abi())
+    @nospecialize platform
     if !haskey(artifact_dict, name)
         return nothing
     end
@@ -547,7 +550,7 @@ function artifact_meta(name::String, artifact_dict::Dict, artifacts_toml::String
 
     # If it's an array, find the entry that best matches our current platform
     if isa(meta, Array)
-        dl_dict = Dict(unpack_platform(x, name, artifacts_toml) => x for x in meta)
+        dl_dict = Dict{Platform,Dict{String,Any}}(unpack_platform(x, name, artifacts_toml) => x for x in meta)
         meta = select_platform(dl_dict, platform)
     # If it's NOT a dict, complain
     elseif !isa(meta, Dict)
@@ -577,6 +580,7 @@ collapsed artifact.  Returns `nothing` if no mapping can be found.
 function artifact_hash(name::String, artifacts_toml::String;
                        platform::Platform = platform_key_abi(),
                        pkg_uuid::Union{Base.UUID,Nothing}=nothing)
+    @nospecialize platform
     meta = artifact_meta(name, artifacts_toml; platform=platform)
     if meta === nothing
         return nothing
@@ -841,6 +845,7 @@ function ensure_artifact_installed(name::String, artifacts_toml::String;
                                    platform::Platform = platform_key_abi(),
                                    pkg_uuid::Union{Base.UUID,Nothing}=nothing,
                                    verbose::Bool = false)
+    @nospecialize platform
     meta = artifact_meta(name, artifacts_toml; pkg_uuid=pkg_uuid, platform=platform)
     if meta === nothing
         error("Cannot locate artifact '$(name)' in '$(artifacts_toml)'")
@@ -852,6 +857,7 @@ end
 function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::String;
                                    platform::Platform = platform_key_abi(),
                                    verbose::Bool = false)
+    @nospecialize platform
     hash = SHA1(meta["git-tree-sha1"])
 
     if !artifact_exists(hash)
@@ -905,6 +911,7 @@ function ensure_all_artifacts_installed(artifacts_toml::String;
                                         pkg_uuid::Union{Nothing,Base.UUID} = nothing,
                                         include_lazy::Bool = false,
                                         verbose::Bool = false)
+    @nospecialize platform
     if !isfile(artifacts_toml)
         return
     end
@@ -942,6 +949,7 @@ function extract_all_hashes(artifacts_toml::String;
                             platform::Platform = platform_key_abi(),
                             pkg_uuid::Union{Nothing,Base.UUID} = nothing,
                             include_lazy::Bool = false)
+    @nospecialize platform
     hashes = Base.SHA1[]
     if !isfile(artifacts_toml)
         return hashes

--- a/src/BinaryPlatforms.jl
+++ b/src/BinaryPlatforms.jl
@@ -827,8 +827,14 @@ function platforms_match(a::Platform, b::Platform)
     return rigid_constraints(a, b) && flexible_constraints(a, b)
 end
 
-platforms_match(a::AbstractString, b::Platform) = platforms_match(platform_key_abi(a), b)
-platforms_match(a::Platform, b::AbstractString) = platforms_match(a, platform_key_abi(b))
+function platforms_match(a::AbstractString, b::Platform)
+    @nospecialize b
+    return platforms_match(platform_key_abi(a), b)
+end
+function platforms_match(a::Platform, b::AbstractString)
+    @nospecialize a
+    return platforms_match(a, platform_key_abi(b))
+end
 platforms_match(a::AbstractString, b::AbstractString) = platforms_match(platform_key_abi(a), platform_key_abi(b))
 
 """
@@ -843,6 +849,7 @@ match exactly, however attributes such as compiler ABI can have wildcards
 within them such as `nothing` which matches any version of GCC.
 """
 function select_platform(download_info::Dict, platform::Platform = platform_key_abi())
+    @nospecialize platform
     ps = collect(filter(p -> platforms_match(p, platform), keys(download_info)))
 
     if isempty(ps)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -540,8 +540,13 @@ const precompile_script = """
     # Create simple artifact, bind it, then use it:
     foo_hash = Pkg.Artifacts.create_artifact(dir -> touch(joinpath(dir, "foo")))
     Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo", foo_hash)
+    # Also create multiple platform-specific ones because that's a codepath we need precompiled
+    Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo_plat", foo_hash; platform=platform_key_abi())
+    Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo_plat", foo_hash; platform=Linux(:x86_64), force=true)
+    Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo_plat", foo_hash; platform=Windows(:x86_64), force=true)
+    Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo_plat", foo_hash; platform=MacOS(:x86_64), force=true)
     # Because @artifact_str doesn't work at REPL-level, we JIT out a file that we can include()
-    open(io -> println(io, "Pkg.Artifacts.artifact\\\"foo\\\""), "load_artifact.jl", "w")
+    open(io -> println(io, "Pkg.Artifacts.artifact\\\"foo\\\"; Pkg.Artifacts.artifact\\\"foo_plat\\\""), "load_artifact.jl", "w")
     foo_path = include("load_artifact.jl")
     rm(tmp; recursive=true)"""
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -537,6 +537,12 @@ const precompile_script = """
     ] add Te\t\t$CTRL_C
     ] st
     $CTRL_C
+    # Create simple artifact, bind it, then use it:
+    foo_hash = Pkg.Artifacts.create_artifact(dir -> touch(joinpath(dir, "foo")))
+    Pkg.Artifacts.bind_artifact!("./Artifacts.toml", "foo", foo_hash)
+    # Because @artifact_str doesn't work at REPL-level, we JIT out a file that we can include()
+    open(io -> println(io, "Pkg.Artifacts.artifact\\\"foo\\\""), "load_artifact.jl", "w")
+    foo_path = include("load_artifact.jl")
     rm(tmp; recursive=true)"""
 
 end # module

--- a/test/FakeTerminals.jl
+++ b/test/FakeTerminals.jl
@@ -1,0 +1,19 @@
+module FakeTerminals
+
+import REPL
+
+mutable struct FakeTerminal <: REPL.Terminals.UnixTerminal
+    in_stream::Base.IO
+    out_stream::Base.IO
+    err_stream::Base.IO
+    hascolor::Bool
+    raw::Bool
+    FakeTerminal(stdin,stdout,stderr,hascolor=true) =
+        new(stdin,stdout,stderr,hascolor,false)
+end
+
+REPL.Terminals.hascolor(t::FakeTerminal) = t.hascolor
+REPL.Terminals.raw!(t::FakeTerminal, raw::Bool) = t.raw = raw
+REPL.Terminals.size(t::FakeTerminal) = (24, 80)
+
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -3,7 +3,7 @@
 module APITests
 import ..Pkg # ensure we are using the correct Pkg
 
-using Pkg, Test
+using Pkg, Test, REPL
 import Pkg.Types.PkgError, Pkg.Resolve.ResolverError
 using UUIDs
 
@@ -80,6 +80,62 @@ end
         touch(joinpath(tmp, "TestArguments", "test", "Project.toml"))
         Pkg.test("TestArguments"; test_args=`a b`, julia_args=`--quiet --check-bounds=no`)
         Pkg.test("TestArguments"; test_args=["a", "b"], julia_args=["--quiet", "--check-bounds=no"])
+    end
+end
+
+
+include("FakeTerminals.jl")
+import .FakeTerminals.FakeTerminal
+
+@testset "Pkg.precompile_script" begin
+    function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_exit=false))
+        # Use pipes so we can easily do blocking reads
+        # In the future if we want we can add a test that the right object
+        # gets displayed by intercepting the display
+        input = Pipe()
+        output = Pipe()
+        err = Pipe()
+        Base.link_pipe!(input, reader_supports_async=true, writer_supports_async=true)
+        Base.link_pipe!(output, reader_supports_async=true, writer_supports_async=true)
+        Base.link_pipe!(err, reader_supports_async=true, writer_supports_async=true)
+
+        repl = REPL.LineEditREPL(FakeTerminal(input.out, output.in, err.in), true)
+        repl.options = options
+
+        f(input.in, output.out, repl)
+        t = @async begin
+            close(input.in)
+            close(output.in)
+            close(err.in)
+        end
+        @test read(err.out, String) == ""
+        #display(read(output.out, String))
+        Base.wait(t)
+        nothing
+    end
+
+    fake_repl() do stdin_write, stdout_read, repl
+        repltask = @async REPL.run_repl(repl)
+
+        for line in split(Pkg.precompile_script, "\n"; keepempty=false)
+            sleep(0.1)
+            # Consume any extra output
+            if bytesavailable(stdout_read) > 0
+                copyback = readavailable(stdout_read)
+                #@info(copyback)
+            end
+
+            # Write the line
+            write(stdin_write, line, "\n")
+
+            # Read until some kind of prompt
+            readuntil(stdout_read, "\n")
+            readuntil(stdout_read, ">")
+            #@info(line)
+        end
+
+        write(stdin_write, "\x04")
+        wait(repltask)
     end
 end
 


### PR DESCRIPTION
After spending some quality time with `--trace-compile=stderr` and `@snoopi`, I have found a fairly minimal set of changes that speeds up loading of [`TestGtkMegaJLL.jl`](https://github.com/giordano/TestGtkMegaJLL.jl) from `2.12s` to `0.69s` on my machine.  It's all essentially nonspecialization hacks.