### PR TITLE
Add hook to augment `Platform` objects for Artifact selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ docs/build
 /docs/src/repl.md
 .DS_Store
 /test/registries/*
+/test/registry_depot/*
 /test/loaded_depot/*

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -227,3 +227,77 @@ Note that while that hash was previously overridden, it is no longer, and theref
 Most methods that are affected by overrides have the ability to ignore overrides by setting `honor_overrides=false` as a keyword argument within them.
 For UUID/name based overrides to work, `Artifacts.toml` files must be loaded with the knowledge of the UUID of the loading package.
 This is deduced automatically by the `artifacts""` string macro, however if you are for some reason manually using the `Pkg.Artifacts` API within your package and you wish to honor overrides, you must provide the package UUID to API calls like `artifact_meta()` and `ensure_artifact_installed()` via the `pkg_uuid` keyword argument.
+
+## Extending Platform Selection
+
+!!! compat "Julia 1.6"
+    Pkg's extended platform selection requires at least Julia 1.6, and is considered experimental.
+
+New in Julia 1.6, `Platform` objects can have extended attributes applied to them, allowing artifacts to be tagged with things such as CUDA driver version compatibility, microarchitectural compatibility, julia version compatibility and more!
+Note that this feature is considered experimental and may change in the future.
+If you as a package developer find yourself needing this feature, please get in contact with us so it can evolve for the benefit of the whole ecosystem.
+In order to support artifact selection at `Pkg.add()` time, `Pkg` will run the specially-named file `<project_root>/.pkg/select_artifacts.jl`, passing the current platform triplet as the first arugment.
+This artifact selection script should print a `TOML`-serialized dictionary representing the artifacts that this package needs according to the given platform, and performing any inspection of the system as necessary to auto-detect platform capabilities, if they are not explicitly provided by the given platform triplet.
+The format of the dictionary should match that returned from `Artifacts.select_downloadable_artifacts()`, and indeed most packages should simply call that function with an augmented `Platform` object.
+An example artifact selection hook definition might look like the following, split across two files:
+
+```julia
+# .pkg/platform_augmentation.jl
+using Libdl, Base.BinaryPlatforms
+function augment_platform!(p::Platform)
+    # If this platform object already has a `cuda` tag set, don't augment
+    if haskey(p, "cuda")
+        return p
+    end
+
+    # Open libcuda explicitly, so it gets `dlclose()`'ed after we're done
+    dlopen("libcuda") do lib
+        # find symbol to ask for driver version; if we can't find it, just silently continue
+        cuDriverGetVersion = dlsym(lib, "cuDriverGetVersion"; throw_error=false)
+        if cuDriverGetVersion !== nothing
+            # Interrogate CUDA driver for driver version:
+            driverVersion = Ref{Cint}()
+            ccall(cuDriverGetVersion, UInt32, (Ptr{Cint},), driverVersion)
+
+            # Store only the major version
+            p["cuda"] = div(driverVersion, 1000)
+        end
+    end
+
+    # Return possibly-altered `Platform` object
+    return p
+end
+```
+
+```julia
+using TOML, Artifacts, Base.BinaryPlatforms
+include("./platform_augmentation.jl")
+artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
+
+# Get "target triplet" from ARGS, if given (defaulting to the host triplet otherwise)
+target_triplet = get(ARGS, 1, Base.BinaryPlatforms.host_triplet())
+
+# Augment this platform object with any special tags we require
+platform = augment_platform!(HostPlatform(parse(Platform, target_triplet)))
+
+# Select all downloadable artifacts that match that platform
+artifacts = select_downloadable_artifacts(artifacts_toml; platform)
+
+# Output the result to `stdout` as a TOML dictionary
+TOML.print(stdout, artifacts)
+```
+
+In this hook definition, our platform augmentation routine opens a system library (`libcuda`), searches it for a symbol to give us the CUDA driver version, then embeds the major version of that version number into the `cuda` property of the `Platform` object we are augmenting.
+While it is not critical for this code to actually attempt to close the loaded library (as it will most likely be opened again by the CUDA package immediately after the package operations are completed) it is best practice to make hooks as lightweight and transparent as possible, as they may be used by other Pkg utilities in the future.
+In your own package, you should also use augmented platform objects when using the `@artifact_str` macro, as follows:
+
+```julia
+include("../.pkg/platform_augmentation.jl")
+
+function __init__()
+    p = augment_platform!(HostPlatform())
+    global my_artifact_dir = @artifact_str("MyArtifact", p)
+end
+```
+
+This ensures that the same artifact is used by your code as Pkg attempted to install.

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -467,8 +467,19 @@ be provided to properly support overrides from `Overrides.toml` entries in depot
 
 If `include_lazy` is set to `true`, then lazy packages will be installed as well.
 
+This function is deprecated and should be replaced with the following snippet:
+
+    artifacts = select_downloadable_artifacts(artifacts_toml; platform, include_lazy)
+    for name in keys(artifacts)
+        ensure_artifact_installed(name, artifacts[name], artifacts_toml; platform=platform)
+    end
+
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3.
+
+!!! warning
+    This function is deprecated in Julia 1.6 and will be removed in a future version.
+    Use `select_downloadable_artifacts()` and `ensure_artifact_installed()` instead.
 """
 function ensure_all_artifacts_installed(artifacts_toml::String;
                                         platform::AbstractPlatform = HostPlatform(),
@@ -476,6 +487,8 @@ function ensure_all_artifacts_installed(artifacts_toml::String;
                                         include_lazy::Bool = false,
                                         verbose::Bool = false,
                                         quiet_download::Bool = false)
+    # This function should not be called anymore; use `select_downloadable_artifacts()` directly.
+    Base.depwarn("`ensure_all_artifacts_installed()` is deprecated; iterate over `select_downloadable_artifacts()` output with `ensure_artifact_installed()`.", :ensure_all_artifacts_installed)
     # Collect all artifacts we're supposed to install
     artifacts = select_downloadable_artifacts(artifacts_toml; platform, include_lazy, pkg_uuid)
     for name in keys(artifacts)

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -355,18 +355,22 @@ end
 
         # Install artifacts such that `c_simple` is not installed properly
         # because of the platform we requested, but `socrates` is.
-        ensure_all_artifacts_installed(artifacts_toml; platform=Platform("powerpc64le", "linux"))
+        missing_platform = Platform("powerpc64le", "linux")
+        artifacts = select_downloadable_artifacts(artifacts_toml; platform=missing_platform)
+        for name in keys(artifacts)
+            ensure_artifact_installed(name, artifacts[name], artifacts_toml; platform=missing_platform)
+        end
 
         # Test that c_simple doesn't even show up
-        c_simple_hash = artifact_hash("c_simple", artifacts_toml; platform=Platform("powerpc64le", "linux"))
+        c_simple_hash = artifact_hash("c_simple", artifacts_toml; platform=missing_platform)
         @test c_simple_hash == nothing
 
         # Test that socrates shows up, but is not installed
-        socrates_hash = artifact_hash("socrates", artifacts_toml; platform=Platform("powerpc64le", "linux"))
+        socrates_hash = artifact_hash("socrates", artifacts_toml; platform=missing_platform)
         @test !artifact_exists(socrates_hash)
 
         # Test that collapse_the_symlink is installed
-        cts_hash = artifact_hash("collapse_the_symlink", artifacts_toml; platform=Platform("powerpc64le", "linux"))
+        cts_hash = artifact_hash("collapse_the_symlink", artifacts_toml; platform=missing_platform)
         @test artifact_exists(cts_hash)
     end
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1,7 +1,7 @@
 module ArtifactTests
 import ..Pkg # ensure we are using the correct Pkg
 
-using Test, Random, Pkg.Artifacts, Pkg.BinaryPlatforms, Pkg.PlatformEngines
+using Test, Random, Pkg.Artifacts, Base.BinaryPlatforms, Pkg.PlatformEngines
 import Pkg.Artifacts: pack_platform!, unpack_platform, with_artifacts_directory, ensure_all_artifacts_installed, extract_all_hashes
 using TOML, Dates
 import Base: SHA1
@@ -368,6 +368,112 @@ end
         # Test that collapse_the_symlink is installed
         cts_hash = artifact_hash("collapse_the_symlink", artifacts_toml; platform=Platform("powerpc64le", "linux"))
         @test artifact_exists(cts_hash)
+    end
+
+    # Ensure that platform augmentation hooks work.  We will switch between two arbitrary artifacts for this,
+    # by inspecting an environment variable in our package hook.
+    engaged_hash = SHA1("a5f8161ca1ab2e94fedd3578586fe06d7906177c")
+    engaged_url = "https://github.com/JuliaBinaryWrappers/HelloWorldGo_jll.jl/releases/download/HelloWorldGo-v1.0.4+0/HelloWorldGo.v1.0.4.aarch64-linux-musl.tar.gz"
+    engaged_sha256 = "9b66d6b02a370d0170a8c217a872cd1f3d53de267d4e63c22a40b49f04367f8a"
+    disengaged_hash = SHA1("ea8ea92ecd57aa602d254ca6c637309642202768")
+    disengaged_url = "https://github.com/JuliaBinaryWrappers/HelloWorldGo_jll.jl/releases/download/HelloWorldGo-v1.0.4+0/HelloWorldGo.v1.0.4.i686-w64-mingw32.tar.gz"
+    disengaged_sha256 = "5c96a327fc6f0dc71d533373bc6cc6719a1e477c72319b800f29abf1b1e7d812"
+
+    function generate_flooblegrank_artifacts(ap_path)
+        # Bind both "engaged" and "disengaged" variants of our `gooblebox` artifact to generate an Artifacts.toml file
+        artifacts_toml = joinpath(ap_path, "Artifacts.toml")
+        engaged_platform = HostPlatform()
+        engaged_platform["flooblecrank"] = "engaged"
+        Pkg.Artifacts.bind_artifact!(
+            artifacts_toml,
+            "gooblebox",
+            engaged_hash;
+            download_info = [(engaged_url, engaged_sha256)],
+            platform = engaged_platform,
+        )
+        disengaged_platform = HostPlatform()
+        disengaged_platform["flooblecrank"] = "disengaged"
+        Pkg.Artifacts.bind_artifact!(
+            artifacts_toml,
+            "gooblebox",
+            disengaged_hash;
+            download_info = [(disengaged_url, disengaged_sha256)],
+            platform = disengaged_platform,
+        )
+    end
+
+    for flooblecrank_status in ("engaged", "disengaged")
+        # Ensure that they're both missing at first so tests can fail properly
+        temp_pkg_dir() do project_path
+            copy_test_package(project_path, "AugmentedPlatform")
+            ap_path = joinpath(project_path, "AugmentedPlatform")
+            generate_flooblegrank_artifacts(ap_path)
+
+            Pkg.activate(ap_path)
+            add_this_pkg()
+            if flooblecrank_status == "engaged"
+                right_hash = engaged_hash
+                wrong_hash = disengaged_hash
+            else
+                right_hash = disengaged_hash
+                wrong_hash = engaged_hash
+            end
+
+            @test !isdir(artifact_path(right_hash))
+            @test !isdir(artifact_path(wrong_hash))
+
+            # Instantiate with this environment variable, to install the proper one
+            withenv("FLOOBLECRANK" => flooblecrank_status) do
+                Pkg.instantiate()
+                @test isdir(artifact_path(right_hash))
+                @test !isdir(artifact_path(wrong_hash))
+            end
+
+            # Manual test that artifact is installed by instantiate()
+            artifacts_toml = joinpath(ap_path, "Artifacts.toml")
+            p = HostPlatform()
+            p["flooblecrank"] = flooblecrank_status
+            flooblecrank_hash = artifact_hash("gooblebox", artifacts_toml; platform=p)
+            @test flooblecrank_hash == right_hash
+            @test artifact_exists(flooblecrank_hash)
+
+            # Test that if we load the package, it knows how to find its own artifact,
+            # because it feeds the right `Platform` object through to `@artifact_str()`
+            cmd = setenv(`$(Base.julia_cmd()) --color=yes --project=$(ap_path) -e 'using AugmentedPlatform; print(get_artifact_dir("gooblebox"))'`,
+                         "JULIA_DEPOT_PATH" => join(Base.DEPOT_PATH, Sys.iswindows() ? ";" : ":"),
+                         "FLOOBLECRANK" => flooblecrank_status)
+            using_output = chomp(String(read(cmd)))
+            @test success(cmd)
+            @test artifact_path(right_hash) == using_output
+
+            mkpath("/tmp/foo/$(flooblecrank_status)")
+            rm("/tmp/foo/$(flooblecrank_status)"; recursive=true, force=true)
+            cp(project_path, "/tmp/foo/$(flooblecrank_status)")
+            cp(Base.DEPOT_PATH[1], "/tmp/foo/$(flooblecrank_status)/depot")
+        end
+    end
+
+    # Also run a test of "cross-installation"
+    temp_pkg_dir() do project_path
+        copy_test_package(project_path, "AugmentedPlatform")
+        ap_path = joinpath(project_path, "AugmentedPlatform")
+        generate_flooblegrank_artifacts(ap_path)
+
+        Pkg.activate(ap_path)
+        add_this_pkg()
+        @test !isdir(artifact_path(engaged_hash))
+        @test !isdir(artifact_path(disengaged_hash))
+
+        # Instantiate with the environment variable set, but with an explicit
+        # tag set in the platform object, which overrides.
+        withenv("FLOOBLECRANK" => "disengaged") do
+            p = HostPlatform()
+            p["flooblecrank"] = "engaged"
+            Pkg.instantiate(;platform=p)
+
+            @test isdir(artifact_path(engaged_hash))
+            @test !isdir(artifact_path(disengaged_hash))
+        end
     end
 end
 

--- a/test/test_packages/AugmentedPlatform/.pkg/platform_augmentation.jl
+++ b/test/test_packages/AugmentedPlatform/.pkg/platform_augmentation.jl
@@ -1,0 +1,18 @@
+using Base.BinaryPlatforms
+
+# Our platform augmentation simply inspects the environment
+function augment_platform!(p::Platform)
+    # If the `flooblecrank` tag is already set, don't auto-detect!
+    if haskey(p, "flooblecrank")
+        return p
+    end
+
+    # If the tag is not set, autodetect through magic (in this case, checking environment variables)
+    flooblecrank_status = get(ENV, "FLOOBLECRANK", "disengaged")
+    if flooblecrank_status == "engaged"
+        p["flooblecrank"] = "engaged"
+    else
+        p["flooblecrank"] = "disengaged"
+    end
+    return p
+end

--- a/test/test_packages/AugmentedPlatform/.pkg/select_artifacts.jl
+++ b/test/test_packages/AugmentedPlatform/.pkg/select_artifacts.jl
@@ -1,0 +1,15 @@
+using TOML, Artifacts, Base.BinaryPlatforms
+include("./platform_augmentation.jl")
+artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
+
+# Get "target triplet" from ARGS, if given (defaulting to the host triplet otherwise)
+target_triplet = get(ARGS, 1, Base.BinaryPlatforms.host_triplet())
+
+# Augment this platform object with any special tags we require
+platform = augment_platform!(HostPlatform(parse(Platform, target_triplet)))
+
+# Select all downloadable artifacts that match that platform
+artifacts = select_downloadable_artifacts(artifacts_toml; platform)
+
+# Output the result to `stdout` as a TOML dictionary
+TOML.print(stdout, artifacts)

--- a/test/test_packages/AugmentedPlatform/Project.toml
+++ b/test/test_packages/AugmentedPlatform/Project.toml
@@ -1,0 +1,13 @@
+name = "AugmentedPlatform"
+uuid = "4d5b37cf-bcfd-af76-759b-4d98ee7f9293"
+version = "0.1.0"
+
+[deps]
+StructIO = "53d494c1-5632-5724-8f4c-31dff12d585f"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/AugmentedPlatform/src/AugmentedPlatform.jl
+++ b/test/test_packages/AugmentedPlatform/src/AugmentedPlatform.jl
@@ -1,0 +1,11 @@
+module AugmentedPlatform
+using Artifacts
+export get_artifact_dir
+
+# Use our platform augmentation function to get consistent results
+include("../.pkg/platform_augmentation.jl")
+function get_artifact_dir(name)
+    return @artifact_str(name, augment_platform!(HostPlatform()))
+end
+
+end # module AugmentedPlatform


### PR DESCRIPTION
This, combined with the recent overhaul of BinaryPlatforms to give
extended tags to `Platform` objects, enables packages to run arbitrary
(ideally, small) pieces of code to better inform artifact selection.

`Platform`-specific Artifacts can now be tagged with arbitrary metadata,
examples of which are `libc` version, processor microarchitecture, or
CUDA version.  Because we do not want to have to teach Julia how to
autodetect its compatibility with all possible tags, we instead add the
ability for a package to perform the autodetection, and run that code
after the package is installed, but before its artifacts are downloaded.

Cooperating packages will create a `.pkg/platform_augmentation_hook.jl`
file within their package, and that file will return a function as its
final value.  This code will be evaluated within an anonymous module,
and within the Package's own environment, allowing the hook to import
functionality if need be (this should be avoided as much as possible, so
as to reduce the possibility of conflicting versions of dependencies
causing an issue at install time).