### PR TITLE
implement why, showing why a package is in the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 Pkg v1.9 Release Notes
 =======================
 
-- Pkg will now respect the version of packages put into the sysimage using e.g. PackageCompiler. For example,
-  if version 1.3.2 of package A is in the sysimage, Pkg will always install that version when adding the package,
-  or when the packge is installed as a dependency to some other package. This can be disabled by calling
-  `Pkg.respect_sysimage_versions(false)` ([#3002]).
+- New functionality: `Pkg.why` and `pkg> why` to show why a package is inside the environment (shows all "paths" to a package starting at the direct dependencies).
 - When code coverage tracking is enabled for `Pkg.test` the new path-specific code-coverage option is used to limit coverage
   to the directory of the package being tested. Previously the `--code-coverage=user` option was used, which tracked files
   in all code outside of Core & Base, i.e. all stdlibs and all user packages, which often made running tests with
@@ -17,6 +14,10 @@ Pkg v1.9 Release Notes
 Pkg v1.8 Release Notes
 ======================
 
+- Pkg will now respect the version of packages put into the sysimage using e.g. PackageCompiler. For example,
+  if version 1.3.2 of package A is in the sysimage, Pkg will always install that version when adding the package,
+  or when the packge is installed as a dependency to some other package. This can be disabled by calling
+  `Pkg.respect_sysimage_versions(false)` ([#3002]).
 - New `⌃` and `⌅` indicators beside packages in `pkg> status` that have new versions available.
   `⌅` indicates when new versions cannot be installed ([#2906]).
 - New `outdated::Bool` kwarg to `Pkg.status` (`--outdated` or `-o` in the REPL mode) to show

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,14 +40,12 @@ Pkg.status
 Pkg.compat
 Pkg.precompile
 Pkg.offline
-Pkg.respect_sysimage_versions
-Pkg.setprotocol!
 Pkg.why
 Pkg.dependencies
+Pkg.respect_sysimage_versions
 Pkg.project
 Pkg.undo
 Pkg.redo
-Pkg.precompile
 Pkg.setprotocol!
 PackageSpec
 PackageMode

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -24,9 +24,6 @@ but more complicated commands, which e.g. specify URLs or version range, require
 This is done by creating an instance of [`PackageSpec`](@ref) which is passed in to functions.
 
 ```@docs
-PackageSpec
-PackageMode
-UpgradeLevel
 Pkg.add
 Pkg.develop
 Pkg.activate
@@ -45,10 +42,16 @@ Pkg.precompile
 Pkg.offline
 Pkg.respect_sysimage_versions
 Pkg.setprotocol!
+Pkg.why
 Pkg.dependencies
 Pkg.project
 Pkg.undo
 Pkg.redo
+Pkg.precompile
+Pkg.setprotocol!
+PackageSpec
+PackageMode
+UpgradeLevel
 ```
 
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -138,7 +138,7 @@ function require_not_empty(pkgs, f::Symbol)
 end
 
 # Provide some convenience calls
-for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
+for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status, :why)
     @eval begin
         $f(pkg::Union{AbstractString, PackageSpec}; kwargs...) = $f([pkg]; kwargs...)
         $f(pkgs::Vector{<:AbstractString}; kwargs...)          = $f([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
@@ -1826,6 +1826,61 @@ end
 compat(pkg::String; kwargs...) = compat(pkg, nothing; kwargs...)
 compat(pkg::String, compat_str::Union{Nothing,String}; kwargs...) = compat(Context(), pkg, compat_str; kwargs...)
 compat(;kwargs...) = compat(Context(); kwargs...)
+
+#######
+# why #
+#######
+
+function why(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+    require_not_empty(pkgs, :why)
+
+    manifest_resolve!(ctx.env.manifest, pkgs)
+    project_deps_resolve!(ctx.env, pkgs)
+    ensure_resolved(ctx, ctx.env.manifest, pkgs)
+
+    # Store all packages that has a dependency on us (all dependees)
+    incoming = Dict{UUID, Set{UUID}}()
+    for (uuid, dep_pkgs) in ctx.env.manifest
+        for (dep, dep_uuid) in dep_pkgs.deps
+            haskey(incoming, dep_uuid) || (incoming[dep_uuid] = Set{UUID}())
+            push!(incoming[dep_uuid], uuid)
+        end
+    end
+
+    function find_paths!(final_paths, current, path = UUID[])
+        push!(path, current)
+        if !(current in values(ctx.env.project.deps))
+            for p in incoming[current]
+                if p in path
+                    # detected dependency cycle and none of the dependencies in the cycle
+                    # are in the project could happen when manually modifying
+                    # the project and running this function function before a
+                    # resolve
+                    continue
+                end
+                find_paths!(final_paths, p, copy(path))
+            end
+        else
+            push!(final_paths, path)
+        end
+    end
+
+    first = true
+    for pkg in pkgs
+        !first && println()
+        first = false
+        final_paths = []
+        find_paths!(final_paths, pkg.uuid)
+        foreach(reverse!, final_paths)
+        final_paths_names = map(x -> [ctx.env.manifest[uuid].name for uuid in x], final_paths)
+        sort!(final_paths_names, by = x -> (x, length(x)))
+        delimiter = sprint((io, args) -> printstyled(io, args...; color=:light_green), "→", context=ctx.io)
+        for path in final_paths_names
+            println("  ", join(path, " $delimiter "))
+        end
+    end
+end
+
 
 ########
 # Undo #

--- a/src/API.jl
+++ b/src/API.jl
@@ -1831,7 +1831,7 @@ compat(;kwargs...) = compat(Context(); kwargs...)
 # why #
 #######
 
-function why(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
+function why(ctx::Context, pkgs::Vector{PackageSpec}; io::IO, kwargs...)
     require_not_empty(pkgs, :why)
 
     manifest_resolve!(ctx.env.manifest, pkgs)
@@ -1867,16 +1867,16 @@ function why(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
 
     first = true
     for pkg in pkgs
-        !first && println()
+        !first && println(io)
         first = false
         final_paths = []
         find_paths!(final_paths, pkg.uuid)
         foreach(reverse!, final_paths)
         final_paths_names = map(x -> [ctx.env.manifest[uuid].name for uuid in x], final_paths)
         sort!(final_paths_names, by = x -> (x, length(x)))
-        delimiter = sprint((io, args) -> printstyled(io, args...; color=:light_green), "→", context=ctx.io)
+        delimiter = sprint((io, args) -> printstyled(io, args...; color=:light_green), "→", context=io)
         for path in final_paths_names
-            println("  ", join(path, " $delimiter "))
+            println(io, "  ", join(path, " $delimiter "))
         end
     end
 end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -183,6 +183,19 @@ See also [`PackageSpec`](@ref), [`PackageMode`](@ref).
 const rm = API.rm
 
 """
+    Pkg.why(pkg::Union{String, Vector{String}})
+    Pkg.why(pkg::Union{PackageSpec, Vector{PackageSpec}})
+
+Show the reason why this package is in the manifest.
+The output is a the different way to reach the package
+through the dependency graph starting from the dependencies.
+
+!!! compat "Julia 1.9"
+    This function requires at least Julia 1.6.
+"""
+const why = API.why
+
+"""
     Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT)
     Pkg.update(pkg::Union{String, Vector{String}})
     Pkg.update(pkg::Union{PackageSpec, Vector{PackageSpec}})

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -191,7 +191,7 @@ The output is a the different way to reach the package
 through the dependency graph starting from the dependencies.
 
 !!! compat "Julia 1.9"
-    This function requires at least Julia 1.6.
+    This function requires at least Julia 1.9.
 """
 const why = API.why
 

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -205,6 +205,20 @@ Free pinned packages, which allows it to be upgraded or downgraded again. If the
 makes the package no longer being checked out.
 """,
 ],
+PSA[:name => "why",
+    :api => API.why,
+    :should_splat => false,
+    :arg_count => 1 => 1,
+    :arg_parser => parse_package,
+    :completions => complete_all_installed_packages,
+    :description => "shows why a package is in the manifest",
+    :help => md"""
+    why pkg[=uuid] ...
+
+Show the reason why packages are in the manifest, printed as a path through the
+dependency graph starting at the direct dependencies.
+""",
+],
 PSA[:name => "pin",
     :api => API.pin,
     :should_splat => false,

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -106,6 +106,15 @@ function complete_installed_packages(options, partial)
         unique!([entry.name for (uuid, entry) in env.manifest])
 end
 
+function complete_all_installed_packages(options, partial)
+    env = try EnvCache()
+    catch err
+        err isa PkgError || rethrow()
+        return String[]
+    end
+    return unique!([entry.name for (uuid, entry) in env.manifest])
+end
+
 function complete_installed_packages_and_compat(options, partial)
     env = try EnvCache()
     catch err

--- a/test/new.jl
+++ b/test/new.jl
@@ -1430,6 +1430,42 @@ end
 end
 
 #
+# # Why
+#
+@testset "why: REPL" begin
+    isolate() do
+        Pkg.REPLMode.TEST_MODE[] = true
+        api, opts = first(Pkg.pkg"why Foo")
+        @test api == Pkg.why
+        @test first(opts).name == "Foo"
+        @test_throws PkgError Pkg.pkg"why Foo Bar"
+    end
+end
+
+@testset "why" begin
+    isolate() do
+        Pkg.add(name = "StaticArrays", version = "1.5.0")
+
+        io = IOBuffer()
+        Pkg.why("StaticArrays"; io)
+        str = String(take!(io))
+        @test str == "  StaticArrays\n"
+
+        Pkg.why("StaticArraysCore"; io)
+        str = String(take!(io))
+        @test str ==  "  StaticArrays → StaticArraysCore\n"
+
+        Pkg.why("LinearAlgebra"; io)
+        str = String(take!(io))
+        @test str == 
+        """  StaticArrays → LinearAlgebra
+          StaticArrays → Statistics → LinearAlgebra
+          StaticArrays → Statistics → SparseArrays → LinearAlgebra
+        """
+    end
+end
+
+#
 # # Update
 #
 @testset "update: input checking" begin

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -343,6 +343,8 @@ temp_pkg_dir() do project_path; cd(project_path) do
         @test "Example" in c
         c, r = test_complete("rm --manifest Exam")
         @test "Example" in c
+        c, r = test_complete("why PackageWithDep")
+        @test "PackageWithDependency" in c
 
         c, r = test_complete("rm PackageWithDep")
         @test "PackageWithDependency" in c


### PR DESCRIPTION
![bild](https://user-images.githubusercontent.com/1282691/81108167-916c4380-8f18-11ea-8af3-94fe236a3439.png)

Don't know if the "Who required Package" is useful... I just took it from https://www.npmjs.com/package/npm-why.

We could also add some compat info here, for example, if a package is being upper bounded by another one but one step at a time.