### PR TITLE
Ability to `Pkg.add` but not download artifacts or run build steps

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -108,7 +108,8 @@ add(pkgs::Vector{<:AbstractString}; kwargs...) =
     add([check_package_name(pkg, :add) for pkg in pkgs]; kwargs...)
 add(pkgs::Vector{PackageSpec}; kwargs...)      = add(Context(), pkgs; kwargs...)
 function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PRESERVE_TIERED,
-             platform::Platform=platform_key_abi(), kwargs...)
+             platform::Platform=platform_key_abi(),
+             artifacts::Bool=true, build::Bool=true, kwargs...)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
@@ -156,7 +157,9 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
         end
     end
 
-    Operations.add(ctx, pkgs, new_git; preserve=preserve, platform=platform)
+    Operations.add(ctx, pkgs, new_git;
+                   preserve=preserve, platform=platform,
+                   artifacts=artifacts, build=build)
     return
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1086,7 +1086,8 @@ function _resolve(ctx::Context, pkgs::Vector{PackageSpec}, preserve::PreserveLev
 end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[];
-             preserve::PreserveLevel=PRESERVE_TIERED, platform::Platform=platform_key_abi())
+             preserve::PreserveLevel=PRESERVE_TIERED, platform::Platform=platform_key_abi(),
+             artifacts::Bool=true, build::Bool=true)
     assert_can_add(ctx, pkgs)
     # load manifest data
     for (i, pkg) in pairs(pkgs)
@@ -1101,11 +1102,11 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[];
 
     # After downloading resolutionary packages, search for (Julia)Artifacts.toml files
     # and ensure they are all downloaded and unpacked as well:
-    download_artifacts(ctx, pkgs; platform=platform)
+    artifacts && download_artifacts(ctx, pkgs; platform=platform)
 
     show_update(ctx)
     write_env(ctx.env) # write env before building
-    build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
+    build && build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
 # Input: name, uuid, and path


### PR DESCRIPTION
I’ve intentionally left this undocumented, because this is really only for internal use. E.g. I’m planning on proposing an additional CI step for the General registry that runs `Pkg.add` for every package. This will be much faster if I can skip artifacts and builds.

cc: @StefanKarpinski 