### PR TITLE
`pin` without arguments

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -287,10 +287,15 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
 end
 
 function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
-    require_not_empty(pkgs, :free)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
+    if isempty(pkgs)
+        for (name::String, uuid::UUID) in ctx.env.project.deps
+            push!(pkgs, PackageSpec(name=name, uuid=uuid))
+        end
+    end
+    
     for pkg in pkgs
         if pkg.name === nothing && pkg.uuid === nothing
             pkgerror("name or UUID specification required when calling `free`")

--- a/src/API.jl
+++ b/src/API.jl
@@ -253,10 +253,15 @@ function resolve(ctx::Context; kwargs...)
 end
 
 function pin(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
-    require_not_empty(pkgs, :pin)
     pkgs = deepcopy(pkgs)  # deepcopy for avoid mutating PackageSpec members
     Context!(ctx; kwargs...)
 
+    if isempty(pkgs)
+        for (name::String, uuid::UUID) in ctx.env.project.deps
+            push!(pkgs, PackageSpec(name=name, uuid=uuid))
+        end
+    end
+    
     for pkg in pkgs
         if pkg.name === nothing && pkg.uuid === nothing
             pkgerror("name or UUID specification required when calling `pin`")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -253,15 +253,17 @@ temp_pkg_dir() do project_path
     end
     
     @testset "pinning / freeing all" begin
-        Pkg.add(PackageSpec(TEST_PKG.name, v"0.2"))
+        Pkg.add(TEST_PKG.name)
         old_v = Pkg.dependencies()[TEST_PKG.uuid].version
+        Pkg.rm(TEST_PKG.name)
+        Pkg.add(PackageSpec(TEST_PKG.name, v"0.2"))
         Pkg.pin()
         @test Pkg.dependencies()[TEST_PKG.uuid].version.minor == 2
         Pkg.update()
         @test Pkg.dependencies()[TEST_PKG.uuid].version.minor == 2
-        Pkg.free(TEST_PKG.name)
+        Pkg.free()
         Pkg.update()
-        @test Pkg.dependencies()[TEST_PKG.uuid].version.minor != 2
+        @test Pkg.dependencies()[TEST_PKG.uuid].version.minor == old_v
         Pkg.rm(TEST_PKG.name)
     end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -251,6 +251,11 @@ temp_pkg_dir() do project_path
         @test Pkg.dependencies()[TEST_PKG.uuid].version == old_v
         Pkg.rm(TEST_PKG.name)
     end
+    
+    @testset "pinning / freeing all" begin # TODO: test versions
+        Pkg.pin()
+        Pkg.free()
+    end
 
     @testset "develop / freeing" begin
         Pkg.add(TEST_PKG.name)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -252,9 +252,17 @@ temp_pkg_dir() do project_path
         Pkg.rm(TEST_PKG.name)
     end
     
-    @testset "pinning / freeing all" begin # TODO: test versions
+    @testset "pinning / freeing all" begin
+        Pkg.add(PackageSpec(TEST_PKG.name, v"0.2"))
+        old_v = Pkg.dependencies()[TEST_PKG.uuid].version
         Pkg.pin()
-        Pkg.free()
+        @test Pkg.dependencies()[TEST_PKG.uuid].version.minor == 2
+        Pkg.update()
+        @test Pkg.dependencies()[TEST_PKG.uuid].version.minor == 2
+        Pkg.free(TEST_PKG.name)
+        Pkg.update()
+        @test Pkg.dependencies()[TEST_PKG.uuid].version.minor != 2
+        Pkg.rm(TEST_PKG.name)
     end
 
     @testset "develop / freeing" begin


### PR DESCRIPTION
Attempt to extend `pin`, to keep all direct dependencies in their current version.
Context: https://discourse.julialang.org/t/pin-all-packages-of-a-project/39308