### PR TITLE
treat compat errors as `ResolverError`s

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -324,8 +324,8 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
         compat = project_compatibility(ctx, pkg.name)
         v = intersect(pkg.version, compat)
         if isempty(v)
-            pkgerror(string("empty intersection between $(pkg.name)@$(pkg.version) and project ",
-                            "compatibility $(compat)"))
+            throw(Resolve.ResolverError(
+                "empty intersection between $(pkg.name)@$(pkg.version) and project compatibility $(compat)"))
         end
         # Work around not clobbering 0.x.y+ for checked out old type of packages
         if !(pkg.version isa VersionNumber)

--- a/test/new.jl
+++ b/test/new.jl
@@ -567,6 +567,14 @@ end
             @test !haskey(pkg.dependencies, "Example")
         end
     end
+    # add should resolve the correct versions even when the manifest is out of sync with the project compat
+    isolate(loaded_depot=true) do; mktempdir() do tempdir
+        Pkg.activate(copy_test_package(tempdir, "CompatOutOfSync"))
+        Pkg.add("Libdl")
+        Pkg.dependencies(exuuid) do pkg
+            @test pkg.version == v"0.3.0"
+        end
+    end end
     # Preserve syntax
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.

--- a/test/test_packages/CompatOutOfSync/Manifest.toml
+++ b/test/test_packages/CompatOutOfSync/Manifest.toml
@@ -1,0 +1,4 @@
+[[Example]]
+git-tree-sha1 = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.3"

--- a/test/test_packages/CompatOutOfSync/Project.toml
+++ b/test/test_packages/CompatOutOfSync/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "= 0.3.0"


### PR DESCRIPTION
`tiered_resolve` treats `ResolverError`s as a signal to retry with different version constraints. I think this is ok because no other code outside of `Resolve` cares about the distinction between `PkgError` v `ResolveError`.

An alternative fix is to check for the error message in `tiered_resolve` but I think that is uglier at this point.