### PR TITLE
Add a poor-mans file lock for telemetry file.

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -764,12 +764,16 @@ const CI_VARIABLES = [
     "TRAVIS",
 ]
 
+const telemetry_file_lock = ReentrantLock()
+
 function get_telemetry_headers(url::AbstractString)
     headers = String[]
     server_dir = get_server_dir(url)
     server_dir === nothing && return headers
     push!(headers, "Julia-Pkg-Protocol: 1.0")
-    info = load_telemetry_file(joinpath(server_dir, "telemetry.toml"))
+    info = lock(telemetry_file_lock) do
+        load_telemetry_file(joinpath(server_dir, "telemetry.toml"))
+    end
     get(info, "telemetry", true) == false && return headers
     # general system information
     push!(headers, "Julia-Version: $VERSION")


### PR DESCRIPTION
It's not perfect (e.g. doesn't lock between processes), but at least stops walls of:
```
pkg> instantiate
┌ Warning: replacing malformed telemetry file
│   file = "/home/fredrik/.julia/servers/pkg.julialang.org/telemetry.toml"
│   err =
│    Pkg.TOML.ParserError(69, 103, "control character `\n` must be escaped")
│    
│    ...and 1 more exception(s).
│    
└ @ Pkg.PlatformEngines ~/julia-master/usr/share/julia/stdlib/v1.5/Pkg/src/PlatformEngines.jl:715
┌ Warning: replacing malformed telemetry file
│   file = "/home/fredrik/.julia/servers/pkg.julialang.org/telemetry.toml"
│   err =
│    Pkg.TOML.ParserError(69, 103, "control character `\n` must be escaped")
│    
│    ...and 1 more exception(s).
│    
└ @ Pkg.PlatformEngines ~/julia-master/usr/share/julia/stdlib/v1.5/Pkg/src/PlatformEngines.jl:715
┌ Warning: replacing malformed telemetry file
│   file = "/home/fredrik/.julia/servers/pkg.julialang.org/telemetry.toml"
│   err =
│    Pkg.TOML.ParserError(69, 103, "control character `\n` must be escaped")
│    
│    ...and 1 more exception(s).
│    
└ @ Pkg.PlatformEngines ~/julia-master/usr/share/julia/stdlib/v1.5/Pkg/src/PlatformEngines.jl:715
[...]
```