### PR TITLE
backport: Allow pkg server in scheme://server/path format (#1671)

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -23,7 +23,7 @@ function pkg_server()
     server = get(ENV, "JULIA_PKG_SERVER", nothing)
     server === nothing && return nothing
     startswith(server, r"\w+://") || (server = "https://$server")
-    return server
+    return rstrip(server, '/')
 end
 
 function telemetryinfo(io::IO = stdout)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -592,13 +592,12 @@ end
 is_secure_url(url::AbstractString) =
     occursin(r"^(https://|\w+://(127\.0\.0\.1|localhost)(:\d+)?($|/))"i, url)
 
-function get_server_dir(url::AbstractString)
-    server = pkg_server()
+function get_server_dir(url::AbstractString, server=pkg_server())
     server === nothing && return
-    startswith(url, server) || return
-    m = match(r"^\w+://([^\\/]+)$", server)
+    url == server || startswith(url, "$server/") || return
+    m = match(r"^\w+://([^\\/]+)(?:$|/)", server)
     if m === nothing
-        @warn "malformed Pkg server value" server=server
+        @warn "malformed Pkg server value" server
         return
     end
     joinpath(depots1(), "servers", m.captures[1])


### PR DESCRIPTION
The tests in #1671 are removed since this branch doesn't have "Authentication Header Hooks" testset yet. I've tested it locally using the following servers:

* `http://juliapkg.lflab.cn`
* `https://mirrors.lflab.cn/julia` and `http://mirrors.lflab.cn/julia`