### PR TITLE
Correctly set the uuid for default registries

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -887,6 +887,7 @@ function populate_known_registries_with_urls!(registries::Vector{RegistrySpec})
                     pkgerror("multiple registries with name `$(reg.name)`, please specify with uuid.")
                 end
                 reg.url = known.url
+                reg.uuid = known.uuid
             end
         end
     end


### PR DESCRIPTION
Fix a bug where Pkg.Registry.add("General") would not use the PkgServer since the uuid was not set correctly.