### PR TITLE
Allow failures of indirect dependencies during parallel precompillation

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -896,8 +896,9 @@ precompile() = precompile(Context())
 function precompile(ctx::Context)
     
     function is_stale(paths, sourcepath)
+        toml_c = Base.TOMLCache()
         for path_to_try in paths::Vector{String}
-            staledeps = Base.stale_cachefile(sourcepath, path_to_try, Base.TOMLCache())
+            staledeps = Base.stale_cachefile(sourcepath, path_to_try, toml_c)
             staledeps ? continue : return false
         end
         return true

--- a/src/API.jl
+++ b/src/API.jl
@@ -937,9 +937,9 @@ function precompile(ctx::Context)
     
     was_processed = Dict{Base.PkgId,Base.Event}()
     was_recompiled = Dict{Base.PkgId,Bool}()
-    for dep in depsmap
-        was_processed[first(dep)] = Base.Event()
-        was_recompiled[first(dep)] = false
+    for pkgid in keys(depsmap)
+        was_processed[pkgid] = Base.Event()
+        was_recompiled[pkgid] = false
     end
     
     errored = false

--- a/src/API.jl
+++ b/src/API.jl
@@ -938,9 +938,10 @@ function precompile(ctx::Context)
     end
     
     errored = false
+    toml_c = Base.TOMLCache()
     @sync for (pkg, deps) in depsmap
         paths = Base.find_all_in_cache_path(pkg)
-        sourcepath = Base.locate_package(pkg)
+        sourcepath = Base.locate_package(pkg, toml_c)
         sourcepath === nothing && continue
         # Heuristic for when precompilation is disabled
         occursin(r"\b__precompile__\(\s*false\s*\)", read(sourcepath, String)) && continue

--- a/src/API.jl
+++ b/src/API.jl
@@ -944,7 +944,10 @@ function precompile(ctx::Context)
         sourcepath = Base.locate_package(pkg, toml_c)
         sourcepath === nothing && continue
         # Heuristic for when precompilation is disabled
-        occursin(r"\b__precompile__\(\s*false\s*\)", read(sourcepath, String)) && continue
+        if occursin(r"\b__precompile__\(\s*false\s*\)", read(sourcepath, String))
+            notify(was_processed[pkg])
+            continue
+        end
         
         @async begin
             for dep in deps # wait for deps to finish

--- a/src/API.jl
+++ b/src/API.jl
@@ -892,21 +892,26 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}; verbose=false, kwargs...
     Operations.build(ctx, pkgs, verbose)
 end
 
-precompile() = precompile(Context())
-function precompile(ctx::Context)
+precompile(;kwargs...) = precompile(Context(); kwargs...)
+function precompile(ctx::Context; parallel=true)
     printpkgstyle(ctx, :Precompiling, "project...")
     
-    num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS + 1)))
+    num_tasks = parallel ? parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS + 1))) : 1
     parallel_limiter = Base.Semaphore(num_tasks)
     
