### PR TITLE
Fix `gen_unpack_cmd()` signature inconsistency

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -38,7 +38,7 @@ This option is mainyl used to exclude symlinks from extraction (see: `copyderef`
 This method is initialized by `probe_platform_engines()`, which should be
 automatically called upon first import of `BinaryProvider`.
 """
-gen_unpack_cmd = (tarball_path::AbstractString, out_path::AbstractString;
+gen_unpack_cmd = (tarball_path::AbstractString, out_path::AbstractString,
                   excludelist::Union{AbstractString, Nothing} = nothing) ->
     error("Call `probe_platform_engines()` before `gen_unpack_cmd()`")
 


### PR DESCRIPTION
We need to make the erroring implementation have the same signature as
the non-erroring implementations.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/1616