### PR TITLE
remove incorrect debug message

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -251,9 +251,7 @@ function collect_developed!(ctx::Context, pkg::PackageSpec, developed::Vector{Pa
     source_ctx = Context(env = EnvCache(projectfile_path(source)))
     pkgs = load_all_deps(source_ctx)
     for pkg in filter(is_tracking_path, pkgs)
-        # Break eventual cycles
         if any(x -> x.uuid == pkg.uuid, developed)
-            @debug "found a cycle when collecting developed packages for $(pkg.name)"
             continue
         end
         # normalize path


### PR DESCRIPTION
This doesn't only happen when there are cycles. It also happens if you have a dependency graph like

```
A -> [B, C]
B -> [C]
```

then `C` will be inside `developed` when parsing dependencies for `B`.

This actually removes a O(n^2) behavior that I hit today when you have a dependency graph like a triangle above.