### PR TITLE
Use https://geo.pkg.julialang.org/ as the default Pkg server

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -20,7 +20,7 @@ function depots1()
 end
 
 function pkg_server()
-    server = get(ENV, "JULIA_PKG_SERVER", "https://pkg.julialang.org")
+    server = get(ENV, "JULIA_PKG_SERVER", "https://geo.pkg.julialang.org")
     isempty(server) && return nothing
     startswith(server, r"\w+://") || (server = "https://$server")
     return server


### PR DESCRIPTION
Instead of https://pkg.julialang.org/