### PR TITLE
Automatically install all registries available from pkg server.

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -362,21 +362,27 @@ Redoes the changes from the latest [`undo`](@ref).
 [   :name => "add",
     :api => Registry.add,
     :should_splat => false,
-    :arg_count => 1 => Inf,
+    :arg_count => 0 => Inf,
     :arg_parser => ((x,y) -> parse_registry(x,y; add = true)),
     :description => "add package registries",
     :help => md"""
     registry add reg...
 
-Add package registries `reg...` to the user depot.
+Add package registries `reg...` to the user depot. Without arguments
+it adds known registries, i.e. the General registry and registries
+served by the configured package server.
 
 !!! compat "Julia 1.1"
     Pkg's registry handling requires at least Julia 1.1.
+
+!!! compat "Julia 1.5"
+    `registry add` without arguments requires at least Julia 1.5.
 
 **Examples**
 ```
 pkg> registry add General
 pkg> registry add https://www.my-custom-registry.com
+pkg> registry add
 ```
 """,
 ],[ :name => "remove",

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -26,7 +26,11 @@ add(regs::Vector{String}; kwargs...) = add([RegistrySpec(name = name) for name i
 add(regs::Vector{RegistrySpec}; kwargs...) = add(Context(), regs; kwargs...)
 function add(ctx::Context, regs::Vector{RegistrySpec}; kwargs...)
     Context!(ctx; kwargs...)
-    Types.clone_or_cp_registries(ctx, regs)
+    if isempty(regs)
+        Types.clone_default_registries(ctx, only_if_empty = false)
+    else
+        Types.clone_or_cp_registries(ctx, regs)
+    end
 end
 
 """

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -852,15 +852,19 @@ const DEFAULT_REGISTRIES =
                               uuid = UUID("23338594-aafe-5451-b93e-139f81909106"),
                               url = "https://github.com/JuliaRegistries/General.git")]
 
-function clone_default_registries(ctx::Context)
-    if isempty(collect_registries()) # only clone if there are no installed registries
-        printpkgstyle(ctx, :Cloning, "default registries into $(pathrepr(depots1()))")
+function clone_default_registries(ctx::Context; only_if_empty = true)
+    installed_registries = [reg.uuid for reg in collect_registries()]
+    # Only clone if there are no installed registries, unless called
+    # with false keyword argument.
+    if isempty(installed_registries) || !only_if_empty
+        printpkgstyle(ctx, :Cloning, "known registries into $(pathrepr(depots1()))")
         registries = copy(DEFAULT_REGISTRIES)
         for uuid in keys(pkg_server_registry_urls())
             if !(uuid in (reg.uuid for reg in registries))
                 push!(registries, RegistrySpec(uuid = uuid))
             end
         end
+        filter!(reg -> !(reg.uuid in installed_registries), registries)
         clone_or_cp_registries(registries)
     end
 end

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -102,6 +102,13 @@ end
             pkgstr("registry rm $(reg)")
             test_installed([])
         end
+
+        ## Pkg REPL without argument
+        pkgstr("registry add")
+        test_installed([General])
+        pkgstr("registry rm General")
+        test_installed([])
+
         ## Registry API
         for reg in ("General",
                     RegistrySpec("General"),


### PR DESCRIPTION
Background discussion: https://github.com/JuliaPackaging/PkgServer.jl/issues/26

This only makes a difference if you have a `JULIA_PKG_SERVER` that serves at least one registry that is not the General registry.

Without this PR, the only way to install such a registry is by UUID, e.g.
```
pkg> registry add 1e95ee64-cd1a-42e9-a29a-16f7a437e6bf
```

With this PR it is installed automatically, in the same way that General is installed automatically today. More precisely all registries served by the pkg server are installed automatically.
