### PR TITLE
fix bug in Operations.source_path with paths relative to project

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -785,7 +785,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Handling packages tracking repos
     for pkg in pkgs
         pkg.repo.source !== nothing || continue
-        sourcepath = Operations.source_path(pkg)
+        sourcepath = Operations.source_path(ctx, pkg)
         isdir(sourcepath) && continue
         ## Download repo at tree hash
         # determine canonical form of repo source

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -35,9 +35,9 @@ end
 tracking_registered_version(pkg) =
     !is_stdlib(pkg.uuid) && pkg.path === nothing && pkg.repo.source === nothing
 
-function source_path(pkg::PackageSpec)
+function source_path(ctx, pkg::PackageSpec)
     return is_stdlib(pkg.uuid)      ? Types.stdlib_path(pkg.name) :
-        pkg.path        !== nothing ? pkg.path :
+        pkg.path        !== nothing ? joinpath(dirname(ctx.env.project_file), pkg.path) :
         pkg.repo.source !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
         pkg.tree_hash   !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
         nothing
@@ -111,7 +111,7 @@ function is_instantiated(ctx::Context)::Bool
     pkgs = load_all_deps(ctx)
     # Make sure all paths exist
     for pkg in pkgs
-        sourcepath = Operations.source_path(pkg)
+        sourcepath = Operations.source_path(ctx, pkg)
         isdir(sourcepath) || return false
         check_artifacts_downloaded(sourcepath) || return false
     end
@@ -216,7 +216,7 @@ function load_deps(ctx::Context, pkg::PackageSpec)::Dict{String,UUID}
         end
         return Dict{String,UUID}()
     else
-        path = project_rel_path(ctx, source_path(pkg))
+        path = project_rel_path(ctx, source_path(ctx, pkg))
         project_file = projectfile_path(path; strict=true)
         project_file === nothing && pkgerror("could not find Project file for package $(pkg.name)")
         project = read_project(project_file)
@@ -255,12 +255,12 @@ is_tracking_registry(pkg) = !is_tracking_path(pkg) && !is_tracking_repo(pkg)
 isfixed(pkg) = !is_tracking_registry(pkg) || pkg.pinned
 
 function collect_developed!(ctx::Context, pkg::PackageSpec, developed::Vector{PackageSpec})
-    source = project_rel_path(ctx, source_path(pkg))
+    source = project_rel_path(ctx, source_path(ctx, pkg))
     source_ctx = Context(env = EnvCache(projectfile_path(source)))
     pkgs = load_all_deps(source_ctx)
     for pkg in filter(is_tracking_path, pkgs)
         # normalize path
-        pkg.path = Types.relative_project_path(ctx, project_rel_path(source_ctx, source_path(pkg)))
+        pkg.path = Types.relative_project_path(ctx, project_rel_path(source_ctx, source_path(source_ctx, pkg)))
         push!(developed, pkg)
         collect_developed!(ctx, pkg, developed)
     end
@@ -277,7 +277,7 @@ end
 function collect_fixed!(ctx::Context, pkgs::Vector{PackageSpec}, names::Dict{UUID, String})
     deps_map = Dict{UUID,Vector{PackageSpec}}()
     for pkg in pkgs
-        path = project_rel_path(ctx, source_path(pkg))
+        path = project_rel_path(ctx, source_path(ctx, pkg))
         if !isdir(path)
             pkgerror("expected package $(err_rep(pkg)) to exist at path `$path`")
         end
@@ -590,7 +590,7 @@ end
 function download_artifacts(ctx::Context, pkgs::Vector{PackageSpec}; platform::Platform=platform_key_abi(),
                             verbose::Bool=false)
     # Filter out packages that have no source_path()
-    pkg_roots = String[p for p in source_path.(pkgs) if p !== nothing]
+    pkg_roots = String[p for p in source_path.((ctx,), pkgs) if p !== nothing]
     return download_artifacts(ctx, pkg_roots; platform=platform, verbose=verbose)
 end
 
