### PR TITLE
ADDED JULIA_PKG_TELEMETRY ENV variable to control sending of telemetry.

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -815,6 +815,7 @@ const CI_VARIABLES = [
 
 function get_telemetry_headers(url::AbstractString)
     headers = String[]
+    haskey(ENV, "JULIA_PKG_TELEMETRY") || return headers
     server_dir = get_server_dir(url)
     server_dir === nothing && return headers
     push!(headers, "Julia-Pkg-Protocol: 1.0")


### PR DESCRIPTION
This PR was created following a lengthy discussion on Slack with the purpose of separating the concepts of using the new Pkg servers (using JULIA_PKG_SERVER) from opting in to sending telemetry.

The JULIA_PKG_TELEMETRY environment variable indicates, if set to any value, that telemetry data will be sent to the Pkg servers.

This should probably be documented some place other than just this PR and I'd be happy to add the documentation, I'll just need some info where to put it.