### PR TITLE
Document authors field in Project.toml

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -38,13 +38,13 @@ shell> tree .
 1 directory, 2 files
 ```
 
-The `Project.toml` file contains the name of the package, its unique UUID, its version, the author and potential dependencies:
+The `Project.toml` file contains the name of the package, its unique UUID, its version, the authors and potential dependencies:
 
 ```toml
 name = "HelloWorld"
 uuid = "b4cd1eb8-1e24-11e8-3319-93036a3eb9f3"
 version = "0.1.0"
-author = ["Some One <someone@email.com>"]
+authors = ["Some One <someone@email.com>"]
 
 [deps]
 ```

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -20,6 +20,16 @@ dependencies and compatibility constraints are listed in the project file. The f
 are described below.
 
 
+### The `authors` field
+
+For a package, the optional `authors` field is a list of strings describing the
+package authors, in the form `NAME <EMAIL>`. For example:
+```toml
+authors = ["Some One <someone@email.com>",
+           "Foo Bar <foo@bar.com>"]
+```
+
+
 ### The `name` field
 
 The name of the package/project is determined by the `name` field, for example:


### PR DESCRIPTION
Also fix a typo in one example that used `author` instead of `authors`