### PR TITLE
Include in ParseError the filename and line-info

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,5 @@
 name = "Pkg"
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,4 @@
 name = "Pkg"
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."

--- a/ext/TOML/src/TOML.jl
+++ b/ext/TOML/src/TOML.jl
@@ -31,8 +31,8 @@ module TOML
     end
 
     "Parse IO input and return result as dictionary."
-    function parse(io::IO)
-        parser = Parser(io)
+    function parse(io::IO, filename="unknown-file")
+        parser = Parser(io, filename)
         res = parse(parser)
         length(parser.errors)>0 && throw(CompositeException(parser.errors))
         return table2dict(res)
@@ -47,6 +47,6 @@ module TOML
     end
 
     "Parse file"
-    parsefile(filename::AbstractString) = parse(IOBuffer(read(filename)))
+    parsefile(filename::AbstractString) = parse(IOBuffer(read(filename)), filename)
 
 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -361,7 +361,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), kwargs...)
                 return usage_data
             end
 
-            for (filename, infos) in TOML.parse(String(read(usage_filepath)))
+            for (filename, infos) in TOML.parsefile(usage_filepath)
                 # If this file was already listed in this index, update it with the later
                 # information
                 for info in infos


### PR DESCRIPTION
# Without this PR
```julia
(@v1.6) pkg> gc
ERROR: Pkg.TOML.ParserError(119214, 119245, "expected a newline after a key")
```

# With this PR
```julia
julia> import Pkg; Pkg.pkg"gc"
[ Info: Precompiling Pkg [e9ea8145-4ac0-5781-a202-fc5c5b8eb05a]
ERROR: Pkg.TOML.ParserError(2594, 2594, "/Users/oxinabox/.julia/logs/manifest_usage.toml", "expected a newline after a key")
```


--- 
Now I can go and fix that file that has a missing newline