### PR TITLE
fix typo from moving to TOML stdlib

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -764,7 +764,7 @@ function hash_data(strs::AbstractString...)
 end
 
 function load_telemetry_file(file::AbstractString)
-    info = TOML.DictType()
+    info = Dict{String, Any}()
     changed = true
     if !ispath(file)
         for depot in depots()


### PR DESCRIPTION
Resolved itself as

```
┌ Warning: could not download https://pkg.julialang.org/registries
└ @ Pkg.Types ~/JuliaPkgs/Pkg.jl/src/Types.jl:952
```

Good ol' `try catch` programming.