### PR TITLE
Reveal subprocess failure details

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1508,10 +1508,11 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
             test_fn !== nothing && test_fn()
             status(Context(); mode=PKGMODE_COMBINED)
             flush(stdout)
-            try
-                run(gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args))
+            cmd = gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args)
+            p = run(ignorestatus(cmd))
+            if success(p)
                 printpkgstyle(ctx, :Testing, pkg.name * " tests passed ")
-            catch err
+            else
                 push!(pkgs_errored, pkg.name)
             end
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,7 +14,7 @@ end
 
 # try to call realpath on as much as possible
 function safe_realpath(path)
-    if ispath(path) 
+    if ispath(path)
         try
             return realpath(path)
         catch

--- a/test/test_packages/TestFailure/Project.toml
+++ b/test/test_packages/TestFailure/Project.toml
@@ -1,0 +1,10 @@
+name = "TestFailure"
+uuid = "35486735-1684-4b57-b67c-0a54aafc3e75"
+authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/TestFailure/src/TestFailure.jl
+++ b/test/test_packages/TestFailure/src/TestFailure.jl
@@ -1,3 +1,4 @@
 module TestFailure
-
+# This is for testing failure cases of a packages tests based on the process exiting abnormally
+# See ../test/runtests.jl for details
 end # module

--- a/test/test_packages/TestFailure/src/TestFailure.jl
+++ b/test/test_packages/TestFailure/src/TestFailure.jl
@@ -1,0 +1,3 @@
+module TestFailure
+
+end # module

--- a/test/test_packages/TestFailure/test/runtests.jl
+++ b/test/test_packages/TestFailure/test/runtests.jl
@@ -1,0 +1,12 @@
+using TestFailure
+using Test
+
+if haskey(ENV, "TEST_SIGNAL")
+    run(`kill -s $(ENV["TEST_SIGNAL"]) $(getpid())`)
+elseif haskey(ENV, "TEST_EXITCODE")
+    exit(parse(Int, ENV["TEST_EXITCODE"]))
+end
+
+@testset "TestFailure" begin
+    @test false
+end


### PR DESCRIPTION
Reports some details about `Pkg.test` subprocess failures such as the signal the process received or the exit code. This information is useful in assisting in debugging process level failures such as having a process killed due by the OS' OOM reaper.

Fixes: https://github.com/JuliaLang/Pkg.jl/issues/1789