### PR TITLE
telemetry: use RandomDevice for random values

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -803,12 +803,12 @@ function load_telemetry_file(file::AbstractString)
     end
     if info["client_uuid"] isa AbstractString &&
         (!haskey(info, "secret_salt") || !is_valid_salt(info["secret_salt"]))
-        info["secret_salt"] = randstring(36)
+        info["secret_salt"] = randstring(RandomDevice(), 36)
         changed = true
     end
     if !haskey(info, "HyperLogLog") || !is_valid_hlls(info["HyperLogLog"])
-        bucket = rand(0:1023)
-        sample = trailing_zeros(rand(UInt64))
+        bucket = rand(RandomDevice(), 0:1023)
+        sample = trailing_zeros(rand(RandomDevice(), UInt64))
         info["HyperLogLog"] = [bucket, sample]
         changed = true
     end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -876,8 +876,11 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
     if info["client_uuid"] != false
         push!(headers, "Julia-Client-UUID: $(info["client_uuid"])")
         if info["secret_salt"] != false
-            project_hash = hash_data("project", Base.active_project(), info["secret_salt"])
-            push!(headers, "Julia-Project-Hash: $project_hash")
+            project = Base.active_project()
+            if project !== nothing
+                project_hash = hash_data("project", project, info["secret_salt"])
+                push!(headers, "Julia-Project-Hash: $project_hash")
+            end
         end
     end
     # CI indicator variables


### PR DESCRIPTION
The `secret_salt` should be as hard to guess as possible, so that has some security implication. The HyperLogLog samples should be random so that estimates aren't skewed by any non-randomness.