### PR TITLE
Pkg protocol: always include protocol version number

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -759,6 +759,7 @@ function get_telemetry_headers(url::AbstractString)
     headers = String[]
     server_dir = get_server_dir(url)
     server_dir === nothing && return headers
+    push!(headers, "Julia-Pkg-Protocol: 1.0")
     info = load_telemetry_file(joinpath(server_dir, "telemetry.toml"))
     get(info, "telemetry", true) == false && return headers
     # general system information


### PR DESCRIPTION
Always a good idea to version your protocol. This is separate from the Julia version because the Julia version leaks more information: multiple different Julia versions could use the same version of the protocol, this only sends information about what protocol features the client supports. We could conceivably even backport the Pkg protocol onto older versions of Julia, in which case you could have situations where an older Julia supports a newer Pkg protocol, so versioning separately is a good idea. Even though this header is added by the telemetry function, it's not really telemetry, it's part of the protocol, so it's sent unconditionally.