### PR TITLE
Compress compat version in compat logs

### DIFF
--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -582,7 +582,7 @@ function init_log!(data::GraphData)
         if isempty(versions)
             msg = "$id has no known versions!" # This shouldn't happen?
         else
-            msg = "possible versions are: $(VersionSpec(VersionRange.(versions))) or uninstalled"
+            msg = "possible versions are: $(compressed_versionspec(versions)) or uninstalled"
         end
         first_entry = get!(rlog.pool, p) do; ResolveLogEntry(rlog.journal, p, "$id log:") end
 
@@ -627,7 +627,7 @@ function log_event_req!(graph::Graph, rp::UUID, rvs::VersionSpec, reason)
     rp0 = pdict[rp]
     @assert !gconstr[rp0][end]
     if any(gconstr[rp0])
-        msg *= ", leaving only versions $(VersionSpec(VersionRange.(pvers[rp0][gconstr[rp0][1:(end-1)]])))"
+        msg *= ", leaving only versions $(compressed_versionspec(pvers[rp0], pvers[rp0][gconstr[rp0][1:(end-1)]]))"
     else
         msg *= " — no versions left"
     end
@@ -650,7 +650,7 @@ function log_event_implicit_req!(graph::Graph, p1::Int, vmask::BitVector, p0::In
 
     function vs_string(p0::Int, vmask::BitVector)
         if any(vmask[1:(end-1)])
-            vns = string(VersionSpec(VersionRange.(pvers[p0][vmask[1:(end-1)]])))
+            vns = string(compressed_versionspec(pvers[p0], pvers[p0][vmask[1:(end-1)]]))
             vmask[end] && (vns *= " or uninstalled")
         else
             @assert vmask[end]
@@ -788,7 +788,7 @@ function log_event_eq_classes!(graph::Graph, p0::Int)
     pvers = graph.data.pvers
 
     if any(gconstr[p0][1:(end-1)])
-        vns = string(VersionSpec(VersionRange.(pvers[p0][gconstr[p0][1:(end-1)]])))
+        vns = string(compressed_versionspec(pvers[p0], pvers[p0][gconstr[p0][1:(end-1)]]))
         gconstr[p0][end] && (vns *= " or uninstalled")
     elseif gconstr[p0][end]
         vns = "uninstalled"

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -582,7 +582,7 @@ function init_log!(data::GraphData)
         if isempty(versions)
             msg = "$id has no known versions!" # This shouldn't happen?
         else
-            msg = "possible versions are: $(compressed_versionspec(versions)) or uninstalled"
+            msg = "possible versions are: $(range_compressed_versionspec(versions)) or uninstalled"
         end
         first_entry = get!(rlog.pool, p) do; ResolveLogEntry(rlog.journal, p, "$id log:") end
 
@@ -627,7 +627,7 @@ function log_event_req!(graph::Graph, rp::UUID, rvs::VersionSpec, reason)
     rp0 = pdict[rp]
     @assert !gconstr[rp0][end]
     if any(gconstr[rp0])
-        msg *= ", leaving only versions $(compressed_versionspec(pvers[rp0], pvers[rp0][gconstr[rp0][1:(end-1)]]))"
+        msg *= ", leaving only versions $(range_compressed_versionspec(pvers[rp0], pvers[rp0][gconstr[rp0][1:(end-1)]]))"
     else
         msg *= " — no versions left"
     end
@@ -650,7 +650,7 @@ function log_event_implicit_req!(graph::Graph, p1::Int, vmask::BitVector, p0::In
 
     function vs_string(p0::Int, vmask::BitVector)
         if any(vmask[1:(end-1)])
-            vns = string(compressed_versionspec(pvers[p0], pvers[p0][vmask[1:(end-1)]]))
+            vns = string(range_compressed_versionspec(pvers[p0], pvers[p0][vmask[1:(end-1)]]))
             vmask[end] && (vns *= " or uninstalled")
         else
             @assert vmask[end]
@@ -788,7 +788,7 @@ function log_event_eq_classes!(graph::Graph, p0::Int)
     pvers = graph.data.pvers
 
     if any(gconstr[p0][1:(end-1)])
-        vns = string(compressed_versionspec(pvers[p0], pvers[p0][gconstr[p0][1:(end-1)]]))
+        vns = string(range_compressed_versionspec(pvers[p0], pvers[p0][gconstr[p0][1:(end-1)]]))
         gconstr[p0][end] && (vns *= " or uninstalled")
     elseif gconstr[p0][end]
         vns = "uninstalled"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -20,7 +20,7 @@ import Base: SHA1
 using SHA
 
 export UUID, pkgID, SHA1, VersionRange, VersionSpec,
-    PackageSpec, EnvCache, Context, PackageInfo, ProjectInfo, GitRepo, Context!, err_rep,
+    PackageSpec, EnvCache, Context, PackageInfo, ProjectInfo, GitRepo, Context!, compressed_versionspec, err_rep,
     PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved,
     manifest_info, registered_uuids, registered_paths, registered_uuid, registered_name,

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -20,7 +20,7 @@ import Base: SHA1
 using SHA
 
 export UUID, pkgID, SHA1, VersionRange, VersionSpec,
-    PackageSpec, EnvCache, Context, PackageInfo, ProjectInfo, GitRepo, Context!, compressed_versionspec, err_rep,
+    PackageSpec, EnvCache, Context, PackageInfo, ProjectInfo, GitRepo, Context!, range_compressed_versionspec, err_rep,
     PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved,
     manifest_info, registered_uuids, registered_paths, registered_uuid, registered_name,

--- a/src/versions.jl
+++ b/src/versions.jl
@@ -276,15 +276,15 @@ Base.show(io::IO, s::VersionSpec) = print(io, "VersionSpec(\"", s, "\")")
 
 
 """
-    compressed_versionspec(pool, subset=pool)
+    range_compressed_versionspec(pool, subset=pool)
 
  - `pool`: all versions that exist (a superset of `subset`)
  - `subset`: the subset of those versions that we want to include in the spec.
 
-Works out a compressed `VersionSpec` that permits everything in the `subset`,
-and nothing else from the `pool`.
+Finds a minimal collection of ranges as a `VersionSpec`, that permits everything in the
+`subset`, but does not permit anything else from the `pool`.
 """
-function compressed_versionspec(pool, subset=pool)
+function range_compressed_versionspec(pool, subset=pool)
     length(subset)==1 && return VersionSpec(only(subset))
     # PREM-OPT: we keep re-sorting these, probably not required.
     sort!(pool)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -837,26 +837,26 @@ end
     end
 end
 
-@testset "compressed_versionspec" begin
+@testset "range_compressed_versionspec" begin
     pool = [v"1.0.0", v"1.1.0", v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0", v"3.1.0"]
-    @test (compressed_versionspec(pool)
-        == compressed_versionspec(pool, pool)
+    @test (range_compressed_versionspec(pool)
+        == range_compressed_versionspec(pool, pool)
         == VersionSpec("1.0.0-3.1.0")
     )
 
     @test isequal(
-        compressed_versionspec(pool, [v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0"]),
+        range_compressed_versionspec(pool, [v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0"]),
         VersionSpec("1.2.0-3.0.0")
     )
 
     @test isequal(  # subset has 1.x and 3.x, but not 2.x
-        compressed_versionspec(
+        range_compressed_versionspec(
             pool, [v"1.0.0", v"1.1.0", v"1.2.0", v"1.2.1", v"3.0.0", v"3.1.0"]
         ),
         VersionSpec([VersionRange(v"1.0.0", v"1.2.1"), VersionRange(v"3.0.0", v"3.1.0")])
     )
 
-    @test compressed_versionspec(pool, [v"1.1.0"]) == VersionSpec("1.1.0")
+    @test range_compressed_versionspec(pool, [v"1.1.0"]) == VersionSpec("1.1.0")
 end
 
 end # module

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -837,4 +837,26 @@ end
     end
 end
 
+@testset "compressed_versionspec" begin
+    pool = [v"1.0.0", v"1.1.0", v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0", v"3.1.0"]
+    @test (compressed_versionspec(pool)
+        == compressed_versionspec(pool, pool)
+        == VersionSpec("1.0.0-3.1.0")
+    )
+
+    @test isequal(
+        compressed_versionspec(pool, [v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0"]),
+        VersionSpec("1.2.0-3.0.0")
+    )
+
+    @test isequal(  # subset has 1.x and 3.x, but not 2.x
+        compressed_versionspec(
+            pool, [v"1.0.0", v"1.1.0", v"1.2.0", v"1.2.1", v"3.0.0", v"3.1.0"]
+        ),
+        VersionSpec([VersionRange(v"1.0.0", v"1.2.1"), VersionRange(v"3.0.0", v"3.1.0")])
+    )
+
+    @test compressed_versionspec(pool, [v"1.1.0"]) == VersionSpec("1.1.0")
+end
+
 end # module


### PR DESCRIPTION
This does one of the suggestions from https://github.com/JuliaLang/Pkg.jl/issues/1855

I think it is a big improvement.

- [x] It needs tests.
- [x] Especially around the edge cases where it is broken into multiple discontigious runs

### Current Master
```julia
julia> using Pkg; pkg"add DataFrames@0.17 CSV@0.5"
#...
ERROR: Unsatisfiable requirements detected for package CSV [336ed68f]:
 CSV [336ed68f] log:
 ├─possible versions are: [0.3.0-0.3.1, 0.4.0-0.4.3, 0.5.0-0.5.26, 0.6.0-0.6.2] or uninstalled
 ├─restricted to versions 0.5 by an explicit requirement, leaving only versions 0.5.0-0.5.26
 └─restricted by compatibility requirements with DataFrames [a93c6f00] to versions: [0.3.0-0.3.1, 0.4.0-0.4.3] or uninstalled — no versions left
   └─DataFrames [a93c6f00] log:
     ├─possible versions are: [0.11.7, 0.12.0, 0.13.0-0.13.1, 0.14.0-0.14.1, 0.15.0-0.15.2, 0.16.0, 0.17.0-0.17.1, 0.18.0-0.18.4, 0.19.0-0.19.4, 0.20.0-0.20.2, 0.21.0-0.21.2] or uninstalled
     └─restricted to versions 0.17 by an explicit requirement, leaving only versions 0.17.0-0.17.1
```

### With this PR
```julia
julia> using Pkg; pkg"add DataFrames@0.17 CSV@0.5"
#...
ERROR: Unsatisfiable requirements detected for package CSV [336ed68f]:
 CSV [336ed68f] log:
 ├─possible versions are: 0.3.0-0.6.2 or uninstalled
 ├─restricted to versions 0.5 by an explicit requirement, leaving only versions 0.5.0-0.5.26
 └─restricted by compatibility requirements with DataFrames [a93c6f00] to versions: 0.3.0-0.4.3 or uninstalled — no versions left
   └─DataFrames [a93c6f00] log:
     ├─possible versions are: 0.11.7-0.21.2 or uninstalled
     └─restricted to versions 0.17 by an explicit requirement, leaving only versions 0.17.0-0.17.1
```