-    man = Pkg.Types.read_manifest(ctx.env.manifest_file)
-    pkgids = [Base.PkgId(first(dep), last(dep).name) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
-    pkg_dep_uuid_lists = [collect(values(last(dep).deps)) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
-    filter!.(!is_stdlib, pkg_dep_uuid_lists)
+    if parallel
+        man = Pkg.Types.read_manifest(ctx.env.manifest_file)
+        pkgids = [Base.PkgId(first(dep), last(dep).name) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
+        pkg_dep_uuid_lists = [collect(values(last(dep).deps)) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
+        filter!.(!is_stdlib, pkg_dep_uuid_lists)
+    else
+        pkgids = [Base.PkgId(uuid, name) for (name, uuid) in ctx.env.project.deps if !is_stdlib(uuid)]
+        pkg_dep_uuid_lists = fill(Base.UUID[], length(pkgids)) # give empty arrays because we're not waiting for deps
+    end
     
     if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
         push!(pkgids, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
-        push!(pkg_dep_uuid_lists, collect(keys(ctx.env.project.deps)))
+        push!(pkg_dep_uuid_lists, parallel ? collect(keys(ctx.env.project.deps)) : Base.UUID[])
     end    
     
     was_processed = Dict{Base.UUID,Base.Event}()

--- a/src/API.jl
+++ b/src/API.jl
@@ -957,7 +957,7 @@ function precompile(ctx::Context)
                         errored = true
                         throw(err) 
                     else
-                        @warn "Precompilation failed for sub-dependency $pkg"
+                        @warn "Precompilation failed for indirect dependency $pkg"
                     end
                 finally
                     notify(was_processed[pkg.uuid])

--- a/src/API.jl
+++ b/src/API.jl
@@ -894,29 +894,6 @@ end
 
 precompile() = precompile(Context())
 function precompile(ctx::Context)
-    printpkgstyle(ctx, :Precompiling, "project...")
-    
-    num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS + 1)))
-    parallel_limiter = Base.Semaphore(num_tasks)
-    
-    toplevel_pkgids = [Base.PkgId(uuid, name) for (name, uuid) in ctx.env.project.deps if !is_stdlib(uuid)]
-    
-    man = Pkg.Types.read_manifest(ctx.env.manifest_file)
-    pkgids = [Base.PkgId(first(dep), last(dep).name) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
-    pkg_dep_uuid_lists = [collect(values(last(dep).deps)) for dep in man if !Pkg.Operations.is_stdlib(first(dep))]
-    filter!.(!is_stdlib, pkg_dep_uuid_lists)
-    
-    if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
-        push!(pkgids, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
-        push!(pkg_dep_uuid_lists, collect(keys(ctx.env.project.deps)))
-    end    
-    
-    was_processed = Dict{Base.UUID,Base.Event}()
-    was_recompiled = Dict{Base.UUID,Bool}()
-    for pkgid in pkgids
-        was_processed[pkgid.uuid] = Base.Event()
-        was_recompiled[pkgid.uuid] = false
-    end
     
     function is_stale(paths, sourcepath)
         for path_to_try in paths::Vector{String}
@@ -925,6 +902,34 @@ function precompile(ctx::Context)
             return false
         end
         return true
+    end
+    
+    # stdlibs that aren't loaded might need precompiling if not part of sysimage
+    function is_stdlib_and_loaded(pkg::Base.PkgId)
+        return Pkg.Operations.is_stdlib(pkg.uuid) && Base.root_module_exists(pkg)
+    end
+    
+    printpkgstyle(ctx, :Precompiling, "project...")
+    
+    num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS + 1)))
+    parallel_limiter = Base.Semaphore(num_tasks)
+    
+    toplevel_pkgids = [Base.PkgId(uuid, name) for (name, uuid) in ctx.env.project.deps if !is_stdlib_and_loaded(Base.PkgId(uuid, name))]
+    
+    man = Pkg.Types.read_manifest(ctx.env.manifest_file)
+    pkgids = [Base.PkgId(first(dep), last(dep).name) for dep in man if !is_stdlib_and_loaded(Base.PkgId(first(dep), last(dep).name))]
+    pkg_dep_lists = [[Base.PkgId(last(x), first(x)) for x in last(dep).deps if !is_stdlib_and_loaded(Base.PkgId(last(x), first(x)))] for dep in man if !is_stdlib_and_loaded(Base.PkgId(first(dep), last(dep).name))]
+    
+    if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
+        push!(pkgids, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
+        push!(pkg_dep_lists, [Base.PkgId(last(x), first(x)) for x in ctx.env.project.deps if !is_stdlib_and_loaded(Base.PkgId(last(x), first(x)))])
+    end    
+    
+    was_processed = Dict{Base.PkgId,Base.Event}()
+    was_recompiled = Dict{Base.PkgId,Bool}()
+    for pkgid in pkgids
+        was_processed[pkgid] = Base.Event()
+        was_recompiled[pkgid] = false
     end
     
     errored = false
@@ -936,21 +941,21 @@ function precompile(ctx::Context)
         occursin(r"\b__precompile__\(\s*false\s*\)", read(sourcepath, String)) && continue
         
         @async begin
-            for dep_uuid in pkg_dep_uuid_lists[i] # wait for deps to finish
-                wait(was_processed[dep_uuid])
+            for dep in pkg_dep_lists[i] # wait for deps to finish
+                wait(was_processed[dep])
             end
             
             # skip stale checking and force compilation if any dep was recompiled in this session
-            any_dep_recompiled = any(map(dep_uuid->was_recompiled[dep_uuid], pkg_dep_uuid_lists[i]))
+            any_dep_recompiled = any(map(dep->was_recompiled[dep], pkg_dep_lists[i]))
             if !errored && (any_dep_recompiled || is_stale(paths, sourcepath))
                 Base.acquire(parallel_limiter)
                 if errored # catch things queued before error occurred
-                    notify(was_processed[pkg.uuid])
+                    notify(was_processed[pkg])
                     Base.release(parallel_limiter)
                     return
                 end
                 try
-                    was_recompiled[pkg.uuid] = true
+                    was_recompiled[pkg] = true
                     Base.compilecache(pkg, sourcepath, false) # don't print errors given we control
                 catch err
                     if pkg in toplevel_pkgids # only throw errors for top-level
@@ -960,11 +965,11 @@ function precompile(ctx::Context)
                         @warn "Precompilation failed for indirect dependency $pkg"
                     end
                 finally
-                    notify(was_processed[pkg.uuid])
+                    notify(was_processed[pkg])
                     Base.release(parallel_limiter)
                 end
             else
-                notify(was_processed[pkg.uuid])
+                notify(was_processed[pkg])
             end
         end  
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -959,11 +959,12 @@ function precompile(ctx::Context)
                     Base.release(parallel_limiter)
                     return
                 end
+                is_direct_dep =  pkg in direct_deps
                 try
                     was_recompiled[pkg] = true
-                    Base.compilecache(pkg, sourcepath, false) # don't print errors given we control
+                    Base.compilecache(pkg, sourcepath, is_direct_dep) # don't print errors from indirect deps
                 catch err
-                    if dep in direct_deps # only throw errors for direct dependencies (in Project)
+                    if is_direct_dep # only throw errors for direct dependencies (in Project)
                         errored = true
                         throw(err) 
                     else

--- a/src/API.jl
+++ b/src/API.jl
@@ -893,7 +893,7 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}; verbose=false, kwargs...
 end
 
 function _is_stale(paths::Vector{String}, sourcepath::String, toml_c::Base.TOMLCache)
-    for path_to_try in paths::Vector{String}
+    for path_to_try in paths
         staledeps = Base.stale_cachefile(sourcepath, path_to_try, toml_c)
         staledeps === true ? continue : return false
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -899,7 +899,7 @@ function precompile(ctx::Context)
         toml_c = Base.TOMLCache()
         for path_to_try in paths::Vector{String}
             staledeps = Base.stale_cachefile(sourcepath, path_to_try, toml_c)
-            staledeps ? continue : return false
+            staledeps === true ? continue : return false
         end
         return true
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -929,7 +929,7 @@ function precompile(ctx::Context)
     depsmap = Dict(Iterators.filter(!isnothing, deps_pair_or_nothing)) #flat map of each dep and its deps
     
     if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
-        depsmap[Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name)  ] = [
+        depsmap[Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name)] = [
             Base.PkgId(last(x), first(x)) 
             for x in ctx.env.project.deps if !is_stdlib_and_loaded(Base.PkgId(last(x), first(x)))
         ]
