### PR TITLE
improve performance of TOML parsing by reading from memory instead of from file

### DIFF
--- a/ext/TOML/src/TOML.jl
+++ b/ext/TOML/src/TOML.jl
@@ -47,6 +47,6 @@ module TOML
     end
 
     "Parse file"
-    parsefile(filename::AbstractString) = open(parse, filename, "r")
+    parsefile(filename::AbstractString) = parse(IOBuffer(read(filename)))
 
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -23,7 +23,7 @@ function find_installed(name::String, uuid::UUID, sha1::SHA1)
     # 4 used to be the default so look there first
     for slug in (Base.version_slug(uuid, sha1, 4), slug_default)
         for depot in depots()
-            path = abspath(depot, "packages", name, slug)
+            path = joinpath(depot, "packages", name, slug)
             ispath(path) && return path
         end
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1651,6 +1651,7 @@ function git_head_context(ctx, project_dir)
             Context(;env=env)
         end
     catch err
+        err isa Pkg.TOML.ParserError || rethrow(err)
         nothing
     end
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1651,7 +1651,7 @@ function git_head_context(ctx, project_dir)
             Context(;env=env)
         end
     catch err
-        err isa Pkg.TOML.ParserError || rethrow(err)
+        err isa PkgError || rethrow(err)
         nothing
     end
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1162,11 +1162,13 @@ function find_registered!(ctx::Context,
     # note: empty vectors will be left for names & uuids that aren't found
     clone_default_registries(ctx)
     for registry in collect_registries()
+
+        reg_abspath = abspath(registry.path)
         data = read_registry(joinpath(registry.path, "Registry.toml"))
         for (_uuid, pkgdata) in data["packages"]
               uuid = UUID(_uuid)
               name = pkgdata["name"]
-              path = abspath(registry.path, pkgdata["path"])
+              path = joinpath(registry.path, pkgdata["path"])
               push!(get!(ctx.env.uuids, name, UUID[]), uuid)
               push!(get!(ctx.env.paths, uuid, String[]), path)
               push!(get!(ctx.env.names, uuid, String[]), name)

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -142,6 +142,7 @@ function Manifest(raw::Dict)::Manifest
             entry.tree_hash   = read_field("git-tree-sha1", nothing, info, safe_SHA1)
             deps = read_deps(get(info, "deps", nothing))
         catch
+            # TODO: Should probably not unconditionally log something
             @error "Could not parse entry for `$name`"
             rethrow()
         end
@@ -164,10 +165,11 @@ function read_manifest(path_or_stream)
             raw = TOML.parse(path_or_stream)
         end
     catch err
+        path = path_or_stream isa String ? path_or_stream : ""
         if err isa TOML.ParserError
-            pkgerror("Could not parse manifest $(something(path,"")): $(err.msg)")
+            pkgerror("Could not parse manifest $path: $(err.msg)")
         elseif all(x -> x isa TOML.ParserError, err)
-            pkgerror("Could not parse manifest $(something(path,"")): $err")
+            pkgerror("Could not parse manifest $path: $err")
         else
             rethrow()
         end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -153,11 +153,16 @@ function Manifest(raw::Dict)::Manifest
     return validate_manifest(stage1)
 end
 
-function read_manifest(path::String)
+function read_manifest(path_or_stream)
     local raw
-    isfile(path) || return Dict{UUID,PackageEntry}()
     try
-        raw = TOML.parsefile(path)
+        if path_or_stream isa String
+            path = path_or_stream
+            isfile(path) || return Dict{UUID,PackageEntry}()
+            raw = TOML.parsefile(path)
+        else
+            raw = TOML.parse(path_or_stream)
+        end
     catch err
         if err isa TOML.ParserError
             pkgerror("Could not parse manifest $(something(path,"")): $(err.msg)")

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -153,10 +153,11 @@ function Manifest(raw::Dict)::Manifest
     return validate_manifest(stage1)
 end
 
-function read_manifest(io::IO; path=nothing)
-    raw = nothing
+function read_manifest(path::String)
+    local raw
+    isfile(path) || return Dict{UUID,PackageEntry}()
     try
-        raw = TOML.parse(io)
+        raw = TOML.parsefile(path)
     catch err
         if err isa TOML.ParserError
             pkgerror("Could not parse manifest $(something(path,"")): $(err.msg)")
@@ -168,9 +169,6 @@ function read_manifest(io::IO; path=nothing)
     end
     return Manifest(raw)
 end
-
-read_manifest(path::String)::Manifest =
-    isfile(path) ? open(io->read_manifest(io;path=path), path) : Dict{UUID,PackageEntry}()
 
 ###########
 # WRITING #


### PR DESCRIPTION
Reading a bunch of small things from a file tends to be much slower than just reading the whole file in one chunk and operating on memory (especially with Julia now locking the stream for every read). None of the files we parse are big enough that operating on a file makes sense.

Benchmark:

```jl
function parse_registry()
    path = joinpath(homedir(), ".julia/registries/General")
    for (root, dirs, files) in walkdir(path)
       for file in files
           if endswith(file, ".toml")
               TOML.parsefile(joinpath(root, file))
           end
       end
   end
end
``` 

Before:

```jl
696.417 ms (2111063 allocations: 157.45 MiB)
```

After:

``` jl
355.687 ms (2164815 allocations: 166.51 MiB)
```