### PR TITLE
test: `Pkg.test` on dependencies with same name but different UUID

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -219,6 +219,16 @@ end
 
 # These tests cover the original "targets" API for specifying test dependencies
 @testset "test: 'targets' based testing" begin
+    # `Pkg.test` should work on dependency graphs with nodes sharing the same name but not the same UUID
+    isolate(loaded_depot=true) do; mktempdir() do tempdir
+        Pkg.activate(joinpath(@__DIR__, "test_packages", "SameNameDifferentUUID"))
+        inside_test_sandbox("Example") do
+            Pkg.dependencies(UUID("6876af07-990d-54b4-ab0e-23690620f79a")) do pkg
+                @test pkg.name == "Example"
+                @test realpath(pkg.source) == realpath(joinpath(@__DIR__, "test_packages", "SameNameDifferentUUID", "dev", "Example"))
+            end
+        end
+    end end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         basic_test_target = UUID("50adb811-5a1f-4be4-8146-2725c7f5d900")
         path = copy_test_package(tempdir, "BasicTestTarget")

--- a/test/test_packages/SameNameDifferentUUID/Manifest.toml
+++ b/test/test_packages/SameNameDifferentUUID/Manifest.toml
@@ -1,0 +1,16 @@
+[[Example]]
+path = "dev/Example"
+uuid = "6876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.4"
+[[Example]]
+git-tree-sha1 = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.3"
+
+[[Unregistered]]
+path = "dev/Unregistered"
+uuid = "dcb67f36-efa0-11e8-0cef-2fc465ed98ae"
+version = "0.2.0"
+
+    [Unregistered.deps]
+    Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/test/test_packages/SameNameDifferentUUID/Project.toml
+++ b/test/test_packages/SameNameDifferentUUID/Project.toml
@@ -1,0 +1,7 @@
+name = "SameNameDifferentUUID"
+uuid = "d1bc03f5-3e3c-4bdc-99c4-d3940cdeba40"
+version = "0.1.0"
+
+[deps]
+Example = "6876af07-990d-54b4-ab0e-23690620f79a"
+Unregistered = "dcb67f36-efa0-11e8-0cef-2fc465ed98ae"

--- a/test/test_packages/SameNameDifferentUUID/dev/Example/Project.toml
+++ b/test/test_packages/SameNameDifferentUUID/dev/Example/Project.toml
@@ -1,0 +1,9 @@
+name = "Example"
+uuid = "6876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.4"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/SameNameDifferentUUID/dev/Example/src/Example.jl
+++ b/test/test_packages/SameNameDifferentUUID/dev/Example/src/Example.jl
@@ -1,0 +1,4 @@
+module Example
+export domath
+domath(x) = x + 2
+end

--- a/test/test_packages/SameNameDifferentUUID/dev/Example/test/runtests.jl
+++ b/test/test_packages/SameNameDifferentUUID/dev/Example/test/runtests.jl
@@ -1,0 +1,2 @@
+using Test, Example
+@test domath(2) == 4

--- a/test/test_packages/SameNameDifferentUUID/dev/Unregistered/Project.toml
+++ b/test/test_packages/SameNameDifferentUUID/dev/Unregistered/Project.toml
@@ -1,0 +1,6 @@
+name = "Unregistered"
+uuid = "dcb67f36-efa0-11e8-0cef-2fc465ed98ae"
+version = "0.2.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/test/test_packages/SameNameDifferentUUID/dev/Unregistered/README.md
+++ b/test/test_packages/SameNameDifferentUUID/dev/Unregistered/README.md
@@ -1,0 +1,2 @@
+# Unregistered.jl
+Test repo

--- a/test/test_packages/SameNameDifferentUUID/dev/Unregistered/src/Unregistered.jl
+++ b/test/test_packages/SameNameDifferentUUID/dev/Unregistered/src/Unregistered.jl
@@ -1,0 +1,3 @@
+module Unregistered
+greet() = print("Hello World!")
+end # module

--- a/test/test_packages/SameNameDifferentUUID/src/SameNameDifferentUUID.jl
+++ b/test/test_packages/SameNameDifferentUUID/src/SameNameDifferentUUID.jl
@@ -1,0 +1,3 @@
+module SameNameDifferentUUID
+greet() = print("Hello World!")
+end # module


### PR DESCRIPTION
this should prevent a regressions for this case: https://discourse.julialang.org/t/cant-test-package-in-manifest-but-not-in-project/32663