### PR TITLE
REPL: Fix parsing git URLs

### DIFF
--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -24,7 +24,7 @@ const PackageToken = Union{PackageIdentifier, VersionRange, Rev, Subdir}
 
     # Match a git repository URL. This includes uses of `@` and `:` but
     # requires that it has `.git` at the end.
-let url = raw"((git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?",
+let url = raw"((git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git$)(/)?",
 
     # Match a `NAME=UUID` package specifier.
     name_uuid = raw"[^@\#\s:]+\s*=\s*[^@\#\s:]+",

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -541,6 +541,13 @@ end
                                                        add_or_develop=true)) == Pkg.Types.PackageSpec
 end
 
+@testset "parse git url (issue #1935) " begin
+    urls = ["https://github.com/abc/ABC.jl.git", "https://abc.github.io/ABC.jl"]
+    for url in urls
+        @test Pkg.REPLMode.package_lex([Pkg.REPLMode.QString((url), false)]) == [url]
+    end
+end
+
 @testset "unit test for REPLMode.promptf" begin
     function set_name(projfile_path, newname)
         sleep(1.1)


### PR DESCRIPTION
This PR adjusts the regex which is used to match a git repository URL. Now, ".git" must be at the end of the URL. It should resolve #1935. Please, check the added test since I was not very sure about that.