### PR TITLE
Yet more inference/invalidation fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ language: julia
 
 julia:
   # - 1.0
-  - 1.4
+  # - 1.4
   - nightly
 
 os:
   - linux
   - osx
+
+env:
+- JULIA_PKG_SERVER="https://pkg.julialang.org"
+- JULIA_PKG_SERVER=""
 
 notifications:
   email: false
@@ -33,7 +37,7 @@ script:
 jobs:
   include:
     - stage: docs
-      julia: 1.4
+      julia: nightly
       os: linux
       script:
         - julia -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"))'

--- a/src/API.jl
+++ b/src/API.jl
@@ -402,7 +402,9 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), kwargs...)
     function write_condensed_usage(usage_by_depot, fname)
         for (depot, usage) in usage_by_depot
             # Keep only the keys of the files that are still extant
-            usage = filter(p -> p[1] in all_index_files, usage)
+            usage = let oldusage = usage
+                filter(p -> p[1] in all_index_files, oldusage)
+            end
 
             # Expand it back into a dict of arrays-of-dicts
             usage = Dict(k => [Dict("time" => v)] for (k, v) in usage)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -390,7 +390,7 @@ end
 Given an `entry` for the artifact named `name`, located within the file `artifacts_toml`,
 returns the `Platform` object that this entry specifies.  Returns `nothing` on error.
 """
-function unpack_platform(entry::Dict, name::String, artifacts_toml::String)
+function unpack_platform(entry::Dict, name::String, artifacts_toml::String)::Union{Nothing,Platform}
     if !haskey(entry, "os")
         @error("Invalid artifacts file at '$(artifacts_toml)': platform-specific artifact entry '$name' missing 'os' key")
         return nothing
@@ -403,9 +403,9 @@ function unpack_platform(entry::Dict, name::String, artifacts_toml::String)
 
     # Helpers to pull out `Symbol`s and `VersionNumber`s while preserving `nothing`.
     nosym(x::Nothing) = nothing
-    nosym(x) = Symbol(lowercase(x))
+    nosym(x) = Symbol(lowercase(x))::Symbol
     nover(x::Nothing) = nothing
-    nover(x) = VersionNumber(x)
+    nover(x) = VersionNumber(x)::VersionNumber
 
     # Extract architecture, libc, libgfortran version and cxxabi (if given)
     arch = nosym(get(entry, "arch", nothing))

--- a/src/BinaryPlatforms.jl
+++ b/src/BinaryPlatforms.jl
@@ -255,7 +255,7 @@ julia> arch(MacOS())
 :x86_64
 ```
 """
-arch(p::Platform) = p.arch
+arch(p::Platform) = p.arch::Symbol
 arch(u::UnknownPlatform) = nothing
 
 """
@@ -271,7 +271,7 @@ julia> libc(Linux(:aarch64))
 julia> libc(FreeBSD(:x86_64))
 ```
 """
-libc(p::Platform) = p.libc
+libc(p::Platform) = p.libc::Union{Nothing,Symbol}
 libc(u::UnknownPlatform) = nothing
 
 """
@@ -288,7 +288,7 @@ julia> call_abi(FreeBSD(:armv7l))
 :eabihf
 ```
 """
-call_abi(p::Platform) = p.call_abi
+call_abi(p::Platform) = p.call_abi::Union{Nothing,Symbol}
 call_abi(u::UnknownPlatform) = nothing
 
 """
@@ -301,7 +301,7 @@ julia> compiler_abi(Linux(:x86_64))
 CompilerABI()
 ```
 """
-compiler_abi(p::Platform) = p.compiler_abi
+compiler_abi(p::Platform) = p.compiler_abi::CompilerABI
 compiler_abi(p::UnknownPlatform) = CompilerABI()
 
 # Also break out CompilerABI getters for our platforms

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -218,12 +218,8 @@ function set_maximum_version_registry!(ctx::Context, pkg::PackageSpec)
         pathvers = keys(load_versions(ctx, path; include_yanked=false))
         union!(pkgversions, pathvers)
     end
