### PR TITLE
Telemetry CI variables: add CI_SERVER, JULIA_PKGEVAL, JULIA_REGISTRYCI_AUTOMERGE, and PKGEVAL

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -847,7 +847,6 @@ const CI_VARIABLES = [
     "JULIA_CI",
     "JULIA_PKGEVAL",
     "JULIA_REGISTRYCI_AUTOMERGE",
-    "PKGEVAL",
     "TF_BUILD",
     "TRAVIS",
 ]

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -839,11 +839,15 @@ end
 const CI_VARIABLES = [
     "APPVEYOR",
     "CI",
+    "CI_SERVER",
     "CIRCLECI",
     "CONTINUOUS_INTEGRATION",
     "GITHUB_ACTIONS",
     "GITLAB_CI",
     "JULIA_CI",
+    "JULIA_PKGEVAL",
+    "JULIA_REGISTRYCI_AUTOMERGE",
+    "PKGEVAL",
     "TF_BUILD",
     "TRAVIS",
 ]


### PR DESCRIPTION
`CI_SERVER` is set by [GitLab](https://docs.gitlab.com/ce/ci/variables/predefined_variables.html).

`PKGEVAL` and `JULIA_PKGEVAL` are set by [NewPkgEval](https://github.com/JuliaComputing/NewPkgEval.jl/blob/master/src/run.jl).

`JULIA_REGISTRYCI_AUTOMERGE` is set by [RegistryCI](https://github.com/JuliaRegistries/RegistryCI.jl/pull/257).