### PR TITLE
Mention that adding `#commit_id` is pinning the package

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -81,7 +81,10 @@ we can explicitly track that branch (or commit) by appending `#branchname` (or `
 ```
 
 The status output now shows that we are tracking the `master` branch of `Example`.
-When updating packages, we will pull updates from that branch.
+When updating packages, we will pull updates from that branch. Notice that if instead
+of a branch name we specified an exact commit id, e.g.
+`add Example#277827f2b18e14a611d98144422eb29f61498104`, then we would be effectively
+"pinned" in that commit (see [Pinning a package](@ref)).
 
 To go back to tracking the registry version of `Example`, the command `free` is used:
 


### PR DESCRIPTION
I had this question on Slack, on whether `add Pkg#master` pins to the branch or also to the commit and if not, how to pin to the commit. Maybe this extra sentence can help clarify things more.