@@ -646,7 +646,7 @@ function download_source(ctx::Context, pkgs::Vector{PackageSpec},
 
     pkgs_to_install = Tuple{PackageSpec, String}[]
     for pkg in pkgs
-        path = source_path(pkg)
+        path = source_path(ctx, pkg)
         ispath(path) && continue
         push!(pkgs_to_install, (pkg, path))
         push!(new_pkgs, pkg)
@@ -1416,7 +1416,7 @@ function gen_target_project(ctx::Context, pkg::PackageSpec, source_path::String,
         if target == "test"
             test_REQUIRE_path = joinpath(source_path, "test", "REQUIRE")
             if isfile(test_REQUIRE_path)
-                @warn "using test/REQUIRE files is deprecated and current support is lacking in some areas" 
+                @warn "using test/REQUIRE files is deprecated and current support is lacking in some areas"
                 test_pkgs = parse_REQUIRE(test_REQUIRE_path)
                 package_specs = [PackageSpec(name=pkg) for pkg in test_pkgs]
                 registry_resolve!(ctx, package_specs)
@@ -1472,7 +1472,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
     missing_runtests = String[]
     source_paths     = String[]
     for pkg in pkgs
-        sourcepath = project_rel_path(ctx, source_path(pkg)) # TODO
+        sourcepath = project_rel_path(ctx, source_path(ctx, pkg)) # TODO
         !isfile(testfile(sourcepath)) && push!(missing_runtests, pkg.name)
         push!(source_paths, sourcepath)
     end
@@ -1536,7 +1536,7 @@ function package_info(ctx::Context, pkg::PackageSpec, entry::PackageEntry)::Pack
         is_tracking_registry = is_tracking_registry(pkg),
         git_revision         = pkg.repo.rev,
         git_source           = git_source,
-        source               = project_rel_path(ctx, source_path(pkg)),
+        source               = project_rel_path(ctx, source_path(ctx, pkg)),
         dependencies         = copy(entry.deps), #TODO is copy needed?
     )
     return info

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -589,7 +589,7 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
 
         # If we already resolved a uuid, we can bail early if this package is already installed at the current tree_hash
         if has_uuid(pkg)
-            version_path = Pkg.Operations.source_path(pkg)
+            version_path = Pkg.Operations.source_path(ctx, pkg)
             isdir(version_path) && return false
         end
 
@@ -599,7 +599,7 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
 
         # Now that we are fully resolved (name, UUID, tree_hash, repo.source, repo.rev), we can finally
         # check to see if the package exists at its canonical path.
-        version_path = Pkg.Operations.source_path(pkg)
+        version_path = Pkg.Operations.source_path(ctx, pkg)
         isdir(version_path) && return false
 
         # Otherwise, move the temporary path into its correct place and set read only

--- a/test/new.jl
+++ b/test/new.jl
@@ -698,8 +698,12 @@ end
         # Now we try to find the package.
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
         Pkg.instantiate()
+        # Test that Operations.is_instantiated works with relative path
+        @test Operations.is_instantiated(Pkg.Types.Context())
         # Now we destroy the relative position and should not be able to find the package.
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
+        # Test that Operations.is_instantiated works with relative path
+        @test !Operations.is_instantiated(Pkg.Types.Context())
         mktempdir() do other_dir
             cp(dirname(Base.active_project()), other_dir; force=true)
             Pkg.activate(other_dir)

--- a/test/new.jl
+++ b/test/new.jl
@@ -699,11 +699,11 @@ end
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
         Pkg.instantiate()
         # Test that Operations.is_instantiated works with relative path
-        @test Operations.is_instantiated(Pkg.Types.Context())
+        @test Pkg.Operations.is_instantiated(Pkg.Types.Context())
         # Now we destroy the relative position and should not be able to find the package.
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
         # Test that Operations.is_instantiated works with relative path
-        @test !Operations.is_instantiated(Pkg.Types.Context())
+        @test !Pkg.Operations.is_instantiated(Pkg.Types.Context())
         mktempdir() do other_dir
             cp(dirname(Base.active_project()), other_dir; force=true)
             Pkg.activate(other_dir)


### PR DESCRIPTION
This manifested itself that the registry got updated when doing `Pkg.instantiate` even though everything was installed if you had a relative path in the manifest and were not in the directory of the project file.