### PR TITLE
remove tls security option

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -369,8 +369,6 @@ function probe_platform_engines!(;verbose::Bool = false)
         psh_download = (psh_path) -> begin
             return (url, path, hdrs...) -> begin
                 webclient_code = """
-                [System.Net.ServicePointManager]::SecurityProtocol =
-                    [System.Net.SecurityProtocolType]::Tls12;
                 \$webclient = (New-Object System.Net.Webclient);
                 \$webclient.UseDefaultCredentials = \$true;
                 \$webclient.Proxy.Credentials = \$webclient.Credentials;


### PR DESCRIPTION
After iterating over different options: `Tls`, `Tls11`, `Tls13` and `SystemDefault`(logs can be found in https://github.com/johnnychen94/Pkg.jl/pull/1). Seems like this fixes #1642  but needs Microsoft & network expert to identify if there's a problem

It would be great if this can be backported to `release-1.4`.

Reference: https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netframework-4.8