### PR TITLE
Docs for interpreting "Unsatisfiable requirement"

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -162,3 +162,34 @@ PkgA = "0.2 - 4"       # 0.2.0 - 4.*.* = [0.2.0, 5.0.0)
 PkgA = "0.2 - 0.5"     # 0.2.0 - 0.5.* = [0.2.0, 0.6.0)
 PkgA = "0.2 - 0"       # 0.2.0 - 0.*.* = [0.2.0, 1.0.0)
 ```
+
+## Fixing conflicts
+
+Version conflicts were introduced previously with an [example](@ref conflicts)
+of a conflict arising in a package `D` used by two other packages, `B` and `C`.
+Our analysis of the error message revealed that `B` is using an outdated
+version of `D`.
+To fix it, the first thing to try is to `pkg> dev B` so that
+you can modify `B` and its compatibility requirements.
+If you open its `Project.toml` file in an editor, you would probably notice something like
+
+```toml
+[compat]
+D = "0.1"
+```
+
+Usually the first step is to modify this to something like
+```toml
+[compat]
+D = "0.1, 0.2"
+```
+
+This indicates that `B` is compatible with both versions 0.1 and version 0.2; if you `pkg> up`
+this would fix the package error.
+However, there is one major concern you need to address first: perhaps there was an incompatible change
+in `v0.2` of `D` that breaks `B`.
+Before proceeding further, you should update all packages and then run `B`'s tests;
+if they pass, you can assume that `B` didn't need any further updating to accomodate `v0.2` of `D`,
+and you can safely submit this change as a pull request to `B`.
+If instead an error is thrown, to be able to use both `A` and `B` simultaneously
+someone will need to update the code of `B` so that it works properly with the newer version of `D`.

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -188,8 +188,13 @@ This indicates that `B` is compatible with both versions 0.1 and version 0.2; if
 this would fix the package error.
 However, there is one major concern you need to address first: perhaps there was an incompatible change
 in `v0.2` of `D` that breaks `B`.
-Before proceeding further, you should update all packages and then run `B`'s tests;
-if they pass, you can assume that `B` didn't need any further updating to accomodate `v0.2` of `D`,
-and you can safely submit this change as a pull request to `B`.
-If instead an error is thrown, to be able to use both `A` and `B` simultaneously
-someone will need to update the code of `B` so that it works properly with the newer version of `D`.
+Before proceeding further, you should update all packages and then run `B`'s tests, scanning the
+output of `pkg> test B` to be sure that `v0.2` of `D` is in fact being used.
+(It is possible that an additional dependency of `D` pins it to `v0.1`, and you wouldn't want to be misled into thinking that you had tested `B` on the newer version.)
+If the new version was used and the tests still pass,
+you can assume that `B` didn't need any further updating to accomodate `v0.2` of `D`;
+you can safely submit this change as a pull request to `B` so that a new release is made.
+If instead an error is thrown, it indicates that `B` requires more extensive updates to be
+compatible with the latest version of `D`; those updates will need to be completed before
+it becomes possible to use both `A` and `B` simultaneously.
+You can, though, continue to use the independently of one another.

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -10,8 +10,8 @@ using UUIDs
 using Pkg.Resolve
 import Pkg.Resolve: VersionWeight, add_reqs!, simplify_graph!, ResolverError, Fixed, Requires
 
-# print info, stats etc.
-const VERBOSE = false
+include("resolve_utils.jl")
+using .ResolveUtils
 
 # Check that VersionWeight keeps the same ordering as VersionNumber
 
@@ -33,111 +33,6 @@ for v1 in vlst, v2 in vlst
     @test clt == (vw1 < vw2)
     ceq = v1 == v2
     @test ceq == (vw1 == vw2)
-end
-
-# auxiliary functions
-const uuid_package = UUID("cfb74b52-ec16-5bb7-a574-95d9e393895e")
-pkguuid(p::String) = uuid5(uuid_package, p)
-function storeuuid(p::String, uuid_to_name::Dict{UUID,String})
-    uuid = p == "julia" ? Resolve.uuid_julia : pkguuid(p)
-    if haskey(uuid_to_name, uuid)
-        @assert uuid_to_name[uuid] == p
-    else
-        uuid_to_name[uuid] = p
-    end
-    return uuid
-end
-wantuuids(want_data) = Dict{UUID,VersionNumber}(pkguuid(p) => v for (p,v) in want_data)
-
-function graph_from_data(deps_data)
-    uuid_to_name = Dict{UUID,String}()
-    uuid(p) = storeuuid(p, uuid_to_name)
-    fixed = Dict{UUID,Fixed}()
-    all_versions = Dict{UUID,Set{VersionNumber}}()
-    all_deps = Dict{UUID,Dict{VersionNumber,Dict{String,UUID}}}()
-    all_compat = Dict{UUID,Dict{VersionNumber,Dict{String,VersionSpec}}}()
-
-    deps = Dict{String,Dict{VersionNumber,Dict{String,VersionSpec}}}()
-    for d in deps_data
-        p, vn, r = d[1], d[2], d[3:end]
-        if !haskey(deps, p)
-            deps[p] = Dict{VersionNumber,Dict{String,VersionSpec}}()
-        end
-        if !haskey(deps[p], vn)
-            deps[p][vn] = Dict{String,VersionSpec}()
-        end
-        isempty(r) && continue
-        rp = r[1]
-        rvs = VersionSpec(r[2:end])
-        deps[p][vn][rp] = rvs
-    end
-    for (p,preq) in deps
-        u = uuid(p)
-        all_versions[u] = Set(keys(deps[p]))
-
-        deps_pkgs = Dict{String,Set{VersionNumber}}()
-        for (vn,vreq) in deps[p], rp in keys(vreq)
-            push!(get!(Set{VersionNumber}, deps_pkgs, rp), vn)
-        end
-        all_deps[u] = Dict{VersionNumber,Dict{String,UUID}}()
-        all_compat[u] = Dict{VersionNumber,Dict{String,VersionSpec}}()
-        for (vn,vreq) in preq
-            all_deps[u][vn] = Dict{String,UUID}()
-            all_compat[u][vn] = Dict{String,VersionSpec}()
-            for (rp,rvs) in vreq
-                all_deps[u][vn][rp] = uuid(rp)
-                all_compat[u][vn][rp] = rvs
-            end
-        end
-    end
-    return Graph(all_versions, all_deps, all_compat, uuid_to_name, Requires(), fixed, VERBOSE)
-end
-function reqs_from_data(reqs_data, graph::Graph)
-    reqs = Dict{UUID,VersionSpec}()
-    function uuid_check(p)
-        uuid = pkguuid(p)
-        @assert graph.data.uuid_to_name[uuid] == p
-        return uuid
-    end
-    for r in reqs_data
-        p = uuid_check(r[1])
-        reqs[p] = VersionSpec(r[2:end])
-    end
-    reqs
-end
-function sanity_tst(deps_data, expected_result; pkgs=[])
-    if VERBOSE
-        println()
-        @info("sanity check")
-        # @show deps_data
-        # @show pkgs
-    end
-    graph = graph_from_data(deps_data)
-    id(p) = pkgID(pkguuid(p), graph)
-    result = sanity_check(graph, Set(pkguuid(p) for p in pkgs), VERBOSE)
-
-    length(result) == length(expected_result) || return false
-    expected_result_uuid = [(id(p), vn) for (p,vn) in expected_result]
-    for r in result
-        r ∈ expected_result_uuid || return  false
-    end
-    return true
-end
-sanity_tst(deps_data; kw...) = sanity_tst(deps_data, []; kw...)
-
-function resolve_tst(deps_data, reqs_data, want_data = nothing; clean_graph = false)
-    if VERBOSE
-        println()
-        @info("resolving")
-        # @show deps_data
-        # @show reqs_data
-    end
-    graph = graph_from_data(deps_data)
-    reqs = reqs_from_data(reqs_data, graph)
-    add_reqs!(graph, reqs)
-    simplify_graph!(graph, clean_graph = clean_graph)
-    want = resolve(graph)
-    return want == wantuuids(want_data)
 end
 
 @testset "schemes" begin

--- a/test/resolve_utils.jl
+++ b/test/resolve_utils.jl
@@ -1,0 +1,129 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module ResolveUtils
+
+using UUIDs
+import ..Pkg # ensure we are using the correct Pkg
+using Pkg.Types
+using Pkg.Resolve
+using Pkg.Resolve: VersionWeight, add_reqs!, simplify_graph!, ResolverError, Fixed, Requires
+
+export sanity_tst, resolve_tst, VERBOSE
+
+# print info, stats etc.
+const VERBOSE = false
+
+# auxiliary functions
+const uuid_package = UUID("cfb74b52-ec16-5bb7-a574-95d9e393895e")
+pkguuid(p::String) = uuid5(uuid_package, p)
+function storeuuid(p::String, uuid_to_name::Dict{UUID,String})
+    uuid = p == "julia" ? Resolve.uuid_julia : pkguuid(p)
+    if haskey(uuid_to_name, uuid)
+        @assert uuid_to_name[uuid] == p
+    else
+        uuid_to_name[uuid] = p
+    end
+    return uuid
+end
+wantuuids(want_data) = Dict{UUID,VersionNumber}(pkguuid(p) => v for (p,v) in want_data)
+
+"""
+    graph = graph_from_data(deps_data)
+
+Generate a package dependency graph from the entries in the array `deps_data`, where each entry
+is an array of the form `["PkgName", v"x.y.z", "DependencyA", v"Ax.Ay.Az", ...]`.
+This states that the package "PkgName" with version `v"x.y.z"` depends on "DependencyA" with the
+specified compatibility information.
+"""
+function graph_from_data(deps_data)
+    uuid_to_name = Dict{UUID,String}()
+    uuid(p) = storeuuid(p, uuid_to_name)
+    fixed = Dict{UUID,Fixed}()
+    all_versions = Dict{UUID,Set{VersionNumber}}()
+    all_deps = Dict{UUID,Dict{VersionNumber,Dict{String,UUID}}}()
+    all_compat = Dict{UUID,Dict{VersionNumber,Dict{String,VersionSpec}}}()
+
+    deps = Dict{String,Dict{VersionNumber,Dict{String,VersionSpec}}}()
+    for d in deps_data
+        p, vn, r = d[1], d[2], d[3:end]
+        if !haskey(deps, p)
+            deps[p] = Dict{VersionNumber,Dict{String,VersionSpec}}()
+        end
+        if !haskey(deps[p], vn)
+            deps[p][vn] = Dict{String,VersionSpec}()
+        end
+        isempty(r) && continue
+        rp = r[1]
+        rvs = VersionSpec(r[2:end])
+        deps[p][vn][rp] = rvs
+    end
+    for (p,preq) in deps
+        u = uuid(p)
+        all_versions[u] = Set(keys(deps[p]))
+
+        deps_pkgs = Dict{String,Set{VersionNumber}}()
+        for (vn,vreq) in deps[p], rp in keys(vreq)
+            push!(get!(Set{VersionNumber}, deps_pkgs, rp), vn)
+        end
+        all_deps[u] = Dict{VersionNumber,Dict{String,UUID}}()
+        all_compat[u] = Dict{VersionNumber,Dict{String,VersionSpec}}()
+        for (vn,vreq) in preq
+            all_deps[u][vn] = Dict{String,UUID}()
+            all_compat[u][vn] = Dict{String,VersionSpec}()
+            for (rp,rvs) in vreq
+                all_deps[u][vn][rp] = uuid(rp)
+                all_compat[u][vn][rp] = rvs
+            end
+        end
+    end
+    return Graph(all_versions, all_deps, all_compat, uuid_to_name, Requires(), fixed, VERBOSE)
+end
+function reqs_from_data(reqs_data, graph::Graph)
+    reqs = Dict{UUID,VersionSpec}()
+    function uuid_check(p)
+        uuid = pkguuid(p)
+        @assert graph.data.uuid_to_name[uuid] == p
+        return uuid
+    end
+    for r in reqs_data
+        p = uuid_check(r[1])
+        reqs[p] = VersionSpec(r[2:end])
+    end
+    reqs
+end
+function sanity_tst(deps_data, expected_result; pkgs=[])
+    if VERBOSE
+        println()
+        @info("sanity check")
+        # @show deps_data
+        # @show pkgs
+    end
+    graph = graph_from_data(deps_data)
+    id(p) = pkgID(pkguuid(p), graph)
+    result = sanity_check(graph, Set(pkguuid(p) for p in pkgs), VERBOSE)
+
+    length(result) == length(expected_result) || return false
+    expected_result_uuid = [(id(p), vn) for (p,vn) in expected_result]
+    for r in result
+        r ∈ expected_result_uuid || return  false
+    end
+    return true
+end
+sanity_tst(deps_data; kw...) = sanity_tst(deps_data, []; kw...)
+
+function resolve_tst(deps_data, reqs_data, want_data = nothing; clean_graph = false)
+    if VERBOSE
+        println()
+        @info("resolving")
+        # @show deps_data
+        # @show reqs_data
+    end
+    graph = graph_from_data(deps_data)
+    reqs = reqs_from_data(reqs_data, graph)
+    add_reqs!(graph, reqs)
+    simplify_graph!(graph, clean_graph = clean_graph)
+    want = resolve(graph)
+    return want == wantuuids(want_data)
+end
+
+end


### PR DESCRIPTION
A lot of people seem to struggle with understanding what the error message means and how to fix it. I figured it was time to have some docs about this.

The approach I've taken here is one step shy of a real doctest: I am trying to generate the actual error message, though its form is untested due to the difficulty of setup and the fact that the means to generate the error is unrelated to how this would be triggered in ordinary usage. (Documenter doesn't seem to let you test the output without showing the input, and here I don't want to show the input.) I then repeat the message via copy/paste in chunked form as I go through the pieces stepwise and help interpret what they mean. If someone changes the presentation of the message without updating the documentation, these two will be desynchronized, but at least readers might be able to detect that there is something wrong and so we should hear about it fairly quickly.

~This currently doesn't do the right thing when building: I get~
```julia
┌ Warning: failed to run `@example` block in src/managing-packages.md:289-291
│ ```@example conflict
│ resolve_tst(deps_data, reqs_data)   # hide
│ ```
│   value =
│    Unsatisfiable requirements detected for package C [c99a7cb2]:
│     C [c99a7cb2] log:
│     ├─possible versions are: [0.1.0-0.1.1, 0.2.0] or uninstalled
│     ├─restricted by compatibility requirements with B [f4259836] to versions: 0.2.0
│     │ └─B [f4259836] log:
│     │   ├─possible versions are: 1.0.0 or uninstalled
│     │   └─restricted to versions * by an explicit requirement, leaving only versions 1.0.0
│     └─restricted by compatibility requirements with A [29c70717] to versions: 0.1.0 — no versions left
│       └─A [29c70717] log:
│         ├─possible versions are: 1.0.0 or uninstalled
│         └─restricted to versions * by an explicit requirement, leaving only versions 1.0.0
└ @ Documenter.Expanders ~/.julia/packages/Documenter/hhZV5/src/Expanders.jl:564
```
~which is an error message that I want to appear in the documentation, but instead it gets shown here and instead the doc page contains~
```julia
resolve_tst(deps_data, reqs_data)   # hide
```
~which is definitely not what I was trying to achieve. Does Documenter need `@example_throws`?~