### PR TITLE
`Pkg.status` improvements

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -968,8 +968,8 @@ function redo_undo(ctx, mode::Symbol, direction::Int)
     state.idx += direction
     snapshot = state.entries[state.idx]
     ctx.env.manifest, ctx.env.project = snapshot.manifest, snapshot.project
-    Operations.show_update(ctx)
     write_env(ctx.env; update_undo=false)
+    Operations.show_update(ctx)
 end
 
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1607,7 +1607,7 @@ function diff_array(old_ctx::Union{Context,Nothing}, new_ctx::Context; manifest=
     return [(uuid, index_pkgs(old, uuid), index_pkgs(new, uuid)) for uuid in all_uuids]
 end
 
-is_package_downloaded(ctx, pkg::PackageSpec) = isdir(project_rel_path(ctx, source_path(pkg)))
+is_package_downloaded(ctx, pkg::PackageSpec) = isdir(project_rel_path(ctx, source_path(ctx, pkg)))
 
 function print_status(ctx::Context, old_ctx::Union{Nothing,Context}, header::Symbol,
                       uuids::Vector, names::Vector; manifest=true, diff=false)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -984,8 +984,8 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     # only keep reachable manifest entires
     prune_manifest(ctx)
     # update project & manifest
-    show_update(ctx)
     write_env(ctx.env)
+    show_update(ctx)
 end
 
 update_package_add(ctx::Context, pkg::PackageSpec, ::Nothing, is_dep::Bool) = pkg
@@ -1103,8 +1103,8 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[];
     # and ensure they are all downloaded and unpacked as well:
     download_artifacts(ctx, pkgs; platform=platform)
 
-    show_update(ctx)
     write_env(ctx.env) # write env before building
+    show_update(ctx)
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1121,8 +1121,8 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Vector{UUID};
     update_manifest!(ctx, pkgs)
     new_apply = download_source(ctx, pkgs; readonly=true)
     download_artifacts(ctx, pkgs; platform=platform)
-    show_update(ctx)
     write_env(ctx.env) # write env before building
+    show_update(ctx)
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1187,8 +1187,8 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel)
     update_manifest!(ctx, pkgs)
     new_apply = download_source(ctx, pkgs)
     download_artifacts(ctx, pkgs)
-    show_update(ctx)
     write_env(ctx.env) # write env before building
+    show_update(ctx)
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1226,8 +1226,8 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
 
     new = download_source(ctx, pkgs)
     download_artifacts(ctx, pkgs)
-    show_update(ctx)
     write_env(ctx.env) # write env before building
+    show_update(ctx)
     build_versions(ctx, UUID[pkg.uuid for pkg in new])
 end
 
@@ -1263,13 +1263,13 @@ function free(ctx::Context, pkgs::Vector{PackageSpec})
         update_manifest!(ctx, pkgs)
         new = download_source(ctx, pkgs)
         download_artifacts(ctx, new)
-        show_update(ctx)
         write_env(ctx.env) # write env before building
+        show_update(ctx)
         build_versions(ctx, UUID[pkg.uuid for pkg in new])
     else
         foreach(pkg -> manifest_info(ctx, pkg.uuid).pinned = false, pkgs)
-        show_update(ctx)
         write_env(ctx.env)
+        show_update(ctx)
     end
 end
 
@@ -1573,12 +1573,12 @@ end
 
 print_single(ctx::Context, pkg::PackageSpec) = printstyled(ctx.io, stat_rep(pkg); color=:white)
 
-is_uninstantiated(::Nothing) = true
-is_uninstantiated(x::PackageSpec) = x.version == VersionSpec() && !is_stdlib(x.uuid)
+is_instantiated(::Nothing) = false
+is_instantiated(x::PackageSpec) = x.version != VersionSpec() || is_stdlib(x.uuid)
 function print_diff(ctx::Context, old::Union{Nothing,PackageSpec}, new::Union{Nothing,PackageSpec})
-    if is_uninstantiated(old) && !is_uninstantiated(new)
+    if !is_instantiated(old) && is_instantiated(new)
         printstyled(ctx.io, "+ $(stat_rep(new))"; color=:light_green)
-    elseif is_uninstantiated(new)
+    elseif !is_instantiated(new)
         printstyled(ctx.io, "- $(stat_rep(old))"; color=:light_red)
     elseif is_tracking_registry(old) && is_tracking_registry(new)
         if new.version > old.version
