### PR TITLE
some microoptimizations for the resolver

### DIFF
--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -7,7 +7,7 @@ using ..Types
 using Printf
 using Random
 
-export resolve, sanity_check, Graph
+export resolve, sanity_check, Graph, pkgID
 
 ####################
 # Requires / Fixed #
@@ -52,9 +52,9 @@ end
 
 const uuid_julia = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
 
-include("graphtype.jl")
 include("versionweights.jl")
 include("fieldvalues.jl")
+include("graphtype.jl")
 include("maxsum.jl")
 
 "Resolve package dependencies."

--- a/src/Resolve/fieldvalues.jl
+++ b/src/Resolve/fieldvalues.jl
@@ -45,22 +45,10 @@ Base.:+(a::FieldValue, b::FieldValue) = FieldValue(a.l0+b.l0, a.l1+b.l1, a.l2+b.
 function Base.isless(a::FieldValue, b::FieldValue)
     a.l0 < b.l0 && return true
     a.l0 > b.l0 && return false
-    c = cmp(a.l1, b.l1)
-    c < 0 && return true
-    c > 0 && return false
-    c = cmp(a.l2, b.l2)
-    c < 0 && return true
-    c > 0 && return false
-    a.l3 < b.l3 && return true
-    return false
+    return (a.l1, a.l2, a.l3) < (b.l1, b.l2, b.l3)
 end
 
-Base.:(==)(a::FieldValue, b::FieldValue) =
-    a.l0 == b.l0 && a.l1 == b.l1 && a.l2 == b.l2 && a.l3 == b.l3
-
 Base.abs(a::FieldValue) = FieldValue(abs(a.l0), abs(a.l1), abs(a.l2), abs(a.l3))
-
-Base.copy(a::FieldValue) = FieldValue(a.l0, copy(a.l1), copy(a.l2), a.l3)
 
 # if the maximum field has l0 < 0, it means that
 # some hard constraint is being violated

--- a/src/Resolve/maxsum.jl
+++ b/src/Resolve/maxsum.jl
@@ -245,7 +245,7 @@ function iterate!(graph::Graph, msgs::Messages, perm::NodePerm)
         graph.ignored[p0] && continue
         maxdiff0 = update!(p0, graph, msgs)
         if maxdiff0 isa Unsat
-            return Unsat
+            return maxdiff0
         end
         maxdiff = max(maxdiff, maxdiff0)
     end

--- a/src/Resolve/maxsum.jl
+++ b/src/Resolve/maxsum.jl
@@ -8,9 +8,9 @@ end
 
 # Some parameters to drive the decimation process
 mutable struct MaxSumParams
-    dec_interval # number of iterations between decimations
-    dec_fraction # fraction of nodes to decimate at every decimation
-                 # step
+    dec_interval::Int # number of iterations between decimations
+    dec_fraction::Float64 # fraction of nodes to decimate at every decimation
+                          # step
 
     function MaxSumParams()
         accuracy = parse(Int, get(ENV, "JULIA_PKGRESOLVE_ACCURACY", "1"))
@@ -148,6 +148,10 @@ function update!(p0::Int, graph::Graph, msgs::Messages)
     ignored = graph.ignored
     spp = graph.spp
     np = graph.np
+    cavfld = graph.cavfld
+    newmsg = graph.newmsg
+    diff = graph.diff
+
     msg = msgs.msg
     fld = msgs.fld
 
@@ -161,7 +165,6 @@ function update!(p0::Int, graph::Graph, msgs::Messages)
 
     # iterate over all neighbors of p0
     for j0 in 1:length(gadj0)
-
         p1 = gadj0[j0]
         ignored[p1] && continue
         j1 = adjdict0[p1]
@@ -171,38 +174,44 @@ function update!(p0::Int, graph::Graph, msgs::Messages)
         msg1 = msg[p1]
 
         # compute the output cavity field p0->p1
-        cavfld = fld0 - msg0[j0]
+        resize!(cavfld, length(fld0))
+        cavfld .= fld0 .- msg0[j0]
 
         # keep the old input cavity message p0->p1
         oldmsg = msg1[j1]
 
         # init the new message to minus infinity
-        newmsg = [FieldValue(-1) for v1 = 1:spp1]
+        resize!(newmsg, spp1)
+        fill!(newmsg, FieldValue(-1))
 
         # compute the new message by passing cavfld
         # through the constraint encoded in the bitmask
         # (equivalent to:
         #    newmsg = [maximum(cavfld[bm1[:,v1]]) for v1 = 1:spp1]
         # )
-        for v1 = 1:spp1, v0 = 1:spp0
+        # This is hot code for the resolver
+        @inbounds for v1 = 1:spp1, v0 = 1:spp0
             bm1[v0, v1] || continue
             newmsg[v1] = max(newmsg[v1], cavfld[v0])
         end
         m = maximum(newmsg)
-        validmax(m) || throw(UnsatError(p0)) # No state available without violating some
-                                             # hard constraint
+        validmax(m) || return Unsat(p0) # No state available without violating some
+                                        # hard constraint
 
         # normalize the new message
-        newmsg .-= m
+        @inbounds for i in 1:length(newmsg)
+            newmsg[i] -= m
+        end
 
-        diff = newmsg - oldmsg
-        maxdiff = max(maxdiff, maximum(abs.(diff)))
+        resize!(diff, spp1)
+        diff .= newmsg .- oldmsg
+        maxdiff = max(maxdiff, maximum(abs, diff))
 
         # update the field of p1
         fld[p1] .+= diff
 
         # put the newly computed message in place
-        msg1[j1] = newmsg
+        copy!(msg1[j1], newmsg)
     end
     return maxdiff
 end
@@ -235,6 +244,9 @@ function iterate!(graph::Graph, msgs::Messages, perm::NodePerm)
     for p0 in perm
         graph.ignored[p0] && continue
         maxdiff0 = update!(p0, graph, msgs)
+        if maxdiff0 isa Unsat
+            return Unsat
+        end
         maxdiff = max(maxdiff, maxdiff0)
     end
     return maxdiff
@@ -346,6 +358,10 @@ function try_simplify_graph_soft!(graph, sources)
     return true
 end
 
+struct Unsat
+    p0::Int
+end
+
 function converge!(graph::Graph, msgs::Messages, strace::SolutionTrace, perm::NodePerm, params::MaxSumParams)
     is_best_sofar = update_solution!(strace, graph)
 
@@ -359,13 +375,10 @@ function converge!(graph::Graph, msgs::Messages, strace::SolutionTrace, perm::No
     # If failure happens during this process, we bail (return false)
     it = 0
     for it = 1:params.dec_interval
-        local maxdiff::FieldValue
-        try
-            maxdiff = iterate!(graph, msgs, perm)
-        catch err
-            err isa UnsatError || rethrow()
+        maxdiff = iterate!(graph, msgs, perm)
+        if maxdiff isa Unsat
             if is_best_sofar
-                p0 = err.p0
+                p0 = maxdiff.p0
                 s0 = findlast(graph.gconstr[p0])
                 strace.staged = (p0, s0)
             end

--- a/src/Resolve/versionweights.jl
+++ b/src/Resolve/versionweights.jl
@@ -25,19 +25,12 @@ Base.:(+)(a::VersionWeight, b::VersionWeight) =
 Base.:(-)(a::VersionWeight) =
     VersionWeight(-a.major, -a.minor, -a.patch)
 
-function Base.cmp(a::VersionWeight, b::VersionWeight)
-    c = cmp(a.major, b.major); c != 0 && return c
-    c = cmp(a.minor, b.minor); c != 0 && return c
-    return cmp(a.patch, b.patch)
+function Base.isless(a::VersionWeight, b::VersionWeight)
+    (a.major, a.minor, a.patch) < (b.major, b.minor, b.patch)
 end
-Base.isless(a::VersionWeight, b::VersionWeight) = cmp(a,b) < 0
-Base.:(==)(a::VersionWeight, b::VersionWeight) = cmp(a,b) == 0
 
 Base.abs(a::VersionWeight) =
     VersionWeight(abs(a.major), abs(a.minor), abs(a.patch))
-
-Base.copy(a::VersionWeight) =
-    VersionWeight(a.major, a.minor, a.patch)
 
 # This isn't nice, but it's for debugging only anyway
 function Base.show(io::IO, a::VersionWeight)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -19,7 +19,7 @@ import ..PlatformEngines: probe_platform_engines!, download, download_verify_unp
 import Base: SHA1
 using SHA
 
-export UUID, pkgID, SHA1, VersionRange, VersionSpec,
+export UUID, SHA1, VersionRange, VersionSpec,
     PackageSpec, EnvCache, Context, PackageInfo, ProjectInfo, GitRepo, Context!, range_compressed_versionspec, err_rep,
     PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved,
@@ -35,13 +35,6 @@ export UUID, pkgID, SHA1, VersionRange, VersionSpec,
 include("versions.jl")
 
 const URL_regex = r"((file|git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?"x
-
-## user-friendly representation of package IDs ##
-function pkgID(p::UUID, uuid_to_name::Dict{UUID,String})
-    name = get(uuid_to_name, p, "(unknown)")
-    uuid_short = string(p)[1:8]
-    return "$name [$uuid_short]"
-end
 
 #################
 # Pkg Error #


### PR DESCRIPTION
These are results for `Pkg.update` in an environment where I added a bunch of big packages (Plots, Makie, DifferentialEquations, ApproxFun etc).


Master:

```
ENV["JULIA_PKGRESOLVE_ACCURACY"] = 1
  966.591 ms (6843000 allocations: 1.01 GiB)

ENV["JULIA_PKGRESOLVE_ACCURACY"] = 2
  2.124 s (11577823 allocations: 3.01 GiB)
```


PR:

```
ENV["JULIA_PKGRESOLVE_ACCURACY"] = 1
  602.627 ms (5432062 allocations: 301.72 MiB)

ENV["JULIA_PKGRESOLVE_ACCURACY"] = 2
   1.308 s (7230777 allocations: 368.51 MiB)
```

The performance improvements here only matter when the greedy solver fails.

The reason for this is that https://github.com/JuliaLang/Pkg.jl/issues/1949 suggests that we might want to bump the resolver accuracy but it would be a bit sad if we lost performance from doing that. The optimized resolver is now pretty close for accuracy 2, as the previous one with accuracy 1.
 
cc @carlobaldassi 