### PR TITLE
Authentication Hooks

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -617,7 +617,7 @@ function handle_auth_error(url, err; verbose::Bool = false)
 end
 
 function register_auth_error_handler(f)
-    pushfirst!(AUTH_ERROR_HANDLERS, f)
+    unique!(pushfirst!(AUTH_ERROR_HANDLERS, f))
     return () -> deregister_auth_error_handler(f)
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -625,9 +625,9 @@ deregister_auth_error_handler(f) = filter!(handler -> handler !== f, AUTH_ERROR_
 
 function get_auth_header(url::AbstractString; verbose::Bool = false)
     server_dir = get_server_dir(url)
-    server_dir === nothing && return
+    server_dir === nothing && return handle_auth_error(url, "no-auth-file"; verbose=verbose)
     auth_file = joinpath(server_dir, "auth.toml")
-    isfile(auth_file) || return
+    isfile(auth_file) || return handle_auth_error(url, "no-auth-file"; verbose=verbose)
     # TODO: check for insecure auth file permissions
     if !is_secure_url(url)
         @warn "refusing to send auth info over insecure connection" url=url

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -653,7 +653,7 @@ end
 
 function get_auth_header(url::AbstractString; verbose::Bool = false)
     server_dir = get_server_dir(url)
-    server_dir === nothing && return handle_auth_error(url, "no-auth-file"; verbose=verbose)
+    server_dir === nothing && return
     auth_file = joinpath(server_dir, "auth.toml")
     isfile(auth_file) || return handle_auth_error(url, "no-auth-file"; verbose=verbose)
     # TODO: check for insecure auth file permissions

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -628,7 +628,7 @@ is currently trying to download.)
 `f` must be a function that takes three input arguments `(url, pkgserver, err)`, where `url` is the
 URL currently being downloaded, `pkgserver = Pkg.pkg_server()` the current package server, and
 `err` is one of `no-auth-file`, `insecure-connection`, `malformed-file`, `no-access-token`,
-`no-refresh-key`, `insecure-refresh-url`,  `malformed-file`, or `no-access-token`.
+`no-refresh-key` or `insecure-refresh-url`.
 
 The handler `f` needs to return a tuple of `Bool`s `(handled, should_retry)`. If `handled` is `false`,
 the next handler in the stack will be called, otherwise `get_auth_header` is called again if `should_retry`

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -631,7 +631,7 @@ URL currently being downloaded, `pkgserver = Pkg.pkg_server()` the current packa
 `no-refresh-key` or `insecure-refresh-url`.
 
 The handler `f` needs to return a tuple of `Bool`s `(handled, should_retry)`. If `handled` is `false`,
-the next handler in the stack will be called, otherwise `get_auth_header` is called again if `should_retry`
+the next handler in the stack will be called, otherwise handling terminates; `get_auth_header` is called again if `should_retry`
 is `true`.
 
 `register_auth_error_handler` returns a zero-arg function that can be called to deregister the handler.

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -215,4 +215,22 @@ end
     end
 end
 
+@testset "Authentication Header Hooks" begin
+    @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
+
+    called = 0
+    dispose = PlatformEngines.register_auth_error_handler(function (url, svr, err)
+        called += 1
+        return true, called < 3
+    end)
+
+    @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
+    @test called == 3
+
+    dispose()
+
+    @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
+    @test called == 3
+end
+
 end # module

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -216,21 +216,33 @@ end
 end
 
 @testset "Authentication Header Hooks" begin
-    @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
+    @test PlatformEngines.get_auth_header("https://foo.bar/baz") == nothing
+
+    old = nothing
+    haskey(ENV, "JULIA_PKG_SERVER") && (old = ENV["JULIA_PKG_SERVER"])
+
+    ENV["JULIA_PKG_SERVER"] = ""
 
     called = 0
-    dispose = PlatformEngines.register_auth_error_handler("https://foo.bar", function (url, svr, err)
+    dispose = PlatformEngines.register_auth_error_handler("https://foo.bar/baz", function (url, svr, err)
         called += 1
         return true, called < 3
     end)
 
-    @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
+    @test PlatformEngines.get_auth_header("https://foo.bar/baz") == nothing
+    @test called == 0
+
+    ENV["JULIA_PKG_SERVER"] = "https://foo.bar"
+
+    @test PlatformEngines.get_auth_header("https://foo.bar/baz") == nothing
     @test called == 3
 
     dispose()
 
-    @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
+    @test PlatformEngines.get_auth_header("https://foo.bar/baz") == nothing
     @test called == 3
+
+    old === nothing ? delete!(ENV, "JULIA_PKG_SERVER") : (ENV["JULIA_PKG_SERVER"] = old)
 end
 
 end # module

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -221,6 +221,8 @@ end
     old = nothing
     haskey(ENV, "JULIA_PKG_SERVER") && (old = ENV["JULIA_PKG_SERVER"])
 
+    push!(Base.DEPOT_PATH, ".")
+
     ENV["JULIA_PKG_SERVER"] = ""
 
     called = 0
@@ -243,6 +245,7 @@ end
     @test called == 3
 
     old === nothing ? delete!(ENV, "JULIA_PKG_SERVER") : (ENV["JULIA_PKG_SERVER"] = old)
+    pop!(Base.DEPOT_PATH)
 end
 
 end # module

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -219,7 +219,7 @@ end
     @test PlatformEngines.get_auth_header("https://foo.bar") == nothing
 
     called = 0
-    dispose = PlatformEngines.register_auth_error_handler(function (url, svr, err)
+    dispose = PlatformEngines.register_auth_error_handler("https://foo.bar", function (url, svr, err)
         called += 1
         return true, called < 3
     end)


### PR DESCRIPTION
This PR adds a hook into `get_auth_header` which is called when Pkg can't find authentication for the current package server.

#### Public API (unexported):
```    
    register_auth_error_handler(f)

Registers `f` as the topmost handler for failures in package server authentication.
`f` must be a function that takes three input arguments `(url, pkgserver, err)`, where `url` is the
URL currently being downloaded, `pkgserver = Pkg.pkg_server()` the current package server, and
`err` is one of `no-auth-file`, `insecure-connection`, `malformed-file`, `no-access-token`,
`no-refresh-key`, `insecure-refresh-url`,  `malformed-file`, or `no-access-token`.
The handler `f` needs to return a tuple of `Bool`s `(handled, should_retry)`. If `handled` is `false`,
the next handler in the stack will be called, otherwise `get_auth_header` is called again if `should_retry`
is `true`.
`register_auth_error_handler` returns a zero-arg function that can be called to deregister the handler.
```
```
    deregister_auth_error_handler(f)

Removes `f` from the stack of authentication error handlers.
```

#### Example handler:
```
julia> dispose = Pkg.PlatformEngines.register_auth_error_handler((url, svr, err) -> begin
                PkgAuth.authenticate(svr*"/auth")
                return true, true
              end)
```