### PR TITLE
fix propagating quiet_downloads to non windows downloads

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -771,7 +771,7 @@ function download_artifact(
         # `create_artifact()` wrapper does, so we use that here.
         calc_hash = try
             create_artifact() do dir
-                download_verify_unpack(tarball_url, tarball_hash, dir, ignore_existence=true, verbose=verbose)
+                download_verify_unpack(tarball_url, tarball_hash, dir, ignore_existence=true, verbose=verbose, quiet_download=quiet_download)
             end
         catch e
             if isa(e, InterruptException)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/1870.

API design like this (keyword function where default values are used everywhere) is sometimes problematic for this reason. It is easy to miss passing through a keyword through the whole call chain and you will not get an error. For that reason, I only typically give default values at the most "toplevel" API (https://github.com/JuliaLang/PackageCompiler.jl/blob/e560504d4dc7feaaed3e0585c6d0a7b79d5d3fc7/src/PackageCompiler.jl#L362-L373) and then turning off the defaults for inner functions (https://github.com/JuliaLang/PackageCompiler.jl/blob/e560504d4dc7feaaed3e0585c6d0a7b79d5d3fc7/src/PackageCompiler.jl#L190-L197).