### PR TITLE
no-arg activate: if already deactivated, activate current project

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -886,9 +886,11 @@ end
 function activate(;temp=false,shared=false)
     shared && pkgerror("Must give a name for a shared environment")
     temp && return activate(mktempdir())
-    Base.ACTIVE_PROJECT[] = nothing
+    Base.ACTIVE_PROJECT[] =
+        Base.ACTIVE_PROJECT[] === nothing ? Base.current_project() : nothing
     p = Base.active_project()
-    p === nothing || printpkgstyle(Context(), :Activating, "environment at $(pathrepr(p))")
+    p === nothing ||
+        printpkgstyle(Context(), :Activating, "environment at $(pathrepr(p))")
     add_snapshot_to_undo()
     return nothing
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -13,7 +13,6 @@ const LOADED_DEPOT = joinpath(@__DIR__, "loaded_depot")
 function isolate(fn::Function; loaded_depot=false, kwargs...)
     old_load_path = copy(LOAD_PATH)
     old_depot_path = copy(DEPOT_PATH)
-    old_home_project = Base.HOME_PROJECT[]
     old_active_project = Base.ACTIVE_PROJECT[]
     old_working_directory = pwd()
     old_general_registry_url = Pkg.Types.DEFAULT_REGISTRIES[1].url
@@ -32,7 +31,6 @@ function isolate(fn::Function; loaded_depot=false, kwargs...)
 
         empty!(LOAD_PATH)
         empty!(DEPOT_PATH)
-        Base.HOME_PROJECT[] = nothing
         Base.ACTIVE_PROJECT[] = nothing
         Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
         Pkg.Types.DEFAULT_REGISTRIES[1].url = generaldir
@@ -62,7 +60,6 @@ function isolate(fn::Function; loaded_depot=false, kwargs...)
         empty!(DEPOT_PATH)
         append!(LOAD_PATH, old_load_path)
         append!(DEPOT_PATH, old_depot_path)
-        Base.HOME_PROJECT[] = old_home_project
         Base.ACTIVE_PROJECT[] = old_active_project
         cd(old_working_directory)
         Pkg.REPLMode.TEST_MODE[] = false # reset unconditionally
@@ -73,7 +70,6 @@ end
 function temp_pkg_dir(fn::Function;rm=true)
     old_load_path = copy(LOAD_PATH)
     old_depot_path = copy(DEPOT_PATH)
-    old_home_project = Base.HOME_PROJECT[]
     old_active_project = Base.ACTIVE_PROJECT[]
     old_general_registry_url = Pkg.Types.DEFAULT_REGISTRIES[1].url
     try
@@ -88,7 +84,6 @@ function temp_pkg_dir(fn::Function;rm=true)
         end
         empty!(LOAD_PATH)
         empty!(DEPOT_PATH)
-        Base.HOME_PROJECT[] = nothing
         Base.ACTIVE_PROJECT[] = nothing
         Pkg.Types.DEFAULT_REGISTRIES[1].url = generaldir
         withenv("JULIA_PROJECT" => nothing,
@@ -115,7 +110,6 @@ function temp_pkg_dir(fn::Function;rm=true)
         empty!(DEPOT_PATH)
         append!(LOAD_PATH, old_load_path)
         append!(DEPOT_PATH, old_depot_path)
-        Base.HOME_PROJECT[] = old_home_project
         Base.ACTIVE_PROJECT[] = old_active_project
         Pkg.Types.DEFAULT_REGISTRIES[1].url = old_general_registry_url
     end


### PR DESCRIPTION
* home project: remove all uses of this

* Previously there was no convenient way to activate the current project from the Pkg REPL or API. This changes `Pkg.activate()` so that if there is no active project to deactivate, it instead activates `Base.current_project()`. This means that we can now say that `julia --project` is exactly equivlent to `julia` followed by `pkg> activate`.