### PR TITLE
Improve inference of call chains to TOML.print

### DIFF
--- a/ext/TOML/src/parser.jl
+++ b/ext/TOML/src/parser.jl
@@ -1,13 +1,14 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+const DictType = Dict{String,Any}
 
 "TOML Table"
 struct Table
-    values::Dict{String,Any}
+    values::DictType
     defined::Bool
 end
 
-Table(defined::Bool) = Table(Dict{String,Any}(), defined)
+Table(defined::Bool) = Table(DictType(), defined)
 function Base.show(io::IO, tbl::Table, level::Int=1)
     Base.print(io, "T($(tbl.defined)){\n")
     for (k,v) in tbl.values

--- a/ext/TOML/src/print.jl
+++ b/ext/TOML/src/print.jl
@@ -57,7 +57,7 @@ function _print(io::IO, a::AbstractDict,
     sorted::Bool = false,
     by = identity,
 )
-    akeys = Base.KeySet(a)   # keys is non-inferrable due to Iterators.Pairs
+    akeys = keys(a)
     if sorted
         akeys = sort!(collect(akeys), by = by)
     end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -629,7 +629,7 @@ function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
             end
         end
     else
-        artifact_dict = Dict()
+        artifact_dict = TOML.DictType()
     end
 
     # Otherwise, the new piece of data we're going to write out is this dict:
@@ -673,8 +673,10 @@ function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
     end
 
     # Spit it out onto disk
-    open(artifacts_toml, "w") do io
-        TOML.print(io, artifact_dict, sorted=true)
+    let artifact_dict = artifact_dict
+        open(artifacts_toml, "w") do io
+            TOML.print(io, artifact_dict, sorted=true)
+        end
     end
 
     # Mark that we have used this Artifact.toml

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -734,8 +734,10 @@ function get_auth_header(url::AbstractString; verbose::Bool = false)
             auth_info["expires_at"] = expires_at
         end
     end
-    open(tmp, write=true) do io
-        TOML.print(io, auth_info, sorted=true)
+    let auth_info = auth_info
+        open(tmp, write=true) do io
+            TOML.print(io, auth_info, sorted=true)
+        end
     end
     mv(tmp, auth_file, force=true)
     return "Authorization: Bearer $(auth_info["access_token"])"
@@ -758,13 +760,13 @@ end
 
 function load_telemetry_file(file::AbstractString)
     if !ispath(file)
-        info, changed = Dict(), true
+        info, changed = TOML.DictType(), true
     else
         info, changed = try
             TOML.parsefile(file), false
         catch err
             @warn "replacing malformed telemetry file" file=file err=err
-            Dict(), true
+            TOML.DictType(), true
         end
     end
     # bail early if fully opted out
@@ -796,8 +798,10 @@ function load_telemetry_file(file::AbstractString)
     # write telemetry file atomically (if on same file system)
     mkpath(dirname(file))
     tmp = tempname()
-    open(tmp, write=true) do io
-        TOML.print(io, info, sorted=true)
+    let info = info
+        open(tmp, write=true) do io
+            TOML.print(io, info, sorted=true)
+        end
     end
     mv(tmp, file, force=true)
     # reparse file in case a different process wrote it first


### PR DESCRIPTION
This is a better fix for #1806, one that resolves the inference problems. A big part of the problem is the dreaded 15276.

Addresses concerns in https://github.com/JuliaLang/www.julialang.org/pull/794#discussion_r424454133.