@@ -943,9 +943,7 @@ function precompile(ctx::Context)
     end
     
     errored = false
-    @sync for deppair in depsmap
-        pkg = first(deppair)
-        deps = last(deppair)
+    @sync for (pkg, deps) in depsmap
         paths = Base.find_all_in_cache_path(pkg)
         sourcepath = Base.locate_package(pkg)
         sourcepath === nothing && continue

--- a/src/API.jl
+++ b/src/API.jl
@@ -956,9 +956,7 @@ function precompile(ctx::Context; parallel=true)
                 end
                 try
                     was_recompiled[pkg.uuid] = true
-                    redirect_stderr(Base.devnull) do
-                        Base.compilecache(pkg, sourcepath)
-                    end
+                    Base.compilecache(pkg, sourcepath, false) # don't print errors given we control
                 catch err
                     if pkg in toplevel_pkgids # only throw errors for top-level
                         errored = true

--- a/src/API.jl
+++ b/src/API.jl
@@ -935,12 +935,9 @@ function precompile(ctx::Context)
         was_recompiled[pkgid] = false
     end
     
-    last_dep_preprocessed = Base.Event()
     errored = false
     toml_c = Base.TOMLCache()
-    i = 0
     @sync for (pkg, deps) in depsmap
-        i += 1
         paths = Base.find_all_in_cache_path(pkg)
         sourcepath = Base.locate_package(pkg, toml_c)
         sourcepath === nothing && continue
