### PR TITLE
Improve inference for paths leading to `similar`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -530,7 +530,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
         artifact_path_list = String[]
         for name in keys(artifact_dict)
             getpaths(meta) = artifact_paths(SHA1(hex2bytes(meta["git-tree-sha1"])))
-            if isa(artifact_dict[name], Array)
+            if isa(artifact_dict[name], Vector)
                 for platform_meta in artifact_dict[name]
                     append!(artifact_path_list, getpaths(platform_meta))
                 end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -499,7 +499,7 @@ function process_overrides(artifact_dict::Dict, pkg_uuid::Base.UUID)
             end
 
             # If we've got a platform-specific friend, override all hashes:
-            if isa(artifact_dict[name], Array)
+            if isa(artifact_dict[name], Vector)
                 for entry in artifact_dict[name]
                     hash = SHA1(entry["git-tree-sha1"])
                     overrides[:hash][hash] = overrides[:UUID][pkg_uuid][name]
@@ -550,7 +550,7 @@ function artifact_meta(name::String, artifact_dict::Dict, artifacts_toml::String
     meta = artifact_dict[name]
 
     # If it's an array, find the entry that best matches our current platform
-    if isa(meta, Array)
+    if isa(meta, Vector)
         dl_dict = Dict{Platform,Dict{String,Any}}(unpack_platform(x, name, artifacts_toml) => x for x in meta)
         meta = select_platform(dl_dict, platform)
     # If it's NOT a dict, complain
@@ -623,9 +623,9 @@ function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
 
         if !force && haskey(artifact_dict, name)
             meta = artifact_dict[name]
-            if !isa(meta, Array)
+            if !isa(meta, Vector)
                 error("Mapping for '$name' within $(artifacts_toml) already exists!")
-            elseif any((unpack_platform(x, name, artifacts_toml) for x in meta) .== Ref(platform))
+            elseif any(isequal(platform), unpack_platform(x, name, artifacts_toml) for x in meta)
                 error("Mapping for '$name'/$(triplet(platform)) within $(artifacts_toml) already exists!")
             end
         end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -292,7 +292,7 @@ on-disk.  Note that it is possible that the given artifact exists in multiple lo
     This function requires at least Julia 1.3.
 """
 function artifact_exists(hash::SHA1; honor_overrides::Bool=true)
-    return any(isdir.(artifact_paths(hash; honor_overrides=honor_overrides)))
+    return any(isdir, artifact_paths(hash; honor_overrides=honor_overrides))
 end
 
 """

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -347,7 +347,7 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
     # fixed packages are `dev`ed or `add`ed by repo
     # at this point, fixed packages have a version and `deps`
 
-    @assert length(Set(pkg.uuid for pkg in pkgs)) == length(pkgs)
+    @assert length(Set(pkg.uuid::UUID for pkg in pkgs)) == length(pkgs)
 
     # check compat
     for pkg in pkgs

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -117,7 +117,7 @@ function update_manifest!(ctx::Context, pkgs::Vector{PackageSpec}, deps_map)
     manifest = ctx.env.manifest
     empty!(manifest)
     if ctx.env.pkg !== nothing
-        pkgs = [pkgs; ctx.env.pkg]
+        pkgs = push!(copy(pkgs), ctx.env.pkg::PackageSpec)
     end
     for pkg in pkgs
         entry = PackageEntry(;name = pkg.name, version = pkg.version, pinned = pkg.pinned,

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -276,7 +276,7 @@ function probe_platform_engines!(;verbose::Bool = false)
     # Symbolic Link =
     # Hard Link =
     gen_7z = (p) -> (unpack_7z(p), package_7z(p), list_7z(p), parse_7z_list, r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s)
-    compression_engines = Tuple[]
+    compression_engines = Tuple{Cmd,Vararg{Any}}[]
 
     (tmpfile, io) = mktemp()
     write(io, "Demo file for tar listing (Pkg.jl)")
@@ -889,7 +889,7 @@ function get_telemetry_headers(url::AbstractString, notify::Bool=true)
             salt_hash = hash_data("salt", client_uuid, secret_salt)
             project = Base.active_project()
             if project !== nothing
-                project_hash = hash_data("project", project, info["secret_salt"])
+                project_hash = hash_data("project", project, info["secret_salt"]::String)
                 push!(headers, "Julia-Project-Hash: $project_hash")
             end
         end

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -523,7 +523,7 @@ function promptf()
 end
 
 # Set up the repl Pkg REPLMode
-function create_mode(repl, main)
+function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
     pkg_mode = LineEdit.Prompt(promptf;
         prompt_prefix = repl.options.hascolor ? Base.text_colors[:blue] : "",
         prompt_suffix = "",
@@ -579,7 +579,7 @@ function create_mode(repl, main)
     return pkg_mode
 end
 
-function repl_init(repl)
+function repl_init(repl::REPL.AbstractREPL)
     main_mode = repl.interface.modes[1]
     pkg_mode = create_mode(repl, main_mode)
     push!(repl.interface.modes, pkg_mode)

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -7,7 +7,7 @@ import ..isdir_nothrow
 Parser for PackageSpec objects.
 """
 function parse_package(args::Vector{QString}, options; add_or_dev=false)::Vector{PackageSpec}
-    args::Vector{PackageToken} = map(PackageToken, package_lex(args))
+    args = PackageToken[PackageToken(pkgword) for pkgword in package_lex(args)]
     return parse_package_args(args; add_or_dev=add_or_dev)
 end
 

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -32,8 +32,11 @@ function complete_local_dir(s, i1, i2)
     end
 
     cmp = REPL.REPLCompletions.complete_path(s, i2)
+    cmp2 = cmp[2]
     completions = [REPL.REPLCompletions.completion_text(p) for p in cmp[1]]
-    completions = filter!(x -> isdir(s[1:prevind(s, first(cmp[2])-i1+1)]*x), completions)
+    completions = let s=s
+        filter!(x -> isdir(s[1:prevind(s, first(cmp2)-i1+1)]*x), completions)
+    end
     if expanded_user
         if length(completions) == 1 && endswith(joinpath(homedir(), ""), first(completions))
             completions = [joinpath(s, "")]

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -855,7 +855,7 @@ function showlog(io::IO, rlog::ResolveLog; view::Symbol = :plain)
     seen = IdDict()
     recursive = (view === :tree)
     _show(io, rlog, rlog.globals, _logindent, seen, false)
-    initentries = [event[1] for event in rlog.init.events]
+    initentries = Union{ResolveLogEntry,Nothing}[event[1]::Union{ResolveLogEntry,Nothing} for event in rlog.init.events]
     for entry in sort!(initentries, by=(entry->pkgID(entry.pkg, rlog)))
         seen[entry] = true
         _show(io, rlog, entry, _logindent, seen, recursive)

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -297,7 +297,7 @@ mutable struct Graph
             req_msk = Dict{Int,BitVector}()
             for (p1, vs) in req
                 pv = pvers[p1]
-                req_msk_p1 = BitArray(undef, spp[p1] - 1)
+                req_msk_p1 = BitVector(undef, spp[p1] - 1)
                 @inbounds for i in 1:spp[p1] - 1
                     req_msk_p1[i] = pv[i] ∈ vs
                 end
@@ -1319,7 +1319,7 @@ function prune_graph!(graph::Graph)
 
     # We will remove all packages that only have one allowed state
     # (includes fixed packages and forbidden packages)
-    pkg_mask = BitArray(count(gconstr[p0]) ≠ 1 for p0 = 1:np)
+    pkg_mask = BitVector(count(gconstr[p0]) ≠ 1 for p0 = 1:np)
     new_np = count(pkg_mask)
 
     # a map that translates the new index ∈ 1:new_np into its
@@ -1368,7 +1368,7 @@ function prune_graph!(graph::Graph)
     # versions that aren't allowed (but not the "uninstalled" state)
     function keep_vers(new_p0)
         p0 = old_idx[new_p0]
-        return BitArray((v0 == spp[p0]) | gconstr[p0][v0] for v0 = 1:spp[p0])
+        return BitVector((v0 == spp[p0]) | gconstr[p0][v0] for v0 = 1:spp[p0])
     end
     vers_mask = [keep_vers(new_p0) for new_p0 = 1:new_np]
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -208,7 +208,7 @@ Base.@kwdef mutable struct Project
     targets::Dict{String,Vector{String}} = Dict{String,Vector{String}}()
     compat::Dict{String,String} = Dict{String,String}()# TODO Dict{String, VersionSpec}
 end
-Base.:(==)(t1::Project, t2::Project) = all([getfield(t1, x) == getfield(t2, x) for x in fieldnames(Project)])
+Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Project))
 Base.hash(x::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
 
 
@@ -859,7 +859,7 @@ const DEFAULT_REGISTRIES =
                               url = "https://github.com/JuliaRegistries/General.git")]
 
 function clone_default_registries(ctx::Context; only_if_empty = true)
-    installed_registries = [reg.uuid for reg in collect_registries()]
+    installed_registries = [reg.uuid::UUID for reg in collect_registries()]
     # Only clone if there are no installed registries, unless called
     # with false keyword argument.
     if isempty(installed_registries) || !only_if_empty
@@ -1242,7 +1242,8 @@ function find_registered!(ctx::Context,
     for registry in collect_registries()
         reg_abspath = abspath(registry.path)
         data = read_registry(joinpath(registry.path, "Registry.toml"))
-        for (_uuid::String, pkgdata::Dict{String, Any}) in data["packages"]
+        for (_uuid, pkgdata) in data["packages"]
+            _uuid, pkgdata = _uuid::String, pkgdata::Dict{String,Any}
             name = pkgdata["name"]::String
             uuid = UUID(_uuid)
             push!(get!(Vector{UUID}, ctx.env.uuids, name), uuid)
@@ -1418,7 +1419,7 @@ end
 parse_toml(ctx::Context, path::String; fakeit::Bool=false) =
     parse_toml(ctx.parser, path; fakeit)
 parse_toml(path::String; fakeit::Bool=false) = parse_toml(TOML.Parser(), path; fakeit)
-parse_toml(parser::TOML.Parser, path::String; fakeit::Bool=false) = 
+parse_toml(parser::TOML.Parser, path::String; fakeit::Bool=false) =
     !fakeit || isfile(path) ? TOML.parsefile(parser, path) : Dict{String,Any}()
 
 end # module

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -144,13 +144,13 @@ function Manifest(raw::Dict)::Manifest
             entry.repo.rev    = read_field("repo-rev",      nothing, info, identity)
             entry.repo.subdir = read_field("repo-subdir",   nothing, info, identity)
             entry.tree_hash   = read_field("git-tree-sha1", nothing, info, safe_SHA1)
-            deps = read_deps(get(info, "deps", nothing))
+            deps = read_deps(get(info::Dict, "deps", nothing))
         catch
             # TODO: Should probably not unconditionally log something
             @error "Could not parse entry for `$name`"
             rethrow()
         end
-        entry.other = info
+        entry.other = info::Union{Dict,Nothing}
         stage1[name] = push!(get(stage1, name, Stage1[]), Stage1(uuid, entry, deps))
     end
     # by this point, all the fields of the `PackageEntry`s have been type casted


### PR DESCRIPTION
The companion PR to https://github.com/JuliaLang/julia/pull/37163

The message in the first commit mentions this, but perhaps worth repeating: using `Vector` rather than `Array` in certain places allows inference to know that `size(A)` is a `Tuple{Int}`, and that ends up fixing some otherwise hard-to-solve problems in inference with the `similar` pipeline.