### PR TITLE
Reduce footprint for invalidation

### DIFF
--- a/ext/TOML/src/print.jl
+++ b/ext/TOML/src/print.jl
@@ -57,7 +57,7 @@ function _print(io::IO, a::AbstractDict,
     sorted::Bool = false,
     by = identity,
 )
-    akeys = keys(a)
+    akeys = Base.KeySet(a)   # keys is non-inferrable due to Iterators.Pairs
     if sorted
         akeys = sort!(collect(akeys), by = by)
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -227,8 +227,14 @@ Base.@kwdef mutable struct PackageEntry
     deps::Dict{String,UUID} = Dict{String,UUID}()
     other::Union{Dict,Nothing} = nothing
 end
-Base.:(==)(t1::PackageEntry, t2::PackageEntry) = all([getfield(t1, x) == getfield(t2, x) for x in filter!(!=(:other), collect(fieldnames(PackageEntry)))])
-Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [getfield(t, x) for x in filter!(!=(:other), collect(fieldnames(PackageEntry)))], init=h)
+Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
+    t1.version == t2.version &&
+    t1.path == t2.path &&
+    t1.pinned == t2.pinned &&
+    t1.repo == t2.repo &&
+    t1.tree_hash == t2.tree_hash &&
+    t1.deps == t2.deps   # omits `other`
+Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps], init=h)  # omits `other`
 const Manifest = Dict{UUID,PackageEntry}
 
 function Base.show(io::IO, pkg::PackageEntry)


### PR DESCRIPTION
This is a companion PR to https://github.com/JuliaLang/julia/pull/35714 and accounts for a subset of the gains reported there. The more specific implementations of `==` and `hash` avoid a `collect`;
that branch prevents many `collect`-induced invalidations via the `iteratorsize` trick, but this change is probably a good idea anyway.

The more important and subtle one is the one in `TOML._print`. This is used by a large number of methods in Pkg, so it's important to prevent it from being invalidated. Do to nospecialize markers, this method gets inferred for partially-specified types, and the `a` is typically just `AbstractDict`. However, `Iterators.Pairs` is also an AbstractDict, and the return type of `keys` cannot be inferred from the parameters of `AbstractDict{K,V}` because the `itr` field of a pair uses a later
parameter.

This short-circuits the whole problem by "hand-inlining" the result of `invoke(keys,  Tuple{AbstractDict}, a)` at the call site, i.e., just creating a `KeySet` directly.

That one-line change accounts for most of the improvement claimed in https://github.com/JuliaLang/julia/pull/35714; you can see that this accounts for more than 200 MethodInstances all by itself: https://gist.github.com/ianshmean/2825c2f9e118217c7855245e508c4f21#file-revise-invalidations-during-load-L115-L322