### PR TITLE
RFC: Warn if `] up Foo` is not able to install the latest version of `Foo`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -241,7 +241,7 @@ function warn_not_latest(ctx::Context = Context(),
         latest = pkg_to_latest[k]
         if latest !== nothing && current < latest
             if any([_pkg_spec_matches(p, k) for p in pkgs])
-                @warn("$(name) is at $(current), but the latest available version is $(latest)")
+                @warn("$(name) could only be updated to $(current) (the latest version is $(latest))")
             end
         end
     end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -153,12 +153,14 @@ See also [`PackageSpec`](@ref), [`PackageMode`](@ref).
 const rm = API.rm
 
 """
-    Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT)
-    Pkg.update(pkg::Union{String, Vector{String}})
-    Pkg.update(pkg::Union{PackageSpec, Vector{PackageSpec}})
+    Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT, warnall::Bool = false)
+    Pkg.update(pkg::Union{String, Vector{String}}; warnall::Bool = false)
+    Pkg.update(pkg::Union{PackageSpec, Vector{PackageSpec}}; warnall::Bool = false)
 
 Update a package `pkg`. If no posistional argument is given, update all packages in the manifest if `mode` is `PKGMODE_MANIFEST` and packages in both manifest and project if `mode` is `PKGMODE_PROJECT`.
 If no positional argument is given, `level` can be used to control by how much packages are allowed to be upgraded (major, minor, patch, fixed).
+
+If `warnall` is `true` and `mode` is `PKGMODE_PROJECT` (resp. `PKGMODE_MANIFEST`), then a warning will be printed for each package in the project (resp. manifest) that cannot be updated to the latest registered version.
 
 See also [`PackageSpec`](@ref), [`PackageMode`](@ref), [`UpgradeLevel`](@ref).
 """

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -253,6 +253,7 @@ it will be placed in the first depot of the stack.
         [:name => "minor", :api => :level => UPLEVEL_MINOR],
         [:name => "patch", :api => :level => UPLEVEL_PATCH],
         [:name => "fixed", :api => :level => UPLEVEL_FIXED],
+        [:name => "warnall", :short_name => "w", :api => :warnall => true],
     ],
     :completions => complete_installed_packages,
     :description => "update packages in manifest",

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -258,8 +258,8 @@ it will be placed in the first depot of the stack.
     :completions => complete_installed_packages,
     :description => "update packages in manifest",
     :help => md"""
-    up [-p|--project]  [opts] pkg[=uuid] [@version] ...
-    up [-m|--manifest] [opts] pkg[=uuid] [@version] ...
+    up [-p|--project]  [-w|--warnall] [opts] pkg[=uuid] [@version] ...
+    up [-m|--manifest] [-w|--warnall] [opts] pkg[=uuid] [@version] ...
 
     opts: --major | --minor | --patch | --fixed
 
@@ -270,7 +270,9 @@ In `--project` mode, package specifications only match project packages, while
 in `manifest` mode they match any manifest package. Bound level options force
 the following packages to be upgraded only within the current major, minor,
 patch version; if the `--fixed` upgrade level is given, then the following
-packages will not be upgraded at all.
+packages will not be upgraded at all. `up -w -p` (resp. `up -w -m`) will print a
+warning for each package in the project (resp. manifest) that cannot be updated
+to the latest registered version.
 """,
 ],[ :name => "generate",
     :api => API.generate,


### PR DESCRIPTION
Fixes #1605 

## Usage:

| Command                | Type of warning(s)                                                                           |
| ------------------- | ---------------------------------------------------------------    |
| `] up`                      | This will never print a warning                                                          |
| `] up Foo`               | Warns if `Foo` can't be updated to latest                                        |
| `] up Foo Bar Baz` | Warns if any of `Foo`, `Bar`, `Baz` can't be updated to latest       |
| `] up -w`                 | Equivalent to `] up -w -p`                                                                 |
| `] up -w -p`            | Warns if any packages in the project can't be updated to latest     |
| `] up -w -m`           | Warns if any packages in the manifest can't be updated to latest  |


## Example output:

<details>
<summary>Click to expand</summary>

```
(@v1.5) pkg> up
   Updating registry at `~/.julia/registries/General`
   Updating `~/.julia/environments/v1.5/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.5/Manifest.toml`
 [no changes]
```

```
(@v1.5) pkg> up BSON
   Updating registry at `~/.julia/registries/General`
   Updating `~/.julia/environments/v1.5/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.5/Manifest.toml`
 [no changes]
┌ Warning: BSON could only be updated to 0.2.0 (the latest version is 0.2.5)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
```

```
(@v1.5) pkg> up BSON JLD2
   Updating registry at `~/.julia/registries/General`
   Updating `~/.julia/environments/v1.5/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.5/Manifest.toml`
 [no changes]
┌ Warning: JLD2 could only be updated to 0.1.0 (the latest version is 0.1.11)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
┌ Warning: BSON could only be updated to 0.2.0 (the latest version is 0.2.5)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
```

```
(@v1.5) pkg> up -w
   Updating registry at `~/.julia/registries/General`
   Updating `~/.julia/environments/v1.5/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.5/Manifest.toml`
 [no changes]
┌ Warning: JLD2 could only be updated to 0.1.0 (the latest version is 0.1.11)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
┌ Warning: BSON could only be updated to 0.2.0 (the latest version is 0.2.5)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
```

```
(@v1.5) pkg> up -w -p
   Updating registry at `~/.julia/registries/General`
   Updating `~/.julia/environments/v1.5/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.5/Manifest.toml`
 [no changes]
┌ Warning: JLD2 could only be updated to 0.1.0 (the latest version is 0.1.11)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
┌ Warning: BSON could only be updated to 0.2.0 (the latest version is 0.2.5)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
```

```
(@v1.5) pkg> up -w -m
   Updating registry at `~/.julia/registries/General`
   Updating `~/.julia/environments/v1.5/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.5/Manifest.toml`
 [no changes]
┌ Warning: JLD2 could only be updated to 0.1.0 (the latest version is 0.1.11)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
┌ Warning: BSON could only be updated to 0.2.0 (the latest version is 0.2.5)
└ @ Pkg.API ~/Downloads/Pkg.jl/src/API.jl:244
```

</details>