### PR TITLE
Pkg.gc: only print active manifests/artifacts in verbose mode.

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -349,14 +349,16 @@ PSA[:name => "gc",
     :api => API.gc,
     :option_spec => [
         PSA[:name => "all", :api => :collect_delay => Hour(0)],
+        PSA[:name => "verbose", :short_name => "v", :api => :verbose => true],
     ],
     :description => "garbage collect packages not used for a significant time",
     :help => md"""
-    gc [--all]
+    gc [-v|--verbose] [--all]
 
 Free disk space by garbage collecting packages not used for a significant time.
 The `--all` option will garbage collect all packages which can not be immediately
 reached from any existing project.
+Use verbose mode for detailed output.
 """,
 ],
 PSA[:name => "undo",


### PR DESCRIPTION
Prints this by default:
````
(Pkg) pkg> gc --all
     Active manifest files: 2 found
     Active artifact files: 4 found
     Active scratchspaces: 0 found
    Deleted 115 package installations (106.439 MiB)
    Deleted 21 artifact installations (117.880 MiB)
````
and this with `--verbose` (the previous default):
````
(Pkg) pkg> gc --all -v
     Active manifest files: 2 found
        `~/dev/Pkg/Manifest.toml`
        `/tmp/tmp.RWwVK3rml9/environments/v1.6/Manifest.toml`
     Active artifact files: 4 found
        `/tmp/tmp.RWwVK3rml9/packages/Zlib_jll/8tl5W/Artifacts.toml`
        `/tmp/tmp.RWwVK3rml9/packages/CUDA/xGgiY/Artifacts.toml`
        `/tmp/tmp.RWwVK3rml9/packages/CompilerSupportLibraries_jll/kmL78/Artifacts.toml`
        `/tmp/tmp.RWwVK3rml9/packages/OpenSpecFun_jll/HMSwk/Artifacts.toml`
     Active scratchspaces: 0 found
    Deleted `/tmp/tmp.RWwVK3rml9/packages/AbstractAlgebra/7m2YN` (1.644 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ArnoldiMethod/5fDBS` (109.288 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Arpack/o35I5` (54.412 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Arpack_jll/V7Qow` (98.404 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ArrayInterface/qNPRL` (38.298 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/BandedMatrices/dobxA` (327.265 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/BoundaryValueDiffEq/xzrfZ` (23.706 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Bzip2_jll/OAK6k` (29.081 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/CanonicalTraits/jEjaE` (36.231 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/CategoricalArrays/nd8kj` (397.066 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ColorSchemes/3n8HS` (19.036 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Combinatorics/Udg6X` (57.245 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Compat/onkbN` (60.429 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ConstructionBase/BMpJA` (16.788 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Contour/Ezecs` (712.030 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DataFrames/4ov0U` (1.296 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DataValueInterfaces/0j6Kp` (4.807 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DelayDiffEq/BCL4Q` (152.836 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DiffEqBase/VoY3t` (428.983 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DiffEqCallbacks/b4ahb` (61.575 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DiffEqFinancial/MGERb` (10.497 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DiffEqJump/TfjIU` (152.899 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DiffEqNoiseProcess/j6RbQ` (86.402 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DiffEqPhysics/7miyX` (18.571 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DifferentialEquations/fpohE` (483.098 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/DimensionalPlotRecipes/c6KlK` (8.428 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Distances/jwhuc` (94.684 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Distributions/dTXqn` (1.049 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ExponentialUtilities/0d0Nm` (77.832 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FFMPEG/aazvf` (11.865 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FFMPEG_jll/Ro9Bi` (149.222 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FastClosures/3LNoZ` (17.267 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FiniteDiff/irNCY` (100.264 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Formatting/LU9hd` (55.204 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FreeType2_jll/pXD7r` (34.724 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FriBidi_jll/ZteCU` (43.104 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/FunctionWrappers/OAZAk` (10.858 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/GR/8mv9N` (62.283 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/GeneralizedGenerated/wp5nX` (69.181 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/GenericSVD/cT5Cu` (22.605 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/GeometryBasics/CMxB4` (126.891 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/GeometryTypes/gpBFp` (666.193 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/HTTP/atT5q` (591.382 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Inflate/2FRsL` (50.081 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/IniFile/R4eEN` (9.813 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/InvertedIndices/l2dyo` (15.859 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/IterTools/0dYLc` (84.078 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/IterativeSolvers/3g7hG` (243.405 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/IteratorInterfaceExtensions/NZdaj` (8.293 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/JSON/d89fA` (89.197 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/JuliaVariables/IDeGV` (35.059 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/LAME_jll/XRwRf` (42.486 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/LaTeXStrings/JOBV0` (9.015 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/LabelledArrays/74Tbn` (46.810 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Latexify/Ef3RB` (223.454 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/LibVPX_jll/Mn8DQ` (25.063 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/LightGraphs/siFgP` (823.539 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/LineSearches/pJuyA` (97.792 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/METIS_jll/3lOIj` (32.845 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/MLStyle/xyGS4` (620.196 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/MbedTLS/VbsaQ` (318.291 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/MbedTLS_jll/txOzO` (49.469 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Measures/0Zkai` (12.245 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ModelingToolkit/kfLoQ` (357.454 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/MultiScaleArrays/c9WNi` (73.397 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/NLSolversBase/5oIMo` (106.915 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/NLsolve/04rfI` (103.298 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/NameResolution/2mo9R` (16.681 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Ogg_jll/TENr1` (28.595 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/OpenBLAS_jll/MwgWt` (96.936 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/OpenSSL_jll/KmgDa` (51.874 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Opus_jll/gaJZJ` (28.869 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/OrdinaryDiffEq/VPJBD` (4.933 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/PDMats/HCniD` (49.526 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ParameterizedFunctions/aXAZr` (25.372 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Parameters/CVyBv` (57.628 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Parsers/DAskp` (217.022 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/PlotThemes/4DCOG` (23.263 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/PlotUtils/nCtbM` (74.608 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Plots/6RLiv` (2.298 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/PoissonRandom/Ohb1g` (12.772 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/PooledArrays/yiLq3` (19.326 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/PrettyPrint/z2Fty` (13.630 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/QuadGK/zzx9s` (40.897 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/RandomNumbers/m57pA` (250.446 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/RecipesBase/AN696` (54.663 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/RecipesPipeline/qM4Ea` (55.227 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/RecursiveArrayTools/OAIEc` (55.807 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/RecursiveFactorization/wAEz3` (14.197 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/ResettableStacks/bI9FN` (8.691 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Rmath/lo1Ao` (30.996 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Rmath_jll/1l5HW` (32.795 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Roots/Z5Mal` (235.713 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/SafeTestsets/A83XK` (4.967 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Showoff/RaPxi` (13.938 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/SimpleTraits/1wYi7` (51.008 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/SparseDiffTools/Z3AsD` (82.325 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/StatsFuns/CXyCV` (82.701 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/SteadyStateDiffEq/0CYST` (10.429 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/StochasticDiffEq/mrB1i` (1.233 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/StructArrays/OtfvU` (71.552 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/SuiteSparse_jll/CZHvV` (147.937 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Sundials/2KP0s` (551.571 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Sundials_jll/heTyl` (838.170 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/SymbolicUtils/6ESJb` (95.893 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/TableTraits/oldOj` (6.553 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Tables/Eti9i` (105.268 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/TreeViews/EdGaj` (4.207 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/Unitful/hsM3B` (279.846 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/VertexSafeGraphs/tikYt` (8.880 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/libass_jll/8mp0D` (35.559 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/libfdk_aac_jll/Yk9Ha` (29.408 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/libvorbis_jll/RCO19` (53.555 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/x264_jll/nSMcD` (42.121 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/packages/x265_jll/yFfy0` (41.912 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/0b8ee36fe94c508796f536a5304aec7192799148` (26.101 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/102f816ca06bb09d0c48c880204bbd3dcd223491` (588.122 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/21b8ba5bf6474cac6fa64d9ad681e6b506eba90a` (817.812 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/2c115da09a12e51cc1763e8ae70196d023426e52` (1.118 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/55faeedeb44aa3bdadd606a01d15b172ef21c948` (782.624 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/5f0cf6e1160fdb5050617e278c5b6e21e0b5d603` (323.071 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/60094fa9668e77dd28cae5f95f7d3163db63203a` (2.887 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/746f3085962108a6a143ae685781235717cec381` (4.641 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/82cc60b04f9bf568b4a1498cd803a4f94b6af7e0` (1.460 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/83b809e41c8e9a9ef35ad0c684b86a08d6e74c95` (6.743 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/869e63e913443f9fcc829a42fe4258a6a0b7dec8` (4.060 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/8a08e0194be328a41baaccd251d9b94e0918be75` (4.547 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/9dc820aa11732195fab75ed545a0705dca8ee456` (927.679 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/b3dc568ea9ba5a9716fdb2822f749090403c18b1` (3.014 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/b5a0dfeba3b35b629beca780ed0c01067f33c3e1` (4.924 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/c8b6bfed535b6e5c8222e27c57d50bc429cd5185` (30.704 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/cb95793ae0e822cf354197574a89d04de81d31cb` (4.450 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/dae09e29891a3b2652c65300c5921ea90d2f3f08` (5.827 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/e6e5f41352118bbeb44677765ebccab8c151c72a` (12.917 MiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/f73f822883915d7ae67651995e7596024a9ed531` (899.235 KiB)
    Deleted `/tmp/tmp.RWwVK3rml9/artifacts/fa7a95c807b2fbc4e13451994fe92463203ce891` (252.789 KiB)
    Deleted 115 package installations (106.439 MiB)
    Deleted 21 artifact installations (117.880 MiB)
````