### PR TITLE
fix bind_artifact! docstring for download_info

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -602,7 +602,7 @@ a multi-mapping.  It is valid to bind multiple artifacts with the same name, but
 different `platform`s and `hash`'es within the same `artifacts_toml`.  If `force` is set
 to `true`, this will overwrite a pre-existant mapping, otherwise an error is raised.
 
-`download_info` is an optional tuple that contains a vector of URLs and a hash.  These
+`download_info` is an optional vector that contains tuples of URLs and a hash.  These
 URLs will be listed as possible locations where this artifact can be obtained.  If `lazy`
 is set to `true`, even if download information is available, this artifact will not be
 downloaded until it is accessed via the `artifact"name"` syntax, or


### PR DESCRIPTION
`download_info` can be a vector of tuples, not the other way around.

Fixes: https://github.com/JuliaLang/Pkg.jl/issues/1463