### PR TITLE
Improve consistency of Dict types & construction

### DIFF
--- a/src/BinaryPlatforms.jl
+++ b/src/BinaryPlatforms.jl
@@ -430,7 +430,7 @@ function platform_key_abi(machine::String)
         :libgfortran4 => "(-libgfortran4)|(-gcc7)",
         :libgfortran5 => "(-libgfortran5)|(-gcc8)",
     )
-    libstdcxx_version_mapping = Dict(
+    libstdcxx_version_mapping = Dict{Symbol,String}(
         :libstdcxx_nothing => "",
         # This is sadly easier than parsing out the digit directly
         (Symbol("libstdcxx$(idx)") => "-libstdcxx$(idx)" for idx in 18:26)...,
@@ -494,7 +494,7 @@ function platform_key_abi(machine::String)
         # First, figure out what platform we're dealing with, then sub that off
         # to the appropriate constructor.  If a constructor runs into trouble,
         # catch the error and return `UnknownPlatform()` here to be nicer to client code.
-        ctors = Dict(:darwin => MacOS, :mingw32 => Windows, :freebsd => FreeBSD, :linux => Linux)
+        ctors = Dict{Symbol,Type{<:Platform}}(:darwin => MacOS, :mingw32 => Windows, :freebsd => FreeBSD, :linux => Linux)
         try
             T = ctors[platform]
             compiler_abi = CompilerABI(;
@@ -502,7 +502,7 @@ function platform_key_abi(machine::String)
                 libstdcxx_version=libstdcxx_version,
                 cxxstring_abi=cxxstring_abi
             )
-            return T(arch, libc=libc, call_abi=call_abi, compiler_abi=compiler_abi)
+            return T(arch, libc=libc, call_abi=call_abi, compiler_abi=compiler_abi)::Platform
         catch err
             if isa(err, ArgumentError)
                 msg = " ($(err.msg))"
@@ -731,7 +731,7 @@ default_platkey = platform_key_abi(string(
 ))
 function platform_key_abi()
     global default_platkey
-    return default_platkey
+    return default_platkey::Platform
 end
 
 function platforms_match(a::Platform, b::Platform)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -413,14 +413,14 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
     uuids = collect(union(keys(reqs), keys(fixed), map(fx->keys(fx.requires), values(fixed))...))
     seen = UUID[]
 
-    all_versions = Dict{UUID,Set{VersionNumber}}()
-    all_deps     = Dict{UUID,Dict{VersionNumber,Dict{String,UUID}}}()
-    all_compat   = Dict{UUID,Dict{VersionNumber,Dict{String,VersionSpec}}}()
+    all_versions = VersionsDict()
+    all_deps     = DepsDict()
+    all_compat   = CompatDict()
 
     for (fp, fx) in fixed
         all_versions[fp] = Set([fx.version])
-        all_deps[fp]     = Dict(fx.version => Dict())
-        all_compat[fp]   = Dict(fx.version => Dict())
+        all_deps[fp]     = Dict(fx.version => valtype(DepsValDict)())
+        all_compat[fp]   = Dict(fx.version => valtype(CompatValDict)())
     end
 
     while true

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -39,8 +39,8 @@ function OptionSpec(;name::String,
     return OptionSpec(name, short_name, api, takes_arg)
 end
 
-function OptionSpecs(decs::Vector{OptionDeclaration})::Dict{String, OptionSpec}
-    specs = Dict()
+function OptionSpecs(decs::Vector{OptionDeclaration})
+    specs = Dict{String, OptionSpec}()
     for x in decs
         opt_spec = OptionSpec(;x...)
         @assert !haskey(specs, opt_spec.name) # don't overwrite
@@ -97,8 +97,8 @@ function CommandSpec(;name::Union{Nothing,String}           = nothing,
                        OptionSpecs(option_spec), completions, description, help)
 end
 
-function CommandSpecs(declarations::Vector{CommandDeclaration})::Dict{String,CommandSpec}
-    specs = Dict()
+function CommandSpecs(declarations::Vector{CommandDeclaration})
+    specs = Dict{String,CommandSpec}()
     for dec in declarations
         spec = CommandSpec(;dec...)
         @assert !haskey(specs, spec.canonical_name) "duplicate spec entry"
@@ -111,8 +111,8 @@ function CommandSpecs(declarations::Vector{CommandDeclaration})::Dict{String,Com
     return specs
 end
 
-function CompoundSpecs(compound_declarations)::Dict{String,Dict{String,CommandSpec}}
-    compound_specs = Dict()
+function CompoundSpecs(compound_declarations)
+    compound_specs = Dict{String,Dict{String,CommandSpec}}()
     for (name, command_declarations) in compound_declarations
         specs = CommandSpecs(command_declarations)
         @assert !haskey(compound_specs, name) "duplicate super spec entry"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -31,8 +31,15 @@ export UUID, SHA1, VersionRange, VersionSpec,
     printpkgstyle, isurl,
     projectfile_path, manifestfile_path,
     RegistrySpec
+export DepsValDict, CompatValDict, VersionsDict, DepsDict, CompatDict
 
 include("versions.jl")
+
+const DepsValDict   = Dict{VersionNumber,Dict{String,UUID}}
+const CompatValDict = Dict{VersionNumber,Dict{String,VersionSpec}}
+const VersionsDict  = Dict{UUID,Set{VersionNumber}}
+const DepsDict      = Dict{UUID,DepsValDict}
+const CompatDict    = Dict{UUID,CompatValDict}
 
 const URL_regex = r"((file|git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?"x
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -551,7 +551,7 @@ end
         end
 
         # Force Pkg to reload what it knows about artifact overrides
-        Pkg.Artifacts.load_overrides(;force=true)
+        @inferred Union{Nothing,Dict{Symbol,Any}} Pkg.Artifacts.load_overrides(;force=true)
 
         # Verify that the hash-based override worked
         @test artifact_path(baz_hash) == artifact_path(bar_hash)

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -5,7 +5,7 @@ using Test, Pkg.BinaryPlatforms
 import Pkg.BinaryPlatforms: platform_name
 
 # The platform we're running on
-const platform = platform_key_abi()
+const platform = @inferred Platform platform_key_abi()
 
 @testset "PlatformNames" begin
     # Ensure the platform type constructors are well behaved
@@ -114,7 +114,7 @@ const platform = platform_key_abi()
 
     @testset "platform_key_abi parsing" begin
         # Make sure the platform_key_abi() with explicit triplet works
-        @test platform_key_abi("x86_64-linux-gnu") == Linux(:x86_64)
+        @test @inferred(Platform, platform_key_abi("x86_64-linux-gnu")) == Linux(:x86_64)
         @test platform_key_abi("x86_64-linux-musl") == Linux(:x86_64, libc=:musl)
         @test platform_key_abi("i686-unknown-linux-gnu") == Linux(:i686)
         @test platform_key_abi("x86_64-apple-darwin14") == MacOS()

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -212,7 +212,7 @@ temp_pkg_dir() do project_path
     @testset "adding and upgrading different versions" begin
         # VersionNumber
         Pkg.add(PackageSpec(TEST_PKG.name, v"0.3"))
-        @test Pkg.dependencies()[TEST_PKG.uuid].version == v"0.3"
+        @test @inferred(Pkg.dependencies())[TEST_PKG.uuid].version == v"0.3"
         Pkg.add(PackageSpec(TEST_PKG.name, v"0.3.1"))
         @test Pkg.dependencies()[TEST_PKG.uuid].version == v"0.3.1"
         Pkg.rm(TEST_PKG.name)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -637,4 +637,10 @@ end
     end end
 end
 
+@testset "Inference" begin
+    @inferred Pkg.REPLMode.OptionSpecs(Pkg.REPLMode.OptionDeclaration[])
+    @inferred Pkg.REPLMode.CommandSpecs(Pkg.REPLMode.CommandDeclaration[])
+    @inferred Pkg.REPLMode.CompoundSpecs(Pair{String,Vector{Pkg.REPLMode.CommandDeclaration}}[])
+end
+
 end # module

--- a/test/resolve_utils.jl
+++ b/test/resolve_utils.jl
@@ -40,7 +40,7 @@ function graph_from_data(deps_data)
     uuid(p) = storeuuid(p, uuid_to_name)
     fixed = Dict{UUID,Fixed}()
     all_versions = Dict{UUID,Set{VersionNumber}}()
-    all_deps = Dict{UUID,Dict{VersionNumber,Dict{String,UUID}}}()
+    all_deps = DepsDict()
     all_compat = Dict{UUID,Dict{VersionNumber,Dict{String,VersionSpec}}}()
 
     deps = Dict{String,Dict{VersionNumber,Dict{String,VersionSpec}}}()


### PR DESCRIPTION
This defines some aliases and otherwise increases consistency in Dict types. Note that in some cases the final result is no different, but this avoids an unnecessary conversion by creating the Dict to be of the correct type at the outset. Essentially the Pkg equivalent of https://github.com/JuliaLang/julia/pull/37088.