### PR TITLE
make telemetry file writing more likely to be atomic

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -741,14 +741,15 @@ function load_telemetry_file(file::AbstractString)
         delete!(info, "ci_variables")
         changed = true
     end
-    if changed
-        mkpath(dirname(file))
-        mktemp() do tmp, io
-            TOML.print(io, info, sorted=true)
-            mv(tmp, file, force=true)
-        end
+    changed || return info
+    # write telemetry file atomically (if on same file system)
+    mkpath(dirname(file))
+    mktemp() do tmp, io
+        TOML.print(io, info, sorted=true)
+        mv(tmp, file, force=true)
     end
-    return info
+    # reparse file in case a different process wrote it first
+    return load_telemetry_file(file)
 end
 
 # based on information in this post:

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -743,8 +743,9 @@ function load_telemetry_file(file::AbstractString)
     end
     if changed
         mkpath(dirname(file))
-        open(file, write=true) do io
+        mktemp() do tmp, io
             TOML.print(io, info, sorted=true)
+            mv(tmp, file, force=true)
         end
     end
     return info


### PR DESCRIPTION
Alternative to https://github.com/JuliaLang/Pkg.jl/pull/1625. Write the telemetry file to a temp file and then move it into place.