### PR TITLE
add an API option to ignore compat

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -323,7 +323,7 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
     for pkg in pkgs
         compat = project_compatibility(ctx, pkg.name)
         v = intersect(pkg.version, compat)
-        if isempty(v)
+        if !ctx.ignore_compat && isempty(v)
             throw(Resolve.ResolverError(
                 "empty intersection between $(pkg.name)@$(pkg.version) and project compatibility $(compat)"))
         end
@@ -422,11 +422,13 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                             other_uuid in uuids || push!(uuids, other_uuid)
                         end
                     end
-                    for (vr, cd) in compat_data
-                        all_compat_u_vr = get_or_make!(all_compat_u, vr)
-                        for (name,vs) in cd
-                            # check conflicts??
-                            all_compat_u_vr[name] = vs
+                    if !ctx.ignore_compat
+                        for (vr, cd) in compat_data
+                            all_compat_u_vr = get_or_make!(all_compat_u, vr)
+                            for (name,vs) in cd
+                                # check conflicts??
+                                all_compat_u_vr[name] = vs
+                            end
                         end
                     end
                 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -335,6 +335,7 @@ Base.@kwdef mutable struct Context
     # the future. It currently stands as an unofficial workaround for issue #795.
     num_concurrent_downloads::Int = haskey(ENV, "JULIA_PKG_CONCURRENCY") ? parse(Int, ENV["JULIA_PKG_CONCURRENCY"]) : 8
     graph_verbose::Bool = false
+    ignore_compat::Bool = false
     currently_running_target::Bool = false
 end
 


### PR DESCRIPTION
Since this change is so small, I might as well probe what people think about this.

This adds an option that just turns off all compat (except the compat in your project) and gives you the latest versions of everything.

```jl
julia> Pkg.update()
   Updating `~/.julia/environments/v1.3/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.3/Manifest.toml`
 [no changes]

julia> Pkg.update(; ignore_compat=true)
   Updating `~/.julia/environments/v1.3/Project.toml`
 [no changes]
   Updating `~/.julia/environments/v1.3/Manifest.toml`
  [68821587] ↑ Arpack_jll v3.5.0+2 ⇒ v3.7.0+0
  [a81c6b42] ↑ Compose v0.7.3 ⇒ v0.8.0
  [31c24e10] ↑ Distributions v0.21.12 ⇒ v0.22.0
  [ae029012] ↑ Requires v0.5.2 ⇒ v1.0.0
```

No docs yet because that will be the majority of the work for this PR and I want to see some opinions first.