### PR TITLE
Include directories that contain only symlinks to other directories

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -258,7 +258,9 @@ direct parent of a file or it contains some other directory that itself is a
 direct parent of a file. This is used to exclude directories from tree hashing.
 """
 function contains_files(path::AbstractString)
-    isdir(lstat(path)) || return true
+    st = lstat(path)
+    ispath(st) || throw(ArgumentError("non-existent path: $(repr(path))"))
+    isdir(st) || return true
     for p in readdir(path)
         contains_files(joinpath(path, p)) && return true
     end

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -251,19 +251,18 @@ function blob_hash(path::AbstractString, HashType = SHA.SHA1_CTX)
 end
 
 """
-    contains_no_files(root::AbstractString)
+    contains_files(root::AbstractString)
 
-Helper function to determine whether a directory contains no files; e.g. it is
-either empty or contains only other directories that contain nothing but other
-directories.  This is used to exclude directories from tree hashing.
+Helper function to determine whether a directory contains files; e.g. it is a
+direct parent of a file or it contains some other directory that itself is a
+direct parent of a file. This is used to exclude directories from tree hashing.
 """
-function contains_no_files(root::AbstractString)
-    for (root, dirs, files) in walkdir(root)
-        if !isempty(files)
-            return false
-        end
+function contains_files(path::AbstractString)
+    isdir(lstat(path)) || return true
+    for p in readdir(path)
+        contains_files(joinpath(path, p)) && return true
     end
-    return true
+    return false
 end
     
 
@@ -285,7 +284,7 @@ function tree_hash(root::AbstractString; HashType = SHA.SHA1_CTX)
         mode = gitmode(filepath)
         if mode == mode_dir
             # If this directory contains no files, then skip it
-            contains_no_files(filepath) && continue
+            contains_files(filepath) || continue
 
             # Otherwise, hash it up!
             hash = tree_hash(filepath)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2125,8 +2125,8 @@ tree_hash(root::AbstractString) = bytes2hex(Pkg.GitTools.tree_hash(root))
         # Directories containing symlinks (even if they point to other directories)
         # are NOT empty:
         if !Sys.iswindows()
-            symlink(joinpath(dir, "foo", "bar_link"), joinpath(dir, "bar"))
-            @test "ad4d1c57dd90a4c66671c788c3dd122ce68d6b47" == tree_hash(dir)
+            symlink("bar", joinpath(dir, "foo", "bar_link"))
+            @test "8bc80be82b2ae4bd69f50a1a077a81b8678c9024" == tree_hash(dir)
         end
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2112,6 +2112,23 @@ tree_hash(root::AbstractString) = bytes2hex(Pkg.GitTools.tree_hash(root))
             @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
         end
     end
+
+    # Test for empty directory hashing
+    mktempdir() do dir
+        @test "4b825dc642cb6eb9a060e54bf8d69288fbee4904" == tree_hash(dir)
+
+        # Directories containing other empty directories are also empty
+        mkdir(joinpath(dir, "foo"))
+        mkdir(joinpath(dir, "foo", "bar"))
+        @test "4b825dc642cb6eb9a060e54bf8d69288fbee4904" == tree_hash(dir)
+
+        # Directories containing symlinks (even if they point to other directories)
+        # are NOT empty:
+        if !Sys.iswindows()
+            symlink(joinpath(dir, "foo", "bar_link"), joinpath(dir, "bar"))
+            @test "ad4d1c57dd90a4c66671c788c3dd122ce68d6b47" == tree_hash(dir)
+        end
+    end
 end
 
 end #module


### PR DESCRIPTION
When hashing, we were accidentally excluding directories that contained
only symlinks that pointed to other directories.  This fixes that, and
adds a regression test