-    if length(pkgversions) == 0
-        pkg.version = VersionNumber(0)
-    else
-        max_version = maximum(pkgversions)
-        pkg.version = VersionNumber(max_version.major, max_version.minor, max_version.patch, max_version.prerelease, ("",))
-    end
+    max_version = maximum(pkgversions; init=VersionNumber(0))
+    pkg.version = VersionNumber(max_version.major, max_version.minor, max_version.patch, max_version.prerelease, ("",))
 end
 
 function collect_project!(ctx::Context, pkg::PackageSpec, path::String,
@@ -694,7 +690,7 @@ function download_source(ctx::Context, pkgs::Vector{PackageSpec},
     end
 
     widths = [textwidth(pkg.name) for (pkg, _) in pkgs_to_install]
-    max_name = length(widths) == 0 ? 0 : maximum(widths)
+    max_name = maximum(widths; init=0)
 
     ########################################
     # Install from archives asynchronously #
@@ -906,7 +902,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
     # toposort builds by dependencies
     order = dependency_order_uuids(ctx, map(first, builds))
     sort!(builds, by = build -> order[first(build)])
-    max_name = isempty(builds) ? 0 : maximum(textwidth.([build[2] for build in builds]))
+    max_name = maximum(build->textwidth(build[2]), builds; init=0)
     # build each package versions in a child process
     for (uuid, name, source_path, version) in builds
         pkg = PackageSpec(;uuid=uuid, name=name, version=version)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -627,7 +627,12 @@ end
 function download_artifacts(ctx::Context, pkgs::Vector{PackageSpec}; platform::Platform=platform_key_abi(),
                             verbose::Bool=false)
     # Filter out packages that have no source_path()
-    pkg_roots = String[p for p in source_path.((ctx,), pkgs) if p !== nothing]
+    # pkg_roots = String[p for p in source_path.((ctx,), pkgs) if p !== nothing]  # this runs up against inference limits?
+    pkg_roots = String[]
+    for pkg in pkgs
+        p = source_path(ctx, pkg)
+        p !== nothing && push!(pkg_roots, p)
+    end
     return download_artifacts(ctx, pkg_roots; platform=platform, verbose=verbose)
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -420,7 +420,9 @@ function probe_platform_engines!(;verbose::Bool = false)
     if haskey(ENV, "BINARYPROVIDER_DOWNLOAD_ENGINE")
         engine = ENV["BINARYPROVIDER_DOWNLOAD_ENGINE"]
         es = split(engine)
-        dl_ngs = filter(e -> e[1].exec[1:length(es)] == es, download_engines)
+        dl_ngs = let es=es
+            filter(e -> e[1].exec[1:length(es)] == es, download_engines)
+        end
         if isempty(dl_ngs)
             all_ngs = join([d[1].exec[1] for d in download_engines], ", ")
             warn_msg  = "Ignoring BINARYPROVIDER_DOWNLOAD_ENGINE as its value "
@@ -437,7 +439,9 @@ function probe_platform_engines!(;verbose::Bool = false)
     if haskey(ENV, "BINARYPROVIDER_COMPRESSION_ENGINE")
         engine = ENV["BINARYPROVIDER_COMPRESSION_ENGINE"]
         es = split(engine)
-        comp_ngs = filter(e -> e[1].exec[1:length(es)] == es, compression_engines)
+        comp_ngs = let es=es
+            filter(e -> e[1].exec[1:length(es)] == es, compression_engines)
+        end
         if isempty(comp_ngs)
             all_ngs = join([c[1].exec[1] for c in compression_engines], ", ")
             warn_msg  = "Ignoring BINARYPROVIDER_COMPRESSION_ENGINE as its "

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -43,11 +43,11 @@ function OptionSpecs(decs::Vector{OptionDeclaration})::Dict{String, OptionSpec}
     specs = Dict()
     for x in decs
         opt_spec = OptionSpec(;x...)
-        @assert get(specs, opt_spec.name, nothing) === nothing # don't overwrite
+        @assert !haskey(specs, opt_spec.name) # don't overwrite
         specs[opt_spec.name] = opt_spec
         if opt_spec.short_name !== nothing
-            @assert get(specs, opt_spec.short_name, nothing) === nothing # don't overwrite
-            specs[opt_spec.short_name] = opt_spec
+            @assert !haskey(specs, opt_spec.short_name::String) # don't overwrite
+            specs[opt_spec.short_name::String] = opt_spec
         end
     end
     return specs
@@ -104,8 +104,8 @@ function CommandSpecs(declarations::Vector{CommandDeclaration})::Dict{String,Com
         @assert !haskey(specs, spec.canonical_name) "duplicate spec entry"
         specs[spec.canonical_name] = spec
         if spec.short_name !== nothing
-            @assert !haskey(specs, spec.short_name) "duplicate spec entry"
-            specs[spec.short_name] = spec
+            @assert !haskey(specs, spec.short_name::String) "duplicate spec entry"
+            specs[spec.short_name::String] = spec
         end
     end
     return specs

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -3,7 +3,7 @@ module Registry
 import ..Pkg, ..Types, ..API
 using ..Pkg: depots1
 using ..Types: RegistrySpec, Context, Context!
-
+using UUIDs
 
 """
     Pkg.Registry.add(url::String)
@@ -103,7 +103,7 @@ status(; kwargs...) = status(Context(); kwargs...)
 function status(ctx::Context; io::IO=stdout, as_api=false, kwargs...) # TODO split as_api into own function
     Context!(ctx; io=io, kwargs...)
     regs = Types.collect_registries()
-    regs = unique(r -> r.uuid, regs) # Maybe not?
+    regs = unique(r -> r.uuid, regs; seen=Set{Union{UUID,Nothing}}()) # Maybe not?
     as_api && return regs
     Types.printpkgstyle(ctx, Symbol("Registry Status"), "")
     if isempty(regs)

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -853,7 +853,7 @@ end
 function showlogjournal(io::IO, rlog::ResolveLog)
     journal = rlog.journal
     id(p) = p == UUID0 ? "[global event]" : pkgID(p, rlog)
-    padding = maximum(length(id(p)) for (p,_) in journal)
+    padding = maximum(length(id(p)) for (p,_) in journal; init=0)
     for (p,msg) in journal
         println(io, ' ', rpad(id(p), padding), ": ", msg)
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -292,9 +292,9 @@ function EnvCache(env::Union{Nothing,String}=nothing)
     end
     # determine manifest file
     dir = abspath(project_dir)
-    manifest_file = project.manifest !== nothing ?
-        abspath(project.manifest) :
-        manifestfile_path(dir)
+    manifest_file = project.manifest
+    manifest_file = manifest_file !== nothing ?
+        abspath(manifest_file) : manifestfile_path(dir)::String
     write_env_usage(manifest_file, "manifest_usage.toml")
     manifest = read_manifest(manifest_file)
     uuids = Dict{String,Vector{UUID}}()
@@ -887,9 +887,9 @@ function collect_registries(depot::String)
         if isfile(file)
             registry = read_registry(file)
             verify_registry(registry)
-            spec = RegistrySpec(name = registry["name"],
-                                uuid = UUID(registry["uuid"]),
-                                url = get(registry, "repo", nothing),
+            spec = RegistrySpec(name = registry["name"]::String,
+                                uuid = UUID(registry["uuid"]::String),
+                                url = get(registry, "repo", nothing)::Union{String,Nothing},
                                 path = dirname(file))
             push!(regs, spec)
         end
@@ -1246,13 +1246,13 @@ function find_registered!(ctx::Context,
     for registry in collect_registries()
         reg_abspath = abspath(registry.path)
         data = read_registry(joinpath(registry.path, "Registry.toml"))
-        for (_uuid, pkgdata) in data["packages"]
-              uuid = UUID(_uuid)
-              name = pkgdata["name"]
-              path = joinpath(reg_abspath, pkgdata["path"])
-              push!(get!(ctx.env.uuids, name, UUID[]), uuid)
-              push!(get!(ctx.env.paths, uuid, String[]), path)
-              push!(get!(ctx.env.names, uuid, String[]), name)
+        for (_uuid::String, pkgdata::TOML.DictType) in data["packages"]
+            name = pkgdata["name"]::String
+            uuid = UUID(_uuid)
+            push!(get!(Vector{UUID}, ctx.env.uuids, name), uuid)
+            path = joinpath(reg_abspath, pkgdata["path"])
+            push!(get!(Vector{String}, ctx.env.names, uuid), name)
+            push!(get!(Vector{String}, ctx.env.paths, uuid), path)
         end
     end
     for d in (ctx.env.uuids, ctx.env.paths, ctx.env.names)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1109,7 +1109,7 @@ function update_registries(ctx::Context, regs::Vector{RegistrySpec} = collect_re
     !force && UPDATED_REGISTRY_THIS_SESSION[] && return
     errors = Tuple{String, String}[]
     registry_urls = nothing
-    for reg in unique(r -> r.uuid, find_installed_registries(ctx, regs))
+    for reg in unique(r -> r.uuid, find_installed_registries(ctx, regs); seen=Set{Union{UUID,Nothing}}())
         let reg=reg
             regpath = pathrepr(reg.path)
             if isfile(joinpath(reg.path, ".tree_info.toml"))

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -47,11 +47,11 @@ function project(ctx::Context, pkg::String, dir::String)
 
     uuid = UUIDs.uuid4()
     genfile(ctx, pkg, dir, "Project.toml") do io
-        toml = Dict("authors" => authors,
-                    "name" => pkg,
-                    "uuid" => string(uuid),
-                    "version" => "0.1.0",
-                    )
+        toml = Dict{String,Any}("authors" => authors,
+                                "name" => pkg,
+                                "uuid" => string(uuid),
+                                "version" => "0.1.0",
+                                )
         TOML.print(io, toml, sorted=true, by=key -> (Types.project_key_order(key), key))
     end
     return uuid

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -3,7 +3,11 @@
 ###########
 function read_field(name::String, default, info, map)
     x = get(info, name, default)
-    x == default && return default
+    if default === nothing
+        x === nothing && return nothing
+    else
+        x == default && return default
+    end
     x isa String || pkgerror("Expected field `$name` to be a String.")
     return map(x)
 end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -154,7 +154,7 @@ function Manifest(raw::Dict)::Manifest
     return validate_manifest(stage1)
 end
 
-function read_manifest(path_or_stream)
+function read_manifest(path_or_stream::Union{String,IO})
     local raw
     try
         if path_or_stream isa String
@@ -168,7 +168,7 @@ function read_manifest(path_or_stream)
         path = path_or_stream isa String ? path_or_stream : ""
         if err isa TOML.ParserError
             pkgerror("Could not parse manifest $path: $(err.msg)")
-        elseif all(x -> x isa TOML.ParserError, err)
+        elseif isa(err, CompositeException) && all(x -> x isa TOML.ParserError, err)
             pkgerror("Could not parse manifest $path: $err")
         else
             rethrow()


### PR DESCRIPTION
This is the Pkg part of what I found in my investigations of invalidations due to extending `==`, c.f. https://github.com/JuliaLang/julia/pull/36282. This also requires https://github.com/JuliaLang/julia/pull/36280, so if that's not on nightly yet this wiil fail tests. (It also requires https://github.com/JuliaLang/julia/pull/36188, but I imagine that's on nightly by now.)

This will be easiest to review ignoring whitespace changes, due to some big `let` blocks from circumventing more cases of the infamous 15276.