### PR TITLE
`cp` instead of `mv` in `update_registries`

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1053,7 +1053,7 @@ function update_registries(ctx::Context, regs::Vector{RegistrySpec} = collect_re
                     registry_file = joinpath(tmp, "Registry.toml")
                     registry = read_registry(registry_file; cache=false)
                     verify_registry(registry)
-                    mv(tmp, reg.path, force=true)
+                    cp(tmp, reg.path, force=true)
                 end
             end
         elseif isdir(joinpath(reg.path, ".git"))


### PR DESCRIPTION
`mktempdir` shows an error if the dir is removed in the `do` block:
```
┌ Error: mktempdir cleanup
│   exception =
│    IOError: chmod: no such file or directory (ENOENT)
│    Stacktrace:
│     [1] uv_error at .\libuv.jl:97 [inlined]
│     [2] #chmod#21(::Bool, ::typeof(chmod), ::String, ::UInt16) at .\file.jl:888
│     [3] chmod at .\file.jl:887 [inlined]
│     [4] #rm#9(::Bool, ::Bool, ::typeof(rm), ::String) at .\file.jl:258
│     [5] #rm at .\none:0 [inlined]
│     [6] #mktempdir#18(::String, ::typeof(mktempdir), ::Pkg.Types.var"#113#116"{String}, ::String) at .\file.jl:637
│     [7] mktempdir(::Function, ::String) at .\file.jl:632 (repeats 2 times)
│     [8] #update_registries#111(::Bool, ::typeof(Pkg.Types.update_registries), ::Pkg.Types.Context, ::Array{Pkg.Types.RegistrySpec,1}) at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\Types.jl:1041
│     [9] #update_registries at .\none:0 [inlined] (repeats 2 times)
│     [10] #up#50(::Pkg.Types.UpgradeLevel, ::Pkg.Types.PackageMode, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(Pkg.API.up), ::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}) at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\API.jl:207
│     [11] up at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\API.jl:201 [inlined]
│     [12] #up#49 at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\API.jl:196 [inlined]
│     [13] up at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\API.jl:196 [inlined]
│     [14] #up#46 at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\API.jl:193 [inlined]
│     [15] up() at C:\Users\julia\AppData\Local\Julia-1.3.1\share\julia\stdlib\v1.3\Pkg\src\API.jl:193
│     [16] top-level scope at untitled-119f9ec655141e6ac8fdf0934c033e22:1
```