### PR TITLE
Deprecate the REPL command `] generate`

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -278,7 +278,7 @@ patch version; if the `--fixed` upgrade level is given, then the following
 packages will not be upgraded at all.
 """,
 ],[ :name => "generate",
-    :api => API.generate,
+    :api => API.generate_deprecated,
     :arg_count => 1 => 1,
     :arg_parser => ((x,y) -> map(expanduser, unwrap(x))),
     :description => "generate files for a new project",

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+function generate_deprecated(varargs...; kwargs...)
+    Base.depwarn("Pkg.generate is deprecated. Please use PkgTemplates.jl instead.", Core.Typeof(generate).name.mt.name)
+    return generate(varargs...; kwargs...)
+end
+
 generate(path::String; kwargs...) = generate(Context(), path; kwargs...)
 function generate(ctx::Context, path::String; kwargs...)
     Context!(ctx; kwargs...)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 function generate_deprecated(varargs...; kwargs...)
-    Base.depwarn("Pkg.generate is deprecated. Please use PkgTemplates.jl instead.", Core.Typeof(generate).name.mt.name)
+    Base.depwarn("Pkg.generate is deprecated. Please use PkgTemplates.jl instead.", Symbol("Pkg.generate"))
     return generate(varargs...; kwargs...)
 end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -1816,7 +1816,7 @@ end
     isolate() do
         Pkg.REPLMode.TEST_MODE[] = true
         api, arg, opts = first(Pkg.pkg"generate Foo")
-        @test api == Pkg.generate_deprecated
+        @test api == Pkg.API.generate_deprecated
         @test arg == "Foo"
         @test isempty(opts)
         mktempdir() do dir

--- a/test/new.jl
+++ b/test/new.jl
@@ -1816,7 +1816,7 @@ end
     isolate() do
         Pkg.REPLMode.TEST_MODE[] = true
         api, arg, opts = first(Pkg.pkg"generate Foo")
-        @test api == Pkg.generate
+        @test api == Pkg.generate_deprecated
         @test arg == "Foo"
         @test isempty(opts)
         mktempdir() do dir


### PR DESCRIPTION
This PR deprecates the REPL command `] generate` but leaves `Pkg.generate` untouched.

@StefanKarpinski @KristofferC 