@@ -1596,45 +1596,56 @@ function diff_array(old_ctx::Union{Context,Nothing}, new_ctx::Context; manifest=
         idx = findfirst(pkg -> pkg.uuid == uuid, pkgs)
         return idx === nothing ? nothing : pkgs[idx]
     end
-
+    # load deps
     new = manifest ? load_manifest_deps(new_ctx) : load_direct_deps(new_ctx)
     if old_ctx === nothing
         return [(pkg.uuid, nothing, pkg) for pkg in new]
     end
     old = manifest ? load_manifest_deps(old_ctx) : load_direct_deps(old_ctx)
-
+    # merge old and new into single array
     all_uuids = union([pkg.uuid for pkg in old], [pkg.uuid for pkg in new])
     return [(uuid, index_pkgs(old, uuid), index_pkgs(new, uuid)) for uuid in all_uuids]
 end
+
+is_package_downloaded(ctx, pkg::PackageSpec) = isdir(project_rel_path(ctx, source_path(pkg)))
 
 function print_status(ctx::Context, old_ctx::Union{Nothing,Context}, header::Symbol,
                       uuids::Vector, names::Vector; manifest=true, diff=false)
     ctx.io = something(ctx.status_io, ctx.io) # for instrumenting tests
     filter = !isempty(uuids) || !isempty(names)
-    # print header
-    printpkgstyle(ctx, header, pathrepr(manifest ? ctx.env.manifest_file : ctx.env.project_file))
     # setup
-    printed_something, empty_diff = false, true
     xs = diff_array(old_ctx, ctx; manifest=manifest)
-    xs = sort!(xs, by = (x -> (is_stdlib(x[1]), something(x[3], x[2]).name, x[1])))
-    # return early
+    # filter and return early if possible
+    if isempty(xs) && !diff
+        printpkgstyle(ctx, header, "$(pathrepr(manifest ? ctx.env.manifest_file : ctx.env.project_file)) (empty " *
+                      (manifest ? "manifest" : "project") * ")")
+        return nothing
+    end
+    xs = !diff ? xs : [(id, old, new) for (id, old, new) in xs if old != new]
     if isempty(xs)
-        printpkgstyle(ctx, header, manifest ? "empty manifest" : "empty project")
+        printpkgstyle(ctx, Symbol("No Changes"), "to $(pathrepr(manifest ? ctx.env.manifest_file : ctx.env.project_file))")
+        return nothing
+    end
+    xs = !filter ? xs : [(id, old, new) for (id, old, new) in xs if (id in uuids || something(new, old).name in names)]
+    if isempty(xs)
+        printpkgstyle(ctx, Symbol("No Matches"),
+                      "in $(diff ? "diff for " : "")$(pathrepr(manifest ? ctx.env.manifest_file : ctx.env.project_file))")
         return nothing
     end
     # main print
+    printpkgstyle(ctx, header, pathrepr(manifest ? ctx.env.manifest_file : ctx.env.project_file))
+    xs = sort!(xs, by = (x -> (is_stdlib(x[1]), something(x[3], x[2]).name, x[1])))
+    all_packages_downloaded = true
     for (uuid, old, new) in xs
-        diff && old == new && continue # in diff mode and no diff to show
-        empty_diff = false
-        filter && !(uuid in uuids) && !(something(new, old).name in names) && continue
-        printed_something = true
-
-        printstyled(ctx.io, "   $(string(uuid)[1:8]) "; color = :light_black)
+        pkg_downloaded = !is_instantiated(new) || is_package_downloaded(ctx, new)
+        all_packages_downloaded &= pkg_downloaded
+        printstyled(ctx.io, pkg_downloaded ? " " : "→"; color = :red)
+        printstyled(ctx.io, " [", string(uuid)[1:8], "] "; color = :light_black)
         diff ? print_diff(ctx, old, new) : print_single(ctx, new)
         println(ctx.io)
     end
-    if !printed_something
-        printpkgstyle(ctx, header, (diff && empty_diff) ? "empty diff" : "no matches")
+    if !all_packages_downloaded
+        printpkgstyle(ctx, :Info, "packages marked with → are not downloaded, use `instantiate` to download", true)
     end
     return nothing
 end
@@ -1660,9 +1671,7 @@ function show_update(ctx::Context)
     old_env = EnvCache()
     old_env.project = ctx.env.original_project
     old_env.manifest = ctx.env.original_manifest
-    if old_env.project != ctx.env.project || old_env.manifest != ctx.env.manifest
-        status(ctx; header=:Updating, mode=PKGMODE_COMBINED, env_diff=old_env)
-    end
+    status(ctx; header=:Updating, mode=PKGMODE_COMBINED, env_diff=old_env)
     return nothing
 end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -1922,13 +1922,13 @@ end
         @test occursin(r"Status `.+Project.toml`", readline(io))
         @test occursin(r"→ \[7876af07\] Example v\d\.\d\.\d", readline(io))
         @test occursin(r"\[d6f4376e\] Markdown", readline(io))
-        @test "Info packages marked with → are not downloaded, use `instantiate` to download" == readline(io)
+        @test "Info packages marked with → not downloaded, use `instantiate` to download" == readline(io)
         Pkg.status(;io=io, mode=Pkg.PKGMODE_MANIFEST)
         @test occursin(r"Status `.+Manifest.toml`", readline(io))
         @test occursin(r"→ \[7876af07\] Example v\d\.\d\.\d", readline(io))
         @test occursin(r"\[2a0f44e3\] Base64", readline(io))
         @test occursin(r"\[d6f4376e\] Markdown", readline(io))
-        @test "Info packages marked with → are not downloaded, use `instantiate` to download" == readline(io)
+        @test "Info packages marked with → not downloaded, use `instantiate` to download" == readline(io)
     end
     # Manifest Status API
     isolate(loaded_depot=true) do

--- a/test/new.jl
+++ b/test/new.jl
@@ -20,6 +20,7 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 #
 # # Depot Changes
 #
+
 @testset "Depot setup" begin
     isolate() do
         # Lets make sure we start with a clean slate.
@@ -1845,7 +1846,6 @@ end
 #
 # # Status
 #
-matchesline(rx, io) = occursin(rx, readline(io))
 @testset "Pkg.status" begin
     # other
     isolate(loaded_depot=true) do
@@ -1858,50 +1858,50 @@ matchesline(rx, io) = occursin(rx, readline(io))
         # Basic Add
         Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"); status_io=io)
         @test occursin(r"Updating `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 \+ Example v0\.3\.0", readline(io))
+        @test occursin(r"\[7876af07\] \+ Example v0\.3\.0", readline(io))
         @test occursin(r"Updating `.+Manifest\.toml`", readline(io))
-        @test occursin(r"7876af07 \+ Example v0\.3\.0", readline(io))
+        @test occursin(r"\[7876af07\] \+ Example v0\.3\.0", readline(io))
         # Double add should not claim "Updating"
         Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"); status_io=io)
-        @test isempty(take!(io))
+        @test occursin(r"No Changes to `.+Project\.toml`", readline(io))
+        @test occursin(r"No Changes to `.+Manifest\.toml`", readline(io))
         # From tracking registry to tracking repo
         Pkg.add(Pkg.PackageSpec(; name="Example", rev="master"); status_io=io)
         @test occursin(r"Updating `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v0\.3\.0 ⇒ v\d\.\d\.\d `https://github\.com/JuliaLang/Example\.jl\.git#master`", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v0\.3\.0 ⇒ v\d\.\d\.\d `https://github\.com/JuliaLang/Example\.jl\.git#master`", readline(io))
         @test occursin(r"Updating `.+Manifest\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v0\.3\.0 ⇒ v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master`", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v0\.3\.0 ⇒ v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master`", readline(io))
         # From tracking repo to tracking path
         Pkg.develop("Example"; status_io=io)
         @test occursin(r"Updating `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v\d\.\d\.\d `https://github\.com/JuliaLang/Example\.jl\.git#master` ⇒ v\d\.\d\.\d `.+`", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d `https://github\.com/JuliaLang/Example\.jl\.git#master` ⇒ v\d\.\d\.\d `.+`", readline(io))
         @test occursin(r"Updating `.+Manifest\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v\d\.\d\.\d `https://github\.com/JuliaLang/Example\.jl\.git#master` ⇒ v\d\.\d\.\d `.+`", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d `https://github\.com/JuliaLang/Example\.jl\.git#master` ⇒ v\d\.\d\.\d `.+`", readline(io))
         # From tracking path to tracking repo
         Pkg.add(Pkg.PackageSpec(; name="Example", rev="master"); status_io=io)
         @test occursin(r"Updating `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v\d\.\d\.\d `.+` ⇒ v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master`", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d `.+` ⇒ v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master`", readline(io))
         @test occursin(r"Updating `.+Manifest\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v\d\.\d\.\d `.+` ⇒ v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master`", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d `.+` ⇒ v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master`", readline(io))
         # From tracking repo to tracking registered version
         Pkg.free("Example"; status_io=io)
         @test occursin(r"Updating `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master` ⇒ v\d\.\d\.\d", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master` ⇒ v\d\.\d\.\d", readline(io))
         @test occursin(r"Updating `.+Manifest\.toml`", readline(io))
-        @test occursin(r"7876af07 ~ Example v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master` ⇒ v\d\.\d\.\d", readline(io))
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d `https://github.com/JuliaLang/Example.jl.git#master` ⇒ v\d\.\d\.\d", readline(io))
         # Removing registered version
         Pkg.rm("Example"; status_io=io)
         @test occursin(r"Updating `.+Project.toml`", readline(io))
-        @test occursin(r"7876af07 - Example v\d\.\d\.\d", readline(io))
+        @test occursin(r"\[7876af07\] - Example v\d\.\d\.\d", readline(io))
         @test occursin(r"Updating `.+Manifest.toml`", readline(io))
-        @test occursin(r"7876af07 - Example v\d\.\d\.\d", readline(io))
+        @test occursin(r"\[7876af07\] - Example v\d\.\d\.\d", readline(io))
     end
     # Project Status API
     isolate(loaded_depot=true) do
         io = PipeBuffer()
         ## empty project
         Pkg.status(;io=io)
-        @test occursin(r"Status `.+Project.toml`", readline(io))
-        @test occursin(r"Status empty project", readline(io))
+        @test occursin(r"Status `.+Project.toml` \(empty project\)", readline(io))
         ## loaded project
         Pkg.add("Markdown")
         Pkg.add(Pkg.PackageSpec(; name="JSON", version="0.18.0"))
@@ -1909,26 +1909,41 @@ matchesline(rx, io) = occursin(rx, readline(io))
         Pkg.add(Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl"))
         Pkg.status(; io = io)
         @test occursin(r"Status `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 Example v\d\.\d\.\d `.+`", readline(io))
-        @test occursin(r"682c06a0 JSON v0.18.0", readline(io))
-        @test occursin(r"dcb67f36 Unregistered v\d\.\d\.\d `https://github\.com/00vareladavid/Unregistered\.jl#master`", readline(io))
-        @test occursin(r"d6f4376e Markdown", readline(io))
+        @test occursin(r"\[7876af07\] Example v\d\.\d\.\d `.+`", readline(io))
+        @test occursin(r"\[682c06a0\] JSON v0.18.0", readline(io))
+        @test occursin(r"\[dcb67f36\] Unregistered v\d\.\d\.\d `https://github\.com/00vareladavid/Unregistered\.jl#master`", readline(io))
+        @test occursin(r"\[d6f4376e\] Markdown", readline(io))
+    end
+    ## status warns when package not installed
+    isolate() do
+        Pkg.activate(joinpath(@__DIR__, "test_packages", "Status"))
+        io = PipeBuffer()
+        Pkg.status(; io=io)
+        @test occursin(r"Status `.+Project.toml`", readline(io))
+        @test occursin(r"→ \[7876af07\] Example v\d\.\d\.\d", readline(io))
+        @test occursin(r"\[d6f4376e\] Markdown", readline(io))
+        @test "Info packages marked with → are not downloaded, use `instantiate` to download" == readline(io)
+        Pkg.status(;io=io, mode=Pkg.PKGMODE_MANIFEST)
+        @test occursin(r"Status `.+Manifest.toml`", readline(io))
+        @test occursin(r"→ \[7876af07\] Example v\d\.\d\.\d", readline(io))
+        @test occursin(r"\[2a0f44e3\] Base64", readline(io))
+        @test occursin(r"\[d6f4376e\] Markdown", readline(io))
+        @test "Info packages marked with → are not downloaded, use `instantiate` to download" == readline(io)
     end
     # Manifest Status API
     isolate(loaded_depot=true) do
         io = PipeBuffer()
         ## empty manfiest
         Pkg.status(;io=io, mode=Pkg.PKGMODE_MANIFEST)
-        @test occursin(r"Status `.+Manifest\.toml`", readline(io))
-        @test occursin(r"Status empty manifest", readline(io))
+        @test occursin(r"Status `.+Manifest\.toml` \(empty manifest\)", readline(io))
         # loaded manifest
         Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"))
         Pkg.add("Markdown")
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST)
         @test occursin(r"Status `.+Manifest.toml`", readline(io))
-        @test occursin(r"7876af07 Example v0\.3\.0", readline(io))
-        @test occursin(r"2a0f44e3 Base64", readline(io))
-        @test occursin(r"d6f4376e Markdown", readline(io))
+        @test occursin(r"\[7876af07\] Example v0\.3\.0", readline(io))
+        @test occursin(r"\[2a0f44e3\] Base64", readline(io))
+        @test occursin(r"\[d6f4376e\] Markdown", readline(io))
     end
     # Diff API
     isolate(loaded_depot=true) do
@@ -1936,60 +1951,52 @@ matchesline(rx, io) = occursin(rx, readline(io))
         projdir = dirname(Pkg.project().path)
         mkpath(projdir)
         git_init_and_commit(projdir)
-        ## empty project diff
+        ## empty project + empty diff
         Pkg.status(; io=io, diff=true)
-        @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"Diff empty project", readline(io))
+        @test occursin(r"No Changes to `.+Project\.toml`", readline(io))
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
-        @test occursin(r"Diff `.+Manifest\.toml`", readline(io))
-        @test occursin(r"Diff empty manifest", readline(io))
-        ### filter should still show "empty project"
+        @test occursin(r"No Changes to `.+Manifest\.toml`", readline(io))
+        ### empty diff + filter
         Pkg.status("Example"; io=io, diff=true)
-        @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"Diff empty project", readline(io))
-        ## non empty project but empty diff
+        @test occursin(r"No Changes to `.+Project\.toml`", readline(io))
+        ## non-empty project but empty diff
         Pkg.add("Markdown")
         git_init_and_commit(dirname(Pkg.project().path))
         Pkg.status(; io=io, diff=true)
-        @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"Diff empty diff", readline(io))
+        @test occursin(r"No Changes to `.+Project\.toml`", readline(io))
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
-        @test occursin(r"Diff `.+Manifest\.toml`", readline(io))
-        @test occursin(r"Diff empty diff", readline(io))
+        @test occursin(r"No Changes to `.+Manifest\.toml`", readline(io))
         ### filter should still show "empty diff"
         Pkg.status("Example"; io=io, diff=true)
-        @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"Diff empty diff", readline(io))
-        ## non empty project + non empty diff
+        @test occursin(r"No Changes to `.+Project\.toml`", readline(io))
+        ## non-empty project + non-empty diff
         Pkg.rm("Markdown")
         Pkg.add(Pkg.PackageSpec(; name="Example", version="0.3.0"))
         ## diff project
         Pkg.status(; io=io, diff=true)
         @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"7876af07 \+ Example v0\.3\.0", readline(io))
