### PR TITLE
BinaryPlatforms: Add `armv6l` architecture

### DIFF
--- a/src/BinaryPlatforms.jl
+++ b/src/BinaryPlatforms.jl
@@ -165,7 +165,7 @@ struct Linux <: Platform
                    libc::Union{Nothing,Symbol}=nothing,
                    call_abi::Union{Nothing,Symbol}=nothing,
                    compiler_abi::CompilerABI=CompilerABI())
-        if !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv7l])
+        if !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv6l, :armv7l])
             throw(ArgumentError("Unsupported architecture '$arch' for Linux"))
         end
 
@@ -178,8 +178,8 @@ struct Linux <: Platform
             throw(ArgumentError("Unsupported libc '$libc' for Linux"))
         end
 
-        # Auto-map the `call_abi` to be `eabihf` on armv7l
-        if call_abi === nothing && arch === :armv7l
+        # Auto-map the `call_abi` to be `eabihf` on armv6l/armv7l
+        if call_abi === nothing && arch in (:armv6l, :armv7l)
             call_abi = :eabihf
         end
 
@@ -187,13 +187,13 @@ struct Linux <: Platform
             throw(ArgumentError("Unsupported calling abi '$call_abi' for Linux"))
         end
 
-        # If we're constructing for armv7l, we MUST have the eabihf abi
-        if arch === :armv7l && call_abi !== :eabihf
-            throw(ArgumentError("armv7l Linux must use eabihf, not '$call_abi'"))
+        # If we're constructing for armv7l/armv6l, we MUST have the eabihf abi
+        if arch in (:armv6l, :armv7l) && call_abi !== :eabihf
+            throw(ArgumentError("armv6l/armv7l Linux must use eabihf, not '$call_abi'"))
         end
         # ...and vice-versa
-        if arch !== :armv7l && call_abi === :eabihf
-            throw(ArgumentError("eabihf Linux is only on armv7l, not '$arch'!"))
+        if !(arch in (:armv6l, :armv7l)) && call_abi === :eabihf
+            throw(ArgumentError("eabihf Linux is only supported on armv6l/armv7l, not '$arch'!"))
         end
 
         return new(arch, libc, call_abi, compiler_abi)
@@ -269,7 +269,7 @@ struct FreeBSD <: Platform
             arch = :x86_64
         elseif arch === :i386
             arch = :i686
-        elseif !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv7l])
+        elseif !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv6l, :armv7l])
             throw(ArgumentError("Unsupported architecture '$arch' for FreeBSD"))
         end
 
@@ -279,8 +279,8 @@ struct FreeBSD <: Platform
             throw(ArgumentError("Unsupported libc '$libc' for FreeBSD"))
         end
 
-        # Auto-map the `call_abi` to be `eabihf` on armv7l
-        if call_abi === nothing && arch === :armv7l
+        # Auto-map the `call_abi` to be `eabihf` on armv6l/armv7l
+        if call_abi === nothing && arch in (:armv6l, :armv7l)
             call_abi = :eabihf
         end
 
@@ -289,12 +289,12 @@ struct FreeBSD <: Platform
         end
 
         # If we're constructing for armv7l, we MUST have the eabihf abi
-        if arch === :armv7l && call_abi !== :eabihf
-            throw(ArgumentError("armv7l FreeBSD must use eabihf, not '$call_abi'"))
+        if arch in (:armv6l, :armv7l) && call_abi !== :eabihf
+            throw(ArgumentError("armv6l/armv7l FreeBSD must use eabihf, not '$call_abi'"))
         end
         # ...and vice-versa
-        if arch !== :armv7l && call_abi === :eabihf
-            throw(ArgumentError("eabihf FreeBSD is only on armv7l, not '$arch'!"))
+        if !(arch in (:armv6l, :armv7l)) && call_abi === :eabihf
+            throw(ArgumentError("eabihf FreeBSD is supported only on armv6l/armv7l, not '$arch'!"))
         end
 
         return new(arch, libc, call_abi, compiler_abi)
@@ -431,7 +431,7 @@ vendor_str(p::FreeBSD) = "-unknown-freebsd11.1"
 triplet(p::UnknownPlatform) = "unknown-unknown-unknown"
 
 # Helper functions for Linux and FreeBSD libc/abi mishmashes
-arch_str(p::Platform) = (arch(p) === :armv7l) ? "arm" : string(arch(p))
+arch_str(p::Platform) = string(arch(p))
 function libc_str(p::Platform)
     if libc(p) === nothing
         return ""
