### PR TITLE
Fix that version ranges in keys for one registry also applies to versions in another registry

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -149,12 +149,12 @@ function load_package_data(f::Base.Callable, path::String, versions)
     uncompressed = Dict{VersionNumber, Dict{String, f isa Type ? f : Any}}()
     for (vers, data) in compressed
         vs = VersionSpec(vers)
-        for v in versions
+        for v in sort(versions)
             v in vs || continue
             uv = get!(uncompressed, v, Dict())
             for (key, value) in data
                 if haskey(uv, key)
-                    error("Overlapping ranges for $(key) in $(repr(path)). Detected for version $(v) with $(uv).")
+                    @warn "Overlapping ranges for $(key) in $(repr(path)) for version $v."
                 else
                     uv[key] = f(value)
                 end

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -54,8 +54,11 @@ function complete_remote_package(partial)
         for (uuid, pkginfo) in data["packages"]
             name = pkginfo["name"]
             if startswith(name, partial)
-                compat_data = Operations.load_package_data_raw(
-                    VersionSpec, joinpath(reg.path, pkginfo["path"], "Compat.toml"))
+                path = pkginfo["path"]
+                version_info = Operations.load_versions(path; include_yanked = false)
+                versions = sort!(collect(keys(version_info)))
+                compat_data = Operations.load_package_data(
+                    VersionSpec, joinpath(reg.path, path, "Compat.toml"), versions)
                 supported_julia_versions = VersionSpec()
                 found_julia_compat = false
                 for (ver_range, compats) in compat_data

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -240,7 +240,6 @@ mutable struct Graph
         )
         # make sure all versions of all packages know about julia uuid
         for (uuid, _) in deps
-            deps[uuid][VersionRange()] = Dict("julia" => uuid_julia)
             for v in versions[uuid]
                 get!(deps[uuid], v, Dict())["julia"] = uuid_julia
             end
@@ -268,13 +267,14 @@ mutable struct Graph
         for p0 = 1:np, v0 = 1:(spp[p0]-1)
             n2u = Dict{String,UUID}()
             vn = pvers[p0][v0]
-            vrmap = deps[pkgs[p0]][vn]
+            vrmap = get(() -> Dict(), deps[pkgs[p0]], vn)
             for (name, uuid) in vrmap
                 # check conflicts ??
                 n2u[name] = uuid
             end
             req = Dict{Int,VersionSpec}()
-            vrmap = compat[pkgs[p0]][vn]
+            uuid = pkgs[p0]
+            vrmap = get(() -> Dict(), compat[pkgs[p0]], vn)
             for (name,vs) in vrmap
                 haskey(n2u, name) || error("Unknown package $name found in the compatibility requirements of $(pkgID(pkgs[p0], uuid_to_name))")
                 uuid = n2u[name]

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -268,12 +268,8 @@ mutable struct Graph
         for p0 = 1:np, v0 = 1:(spp[p0]-1)
             n2u = Dict{String,UUID}()
             vn = pvers[p0][v0]
-            for (vr,vrmap) in deps[pkgs[p0]]
-                vn ∈ vr || continue
-                for (name, uuid) in vrmap
             vrmap = deps[pkgs[p0]][vn]
             for (name, uuid) in vrmap
