### PR TITLE
[docs] add a section to pkg server feature

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -298,3 +298,56 @@ To run a typical garbage collection with default arguments, simply use the `gc` 
 ```
 
 Note that only packages in `~/.julia/packages` are deleted.
+
+
+## Pkg client/server
+
+!!! compat "Julia 1.4"
+    Pkg client/server feature requires at least Julia 1.4. It is opt-in for Julia 1.4 and is enabled
+    by default since Julia 1.5.
+
+When you add a new registered package, usually three things would happen:
+
+1. update registries,
+2. download source codes of the package,
+3. if not available, download [artifacts](@ref Artifacts) required by the package.
+
+The [General](https://github.com/JuliaRegistries/General) registry and most packages in it are
+developed on Github, while the artifacts data are hosted in various platforms. When the network
+connection to Github and AWS S3 is not stable, it is usually not a good experience to install or
+update packages. Fortunately, the pkg client/server feature improves the experience in the sense that:
+
+1. If set, pkg client would first try to download data from the pkg server,
+2. if that fails, then it falls back to download from the origianl sources (e.g., Github).
+
+Since Julia 1.5, `https://pkg.julialang.org` provided by the JuliaLang org. is used as the default
+pkg server. In most cases this should be transparent, but users can still set/unset an pkg server
+upstream via the environment variable `JULIA_PKG_SERVER`.
+
+```julia
+# manually set it to some pkg server
+julia> ENV["JULIA_PKG_SERVER"] = "pkg.julialang.org"
+"pkg.julialang.org"
+
+# unset to always download data from original sources
+julia> ENV["JULIA_PKG_SERVER"] = ""
+""
+```
+
+For clarification, some sources are not provided by Pkg server
+
+* packages/registries fetched via `git`
+  * `]add https://github.com/JuliaLang/Example.jl.git`
+  * `]add Example#v0.5.3` (Note that this is different from `]add Example@0.5.3`)
+  * `]registry add https://github.com/JuliaRegistries/General.git`, including registries installed by Julia before 1.4.
+* artifacts without download info
+  * [TestImages](https://github.com/JuliaImages/TestImages.jl/blob/eaa94348df619c65956e8cfb0032ecddb7a29d3a/Artifacts.toml#L1-L2)
+
+
+!!! note
+    If you have a new registry installed via pkg server, then it's impossible for old Julia versions to
+    update the registry because Julia before 1.4 don't know how to fetch new data.
+    Hence, for users that frequently switches between multiple julia versions, it is recommended to
+    still use git-controlled regsitries.
+
+For the deployment of pkg server, please refer to [PkgServer.jl](https://github.com/JuliaPackaging/PkgServer.jl).


### PR DESCRIPTION
I'm very positive that this isn't complete, but just propose a section for this. When I tell others how to set/switch pkg server, I don't really want to point them to the epic #1377 design. The contents mainly come from questions when we advertise the pkg server feature in the Chinese community.

I haven't tried a private pkg server with authentication, so I didn't document this part. Also, feel free to rephrase or drop these words as I'm not a native English speaker.