@@ -950,11 +947,7 @@ function precompile(ctx::Context)
             continue
         end
         
-        # pre-process all first to make tomlcache read-only during async
-        i == length(depsmap) && notify(last_dep_preprocessed) 
-        
         @async begin
-            wait(last_dep_preprocessed) # wait for tomlcache to be ready
             for dep in deps # wait for deps to finish
                 wait(was_processed[dep])
             end

--- a/src/API.jl
+++ b/src/API.jl
@@ -898,8 +898,7 @@ function precompile(ctx::Context)
     function is_stale(paths, sourcepath)
         for path_to_try in paths::Vector{String}
             staledeps = Base.stale_cachefile(sourcepath, path_to_try, Base.TOMLCache())
-            staledeps === true && continue
-            return false
+            staledeps ? continue : return false
         end
         return true
     end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -124,13 +124,12 @@ See also [`PackageSpec`](@ref).
 const add = API.add
 
 """
-    Pkg.precompile(;parallel=true)
+    Pkg.precompile()
 
-Precompile all dependencies of the project. 
-By default runs an optimized parallel precompillation of all dependencies in the 
-project manifest. By setting `parallel=false` the strategy reverts to the prior behavior
-of precompiling each top level dependency sequentially, and will only precompile dependencies 
-that are actually loaded on the given system.
+Precompile all dependencies of the project via a depth-first depdendency tree-based 
+parallel precompilation of all dependencies in the project manifest. 
+Errors will only throw when precompiling the top-level dependencies, given that 
+not all manifest dependencies may be loaded by the top-level dependencies on the given system.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3. On earlier versions

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -124,9 +124,13 @@ See also [`PackageSpec`](@ref).
 const add = API.add
 
 """
-    Pkg.precompile()
+    Pkg.precompile(;parallel=true)
 
-Precompile all the dependencies of the project.
+Precompile all dependencies of the project. 
+By default runs an optimized parallel precompillation of all dependencies in the 
+project manifest. By setting `parallel=false` the strategy reverts to the prior behavior
+of precompiling each top level dependency sequentially, and will only precompile dependencies 
+that are actually loaded on the given system.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3. On earlier versions

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -126,10 +126,10 @@ const add = API.add
 """
     Pkg.precompile()
 
-Precompile all dependencies of the project via a depth-first depdendency tree-based 
-parallel precompilation of all dependencies in the project manifest. 
-Errors will only throw when precompiling the top-level dependencies, given that 
-not all manifest dependencies may be loaded by the top-level dependencies on the given system.
+Precompile all the dependencies of the project in parallel.
+!!! note
+    Errors will only throw when precompiling the top-level dependencies, given that 
+    not all manifest dependencies may be loaded by the top-level dependencies on the given system.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3. On earlier versions


### PR DESCRIPTION
Edit: The mechanism below has now been removed from this PR, given a better approach of allowing failures for indirect dependencies

----

Builds on #2018 to add the option to revert to the old-style `Pkg.precompile()` behavior if the user just wants/needs to precompile dependencies that are loaded.

```
julia> Pkg.precompile(parallel=false)
Precompiling project...
[ Info: Precompiling DifferentialEquations [0c46a032-eb83-5123-abaf-570d42b7fbaa]
[ Info: Precompiling Plots [91a5bcdd-55d7-5caf-9e0b-520d859cae80]
```

```
julia> Pkg.precompile()
Precompiling project...
[ Info: Precompiling DocStringExtensions [ffbed154-4ef7-542d-bbb7-c09d3a79fcae]
[ Info: Precompiling PoissonRandom [e409e4f3-bfea-5376-8464-e040bb5c01ab]
...
[ Info: Precompiling Plots [91a5bcdd-55d7-5caf-9e0b-520d859cae80]
...
[ Info: Precompiling DifferentialEquations [0c46a032-eb83-5123-abaf-570d42b7fbaa]
```