### PR TITLE
remove the env var for setting download concurrency

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -326,9 +326,7 @@ Base.@kwdef mutable struct Context
     io::IO = something(DEFAULT_IO[], stderr)
     use_libgit2_for_all_downloads::Bool = false
     use_only_tarballs_for_downloads::Bool = false
-    # NOTE: The JULIA_PKG_CONCURRENCY environment variable is likely to be removed in
-    # the future. It currently stands as an unofficial workaround for issue #795.
-    num_concurrent_downloads::Int = haskey(ENV, "JULIA_PKG_CONCURRENCY") ? parse(Int, ENV["JULIA_PKG_CONCURRENCY"]) : 8
+    num_concurrent_downloads::Int = 8
     graph_verbose::Bool = false
     currently_running_target::Bool = false
     # test instrumenting

--- a/test/new.jl
+++ b/test/new.jl
@@ -2248,15 +2248,6 @@ end
     end
 end
 
-@testset "Set download concurrency" begin
-    isolate() do
-        withenv("JULIA_PKG_CONCURRENCY" => 1) do
-            ctx = Pkg.Types.Context()
-            @test ctx.num_concurrent_downloads == 1
-        end
-    end
-end
-
 @testset "API details" begin
     # API should not mutate
     isolate() do

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -526,13 +526,6 @@ end end
     @test Pkg.Types.pathrepr(path) == "`@stdlib/Test`"
 end
 
-@testset "Set download concurrency" begin
-    withenv("JULIA_PKG_CONCURRENCY" => 1) do
-        ctx = Pkg.Types.Context()
-        @test ctx.num_concurrent_downloads == 1
-    end
-end
-
 @testset "stdlib_resolve!" begin
     a = Pkg.Types.PackageSpec(name="Markdown")
     b = Pkg.Types.PackageSpec(uuid=UUID("9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"))


### PR DESCRIPTION
This has been fixed upstream: https://github.com/JuliaLang/julia/pull/30989.

Ref #795

cc @ararslan 