### PR TITLE
fix not trying to delete moved file in load_telemetry_file

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -791,10 +791,11 @@ function load_telemetry_file(file::AbstractString)
     changed || return info
     # write telemetry file atomically (if on same file system)
     mkpath(dirname(file))
-    mktemp() do tmp, io
+    tmp = tempname()
+    open(tmp, write=true) do io
         TOML.print(io, info, sorted=true)
-        mv(tmp, file, force=true)
     end
+    mv(tmp, file, force=true)
     # reparse file in case a different process wrote it first
     return load_telemetry_file(file)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/1640.

`mktemp` doesn't make sense to me if we want to move the whole file after, and also, `mktemp` means that we have the file open and Windows might not like to move opened files.