### PR TITLE
Ensure --depwarn=yes by default in Pkg.test

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1282,7 +1282,7 @@ function gen_test_code(testfile::String;
         --color=$(Base.have_color === nothing ? "auto" : Base.have_color ? "yes" : "no")
         --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
         --check-bounds=yes
-        --depwarn=yes
+        --depwarn=$(Base.JLOptions().depwarn == 2 ? "error" : "yes")
         --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
         --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1282,6 +1282,7 @@ function gen_test_code(testfile::String;
         --color=$(Base.have_color === nothing ? "auto" : Base.have_color ? "yes" : "no")
         --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
         --check-bounds=yes
+        --depwarn=yes
         --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
         --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])

--- a/test/test_packages/TestArguments/test/runtests.jl
+++ b/test/test_packages/TestArguments/test/runtests.jl
@@ -1,3 +1,4 @@
 @assert ARGS == ["a", "b"]
 @assert Base.JLOptions().quiet == 1 # --quiet
 @assert Base.JLOptions().check_bounds == 2 # overriden default when testing
+@assert Base.JLOptions().depwarn == 1 # Default to depwarn on


### PR DESCRIPTION
If https://github.com/JuliaLang/julia/pull/35362 is merged, adding `--depwarn=yes` by default will be important for continuity. See @tkf's comment https://github.com/JuliaLang/julia/pull/35362#issuecomment-611818361 for more detail.

(Even without merging that PR in Base, merging this PR should be harmless: it's currently the default in Julia and users can still disable it with `julia_args`.)