-        @test occursin(r"d6f4376e - Markdown", readline(io))
+        @test occursin(r"\[7876af07\] \+ Example v0\.3\.0", readline(io))
+        @test occursin(r"\[d6f4376e\] - Markdown", readline(io))
         ## diff manifest
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
         @test occursin(r"Diff `.+Manifest.toml`", readline(io))
-        @test occursin(r"7876af07 \+ Example v0\.3\.0", readline(io))
-        @test occursin(r"2a0f44e3 - Base64", readline(io))
-        @test occursin(r"d6f4376e - Markdown", readline(io))
+        @test occursin(r"\[7876af07\] \+ Example v0\.3\.0", readline(io))
+        @test occursin(r"\[2a0f44e3\] - Base64", readline(io))
+        @test occursin(r"\[d6f4376e\] - Markdown", readline(io))
         ## diff project with filtering
         Pkg.status("Markdown"; io=io, diff=true)
         @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"d6f4376e - Markdown", readline(io))
-        ## empty project diff filter
+        @test occursin(r"\[d6f4376e\] - Markdown", readline(io))
+        ## empty diff + filter
         Pkg.status("Base64"; io=io, diff=true)
-        @test occursin(r"Diff `.+Project\.toml`", readline(io))
-        @test occursin(r"Diff no matches", readline(io))
+        @test occursin(r"No Matches in diff for `.+Project\.toml`", readline(io))
         ## diff manifest with filtering
         Pkg.status("Base64"; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
         @test occursin(r"Diff `.+Manifest.toml`", readline(io))
-        @test occursin(r"2a0f44e3 - Base64", readline(io))
-        ## empty manifest diff filter
+        @test occursin(r"\[2a0f44e3\] - Base64", readline(io))
+        ## manifest diff + empty filter
         Pkg.status("FooBar"; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
-        @test occursin(r"Diff `.+Manifest.toml`", readline(io))
-        @test occursin(r"Diff no matches", readline(io))
+        @test occursin(r"No Matches in diff for `.+Manifest.toml`", readline(io))
     end
 end
 

--- a/test/test_packages/Status/Manifest.toml
+++ b/test/test_packages/Status/Manifest.toml
@@ -1,0 +1,11 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Example]]
+git-tree-sha1 = "902feab6e7a5830f67868832fcf6995fa74143ac"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.3.0"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/test/test_packages/Status/Project.toml
+++ b/test/test_packages/Status/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -10,7 +10,7 @@ export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
 
 const LOADED_DEPOT = joinpath(@__DIR__, "loaded_depot")
 
