### PR TITLE
Add [offline] to prompt in offline mode

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -421,6 +421,9 @@ In offline mode Pkg tries to do as much as possible without connecting
 to internet. For example, when adding a package Pkg only considers
 versions that are already downloaded in version resolution.
 
+To work in offline mode across Julia sessions you can
+set the environment variable `JULIA_PKG_OFFLINE` to `"true"`.
+
 !!! compat "Julia 1.5"
     Pkg's offline mode requires Julia 1.5 or later.
 """
@@ -545,6 +548,8 @@ function __init__()
             end
         end
     end
+    OFFLINE_MODE[] = get(ENV, "JULIA_PKG_OFFLINE", nothing) == "true"
+    return nothing
 end
 
 ################

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -8,7 +8,8 @@ import REPL
 import REPL: LineEdit, REPLCompletions
 
 import ..casesensitive_isdir
-using ..Types, ..Operations, ..API, ..Registry, .. Resolve
+using ..Types, ..Operations, ..API, ..Registry, ..Resolve
+import ..Pkg: Pkg
 
 const SPECS = Ref{Union{Nothing,Dict}}(nothing)
 const TEST_MODE = Ref{Bool}(false)
@@ -515,6 +516,9 @@ function promptf()
                 prev_project_file = project_file
             end
         end
+    end
+    if Pkg.OFFLINE_MODE[]
+        prefix = prefix * "[offline] "
     end
     return prefix * "pkg> "
 end


### PR DESCRIPTION
Add `[offline]` to prompt in offline mode and make it possible to use `JULIA_PKG_OFFLINE=true` to run in offline mode conveniently across sessions.

I think the main usecase here is when you are offline for a longer time (flights, public transport etc) and it might be annoying to have to `using Pkg; Pkg.offline()` every Julia startup so I think it is nice to be able to configure this outside of Julia for multiple sessions. Also, in order to remember that you have indeed set this variable, this adds `[offline]` to the Pkg prompt:
```
(@v1) [offline] pkg>
```