### PR TITLE
Check for "permissions-blindness" before calculating Artifacts git tree hashes

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -6,7 +6,7 @@ import ..GitTools
 using ..BinaryPlatforms
 import ..TOML
 import ..Types: parse_toml, write_env_usage, printpkgstyle
-import ...Pkg: pkg_server
+import ...Pkg: pkg_server, safe_realpath
 using ..PlatformEngines
 using SHA
 
@@ -729,7 +729,7 @@ function permissions_blind_filesystem(path::AbstractString)
     global _permissions_blind_filesystem_cache
 
     # Immediately normalize `path`
-    path = realpath(path)
+    path = safe_realpath(path)
     if !isdir(path)
         error("Must provide a directory as `path`")
     end

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -206,6 +206,7 @@ function gitmode(path::AbstractString)
     elseif isdir(path)
         return mode_dir
     # We cannot use `Sys.isexecutable()` because on Windows, that simply calls `isfile()`
+    # This will change in Julia 1.5.
     elseif !iszero(filemode(path) & 0o100)
         return mode_executable
     else

--- a/test/new.jl
+++ b/test/new.jl
@@ -2297,24 +2297,23 @@ tree_hash(root::AbstractString) = bytes2hex(Pkg.GitTools.tree_hash(root))
 
 @testset "git tree hash computation" begin
     mktempdir() do dir
-        # test "well known" empty tree hash
-        @test "4b825dc642cb6eb9a060e54bf8d69288fbee4904" == tree_hash(dir)
-        # create a text file
-        file = joinpath(dir, "hello.txt")
-        open(file, write=true) do io
-            println(io, "Hello, world.")
-        end
-        # reference hash generated with command-line git
-        @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
-        # test with various executable bits set
-        chmod(file, 0o645) # other x bit doesn't matter
-        @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
-        chmod(file, 0o654) # group x bit doesn't matter
-        @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
-        chmod(file, 0o744) # user x bit matters
-        if Sys.iswindows()
-            @test_broken "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
-        else
+        # Skip git tree hashing on permissions-blind filesystems
+        if !Pkg.Artifacts.permissions_blind_filesystem(dir)
+            # test "well known" empty tree hash
+            @test "4b825dc642cb6eb9a060e54bf8d69288fbee4904" == tree_hash(dir)
+            # create a text file
+            file = joinpath(dir, "hello.txt")
+            open(file, write=true) do io
+                println(io, "Hello, world.")
+            end
+            # reference hash generated with command-line git
+            @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
+            # test with various executable bits set
+            chmod(file, 0o645) # other x bit doesn't matter
+            @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
+            chmod(file, 0o654) # group x bit doesn't matter
+            @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
+            chmod(file, 0o744) # user x bit matters
             @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
         end
     end


### PR DESCRIPTION
We need this to be more general than just skipping Windows; if we are on
Linux but using an NFS share or FAT32 filesystems, (for instance) we can
run into the same issues.  So we instead probe for the ability to have a
sane `chmod()`/`isexecutable()` run, and if that fails, we do not bother
to calculate git tree hashes.  This should transparently start to
calculate the proper git tree hashes on Windows once
https://github.com/JuliaLang/julia/issues/33212 is fixed