### PR TITLE
Re-add AbstractString method to platform_key_abi

### DIFF
--- a/src/BinaryPlatforms.jl
+++ b/src/BinaryPlatforms.jl
@@ -513,6 +513,7 @@ function platform_key_abi(machine::String)
     @warn("Platform `$(machine)` is not an officially supported platform$msg")
     return UnknownPlatform()
 end
+platform_key_abi(machine::AbstractString) = platform_key_abi(String(machine))
 
 
 # Define show() for these Platform objects for two reasons:


### PR DESCRIPTION
BinaryBuilder tries to call it with a SubString. That seems like a reasonable thing to do from
a user API perspective:
```
ERROR: MethodError: no method matching platform_key_abi(::SubString{String})
Closest candidates are:
  platform_key_abi(::String) at /home/keno/julia/usr/share/julia/stdlib/v1.6/Pkg/src/BinaryPlatforms.jl:402
  platform_key_abi() at /home/keno/julia/usr/share/julia/stdlib/v1.6/Pkg/src/BinaryPlatforms.jl:732
Stacktrace:
 [1] CompilerShard(name::SubString{String}, version::VersionNumber, host::SubString{String}, archive_type::Symbol; target::SubString{String})
   @ BinaryBuilderBase ~/.julia/dev/BinaryBuilderBase/src/Rootfs.jl:31
 [2] CompilerShard(art_name::String)
   @ BinaryBuilderBase ~/.julia/dev/BinaryBuilderBase/src/Rootfs.jl:83
 [3] all_compiler_shards()
   @ BinaryBuilderBase ~/.julia/dev/BinaryBuilderBase/src/Rootfs.jl:100
 [4] top-level scope
   @ REPL[3]:1
```

Add back that method, but simply have it convert to string, since there
are no performance concerns.