### PR TITLE
correct documentation of default value for JULIA_PKG_DEVDIR

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -145,7 +145,7 @@ Let's try to `dev` a registered package:
   [7876af07] + Example v0.5.1+ [`~/.julia/dev/Example`]
 ```
 
-The `dev` command fetches a full clone of the package to `~/.julia/dev/` (the path can be changed by setting the environment variable `JULIA_PKG_DEVDIR`).
+The `dev` command fetches a full clone of the package to `~/.julia/dev/` (the path can be changed by setting the environment variable `JULIA_PKG_DEVDIR`, the default being `joinpath(DEPOT_PATH[1],"dev")`).
 When importing `Example` julia will now import it from `~/.julia/dev/Example` and whatever local changes have been made to the files in that path are consequently
 reflected in the code loaded. When we used `add` we said that we tracked the package repository, we here say that we track the path itself.
 Note the package manager will never touch any of the files at a tracked path. It is therefore up to you to pull updates, change branches etc.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -266,7 +266,7 @@ const free = API.free
 Make a package available for development by tracking it by path.
 If `pkg` is given with only a name or by a URL, the package will be downloaded
 to the location specified by the environment variable `JULIA_PKG_DEVDIR`, with
-`.julia/dev` as the default.
+`joinpath(DEPOT_PATH[1],"dev")` being the default.
 
 If `pkg` is given as a local path, the package at that path will be tracked.
 


### PR DESCRIPTION
The default for `JULIA_PKG_DEVDIR` is *not* `.julia/dev` but `joinpath(DEPOT_PATH[1],"dev")`. This is important: users are currently not warned in [the documentation of `JULIA_DEPOT_PATH`](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH) that changing the first element of that environment variable will change the default of `JULIA_PKG_DEVDIR` as well.