### PR TITLE
Properly `esc()` variable in `@artifact_str`

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -1029,7 +1029,7 @@ macro artifact_str(name)
         # Use invokelatest() to introduce a compiler barrier, preventing many backedges from being added
         # and slowing down not only compile time, but also `.ji` load time.  This is critical here, as
         # artifact"" is used in other modules, so we don't want to be spreading backedges around everywhere.
-        Base.invokelatest(do_artifact_str, $name, $(artifact_dict), $(artifacts_toml), $__module__)
+        Base.invokelatest(do_artifact_str, $(esc(name)), $(artifact_dict), $(artifacts_toml), $__module__)
     end
 end
 

--- a/test/test_packages/ArtifactInstallation/src/ArtifactInstallation.jl
+++ b/test/test_packages/ArtifactInstallation/src/ArtifactInstallation.jl
@@ -14,6 +14,14 @@ function do_test()
     end
     @test isfile(c_simple_exe)
 
+    # Test that we can use a variable, not just a literal:
+    c_simple = "c_simple"
+    c_simple_exe = joinpath(@artifact_str(c_simple), "bin", "c_simple")
+    if Sys.iswindows()                                                                                    
+        c_simple_exe = "$(c_simple_exe).exe"
+    end
+    @test isfile(c_simple_exe)
+
     # Test that we can dlopen and ccall libc_simple
     libc_simple_path = if Sys.iswindows()
         joinpath(artifact"c_simple", "bin", "libc_simple.dll")


### PR DESCRIPTION
We need to properly escape a macro input variable.  This should fix https://github.com/JuliaLang/Pkg.jl/issues/1579