### PR TITLE
Clean up `jl_XXX-download.gz.sha256` files

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -1226,7 +1226,9 @@ function download_verify_unpack(
         unpack(tarball_path, dest; verbose=verbose)
     finally
         if remove_tarball
-            Base.rm(tarball_path)
+            Base.rm(tarball)
+            # Remove cached tarball hash, if it exists.
+            Base.rm(string(tarball, ".sha256"); force=true)
         end
     end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -1226,9 +1226,9 @@ function download_verify_unpack(
         unpack(tarball_path, dest; verbose=verbose)
     finally
         if remove_tarball
-            Base.rm(tarball)
+            Base.rm(tarball_path)
             # Remove cached tarball hash, if it exists.
-            Base.rm(string(tarball, ".sha256"); force=true)
+            Base.rm(string(tarball_path, ".sha256"); force=true)
         end
     end
 


### PR DESCRIPTION
Because PlatformEngines assumes you may want to verify a tarball later, it spits out `.sha256` files to optimize for hashing in the future.  This is fine when you're downloading to a permanent location or a directory that was created by `mktempdir()`, but if your download location is just a file sitting in `/tmp` which you clean up manually afterward, you need to clean up that `.sha256` file as well.