### PR TITLE
telemetry: print legal notice first time talking to each pkg server

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -27,7 +27,8 @@ function pkg_server()
 end
 
 function telemetryinfo(io::IO = stdout)
-    for header in Pkg.PlatformEngines.get_telemetry_headers(pkg_server())
+    headers = Pkg.PlatformEngines.get_telemetry_headers(pkg_server(), false)
+    for header in headers
         println(io, header)
     end
 end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -874,9 +874,7 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     if info["client_uuid"] != false
         push!(headers, "Julia-Client-UUID: $(info["client_uuid"])")
         if info["secret_salt"] != false
-            salt_hash = hash_data("salt", info["client_uuid"], info["secret_salt"])
             project_hash = hash_data("project", Base.active_project(), info["secret_salt"])
-            push!(headers, "Julia-Salt-Hash: $salt_hash")
             push!(headers, "Julia-Project-Hash: $project_hash")
         end
     end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -845,6 +845,7 @@ const CI_VARIABLES = [
 ]
 
 const telemetry_file_lock = ReentrantLock()
+const telemetry_notice_printed = Ref(false)
 
 function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     headers = String[]
@@ -859,9 +860,12 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     end
     get(info, "telemetry", true) == false && return headers
     # legal (GDPR/CCPA) message about telemetry
-    notify && @info """
-    LEGAL NOTICE: package operations send anonymous data about your install to $server (your current package server), including the operating system and Julia versison you are running and a random client UUID. Running `Pkg.telemetryinfo()` will show exactly what is sent to. See https://julialang.org/legal/data/ for more details about what data is sent, what it is used for, how long it is retained, and how to opt out of sending this information.
-    """
+    if notify && !telemetry_notice_printed[]
+        telemetry_notice_printed[] = true
+        @info """
+        LEGAL NOTICE: package operations send anonymous data about your install to $server (your current package server), including the operating system and Julia versison you are running and a random client UUID. Running `Pkg.telemetryinfo()` will show exactly what is sent to. See https://julialang.org/legal/data/ for more details about what data is sent, what it is used for, how long it is retained, and how to opt out of sending this information.
+        """
+    end
     # general system information
     push!(headers, "Julia-Version: $VERSION")
     system = Pkg.BinaryPlatforms.triplet(Pkg.BinaryPlatforms.platform_key_abi())

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -844,6 +844,8 @@ const CI_VARIABLES = [
     "TRAVIS",
 ]
 
+const telemetry_file_lock = ReentrantLock()
+
 function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     headers = String[]
     server = pkg_server()
@@ -852,7 +854,9 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     push!(headers, "Julia-Pkg-Protocol: 1.0")
     telemetry_file = joinpath(server_dir, "telemetry.toml")
     notify &= !ispath(telemetry_file)
-    info = load_telemetry_file(telemetry_file)
+    info = lock(telemetry_file_lock) do
+        load_telemetry_file(telemetry_file)
+    end
     get(info, "telemetry", true) == false && return headers
     # legal (GDPR/CCPA) message about telemetry
     notify && @info """

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -847,6 +847,10 @@ const CI_VARIABLES = [
 const telemetry_file_lock = ReentrantLock()
 const telemetry_notice_printed = Ref(false)
 
+telemetry_notice(server::AbstractString=pkg_server()) = """
+    LEGAL NOTICE: package operations send anonymous data about your system to $server (your current package server), including the operating system and Julia versisons you are using, and a random client UUID. Running `Pkg.telemetryinfo()` will show exactly what data is sent. See https://julialang.org/legal/data/ for more details about what this data is used for, how long it is retained, and how to opt out of sending it.
+    """
+
 function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     headers = String[]
     server = pkg_server()
@@ -862,9 +866,7 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     # legal (GDPR/CCPA) message about telemetry
     if notify && !telemetry_notice_printed[]
         telemetry_notice_printed[] = true
-        @info """
-        LEGAL NOTICE: package operations send anonymous data about your install to $server (your current package server), including the operating system and Julia versison you are running and a random client UUID. Running `Pkg.telemetryinfo()` will show exactly what is sent to. See https://julialang.org/legal/data/ for more details about what data is sent, what it is used for, how long it is retained, and how to opt out of sending this information.
-        """
+        @info telemetry_notice()
     end
     # general system information
     push!(headers, "Julia-Version: $VERSION")


### PR DESCRIPTION
* print legal notice first time talking to each pkg server

* generate and send HyperLogLog estimator values

* use ~/.julia/servers/telemetry.toml for defaults

This allows, for example, a user to do

    echo 'telemetry = false' >> ~/.julia/servers/telemetry.toml

and opt out of all telemetry for all servers they might connect to. If they
only want to opt out of sending any telemetry that is based on a client
UUID, then they can do

	echo 'client_uuid = false' >> ~/.julia/servers/telemetry.toml

This can be done anywhere in the depot path, so if a sysadmin wants to set
up a shared system so that all users default to sending no telemetry, they
can do that. A user can opt back into telemetry by Putting an empty default
`telemetry.toml` file in their own depot.