-function isolate(fn::Function; kwargs...)
+function isolate(fn::Function; loaded_depot=false, kwargs...)
     old_load_path = copy(LOAD_PATH)
     old_depot_path = copy(DEPOT_PATH)
     old_home_project = Base.HOME_PROJECT[]
@@ -45,7 +45,7 @@ function isolate(fn::Function; kwargs...)
                 target_depot = mktempdir()
                 push!(LOAD_PATH, "@", "@v#.#", "@stdlib")
                 push!(DEPOT_PATH, target_depot)
-                push!(DEPOT_PATH, LOADED_DEPOT)
+                loaded_depot && push!(DEPOT_PATH, LOADED_DEPOT)
                 fn()
             finally
                 if target_depot !== nothing && isdir(target_depot)


### PR DESCRIPTION
A possible alternative to #1656.

This attempts to rectify the concerns in #1621. 

Some example output:
```
(demo0) pkg> status
     Status `/tmp/demo0/Project.toml` (empty project)

(demo0) pkg> status --manifest
     Status `/tmp/demo0/Manifest.toml` (empty manifest)

(demo0) pkg> status --diff
 No Changes to `/tmp/demo0/Project.toml`

(demo0) pkg> status --diff --manifest
 No Changes to `/tmp/demo0/Manifest.toml`

(demo0) pkg> add Example
  Resolving package versions...
   Updating `/tmp/demo0/Project.toml`
  [7876af07] + Example v0.5.3
   Updating `/tmp/demo0/Manifest.toml`
  [7876af07] + Example v0.5.3

(demo0) pkg> add Example
  Resolving package versions...
 No Changes to `/tmp/demo0/Project.toml`
 No Changes to `/tmp/demo0/Manifest.toml`

(demo0) pkg> status
     Status `/tmp/demo0/Project.toml`
  [7876af07] Example v0.5.3

(demo0) pkg> status --diff
       Diff `/tmp/demo0/Project.toml`
  [7876af07] + Example v0.5.3

(demo0) pkg> status --diff Foo
 No Matches in diff for `/tmp/demo0/Project.toml`

(demo0) pkg> status --diff Example
       Diff `/tmp/demo0/Project.toml`
  [7876af07] + Example v0.5.3

(demo0) pkg> status --diff --manifest Example
       Diff `/tmp/demo0/Manifest.toml`
  [7876af07] + Example v0.5.3

(demo0) pkg> add Markdown
  Resolving package versions...
   Updating `/tmp/demo0/Project.toml`
  [d6f4376e] + Markdown
   Updating `/tmp/demo0/Manifest.toml`
  [2a0f44e3] + Base64
  [d6f4376e] + Markdown

julia> push!(empty!(DEPOT_PATH), "/tmp/depot")
1-element Array{String,1}:
 "/tmp/depot"

(demo0) pkg> status
     Status `/tmp/demo0/Project.toml`
→ [7876af07] Example v0.5.3
  [d6f4376e] Markdown
Info packages marked with → are not downloaded, use `instantiate` to download
```