### PR TITLE
add Pkg.uuid and uuid REPL command

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -836,6 +836,22 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=
     return nothing
 end
 
+uuid(pkg::Union{AbstractString,PackageSpec}; kws...) = uuid(Context(), pkg; kws...)
+uuid(ctx::Context, pkg::Union{AbstractString,PackageSpec}; mode=PKGMODE_COMBINED) = Types.resolve!(ctx, [check_package_name(pkg)]; mode=mode)[1].uuid
+
+print_uuids(pkg::Union{AbstractString,PackageSpec}; kwargs...) = print_uuids([pkg]; kwargs...)
+print_uuids(pkgs::Vector{<:AbstractString}; kwargs...) = print_uuids(check_package_name.(pkgs); kwargs...)
+print_uuids(pkgs::Vector{PackageSpec}; kwargs...) = print_uuids(Context(), pkgs; kwargs...)
+function print_uuids(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_COMBINED,
+                     io::IO=stdout, kwargs...)
+    Context!(ctx; io=io, kwargs...)
+    for p in Types.resolve!(ctx, pkgs; mode=mode)
+        printstyled(io, "   ", p.uuid, " "; color = :light_black)
+        printstyled(io, p.name; color = :white)
+        print(io, '\n')
+    end
+    return nothing
+end
 
 function activate()
     Base.ACTIVE_PROJECT[] = nothing

--- a/src/API.jl
+++ b/src/API.jl
@@ -836,8 +836,8 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=
     return nothing
 end
 
-uuid(pkg::Union{AbstractString,PackageSpec}; kws...) = uuid(Context(), pkg; kws...)
-uuid(ctx::Context, pkg::Union{AbstractString,PackageSpec}; mode=PKGMODE_COMBINED) = Types.resolve!(ctx, [check_package_name(pkg)]; mode=mode)[1].uuid
+uuid(pkg::AbstractString; kws...) = uuid(Context(), pkg; kws...)
+uuid(ctx::Context, pkg::AbstractString; mode=PKGMODE_COMBINED) = Types.resolve!(ctx, [check_package_name(pkg)]; mode=mode)[1].uuid
 
 print_uuids(pkg::Union{AbstractString,PackageSpec}; kwargs...) = print_uuids([pkg]; kwargs...)
 print_uuids(pkgs::Vector{<:AbstractString}; kwargs...) = print_uuids(check_package_name.(pkgs); kwargs...)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -476,6 +476,13 @@ See also: [`redo`](@ref).
 const undo = API.undo
 
 """
+    uuid(pkg)
+
+Returns the `UUID` of the package `pkg`.
+"""
+const uuid = API.uuid
+
+"""
     redo()
 
 Redoes the changes from the latest [`undo`](@ref).

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -322,6 +322,34 @@ the output to the difference as compared to the last git commit.
     The `--diff` option requires Julia 1.3. In earlier versions `--diff`
     is the default for environments in git repositories.
 """,
+],[ :name => "uuid",
+:short_name => "id",
+:api => API.print_uuids,
+:should_splat => false,
+:arg_count => 1 => Inf,
+:arg_parser => parse_package,
+:option_spec => OptionDeclaration[
+    [:name => "combined",  :short_name => "c", :api => :mode => PKGMODE_COMBINED],
+    [:name => "project",  :short_name => "p", :api => :mode => PKGMODE_PROJECT],
+    [:name => "registry", :short_name => "r", :api => :mode => PKGMODE_REGISTRY],
+],
+:completions => complete_installed_packages,
+:description => "show package UUIDs",
+:help => md"""
+    uuid [-c|--combined] pkgs...
+    uuid [-p|--project] pkgs...
+    uuid [-r|--registry] pkgs...
+
+Shows the full UUIDs of the listed packages. In `--combined` mode (default),
+it looks for the packages in the currently project and manifest and
+then in the registry of installable packages, whereas in `--project`
+mode it only looks in the current project and manifest, and
+in `--registry` mode it looks only in the registry (updated if needed)
+and the standard library.
+
+!!! compat "Julia 1.5"
+    `pkg> uuid pkgs...` equires at least Julia 1.5.
+""",
 ],[ :name => "gc",
     :api => API.gc,
     :option_spec => OptionDeclaration[

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -85,6 +85,7 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
     #@eval import Example
     #@eval import $(Symbol(pkg2))
     @test Pkg.dependencies()[pkg2_uuid].version == v"0.1.0"
+    @test Pkg.uuid(pkg2) == pkg2_uuid
     Pkg.REPLMode.pkgstr("free $pkg2")
     @test_throws PkgError Pkg.REPLMode.pkgstr("free $pkg2")
     Pkg.test("UnregisteredWithProject")
@@ -125,6 +126,7 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
                     pushfirst!(DEPOT_PATH, depot_dir)
                     pkg"instantiate"
                     @test Pkg.dependencies()[pkg2_uuid].version == v"0.2.0"
+                    @test Pkg.uuid(pkg2) == pkg2_uuid
                 end
             finally
                 empty!(DEPOT_PATH)


### PR DESCRIPTION
This PR allows you to do `Pkg.uuid("Foo")` to look up the UUID for an installed and/or registered package `Foo`, and adds a corresponding command `uuid pkgs...` to the `pkg>` REPL.

This was discussed [on discourse](https://discourse.julialang.org/t/how-can-i-know-the-uuid-of-a-registered-package/14081) multiple [times](https://discourse.julialang.org/t/pkg-api-for-getting-uuid-of-another-package/15061), and I find the existing solutions rather awkward.