### PR TITLE
Ignore symlinks when fixing permissions during artifacts tests

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -8,7 +8,7 @@ import Base: SHA1
 
 using ..Utils
 
-# Helper function to create an artifact, then chmod() the whole thing to 0o755.  This is
+# Helper function to create an artifact, then chmod() the whole thing to 0o644.  This is
 # important to keep hashes stable across platforms that have different umasks, changing
 # the permissions within a tree hash, breaking our tests.
 function create_artifact_chmod(f::Function)
@@ -18,7 +18,8 @@ function create_artifact_chmod(f::Function)
         # Change all files to have 644 permissions, leave directories alone
         for (root, dirs, files) in walkdir(path)
             for f in files
-                chmod(joinpath(root, f), 0o644)
+                f = joinpath(root, f)
+                islink(f) || chmod(f, 0o644)
             end
         end
     end


### PR DESCRIPTION
When doing Artifact tests, we need to be resilient to strange umasks
that we have inherited from our environment, screwing up git tree hash
calculations.  To do this, we have a `walkdir()` -> `chmod()` wrapper
function that started setting permissions on what it thought were files
(due to the fixed `follow_symlink == false` behavior in
https://github.com/JuliaLang/julia/pull/35006) but were actually
directories.  This caused `chmod()` to apply `0o664` permissions to
directories, which were then inaccessible to `rm()` as it tried to
delete them.

This fixes https://github.com/JuliaLang/Pkg.jl/issues/1716