### PR TITLE
Try to improve output of wget

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -198,7 +198,7 @@ function probe_platform_engines!(;verbose::Bool = false)
             (`curl --help`, (url, path, hdrs...) ->
             `curl -H$hdrs -C - -\# -f -o $path -L $url`),
         (`wget --help`, (url, path, hdrs...) ->
-            `wget --tries=5 --header=$hdrs -c -O $path $url`),
+            `wget --tries=5 --header=$hdrs -q --show-progress -c -O $path $url`),
         (`fetch --help`, helpfetcher),
         (`busybox wget --help`, (url, path, hdrs...) ->
             `busybox wget --header=$hdrs -c -O $path $url`),


### PR DESCRIPTION
I noticed that using wget the output is very verbose. For artifacts it is even worse because of the forwarding. It prints a screen full of amazon urls (see P.S.). Before:
```julia
julia> Pkg.PlatformEngines.gen_download_cmd("https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip", "/dev/null")
`wget --tries=5 -c -O /dev/null https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip`

julia> run(ans)
--2020-09-03 16:12:01--  https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip
Auflösen des Hostnamens file-examples-com.github.io (file-examples-com.github.io) … 185.199.108.153, 185.199.109.153, 185.199.110.153, ...
Verbindungsaufbau zu file-examples-com.github.io (file-examples-com.github.io)|185.199.108.153|:443 … verbunden.
HTTP-Anforderung gesendet, auf Antwort wird gewartet … 200 OK
Länge: 10679630 (10M) [application/zip]
Wird in »/dev/null« gespeichert.

/dev/null                               100%[==============================================================================>]  10,18M  1,32MB/s    in 7,7s    

2020-09-03 16:12:10 (1,32 MB/s) - »/dev/null« gespeichert [10679630/10679630]

Process(`wget --tries=5 -c -O /dev/null https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip`, ProcessExited(0))
```
With this PR:
```julia
julia> Pkg.PlatformEngines.gen_download_cmd("https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip", "/dev/null")
`wget --tries=5 -q --show-progress -c -O /dev/null https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip`

julia> run(ans)
/dev/null                               100%[==============================================================================>]  10,18M  1,38MB/s    in 8,8s    
Process(`wget --tries=5 -q --show-progress -c -O /dev/null https://file-examples-com.github.io/uploads/2017/02/zip_10MB.zip`, ProcessExited(0))
```
It is still not as nice as curl, which does not print the output file, but an improvement.

The `--show-progress` was introduced in wget version 1.16, which was released in 2014 (http://savannah.gnu.org/forum/forum.php?forum_id=8133). So this might be a problem, but I let the maintainers decide this.

P.S. Here is the output for master for an artifact
```julia
Downloading artifact: GLPK
--2020-09-03 14:51:46-- 
https://github.com/JuliaBinaryWrappers/GLPK_jll.jl/releases/download/GLPK-v4.65.0+0/GLPK.v4.65.0.x86_64-linux-gnu.tar.gz

Auflösen des Hostnamens github.com (github.com) … 140.82.121.4
Verbindungsaufbau zu github.com (github.com)|140.82.121.4|:443 … verbunden.
HTTP-Anforderung gesendet, auf Antwort wird gewartet … 302 Found
Platz:
https://github-production-release-asset-2e65be.s3.amazonaws.com/250909539/31f66900-710c-11ea-82bc-98f2023b2a46?X-Amz-Alg
orithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=2020
0903T125147Z&X-Amz-Expires=300&X-Amz-Signature=3e45a2a8764cf91eb8ffd444e5f3a5c95ea3818ab7d3792aeb2516bf859f194c&X-Amz-Si
gnedHeaders=host&actor_id=0&key_id=0&repo_id=250909539&response-content-disposition=attachment%3B%20filename%3DGLPK.v4.6
5.0.x86_64-linux-gnu.tar.gz&response-content-type=application%2Foctet-stream [folgend]
--2020-09-03 14:51:47-- 
https://github-production-release-asset-2e65be.s3.amazonaws.com/250909539/31f66900-710c-11ea-82bc-98f2023b2a46?X-Amz-Alg
orithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=2020
0903T125147Z&X-Amz-Expires=300&X-Amz-Signature=3e45a2a8764cf91eb8ffd444e5f3a5c95ea3818ab7d3792aeb2516bf859f194c&X-Amz-Si
gnedHeaders=host&actor_id=0&key_id=0&repo_id=250909539&response-content-disposition=attachment%3B%20filename%3DGLPK.v4.6
5.0.x86_64-linux-gnu.tar.gz&response-content-type=application%2Foctet-stream
Auflösen des Hostnamens github-production-release-asset-2e65be.s3.amazonaws.com
(github-production-release-asset-2e65be.s3.amazonaws.com) … 54.231.81.184
Verbindungsaufbau zu github-production-release-asset-2e65be.s3.amazonaws.com
(github-production-release-asset-2e65be.s3.amazonaws.com)|54.231.81.184|:443 … verbunden.
HTTP-Anforderung gesendet, auf Antwort wird gewartet … 200 OK
Länge: 3323778 (3,2M) [application/octet-stream]
Wird in »/tmp/jl_PjpZZH-download.gz« gespeichert.

/tmp/jl_PjpZZH-download.gz    100%[================================================>]   3,17M   485KB/s    in 14s 
```