### PR TITLE
Docs: moved Julia 1.4 compat below the section

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -120,13 +120,6 @@ PkgD = "< 1.2.3"  # [0.0.0, 1.2.3) = [0.0.0, 1.2.2]
 
 ### Hyphen specifiers
 
-!!! compat "Julia 1.4"
-    Hyphen specifiers requires at least Julia 1.4, so it is recomended to also add
-    ```toml
-    [compat]
-    julia = "1.4"
-    ```
-    to the project file when using them.
 Hyphen syntax can also be used to specify version ranges. Make sure that you have a space on both sides of the hyphen.
 
 ```toml
@@ -162,6 +155,14 @@ PkgA = "0.2 - 4"       # 0.2.0 - 4.*.* = [0.2.0, 5.0.0)
 PkgA = "0.2 - 0.5"     # 0.2.0 - 0.5.* = [0.2.0, 0.6.0)
 PkgA = "0.2 - 0"       # 0.2.0 - 0.*.* = [0.2.0, 1.0.0)
 ```
+
+!!! compat "Julia 1.4"
+    Hyphen specifiers requires at least Julia 1.4, so it is strongly recomended to also add
+    ```toml
+    [compat]
+    julia = "1.4"
+    ```
+    to the project file when using them.
 
 ## Fixing conflicts
 


### PR DESCRIPTION
Compat warnings seem to always come _after_ the relevant section in Julia docs ([example](https://docs.julialang.org/en/v1/base/parallel/#Base.Threads.Condition), [example](https://docs.julialang.org/en/v1/base/file/#Base.Filesystem.readdir), [example](https://docs.julialang.org/en/v1/base/multi-threading/#Base.Threads.@spawn)). It is important that these messages are never missed, so training Julia docs readers where to look is useful!