### PR TITLE
some perf improvements

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -170,6 +170,7 @@ load_package_data(::Type{T}, path::String, version::VersionNumber) where {T} =
 # TODO: This function is very expensive. Optimize it
 function load_package_data(::Type{T}, path::String, versions::Vector{VersionNumber}) where {T}
     compressed = parse_toml(path, fakeit=true)
+    compressed = convert(Dict{String, Dict{String, Union{String, Vector{String}}}}, compressed)
     uncompressed = Dict{VersionNumber, Dict{String,T}}()
     vsorted = sort(versions)
     for (vers, data) in compressed

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -87,8 +87,30 @@ end
 
 Base.hash(r::VersionBound, h::UInt) = hash(hash(r.t, h), r.n)
 
-VersionBound(s::AbstractString) =
-    s == "*" ? VersionBound() : VersionBound(map(x -> parse(Int, x), split(s, '.'))...)
+# Hot code
+function VersionBound(s::AbstractString)
+    s == "*" && return VersionBound()
+    l = lastindex(s)
+
+    p = findnext('.', s, 1)
+    b = p === nothing ? l : (p-1)
+    i = parse(Int64, SubString(s, 1, b))
+    p === nothing && return VersionBound(i)
+
+    a = p+1
+    p = findnext('.', s, a)
+    b = p === nothing ? l : (p-1)
+    j = parse(Int64, SubString(s, a, b))
+    p === nothing && return VersionBound(i, j)
+
+    a = p+1
+    p = findnext('.', s, a)
+    b = p === nothing ? l : (p-1)
+    k = parse(Int64, SubString(s, a, b))
+    p === nothing && return VersionBound(i, j, k)
+
+    error("invalid VersionBound string $(repr(s))")
+end
 
 ################
 # VersionRange #


### PR DESCRIPTION
Benchmark is `@btime Pkg.add("DifferentialEquations")` in the Pkg project.

Before: `215.759 ms (2557554 allocations: 189.00 MiB)`
After: `180.268 ms (1958939 allocations: 152.31 MiB)`
