### PR TITLE
Various updates and fixes to doc-build

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterLaTeX = "cd674d7a-5f81-5cf3-af33-235ef1834b99"
 
 [compat]
-Documenter = "~0.24"
+Documenter = "~0.25"

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -6,22 +6,23 @@ function generate(io, command)
     cmd_nospace = replace(command, " " => "-")
     println(io, """
     ```@raw html
-    <section class="docstring">
-    <div class="docstring-header">
-        <a class="docstring-binding" id="repl-$(cmd_nospace)" href="#repl-$(cmd_nospace)">
-            <code>$(command)</code>
-        </a>
-        —
-        <span class="docstring-category">REPL command</span>
-    .
-    </div>
+    <article class="docstring">
+        <header>
+            <a class="docstring-binding" id="repl-$(cmd_nospace)" href="#repl-$(cmd_nospace)">
+                <code>$(command)</code>
+            </a>
+            —
+            <span class="docstring-category">REPL command</span>
+        </header>
+        <section>
     ```
     ```@eval
     using Pkg
     Dict(Pkg.REPLMode.canonical_names())["$(command)"].help
     ```
     ```@raw html
-    </section>
+        </section>
+    </article>
     ```
     """)
 end

--- a/docs/src/assets/custom.css
+++ b/docs/src/assets/custom.css
@@ -1,11 +1,3 @@
-.admonition.compat > .admonition-title {
- background-color: hsla(90, 60%, 50%, 1);
-}
-
-.admonition.compat {
- background-color: hsla(90, 70%, 90%, 1);
-}
-
-nav.toc .logo {
+#documenter .docs-sidebar .docs-logo > img {
     max-height: 12em;
 }


### PR DESCRIPTION
Various updates to doc-build:
 - fix REPL mode docstring generation;
 - fix CSS for logo size;
 - remove unnecessary CSS for compat admonitions;
 - upgrade Documenter to 0.25.