### PR TITLE
Change develop error message to state it doesn't support rev

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -104,8 +104,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
             pkgerror("name, UUID, URL, or filesystem path specification required when calling `develop`")
         end
         if pkg.repo.rev !== nothing
-            pkgerror("git revision specification invalid when calling `develop`:",
-                     " `$(pkg.repo.rev)` specified for package $(err_rep(pkg))")
+            pkgerror("rev argument not supported by `develop`; consider using `add` instead")
         end
         if pkg.version != VersionSpec()
             pkgerror("version specification invalid when calling `develop`:",

--- a/test/new.jl
+++ b/test/new.jl
@@ -881,7 +881,7 @@ end
             ) Pkg.develop(Pkg.PackageSpec())
         # git revisions imply that `develop` tracks a git repo.
         @test_throws PkgError(
-            "git revision specification invalid when calling `develop`: `master` specified for package `Example`"
+            "rev argument not supported by `develop`; consider using `add` instead"
             ) Pkg.develop(name="Example", rev="master")
         # Adding an unregistered package by name.
         @test_throws PkgError Pkg.develop("ThisIsHopefullyRandom012856014925701382")


### PR DESCRIPTION
The original error message made me think that I was passing arguments incorrectly or there was some internal bug; turns out that I was just not supposed to use `develop` like that.

I'm not sure if there are any valid uses of `develop` for which this error message is incorrect.