### PR TITLE
Add REPL mode telemetry enabling/disabling

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -852,7 +852,7 @@ const telemetry_file_lock = ReentrantLock()
 const telemetry_notice_printed = Ref(false)
 
 telemetry_notice(server::AbstractString=pkg_server()) = """
-    LEGAL NOTICE: package operations send anonymous data about your system to $server (your current package server), including the operating system and Julia versions you are using, and a random client UUID. Running `Pkg.telemetryinfo()` will show exactly what data is sent. See https://julialang.org/legal/data/ for more details about what this data is used for, how long it is retained, and how to opt out of sending it.
+    LEGAL NOTICE: package operations send anonymous data about your system to $server (your current package server), including the operating system and Julia versions you are using, and a random client UUID. Running `Pkg.telemetryinfo()` will show exactly what data is sent. See https://julialang.org/legal/data/ for more details about what this data is used for, how long it is retained, and details on how to customize its behavior.  To enable/disable this for your current Julia installation, use the `telemetry enable/disable` command in the Pkg REPL.
     """
 
 """

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -447,6 +447,67 @@ Display information about installed registries.
 pkg> registry status
 ```
 """,
-]
+],
 ], #registry
+"telemetry" => CommandDeclaration[
+[   :name => "enable",
+    :api => API.telemetry_enable,
+    :description => "Enable Pkg telemetry headers",
+    :option_spec => OptionDeclaration[
+        [:name => "all", :api => :all => true],
+    ],
+    :help => md"""
+    telemetry enable [--all]
+
+Enable Pkg telemetry headers for the current Julia Pkg server.
+To enable for all current and future servers, use `--all`.
+
+!!! compat "Julia 1.6"
+    Pkg's telemetry header handling requires at least Julia 1.1.
+
+**Examples**
+```
+pkg> telemetry enable
+```
+""",
+], [
+    :name => "disable",
+    :api => API.telemetry_disable,
+    :description => "Disable Pkg telemetry headers",
+    :option_spec => OptionDeclaration[
+        [:name => "all", :api => :all => true],
+    ],
+    :help => md"""
+    telemetry disable [--all]
+
+Disable Pkg telemetry headers for the current Julia Pkg server.
+To enable for all current and future servers, use `--all`.
+
+!!! compat "Julia 1.6"
+Pkg's telemetry header handling requires at least Julia 1.1.
+
+**Examples**
+```
+pkg> telemetry disable
+```
+""",
+], [
+    :name => "status",
+    :api => API.telemetry_status,
+    :description => "Display Pkg telemetry header status",
+    :help => md"""
+    telemetry status
+
+Display Pkg telemetry header status for all known servers.
+
+!!! compat "Julia 1.6"
+Pkg's telemetry header handling requires at least Julia 1.1.
+
+**Examples**
+```
+pkg> telemetry status
+```
+""",
+],
+], #telemetry
 ] #command_declarations


### PR DESCRIPTION
This adds a new set of REPL mode commands for manipulating telemetry
reporting preferences.  By running `pkg> telemetry disable`, a user is
able to disable telemetry reporting for the current server, and with
`pkg> telemetry enable` it can be enabled again.

To enable/disable for all currently-known servers (and all servers in
the future) use `pkg> telemetry <verb> --all`.

The current telemetry header transmission status can be view by the
third command, `pkg> telemetry status`.

Note, the output from these commands is not very beautiful.  If Kristoffer or anyone has suggestions on how to spice it up, that'd be great.  :)