### PR TITLE
remove @show debug output when test fails

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1455,7 +1455,6 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
                 run(gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args))
                 printpkgstyle(ctx, :Testing, pkg.name * " tests passed ")
             catch err
-                @show err
                 push!(pkgs_errored, pkg.name)
             end
         end


### PR DESCRIPTION
This seems accidentally left in?

This causes an ugly

```
rr = ProcessFailedException(Base.Process[Process(`/opt/julia/bin/julia -Cnative -J/opt/julia/lib/julia/sys.so -g1 --code-coverage=none --color=no --compiled-modules=yes --check-bounds=yes --inline=yes --startup-file=no --track-allocation=none --eval 'append!(empty!(Base.DEPOT_PATH), ["/home/pkgeval/.julia", "/opt/julia/local/share/julia", "/opt/julia/share/julia", "/usr/local/share/julia"])
append!(empty!(Base.DL_LOAD_PATH), String[])

cd("/home/pkgeval/.julia/packages/AbstractNumbers/VWdQ8/test")
append!(empty!(ARGS), String[])
include("/home/pkgeval/.julia/packages/AbstractNumbers/VWdQ8/test/runtests.jl")
'`, ProcessExited(1))])
```

when `Pkg.test` fails.