### PR TITLE
Add current project as a Fixed package for the resolver and fix a bug when developed packages had cycles in paths

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -259,6 +259,11 @@ function collect_developed!(ctx::Context, pkg::PackageSpec, developed::Vector{Pa
     source_ctx = Context(env = EnvCache(projectfile_path(source)))
     pkgs = load_all_deps(source_ctx)
     for pkg in filter(is_tracking_path, pkgs)
+        # Break eventual cycles
+        if any(x -> x.uuid == pkg.uuid, developed)
+            @debug "found a cycle when collecting developed packages for $(pkg.name)"
+            continue
+        end
         # normalize path
         pkg.path = Types.relative_project_path(ctx, project_rel_path(source_ctx, source_path(source_ctx, pkg)))
         push!(developed, pkg)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2182,6 +2182,23 @@ end
     end
 end
 
+@testset "cycles" begin
+    isolate(loaded_depot=true) do
+        cd_tempdir() do dir
+            Pkg.generate("Cycle_A")
+            cycle_a_uuid = Pkg.Types.read_project("Cycle_A/Project.toml").uuid
+            Pkg.generate("Cycle_B")
+            cycle_b_uuid = Pkg.Types.read_project("Cycle_A/Project.toml").uuid
+            Pkg.activate("Cycle_A")
+            Pkg.develop(Pkg.PackageSpec(path="Cycle_B"))
+            Pkg.activate("Cycle_B")
+            Pkg.develop(Pkg.PackageSpec(path="Cycle_A"))
+            manifest_b = Pkg.Types.read_manifest("Cycle_B/Manifest.toml")
+            @test cycle_a_uuid in keys(manifest_b)
+            @test_broken !(cycle_b_uuid in keys(manifest_b))
+        end
+    end
+end
 #
 # # Other
 #

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -565,6 +565,8 @@ end
 @testset "targets should survive add/rm" begin
     temp_pkg_dir() do project_path; cd_tempdir() do tmpdir
         cp(joinpath(@__DIR__, "project", "good", "pkg.toml"), "Project.toml")
+        mkdir("src")
+        touch("src/Pkg.jl")
         targets = deepcopy(Pkg.Types.read_project("Project.toml").targets)
         Pkg.activate(".")
         Pkg.add("Example")

--- a/test/test_packages/ExtraDirectDep/src/ExtraDirectDep.jl
+++ b/test/test_packages/ExtraDirectDep/src/ExtraDirectDep.jl
@@ -1,0 +1,3 @@
+module ExtraDirectDep
+
+end


### PR DESCRIPTION
@SimonDanisch posted an error message that didn't make sense to me:

```
(AbstractPlotting) pkg> add MakieGallery#master
ERROR: Unsatisfiable requirements detected for package FreeTypeAbstraction [663a7486]:
 FreeTypeAbstraction [663a7486] log:
 ├─possible versions are: 0.6.0 or uninstalled
 ├─FreeTypeAbstraction [663a7486] is fixed to version 0.6.0
 └─found to have no compatible versions left with AbstractPlotting [537997a7] 
   └─AbstractPlotting [537997a7] log:
     ├─possible versions are: 0.9.0-0.9.21 or uninstalled
     └─restricted to versions 0.9.16-0.9 by MakieGallery [dbd62bd0], leaving only versions 
```

The weirdness here is:

- Why is the resolver saying that the possible versions for `AbstractPlotting` is `0.9.0-0.9.21` when AbstractPlotting is the active project and should thus have a fixed version.
- Simon had added `FreeTypeAbstraction = "0.6"` to the project file but still the resolver said `found to have no compatible versions left with AbstractPlotting [537997a7] `.

I believe the reason for this weirdness is that we never explicitly say that the current project should be considered a fixed package to the resolver. The first commit tries to fix that and running with it makes the package add properly.

The second commit tries to address the fact that `collect_developed` can get into an infinite recursion if two packages are developed and depend on each other. I noticed this here because MakieGallery depends on AbstractPlotting.

However, when we have such a cyclic dependency, the project itself gets written to the Manifest (since it is a dependency). This is kinda weird but I will open a separate issue for that.