### PR TITLE
Do not ever attempt to set owner when extracting tarballs

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -330,7 +330,7 @@ function probe_platform_engines!(;verbose::Bool = false)
             elseif endswith(tarball_path, ".bz2")
                 Jjz = "j"
             end
-            return `$tar_cmd -mx$(Jjz)f $(tarball_path) -C$(out_path) $(excludelist === nothing ? [] : "-X$(excludelist)")`
+            return `$tar_cmd --no-same-owner -mx$(Jjz)f $(tarball_path) -C$(out_path) $(excludelist === nothing ? [] : "-X$(excludelist)")`
         end
         package_tar = (in_path, tarball_path) -> begin
             Jjz = "z"


### PR DESCRIPTION
When extracting files as `root`, `tar` will attempt to set ownership, which doesn't make much sense when moving from one machine to another.  (Props to Stefan for calling this out in the `Tar.jl` readme at the exact same time as it was reported in an issue).

Should fix https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/555