### PR TITLE
Ensure `unique!` is called with concrete type

### DIFF
--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -103,7 +103,7 @@ status(; kwargs...) = status(Context(); kwargs...)
 function status(ctx::Context; io::IO=stdout, as_api=false, kwargs...) # TODO split as_api into own function
     Context!(ctx; io=io, kwargs...)
     regs = Types.collect_registries()
-    regs = unique(r -> r.uuid, regs; seen=Set{Union{UUID,Nothing}}()) # Maybe not?
+    regs = unique(r -> r.uuid, regs; seen=Set{Union{UUID,Nothing}}())
     as_api && return regs
     Types.printpkgstyle(ctx, Symbol("Registry Status"), "")
     if isempty(regs)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1257,11 +1257,12 @@ function find_registered!(ctx::Context,
             push!(get!(Vector{String}, ctx.env.paths, uuid), path)
         end
     end
-    for d in (ctx.env.uuids, ctx.env.paths, ctx.env.names)
-        for (k, v) in d
-            unique!(v)
-        end
-    end
+
+    uniqueall!(d) = for (k, v) in d unique!(v) end
+    uniqueall!(ctx.env.uuids)
+    uniqueall!(ctx.env.paths)
+    uniqueall!(ctx.env.names)
+    return nothing
 end
 
 # Get registered uuids associated with a package name


### PR DESCRIPTION
I've been been working on improving Julia's `unique!` in the face of poor inference information, which is fine, but it's also good to find the callers. I doubt this was the only one when this whole adventure started, but between recent "concretizations" of Dict types and this change, this turns out to be the last of them.

This was challenging because due to runtime dispatch the call chain ended:
```julia
julia> ascend(root)   # SnoopCompile's `ascend`
Choose a call for analysis (q to quit):
 >   _unique!(::typeof(identity), ::AbstractVector{T} where T, ::Set{_A} where _A, ::Int64, ::Int64)
       #unique!#264(::Nothing, ::typeof(unique!), ::typeof(identity), ::AbstractVector{T} where T)
         unique!(::typeof(identity), ::AbstractVector{T} where T)
           _unique!(::AbstractVector{T} where T)
             unique!(::Any)
       _unique!(::typeof(identity), ::AbstractVector{T} where T, ::Set{_A} where _A, ::Int64, ::Int64)
```

So I found this with the new `findcallers` in MethodAnalysis:
```julia
julia> findcallers(unique!, argtyps->length(argtyps)==1 && argtyps[1] === Any, mis)
1-element Vector{Tuple{Core.MethodInstance,Core.CodeInfo,Int64,Vector{Any}}}:
 (MethodInstance for find_registered!(::Pkg.Types.Context, ::Vector{String}, ::Vector{Base.UUID}), CodeInfo(
...
), 252, [Any])
```

This PR fixes about a dozen invalidations from loading OffsetArrays and many other array-focused packages.