### PR TITLE
use more consistent naming for PackageInfo fields

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1491,9 +1491,10 @@ function package_info(ctx::Context, pkg::PackageSpec, entry::PackageEntry)::Pack
         name                 = pkg.name,
         version              = pkg.version != VersionSpec() ? pkg.version : nothing,
         tree_hash            = pkg.tree_hash === nothing ? nothing : string(pkg.tree_hash), # TODO or should it just be a SHA?
-        ispinned             = pkg.pinned,
+        is_pinned            = pkg.pinned,
+        is_tracking_path     = pkg.path !== nothing,
+        is_tracking_repo     = pkg.repo.rev !== nothing || pkg.repo.source !== nothing,
         is_tracking_registry = is_tracking_registry(pkg),
-        isdeveloped          = pkg.path !== nothing,
         git_revision         = pkg.repo.rev,
         git_source           = git_source,
         source               = project_rel_path(ctx, source_path(pkg)),

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -303,14 +303,14 @@ The result is a `Dict` that maps a package UUID to a `PackageInfo` struct repres
 
 # `PackageInfo` fields
 
-| Field        | Description                                                |
-|:-------------|:-----------------------------------------------------------|
-| name         | The name of the package                                    |
-| version      | The version of the package (this is `Nothing` for stdlibs) |
-| isdeveloped  | Whether a package is directly tracking a directory         |
-| ispinned     | Whether a package is pinned                                |
-| source       | The directory containing the source code for that package  |
-| dependencies | The dependencies of that package as a vector of UUIDs      |
+| Field             | Description                                                |
+|:------------------|:-----------------------------------------------------------|
+| name              | The name of the package                                    |
+| version           | The version of the package (this is `Nothing` for stdlibs) |
+| is_tracking_path  | Whether a package is directly tracking a directory         |
+| is_pinned         | Whether a package is pinned                                |
+| source            | The directory containing the source code for that package  |
+| dependencies      | The dependencies of that package as a vector of UUIDs      |
 """
 const dependencies = API.dependencies
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1299,8 +1299,9 @@ Base.@kwdef struct PackageInfo
     name::String
     version::Union{Nothing,VersionNumber}
     tree_hash::Union{Nothing,String}
-    ispinned::Bool
-    isdeveloped::Bool
+    is_pinned::Bool
+    is_tracking_path::Bool
+    is_tracking_repo::Bool
     is_tracking_registry::Bool
     git_revision::Union{Nothing,String}
     git_source::Union{Nothing,String}
@@ -1310,7 +1311,8 @@ end
 
 function Base.:(==)(a::PackageInfo, b::PackageInfo)
     return a.name == b.name && a.version == b.version && a.tree_hash == b.tree_hash &&
-        a.ispinned == b.ispinned && a.isdeveloped == b.isdeveloped &&
+        a.is_pinned == b.is_pinned && a.is_tracking_path == b.is_tracking_path &&
+        a.is_tracking_repo == a.is_tracking_repo &&
         a.is_tracking_registry == b.is_tracking_registry &&
         a.git_revision == b.git_revision && a.git_source == b.git_source &&
         a.source == b.source && a.dependencies == b.dependencies

--- a/test/new.jl
+++ b/test/new.jl
@@ -171,8 +171,8 @@ inside_test_sandbox(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
         Pkg.activate(path)
         inside_test_sandbox() do
             deps = Pkg.dependencies()
-            @test deps[unregistered_uuid].isdeveloped
-            @test deps[exuuid].isdeveloped
+            @test deps[unregistered_uuid].is_tracking_path
+            @test deps[exuuid].is_tracking_path
         end
     end end
     # the active dep graph is transfered to test sandbox, even when tracking unregistered repos
@@ -191,7 +191,7 @@ inside_test_sandbox(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
         path = copy_test_package(tempdir, "TestDepTrackingPath")
         Pkg.activate(path)
         inside_test_sandbox() do
-            @test Pkg.dependencies()[unregistered_uuid].isdeveloped
+            @test Pkg.dependencies()[unregistered_uuid].is_tracking_path
         end
     end end
     # a test dependency can track a repo
@@ -230,7 +230,7 @@ end
             @test haskey(Pkg.project().dependencies, "Test")
             @test haskey(Pkg.project().dependencies, "BasicTestTarget")
             Pkg.dependencies(basic_test_target) do pkg
-                @test pkg.isdeveloped == true
+                @test pkg.is_tracking_path == true
                 @test haskey(pkg.dependencies, "UUIDs")
                 @test !haskey(pkg.dependencies, "Markdown")
                 @test !haskey(pkg.dependencies, "Test")
@@ -502,14 +502,14 @@ end
         Pkg.dependencies(exuuid) do ex
             @test ex.version == v"0.3.0"
             @test ex.is_tracking_registry
-            @test ex.ispinned
+            @test ex.is_pinned
         end
         Pkg.add(Pkg.PackageSpec(;name="Example", version="0.5.0"))
         # We check that the package state is left unchanged.
         Pkg.dependencies(exuuid) do ex
             @test ex.version == v"0.3.0"
             @test ex.is_tracking_registry
-            @test ex.ispinned
+            @test ex.is_pinned
         end
     end
     # Add by version should override add by repo.
@@ -549,13 +549,13 @@ end
         Pkg.add(Pkg.PackageSpec(;name="Example", version="0.3.0"))
         Pkg.pin(Pkg.PackageSpec(;name="Example"))
         Pkg.dependencies(exuuid) do ex
-            @test ex.ispinned
+            @test ex.is_pinned
             @test ex.is_tracking_registry
             @test ex.version == v"0.3.0"
         end
         Pkg.add(Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl"))
         Pkg.dependencies(exuuid) do ex
-            @test ex.ispinned
+            @test ex.is_pinned
             @test ex.is_tracking_registry
             @test ex.version == v"0.3.0"
         end
@@ -1036,7 +1036,7 @@ end
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"
             @test isdir(pkg.source)
-            @test pkg.isdeveloped
+            @test pkg.is_tracking_path
         end
     end end
     # ".." style path
@@ -1048,7 +1048,7 @@ end
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"
             @test isdir(pkg.source)
-            @test pkg.isdeveloped
+            @test pkg.is_tracking_path
         end
     end end
     # bare directory name
@@ -1060,7 +1060,7 @@ end
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"
             @test isdir(pkg.source)
-            @test pkg.isdeveloped
+            @test pkg.is_tracking_path
         end
     end end
 end
@@ -1355,13 +1355,13 @@ end
         Pkg.pin("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
-            @test pkg.ispinned
+            @test pkg.is_pinned
             @test pkg.version == v"0.3.0"
         end
         Pkg.update()
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
-            @test pkg.ispinned
+            @test pkg.is_pinned
             @test pkg.version == v"0.3.0"
         end
     end
@@ -1439,7 +1439,7 @@ end
         end
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
-            @test pkg.isdeveloped
+            @test pkg.is_tracking_path
         end
         Pkg.dependencies(json_uuid) do pkg
             @test pkg.name == "JSON"
@@ -1498,7 +1498,7 @@ end
         Pkg.pin("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
-            @test pkg.ispinned
+            @test pkg.is_pinned
         end
     end
     # packge tracking repo
@@ -1507,7 +1507,7 @@ end
         Pkg.pin("Unregistered")
         Pkg.dependencies(unregistered_uuid) do pkg
             @test !pkg.is_tracking_registry
-            @test pkg.ispinned
+            @test pkg.is_pinned
         end
     end
     # versioned pin
@@ -1516,7 +1516,7 @@ end
         Pkg.pin(Pkg.PackageSpec(; name="Example", version="0.5.1"))
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
-            @test pkg.ispinned
+            @test pkg.is_pinned
         end
     end
     # pin should check for a valid version number
@@ -1551,7 +1551,7 @@ end
         Pkg.free("Example")
         Pkg.dependencies(exuuid) do pkg
             @test pkg.name == "Example"
-            @test !pkg.ispinned
+            @test !pkg.is_pinned
         end
     end
     # free package tracking repo


### PR DESCRIPTION
I think this makes `Pkg.dependencies` a bit nicer to work with.

Also, is it possible for this to go into 1.4 or is it too late?