### PR TITLE
change REPL path resolution

### DIFF
--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -73,10 +73,7 @@ end
 # packages can be identified through: uuid, name, or name+uuid
 # additionally valid for add/develop are: local path, url
 function parse_package_identifier(word::AbstractString; add_or_develop=false)::PackageSpec
-    if add_or_develop && isdir_windows_workaround(expanduser(word))
-        if !occursin(Base.Filesystem.path_separator_re, word)
-            @info "Resolving package identifier `$word` as a directory at `$(Base.contractuser(abspath(word)))`."
-        end
+    if add_or_develop && (occursin(Base.Filesystem.path_separator_re, word) || word in (".", ".."))
         return PackageSpec(repo=Types.GitRepo(source=expanduser(word)))
     elseif occursin(uuid_re, word)
         return PackageSpec(uuid=UUID(word))

--- a/test/new.jl
+++ b/test/new.jl
@@ -1080,7 +1080,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = copy_test_package(tempdir, "SimplePackage")
         cd(dirname(path)) do
-            Pkg.pkg"develop SimplePackage"
+            Pkg.pkg"develop ./SimplePackage"
         end
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -32,21 +32,21 @@ temp_pkg_dir() do project_path
 
         @test_throws PkgError pkg"generate 2019Julia"
         pkg"generate Foo"
-        pkg"dev Foo"
+        pkg"dev ./Foo"
         mv(joinpath("Foo", "src", "Foo.jl"), joinpath("Foo", "src", "Foo2.jl"))
-        @test_throws PkgError pkg"dev Foo"
+        @test_throws PkgError pkg"dev ./Foo"
         ###
         mv(joinpath("Foo", "src", "Foo2.jl"), joinpath("Foo", "src", "Foo.jl"))
         write(joinpath("Foo", "Project.toml"), """
             name = "Foo"
         """
         )
-        @test_throws PkgError pkg"dev Foo"
+        @test_throws PkgError pkg"dev ./Foo"
         write(joinpath("Foo", "Project.toml"), """
             uuid = "b7b78b08-812d-11e8-33cd-11188e330cbe"
         """
         )
-        @test_throws PkgError pkg"dev Foo"
+        @test_throws PkgError pkg"dev ./Foo"
     end
 end
 
@@ -178,7 +178,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
                 with_current_env() do
                     uuid1 = Pkg.generate("SubModule1")["SubModule1"]
                     uuid2 = Pkg.generate("SubModule2")["SubModule2"]
-                    pkg"develop SubModule1"
+                    pkg"develop ./SubModule1"
                     mkdir("tests")
                     cd("tests")
                     pkg"develop ../SubModule2"
@@ -407,10 +407,10 @@ temp_pkg_dir() do project_path; cd(project_path) do
         with_current_env() do
             # the command below also tests multiline input
             pkg"""
-                dev RecursiveDep2
-                dev RecursiveDep
-                dev SubModule
-                dev SubModule2
+                dev ./RecursiveDep2
+                dev ./RecursiveDep
+                dev ./SubModule
+                dev ./SubModule2
                 add Random
                 add Example
                 add JSON


### PR DESCRIPTION
Currently `pkg> add Example` will resolve to a path if `Example` exists in the current working directory. This can be surprising since `pkg> add Example` usually resolves to a registered package. It is also annoying since we have no way to force a registered package: you have to change your working directory in order to add the registered package.

We should only interpret the argument as a path when the user is more explicit i.e. when they include an explicit path separator in the argument

Example:
```
shell> ls
Example

(ex3) pkg> add Example
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Resolving package versions...
   Updating `/tmp/ex3/Project.toml`
  [7876af07] + Example v0.5.3
   Updating `/tmp/ex3/Manifest.toml`
  [7876af07] + Example v0.5.3

(ex3) pkg> add ./Example
   Updating git-repo `/tmp/ex1/dev/Example`
  Resolving package versions...
   Updating `/tmp/ex3/Project.toml`
  [7876af07] ↑ Example v0.5.3 ⇒ v0.5.4 #master (../ex1/dev/Example)
   Updating `/tmp/ex3/Manifest.toml`
  [7876af07] ↑ Example v0.5.3 ⇒ v0.5.4 #master (../ex1/dev/Example)
```