### PR TITLE
Remove trailing slash from URL.

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -85,6 +85,8 @@ function setprotocol!(;
 end
 
 function normalize_url(url::AbstractString)
+    # LibGit2 is fussy about trailing slash. Make sure there is none.
+    url = rstrip(url, '/')
     m = match(GIT_REGEX, url)
     m === nothing && return url
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -743,4 +743,14 @@ end
     end end
 end
 
+# PR #1784 - Remove trailing slash from URL.
+@testset "URL with trailing slash" begin
+    temp_pkg_dir() do project_path
+        with_temp_env() do
+            Pkg.add(Pkg.PackageSpec(url = "https://github.com/JuliaLang/Example.jl.git/"))
+            @test isinstalled("Example")
+        end
+    end
+end
+
 end # module


### PR DESCRIPTION
**Before**:
```
(@v1.5) pkg> add https://github.com/JuliaLang/Example.jl.git
```
adds `Example` as expected, whereas adding a trailing slash asks for username and password:
```
(@v1.5) pkg> add https://github.com/JuliaLang/Example.jl.git/
   Updating git-repo `https://github.com/JuliaLang/Example.jl.git/`
Username for 'https://github.com': 
Password for 'https://github.com': 
ERROR: failed to fetch from https://github.com/JuliaLang/Example.jl.git/, error: GitError(Code:EUSER, Class:Callback, Aborting, user cancelled credential request.)
```
**After**:
Both without and with trailing slash add `Example`.

If you think that this is the wrong way to solve the problem, please object.
