### PR TITLE
make artifact download more similar to rest of Pkg "theme"

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -605,9 +605,8 @@ function download_artifacts(ctx::Context, pkg_roots::Vector{String}; platform::P
     end
 
     if !isempty(artifacts_tomls)
-        printpkgstyle(ctx, :Downloading, "artifacts...")
         for artifacts_toml in artifacts_tomls
-            ensure_all_artifacts_installed(artifacts_toml; platform=platform, verbose=verbose, quiet_download=false)
+            ensure_all_artifacts_installed(artifacts_toml; platform=platform, verbose=verbose, quiet_download=!(stderr isa Base.TTY))
             write_env_usage(artifacts_toml, "artifact_usage.toml")
         end
     end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -835,7 +835,7 @@ function download(
     end
     download_cmd = gen_download_cmd(url, dest, headers...)
     if verbose
-        @info("Downloading $(url) to $(dest)...")
+        # @info("Downloading $(url) to $(dest)...")
     end
     try
         run(download_cmd, (devnull, verbose ? stdout : devnull, verbose ? stderr : devnull))

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1257,10 +1257,13 @@ function manifest_info(ctx::Context, uuid::UUID)::Union{PackageEntry,Nothing}
 end
 
 function printpkgstyle(ctx::Context, cmd::Symbol, text::String, ignore_indent::Bool=false)
+    printpkgstyle(ctx.io, cmd, text, ignore_indent)
+end
+function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false)
     indent = textwidth(string(:Downloading))
     ignore_indent && (indent = 0)
-    printstyled(ctx.io, lpad(string(cmd), indent), color=:green, bold=true)
-    println(ctx.io, " ", text)
+    printstyled(io, lpad(string(cmd), indent), color=:green, bold=true)
+    println(io, " ", text)
 end
 
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/1600, fixes https://github.com/JuliaLang/Pkg.jl/issues/1554

I didn't really like how the artifact download looked for some reasons:

- It printed `Downloading artifacts...` unconditionally.
- It used an `@info` log to print download url and location which showed some temp directory and (for a user) garbage hash name
- It kept the progress bar even after the download was finished.

This is a (arguably) ugly attempt to remedy this. The download now looks like:

![Peek 2020-01-16 15-53](https://user-images.githubusercontent.com/1282691/72535419-cf196380-3878-11ea-98bf-87614469786d.gif)
