### PR TITLE
Add running tests notice

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1539,6 +1539,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         sandbox(ctx, pkg, source_path, testdir(source_path), test_project_override) do
             test_fn !== nothing && test_fn()
             status(Context(); mode=PKGMODE_COMBINED)
+            printpkgstyle(ctx, :Testing, "Running tests...")
             flush(stdout)
             cmd = gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args)
             p = run(ignorestatus(cmd))


### PR DESCRIPTION
Adds a notice to indicate that tests are starting. There are two motivations behind this change:

1. Adds a clear demarcation between resolving test dependencies and starting tests (was more relevant back with Julia 1.3)
2. Provides an easy string to search for in the test output logs to find the start of test execution