-                end
                 # check conflicts ??
                 n2u[name] = uuid
             end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1166,13 +1166,12 @@ function find_registered!(ctx::Context,
     # note: empty vectors will be left for names & uuids that aren't found
     clone_default_registries(ctx)
     for registry in collect_registries()
-
         reg_abspath = abspath(registry.path)
         data = read_registry(joinpath(registry.path, "Registry.toml"))
         for (_uuid, pkgdata) in data["packages"]
               uuid = UUID(_uuid)
               name = pkgdata["name"]
-              path = joinpath(registry.path, pkgdata["path"])
+              path = joinpath(reg_abspath, pkgdata["path"])
               push!(get!(ctx.env.uuids, name, UUID[]), uuid)
               push!(get!(ctx.env.paths, uuid, String[]), path)
               push!(get!(ctx.env.names, uuid, String[]), name)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -19,8 +19,7 @@ import ..PlatformEngines: probe_platform_engines!, download, download_verify_unp
 import Base: SHA1
 using SHA
 
-export UUID, pkgID, SHA1, VersionRange, VersionSpec, empty_versionspec,
-    Requires, Fixed, merge_requires!, satisfies, ResolverError,
+export UUID, pkgID, SHA1, VersionRange, VersionSpec,
     PackageSpec, EnvCache, Context, PackageInfo, ProjectInfo, GitRepo, Context!, err_rep,
     PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved, instantiate_pkg_repo!,

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -49,46 +49,13 @@ function storeuuid(p::String, uuid_to_name::Dict{UUID,String})
 end
 wantuuids(want_data) = Dict{UUID,VersionNumber}(pkguuid(p) => v for (p,v) in want_data)
 
-function gen_versionranges(dict::Dict{K,Set{VersionNumber}}, srtvers::Vector{VersionNumber}) where {K}
-    vranges = Dict{K,Vector{VersionRange}}()
-    for (vreq,vset) in dict
-        vranges[vreq] = VersionRange[]
-        while !isempty(vset)
-            vn0 = minimum(vset)
-            i = findfirst(isequal(vn0), srtvers)
-            @assert i ≠ 0
-            pop!(vset, vn0)
-            vn1 = vn0
-            pushed = false
-            j = i + 1
-            while j ≤ length(srtvers)
-                vn = srtvers[j]
-                if vn ∈ vset
-                    pop!(vset, vn)
-                    vn1 = vn
-                    j += 1
-                else
-                    # vn1 =  srtvers[j-1]
-                    push!(vranges[vreq], VersionRange(VersionBound(vn0),VersionBound(vn1)))
-                    pushed = true
-                    break
-                end
-            end
-            !pushed && push!(vranges[vreq], VersionRange(VersionBound(vn0),VersionBound(vn1)))
-        end
-    end
-    allvranges = unique(vcat(collect(values(vranges))...))
-    return vranges, allvranges
-end
-
 function graph_from_data(deps_data)
     uuid_to_name = Dict{UUID,String}()
     uuid(p) = storeuuid(p, uuid_to_name)
-    # deps = DepsGraph(uuid_to_name)
     fixed = Dict{UUID,Fixed}()
-    all_versions = Dict{UUID,Set{VersionNumber}}(fp => Set([fx.version]) for (fp,fx) in fixed)
-    all_deps = Dict{UUID,Dict{VersionRange,Dict{String,UUID}}}(fp => Dict(VersionRange(fx.version)=>Dict()) for (fp,fx) in fixed)
-    all_compat = Dict{UUID,Dict{VersionRange,Dict{String,VersionSpec}}}(fp => Dict(VersionRange(fx.version)=>Dict()) for (fp,fx) in fixed)
+    all_versions = Dict{UUID,Set{VersionNumber}}()
+    all_deps = Dict{UUID,Dict{VersionNumber,Dict{String,UUID}}}()
+    all_compat = Dict{UUID,Dict{VersionNumber,Dict{String,VersionSpec}}}()
 
     deps = Dict{String,Dict{VersionNumber,Dict{String,VersionSpec}}}()
     for d in deps_data
@@ -104,37 +71,22 @@ function graph_from_data(deps_data)
         rvs = VersionSpec(r[2:end])
         deps[p][vn][rp] = rvs
     end
-    for p in keys(deps)
+    for (p,preq) in deps
         u = uuid(p)
         all_versions[u] = Set(keys(deps[p]))
-        srtvers = sort!(collect(keys(deps[p])))
 
         deps_pkgs = Dict{String,Set{VersionNumber}}()
         for (vn,vreq) in deps[p], rp in keys(vreq)
-            push!(get!(deps_pkgs, rp, Set{VersionNumber}()), vn)
+            push!(get!(Set{VersionNumber}, deps_pkgs, rp), vn)
         end
-        vranges, allvranges = gen_versionranges(deps_pkgs, srtvers)
-        all_deps[u] = Dict{VersionRange,Dict{String,UUID}}(VersionRange()=>Dict{String,UUID}("julia"=>Resolve.uuid_julia))
-        for vrng in allvranges
-            all_deps[u][vrng] = Dict{String,UUID}()
-            for (rp,vvr) in vranges
-                vrng ∈ vvr || continue
-                all_deps[u][vrng][rp] = uuid(rp)
-            end
-        end
-
-        deps_reqs = Dict{Pair{String,VersionSpec},Set{VersionNumber}}()
-        for (vn,vreq) in deps[p], (rp,rvs) in vreq
-            push!(get!(deps_reqs, (rp=>rvs), Set{VersionNumber}()), vn)
-        end
-        vranges, allvranges = gen_versionranges(deps_reqs, srtvers)
-        all_compat[u] = Dict{VersionRange,Dict{String,VersionSpec}}()
-        for vrng in allvranges
-            all_compat[u][vrng] = Dict{String,VersionSpec}()
-            for (req,vvr) in vranges
-                vrng ∈ vvr || continue
-                rp,rvs = req
-                all_compat[u][vrng][rp] = rvs
+        all_deps[u] = Dict{VersionNumber,Dict{String,UUID}}()
+        all_compat[u] = Dict{VersionNumber,Dict{String,VersionSpec}}()
+        for (vn,vreq) in preq
+            all_deps[u][vn] = Dict{String,UUID}()
+            all_compat[u][vn] = Dict{String,VersionSpec}()
+            for (rp,rvs) in vreq
+                all_deps[u][vn][rp] = uuid(rp)
+                all_compat[u][vn][rp] = rvs
             end
         end
     end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -49,18 +49,6 @@ function storeuuid(p::String, uuid_to_name::Dict{UUID,String})
 end
 wantuuids(want_data) = Dict{UUID,VersionNumber}(pkguuid(p) => v for (p,v) in want_data)
 
-function load_package_data_raw(T::Type, input::String)
-    toml = Types.TOML.parse(input)
-    data = Dict{VersionRange,Dict{String,T}}()
-    for (v, d) in toml, (key, value) in d
-        vr = VersionRange(v)
-        dict = get!(data, vr, Dict{String,T}())
-        haskey(dict, key) && pkgerror("$ver/$key is duplicated in $path")
-        dict[key] = T(value)
-    end
-    return data
-end
-
 function gen_versionranges(dict::Dict{K,Set{VersionNumber}}, srtvers::Vector{VersionNumber}) where {K}
     vranges = Dict{K,Vector{VersionRange}}()
     for (vreq,vset) in dict


### PR DESCRIPTION
This "uncompresses" the version ranges that each registry provides using the known versions of the package in that registry. So for example, if the registry says

```
# Compat.toml
[0]
"Foo" = 0.1

# Versions.toml
v"0.3" => ...
v"0.4" => ...
```

this is then uncompressed to

```
v"0.3" => ("Foo" => 0.1, ...)
v"0.4" => ("Foo" => 0.1, ...)
```

TODO:
- Write a test
- ~Change the resolver tests to understand that they should now provide a version number (pretty annoying to fix...)~

cc @carlobaldassi 

Fixes #1434