### PR TITLE
Add `Pkg.API.get_uuid()` and `Pkg.API.get_version()`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1050,4 +1050,31 @@ Package(name::AbstractString) = PackageSpec(name)
 Package(name::AbstractString, uuid::UUID) = PackageSpec(name, uuid)
 Package(name::AbstractString, uuid::UUID, version::VersionTypes) = PackageSpec(name, uuid, version)
 
+
+"""
+    get_uuid(m::Module)
+
+Given a `Module`, find the `UUID` of the parent package to that `Module`.  If none can be
+found (e.g. `Main`, `Base`, anonymous modules, etc...) returns `nothing`.
+"""
+function get_uuid(m::Module)
+    return Base.PkgId(m).uuid
+end
+
+"""
+    get_version(pkg)
+
+Given a `UUID` identifying a package, returns the version of that package within the
+current project.  If the package cannot be found by the given UUID, throws an
+`ArgumentError`.
+"""
+function get_version(uuid::UUID)
+    ctx = Pkg.Types.Context()
+    matching_pkgs = filter(((u, e),) -> u == uuid, ctx.env.manifest)
+    if isempty(matching_pkgs)
+        throw(ArgumentError("Unable to find given UUID in environment"))
+    end
+    return first(matching_pkgs)[2].version
+end
+
 end # module

--- a/test/api.jl
+++ b/test/api.jl
@@ -118,7 +118,6 @@ end
 @testset "get_uuid/get_version" begin
     temp_pkg_dir() do tmp
         copy_test_package(tmp, "TestArguments")
-        Pkg.activate(joinpath(tmp, "TestArguments"))
         uuid, version = Core.eval(Module(:__anon__), quote
             using TestArguments
             uuid = $(Pkg).API.get_uuid(TestArguments)

--- a/test/api.jl
+++ b/test/api.jl
@@ -120,9 +120,9 @@ end
         copy_test_package(tmp, "TestArguments")
         Pkg.activate(joinpath(tmp, "TestArguments"))
         uuid, version = Core.eval(Module(:__anon__), quote
-            using TestArguments, Pkg
-            uuid = Pkg.API.get_uuid(TestArguments)
-            version = Pkg.API.get_version(uuid)
+            using TestArguments
+            uuid = $(Pkg).API.get_uuid(TestArguments)
+            version = $(Pkg).API.get_version(uuid)
             return uuid, version
         end)
         @test uuid == Base.UUID("265b0eca-b78c-42af-9929-ddebf847c026")

--- a/test/api.jl
+++ b/test/api.jl
@@ -115,4 +115,21 @@ import .FakeTerminals.FakeTerminal
     end
 end
 
+@testset "get_uuid/get_version" begin
+    temp_pkg_dir() do tmp
+        copy_test_package(tmp, "TestArguments")
+        Pkg.activate(joinpath(tmp, "TestArguments"))
+        uuid, version = Core.eval(Module(:__anon__), quote
+            using TestArguments, Pkg
+            uuid = Pkg.API.get_uuid(TestArguments)
+            version = Pkg.API.get_version(uuid)
+            return uuid, version
+        end)
+        @test uuid == Base.UUID("265b0eca-b78c-42af-9929-ddebf847c026")
+        @test version == v"0.1.0"
+        @test Pkg.API.get_uuid(Module(:__anon__)) === nothing
+        @test_throws ArgumentError Pkg.API.get_version(Base.UUID(UInt128(0)))
+    end
+end
+
 end # module APITests


### PR DESCRIPTION
These are helper methods to aid in packages wanting to inspect their own
(or their dependencies') versions at runtime.