### PR TITLE
Update package naming guidelines

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -264,7 +264,7 @@ may fit your package better.
 2. Avoid using `Julia` in your package name or prefixing it with `Ju`.
 
      * It is usually clear from context and to your users that the package is a Julia package.
-     * Package names already have a `.jl` extension, which communicates to users that `package.jl` is a Julia package.
+     * Package names already have a `.jl` extension, which communicates to users that `Package.jl` is a Julia package.
      * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors
        to the Julia language itself.
 3. Packages that provide most of their functionality in association with a new type should have pluralized

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -261,9 +261,10 @@ may fit your package better.
 
      * It's ok to say `USA` if you're talking about the USA.
      * It's not ok to say `PMA`, even if you're talking about positive mental attitude.
-2. Avoid using `Julia` in your package name.
+2. Avoid using `Julia` in your package name or prefixing it with `Ju`.
 
      * It is usually clear from context and to your users that the package is a Julia package.
+     * Package names already have a `.jl` extension, which communicates to users that `package.jl` is a Julia package.
      * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors
        to the Julia language itself.
 3. Packages that provide most of their functionality in association with a new type should have pluralized


### PR DESCRIPTION
Suggest not prefixing package names with `Ju` as it is redundant, just like we already suggest not using `Julia` in the package name.

It is generally ok to use `Julia` in a github org name.  I am not sure if this is the right place to mention that.