### PR TITLE
[WIP] fix `fixed` option for `Pkg.update`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1151,18 +1151,16 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel)
     for pkg in pkgs
         up_load_manifest_info!(pkg, manifest_info(ctx, pkg.uuid))
     end
-    pkgs = load_direct_deps(ctx, pkgs) # make sure to include at least direct deps
+    pkgs = load_direct_deps(ctx, pkgs; preserve = (level == UPLEVEL_FIXED ? PRESERVE_NONE : PRESERVE_DIRECT))
     check_registered(ctx, pkgs)
     resolve_versions!(ctx, pkgs)
     prune_manifest(ctx)
     update_manifest!(ctx, pkgs)
     new_apply = download_source(ctx, pkgs)
-
     download_artifacts(pkgs)
     Display.print_env_diff(ctx)
     write_env(ctx.env) # write env before building
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
-    # TODO what to do about repo packages?
 end
 
 function update_package_pin!(ctx::Context, pkg::PackageSpec, entry::PackageEntry)

--- a/test/new.jl
+++ b/test/new.jl
@@ -1467,6 +1467,18 @@ end
         @test haskey(Pkg.project().dependencies, "Markdown")
         @test haskey(Pkg.project().dependencies, "Unicode")
     end
+    # `--fixed` should prevent the target package from being updated, but update other dependencies
+    isolate(loaded_depot=true) do
+        Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"))
+        Pkg.add(Pkg.PackageSpec(; name="JSON", version="0.18.0"))
+        Pkg.update("JSON"; level=Pkg.UPLEVEL_FIXED)
+        Pkg.dependencies(json_uuid) do pkg
+            @test pkg.version == v"0.18.0"
+        end
+        Pkg.dependencies(exuuid) do pkg
+            @test pkg.version > v"0.3.0"
+        end
+    end
 end
 
 @testset "update: REPL" begin


### PR DESCRIPTION
This fixes a bug for `up --fixed`. When this flag is enabled, we actually want to do the inverse operation and *not* preserve any version information for the unspecified direct dependencies.