### PR TITLE
fix issue #1732 Pkg.dependencies docstring not rendering underscore. 

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -310,13 +310,13 @@ The result is a `Dict` that maps a package UUID to a `PackageInfo` struct repres
 
 | Field             | Description                                                |
 |:------------------|:-----------------------------------------------------------|
-| name              | The name of the package                                    |
-| version           | The version of the package (this is `Nothing` for stdlibs) |
-| is_direct_dep     | The package is a direct dependency                         |
-| is_tracking_path  | Whether a package is directly tracking a directory         |
-| is_pinned         | Whether a package is pinned                                |
-| source            | The directory containing the source code for that package  |
-| dependencies      | The dependencies of that package as a vector of UUIDs      |
+| `name`            | The name of the package                                    |
+| `version`         | The version of the package (this is `Nothing` for stdlibs) |
+| `is_direct_dep`   | The package is a direct dependency                         |
+| `is_tracking_path`| Whether a package is directly tracking a directory         |
+| `is_pinned`       | Whether a package is pinned                                |
+| `source`          | The directory containing the source code for that package  |
+| `dependencies`    | The dependencies of that package as a vector of UUIDs      |
 """
 const dependencies = API.dependencies
 


### PR DESCRIPTION
To fix #1732 

Before:
<img width="1169" alt="SS 2020-03-24 at 20 57 01" src="https://user-images.githubusercontent.com/3813847/77423213-22c4a200-6e12-11ea-9fa4-5a77c1f630ff.png">

After:
<img width="1152" alt="SS 2020-03-24 at 20 54 06" src="https://user-images.githubusercontent.com/3813847/77423044-e133f700-6e11-11ea-831f-d5e251983499.png">
