### PR TITLE
Add Color to the conflict log

### DIFF
--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -582,7 +582,13 @@ function wipe_snapshots!(graph::Graph)
     return graph
 end
 
-color_string(c, str...) = string(Base.text_colors[c], str..., Base.text_colors[:default])
+function color_string(c, str...)
+    if stderr[:color]  #check if color has been disabled by `julia --color=no`
+        string(Base.text_colors[c], str..., Base.text_colors[:default])
+    else
+        string(str...)
+    end
+end
 pkgID_color(pkgID) = 17 + hash(pkgID) % 216  # Give each package a probably unique color
 logstr(pkgID, args...) = color_string(pkgID_color(pkgID), args...)
 logstr(pkgID) = logstr(pkgID, pkgID)

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -582,9 +582,6 @@ function wipe_snapshots!(graph::Graph)
     return graph
 end
 
-
-
-
 # system colors excluding whites/greys/blacks and error-red
 const CONFLICT_COLORS = [1:6; 10:14];
 pkgID_color(pkgID) = CONFLICT_COLORS[mod1(hash(pkgID), end)]

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -587,8 +587,18 @@ function color_string(c, str...)
     return sprint((io, args) -> printstyled(io, args...; color=c), str, context=stderr)
 end
 
-const CONTRAST_COLORS =  [21:51; 55:119; 124:142; 160:184; 196:220];
-pkgID_color(pkgID) = CONTRAST_COLORS[1 + hash(pkgID) % end]  # Give each package a probably unique color
+# system colors excluding greys, bright-yellow and dark-blue
+const CONFLICT_COLORS = [5,1,6,3,2,13,12,9,10];
+const pkgID_color = let  # Cycle through each color in turn when a new color is needed
+    pkgID2color = Dict{String, Int}()
+    cur_color_index = 0;
+    function pkgID_color(pkgID)
+        get!(pkgID2color, pkgID) do
+            cur_color_index+=1
+            CONFLICT_COLORS[mod1(cur_color_index, end)]
+        end
+    end
+end
 logstr(pkgID, args...) = color_string(pkgID_color(pkgID), args...)
 logstr(pkgID) = logstr(pkgID, pkgID)
 

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -589,7 +589,9 @@ function color_string(c, str...)
         string(str...)
     end
 end
-pkgID_color(pkgID) = 17 + hash(pkgID) % 216  # Give each package a probably unique color
+
+const CONTRAST_COLORS =  [21:51; 55:119; 124:142; 160:184; 196:220];
+pkgID_color(pkgID) = CONTRAST_COLORS[1 + hash(pkgID) % end]  # Give each package a probably unique color
 logstr(pkgID, args...) = color_string(pkgID_color(pkgID), args...)
 logstr(pkgID) = logstr(pkgID, pkgID)
 

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -583,7 +583,7 @@ function wipe_snapshots!(graph::Graph)
 end
 
 function color_string(c, str...)
-    if stderr[:color]  #check if color has been disabled by `julia --color=no`
+    if get(stderr, :color, false)  #check if color is allowed
         string(Base.text_colors[c], str..., Base.text_colors[:default])
     else
         string(str...)

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -583,16 +583,19 @@ function wipe_snapshots!(graph::Graph)
 end
 
 
-function color_string(c, str...)
-    return sprint((io, args) -> printstyled(io, args...; color=c), str, context=stderr)
-end
+
 
 # system colors excluding whites/greys/blacks and error-red
 const CONFLICT_COLORS = [1:6; 10:14];
 pkgID_color(pkgID) = CONFLICT_COLORS[mod1(hash(pkgID), end)]
 
-logstr(pkgID, args...) = color_string(pkgID_color(pkgID), args...)
 logstr(pkgID) = logstr(pkgID, pkgID)
+function logstr(pkgID, args...)
+    # workout the string with the color codes, check stderr to decide if color is enabled
+    return sprint(args; context=stderr) do io, iargs
+        printstyled(io, iargs...; color=pkgID_color(pkgID))
+    end
+end
 
 function init_log!(data::GraphData)
     np = data.np

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -587,18 +587,10 @@ function color_string(c, str...)
     return sprint((io, args) -> printstyled(io, args...; color=c), str, context=stderr)
 end
 
-# system colors excluding greys, bright-yellow and dark-blue
-const CONFLICT_COLORS = [5,1,6,3,2,13,12,9,10];
-const pkgID_color = let  # Cycle through each color in turn when a new color is needed
-    pkgID2color = Dict{String, Int}()
-    cur_color_index = 0;
-    function pkgID_color(pkgID)
-        get!(pkgID2color, pkgID) do
-            cur_color_index+=1
-            CONFLICT_COLORS[mod1(cur_color_index, end)]
-        end
-    end
-end
+# system colors excluding whites/greys/blacks and error-red
+const CONFLICT_COLORS = [1:6; 10:14];
+pkgID_color(pkgID) = CONFLICT_COLORS[mod1(hash(pkgID), end)]
+
 logstr(pkgID, args...) = color_string(pkgID_color(pkgID), args...)
 logstr(pkgID) = logstr(pkgID, pkgID)
 

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -582,12 +582,9 @@ function wipe_snapshots!(graph::Graph)
     return graph
 end
 