@@ -477,7 +477,8 @@ function platform_key_abi(machine::AbstractString)
         :x86_64 => "(x86_|amd)64",
         :i686 => "i\\d86",
         :aarch64 => "aarch64",
-        :armv7l => "arm(v7l)?",
+        :armv7l => "arm(v7l)?", # if we just see `arm-linux-gnueabihf`, we assume it's `armv7l`
+        :armv6l => "armv6l",
         :powerpc64le => "p(ower)?pc64le",
     )
     platform_mapping = Dict(

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -14,6 +14,7 @@ const platform = platform_key_abi()
         @test_throws ArgumentError Linux(:x86_64; libc=:crazy_libc)
         @test_throws ArgumentError Linux(:x86_64; libc=:glibc, call_abi=:crazy_abi)
         @test_throws ArgumentError Linux(:x86_64; libc=:glibc, call_abi=:eabihf)
+        @test_throws ArgumentError Linux(:arm)
         @test_throws ArgumentError Linux(:armv7l; libc=:glibc, call_abi=:kekeke)
         @test_throws ArgumentError MacOS(:i686)
         @test_throws ArgumentError MacOS(:x86_64; libc=:glibc)
@@ -75,14 +76,16 @@ const platform = platform_key_abi()
         @test wordsize(UnknownPlatform(:x86_64)) == 0
 
         @test call_abi(Linux(:x86_64)) == nothing
+        @test call_abi(Linux(:armv6l)) == :eabihf
         @test call_abi(Linux(:armv7l; call_abi=:eabihf)) == :eabihf
         @test call_abi(UnknownPlatform(;call_abi=:eabihf)) == nothing
 
         @test triplet(Windows(:i686)) == "i686-w64-mingw32"
         @test triplet(Linux(:x86_64; libc=:musl)) == "x86_64-linux-musl"
-        @test triplet(Linux(:armv7l; libc=:musl)) == "arm-linux-musleabihf"
+        @test triplet(Linux(:armv7l; libc=:musl)) == "armv7l-linux-musleabihf"
+        @test triplet(Linux(:armv6l; libc=:musl, call_abi=:eabihf)) == "armv6l-linux-musleabihf"
         @test triplet(Linux(:x86_64)) == "x86_64-linux-gnu"
-        @test triplet(Linux(:armv7l)) == "arm-linux-gnueabihf"
+        @test triplet(Linux(:armv6l)) == "armv6l-linux-gnueabihf"
         @test triplet(MacOS()) == "x86_64-apple-darwin14"
         @test triplet(FreeBSD(:x86_64)) == "x86_64-unknown-freebsd11.1"
         @test triplet(FreeBSD(:i686)) == "i686-unknown-freebsd11.1"
@@ -118,6 +121,8 @@ const platform = platform_key_abi()
         @test platform_key_abi("x86_64-apple-darwin17.0.0") == MacOS()
         @test platform_key_abi("armv7l-pc-linux-gnueabihf") == Linux(:armv7l)
         @test platform_key_abi("armv7l-linux-musleabihf") == Linux(:armv7l, libc=:musl)
+        @test platform_key_abi("armv6l-linux-gnueabihf") == Linux(:armv6l)
+        # Test that the short name "arm" goes to `armv7l`
         @test platform_key_abi("arm-linux-gnueabihf") == Linux(:armv7l)
         @test platform_key_abi("aarch64-unknown-linux-gnu") == Linux(:aarch64)
         @test platform_key_abi("powerpc64le-linux-gnu") == Linux(:powerpc64le)
@@ -210,7 +215,7 @@ const platform = platform_key_abi()
             libgfortran_version=v"5",
             cxxstring_abi=:cxx11,
         )
-        for arch in (:x86_64, :i686, :aarch64, :armv7l),
+        for arch in (:x86_64, :i686, :aarch64, :armv6l, :armv7l),
             cabi in (
                 CompilerABI(libgfortran_version=v"3"),
                 CompilerABI(cxxstring_abi=:cxx03),


### PR DESCRIPTION
It turns out we can actually build Julia for `armv6l` architectures (for use on things like the Raspberry Pi Zero W).  Unfortunately, I had been led to believe that the only 32-bit arm architecture Julia would ever run on would be `armv7l`, so we went for the shortcut of identifying tarballs as `arm-linux-gnueabihf` instead of the full `armv7l-linux-gnueabihf` (since many other projects did this as well).

It turns out, we should have just done the correct, if slightly harder thing, first.  So this PR changes us to emitting `armv7l-linux-gnueabihf` and `armv6l-linux-gnueabihf` by default, but still parsing `arm-linux-gnueabihf` as `armv7l`, so as to maintain backward compatibility (and compatibility with other systems).