### PR TITLE
Parallelize Pkg.precompile

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -942,6 +942,7 @@ function precompile(ctx::Context)
                 return
             end
             
+            # skip stale checking and force compilation if any dep was recompiled in this session
             any_dep_recompiled = any(map(dep_uuid->was_recompiled[dep_uuid], pkg_dep_uuid_lists[i]))
             if any_dep_recompiled || is_stale(paths, sourcepath)
                 Base.acquire(parallel_limiter)

--- a/src/API.jl
+++ b/src/API.jl
@@ -915,7 +915,7 @@ function precompile(ctx::Context)
         precomp_events[pkgid.uuid] = Base.Event()
         was_recompiled[pkgid.uuid] = false
     end
-    # TODO: since we are a complete list, but not topologically sorted, handling of recursion will be completely at random
+    
     errored = false
     @sync for (i, pkg) in pairs(pkgids)
         paths = Base.find_all_in_cache_path(pkg)
@@ -937,7 +937,6 @@ function precompile(ctx::Context)
             for path_to_try in paths::Vector{String}
                 staledeps = Base.stale_cachefile(sourcepath, path_to_try, Base.TOMLCache()) #|| any(deps_recompiled)
                 staledeps === true && continue
-                # TODO: else, this returns a list of packages that may be loaded to make this valid (the topological list)
                 stale = false
                 break
             end

--- a/src/API.jl
+++ b/src/API.jl
@@ -894,6 +894,9 @@ end
 
 precompile() = precompile(Context())
 function precompile(ctx::Context)
+    
+    is_stdlib_from_name(name::String) = name in values(stdlibs())
+    
     printpkgstyle(ctx, :Precompiling, "project...")
     
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS + 1)))
@@ -902,7 +905,7 @@ function precompile(ctx::Context)
     man = Pkg.Types.read_manifest(ctx.env.manifest_file)
     pkgids = [Base.PkgId(first(dep), last(dep).name) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
     pkg_dep_lists = [collect(keys(last(dep).deps)) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
-    filter!.(!Pkg.Operations.is_stdlib, pkg_dep_lists)
+    filter!.(!is_stdlib_from_name, pkg_dep_lists)
 
     if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
         push!(pkgids, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))

--- a/src/API.jl
+++ b/src/API.jl
@@ -900,10 +900,6 @@ function precompile(ctx::Context)
     pkgids = [Base.PkgId(first(dep), last(dep).name) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
     pkg_dep_lists = [collect(keys(last(dep).deps)) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
     filter!.(!Pkg.Operations.is_stdlib, pkg_dep_lists)
-    
-    perm = sortperm(length.(pkg_dep_lists), rev=true) # sort so that we queue pkgs with fewer deps first
-    pkgids = pkgids[perm]
-    pkg_dep_lists = pkg_dep_lists[perm]
 
     if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
         push!(pkgids, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -372,7 +372,6 @@ function stdlibs()
     return STDLIB[]
 end
 is_stdlib(uuid::UUID) = uuid in keys(stdlibs())
-is_stdlib(name::String) = name in values(stdlibs())
 
 Context!(kw_context::Vector{Pair{Symbol,Any}})::Context =
     Context!(Context(); kw_context...)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -372,6 +372,7 @@ function stdlibs()
     return STDLIB[]
 end
 is_stdlib(uuid::UUID) = uuid in keys(stdlibs())
+is_stdlib(name::String) = name in values(stdlibs())
 
 Context!(kw_context::Vector{Pair{Symbol,Any}})::Context =
     Context!(Context(); kw_context...)


### PR DESCRIPTION
Pkg on julia master:
```
(dev) pkg> st
Status `~/Documents/dev/Project.toml`
  [0c46a032] DifferentialEquations v6.15.0
  [91a5bcdd] Plots v1.6.3

julia> @time Pkg.precompile()
Precompiling project...
[ Info: Precompiling DifferentialEquations [0c46a032-eb83-5123-abaf-570d42b7fbaa]
[ Info: Precompiling Plots [91a5bcdd-55d7-5caf-9e0b-520d859cae80]
312.061599 seconds (133.69 k allocations: 9.246 MiB)
```

This PR (same project, with `.julia/compiled` emptied out): 
```
julia> @time Pkg.precompile()
Precompiling project...
[ Info: Precompiling Reexport [189a3867-3050-52da-a836-e630ba90ab69]
[ Info: Precompiling x264_jll [1270edf5-f2f9-52d2-97e9-ab00b5d0237a]
...
[ Info: Precompiling DifferentialEquations [0c46a032-eb83-5123-abaf-570d42b7fbaa]
 87.851553 seconds (4.25 M allocations: 216.406 MiB, 0.13% gc time)
```

The approach taken here async queues up all the precomp jobs for all deps in the manifest, and each watches for when its deps are all precomped before starting.

Thanks to @oxinabox for conceptualization of this approach.

## Performance considerations
- ~~The process could launch an unlimited number of julia instances (via `compilecache`), so we might want to add a hard limit.~~
- CPU load is initially high while there are many deps with few deps of their own, and falls off as the larger packages initiate. I don't see much room for further parallelization optimization
<img width="188" alt="Screen Shot 2020-09-13 at 2 20 23 AM" src="https://user-images.githubusercontent.com/1694067/93011835-f7707380-f567-11ea-801f-c3482a654969.png">

- Memory pressure on my system seemed unaffected in this test case
<img width="399" alt="Screen Shot 2020-09-13 at 2 20 38 AM" src="https://user-images.githubusercontent.com/1694067/93011821-d14ad380-f567-11ea-9c09-c6da136f8b2d.png">