+
 function color_string(c, str...)
-    if get(stderr, :color, false)  #check if color is allowed
-        string(Base.text_colors[c], str..., Base.text_colors[:default])
-    else
-        string(str...)
-    end
+    return sprint((io, args) -> printstyled(io, args...; color=c), str, context=stderr)
 end
 
 const CONTRAST_COLORS =  [21:51; 55:119; 124:142; 160:184; 196:220];

--- a/test/new.jl
+++ b/test/new.jl
@@ -2418,7 +2418,7 @@ end
         catch e
             @test e isa ResolverError
             # `\S*` in regex below will allow for ANSI color escape codes in the logs
-            @test occursin(r"possible versions are: [^\d\s]*0\.5\.1[^\d\s]* or uninstalled", e.msg)
+            @test occursin(r"possible versions are: \S*0\.5\.1\S* or uninstalled", e.msg)
         end
         Pkg.offline(false)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2418,7 +2418,7 @@ end
         catch e
             @test e isa ResolverError
             # `\S*` in regex below will allow for ANSI color escape codes in the logs
-            @test occursin(r"possible versions are: \S*0.5.1\S* or uninstalled", e.msg)
+            @test occursin(r"possible versions are: \S*0\.5\.1\S* or uninstalled", e.msg)
         end
         Pkg.offline(false)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2418,7 +2418,7 @@ end
         catch e
             @test e isa ResolverError
             # `\S*` in regex below will allow for ANSI color escape codes in the logs
-            @test occursin(r"possible versions are: \S*0\.5\.1\S* or uninstalled", e.msg)
+            @test occursin(r"possible versions are: [^\d\s]*0\.5\.1[^\d\s]* or uninstalled", e.msg)
         end
         Pkg.offline(false)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2417,7 +2417,7 @@ end
             Pkg.add(Pkg.PackageSpec(uuid=exuuid, version=v"0.5.3"))
         catch e
             @test e isa ResolverError
-            @test occursin("possible versions are: 0.5.1 or uninstalled", e.msg)
+            @test occursin(r"possible versions are: .*0.5.1.* or uninstalled", e.msg)
         end
         Pkg.offline(false)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2417,7 +2417,8 @@ end
             Pkg.add(Pkg.PackageSpec(uuid=exuuid, version=v"0.5.3"))
         catch e
             @test e isa ResolverError
-            @test occursin(r"possible versions are: .*\b0.5.1\b.* or uninstalled", e.msg)
+            # `\S*` in regex below will allow for ANSI color escape codes in the logs
+            @test occursin(r"possible versions are: \S*0.5.1\S* or uninstalled", e.msg)
         end
         Pkg.offline(false)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2417,7 +2417,7 @@ end
             Pkg.add(Pkg.PackageSpec(uuid=exuuid, version=v"0.5.3"))
         catch e
             @test e isa ResolverError
-            @test occursin(r"possible versions are: .*0.5.1.* or uninstalled", e.msg)
+            @test occursin(r"possible versions are: .*\b0.5.1\b.* or uninstalled", e.msg)
         end
         Pkg.offline(false)
     end


### PR DESCRIPTION
This adds color to the log, to enhance readability, per another point in  #1855 


## WIth this PR + #1863 
![image](https://user-images.githubusercontent.com/5127634/84564764-2fdf9600-ad5c-11ea-9d45-631ea3457f29.png)

## This PR only:
![image](https://user-images.githubusercontent.com/5127634/84595616-aa89dd80-ae50-11ea-84cf-8415c1e970b1.png)


## #1855 only:
<img width="1325" alt="image" src="https://user-images.githubusercontent.com/5127634/84543150-b2cc0680-acf2-11ea-8a53-3d685356bd4b.png">


## Current julia master
![image](https://user-images.githubusercontent.com/5127634/84542989-6a144d80-acf2-11ea-8fee-3223c8202877.png)

`pkgID`s are set using modulo of their  `hash`
Which I think is nice, because it avoids having global state to track which colors we have used, and means seeing the same package in different conflicts has a persistant recognizable hue.
On the downside there is the chance that package colors would conflict, so we could do it in order instead. Seems less fun.


TODO:
- [x] check this works right on terminals without 256 color
- [x] check this doesn't color things if we have run `julia --color=false`
