### PR TITLE
Fix PkgServer download failures

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -886,6 +886,7 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
         if info["secret_salt"] !== false
             secret_salt = info["secret_salt"]::String
             salt_hash = hash_data("salt", client_uuid, secret_salt)
+            project = Base.active_project()
             if project !== nothing
                 project_hash = hash_data("project", project, info["secret_salt"])
                 push!(headers, "Julia-Project-Hash: $project_hash")


### PR DESCRIPTION
Add missing `project` back in, accidentally dropped in 2acb2f9ca7f8b908954d6fdde074b65e30b8395f

This pretty much broke downloading PkgServer resources, so we should update the Pkg on master ASAP.