### PR TITLE
telemetry: print legal notice first time talking to each pkg server

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -803,12 +803,12 @@ function load_telemetry_file(file::AbstractString)
     end
     if info["client_uuid"] isa AbstractString &&
         (!haskey(info, "secret_salt") || !is_valid_salt(info["secret_salt"]))
-        info["secret_salt"] = randstring(36)
+        info["secret_salt"] = randstring(RandomDevice(), 36)
         changed = true
     end
     if !haskey(info, "HyperLogLog") || !is_valid_hlls(info["HyperLogLog"])
-        bucket = rand(0:1023)
-        sample = trailing_zeros(rand(UInt64))
+        bucket = rand(RandomDevice(), 0:1023)
+        sample = trailing_zeros(rand(RandomDevice(), UInt64))
         info["HyperLogLog"] = [bucket, sample]
         changed = true
     end


### PR DESCRIPTION
telemetry: ~/.julia/servers/telemetry.toml for defaults

This allows, for example, a user to do

    echo 'telemetry = false' >> ~/.julia/servers/telemetry.toml

and opt out of all telemetry for all servers they might connect to. If they
only want to opt out of sending any telemetry that is based on a client
UUID, then they can do

	echo 'client_uuid = false' >> ~/.julia/servers/telemetry.toml

This can be done anywhere in the depot path, so if a sysadmin wants to set
up a shared system so that all users default to sending no telemetry, they
can do that. A user can opt back into telemetry by Putting an empty default
`telemetry.toml` file in their own depot.

telemetry: HyperLogLog estimator