### PR TITLE
Guess that REPL-mode registry arguments are names if not matching any…

### DIFF
--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -165,10 +165,11 @@ function parse_registry(word::AbstractString; add=false)::RegistrySpec
         registry.name = String(m.captures[1])
         registry.uuid = UUID(m.captures[2])
     elseif add
-        # Guess it is a url then
+        # Guess it is a url then.
         registry.url = String(word)
     else
-        pkgerror("`$word` cannot be parsed as a registry")
+        # Guess it is a name then.
+        registry.name = String(word)
     end
     return registry
 end


### PR DESCRIPTION
Fixes #1838.

Biggest question is whether someone will expect that `registry rm URL` should work.

