### PR TITLE
Clarify activate command signatures

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -249,7 +249,8 @@ PSA[:name => "activate",
     :description => "set the primary environment the package manager manipulates",
     :help => md"""
     activate
-    activate [--shared|--temp] [path]
+    activate [--shared] path
+    activate --temp
 
 Activate the environment at the given `path`, or the home project environment if no `path` is specified.
 The active environment is the environment that is modified by executing package commands.


### PR DESCRIPTION
The signatures in the help for the activate command were confusing. It seemed to imply that the `activate --shared` and `activate --temp` each took an optional path, when in fact `activate --shared` requires a path and `activate --temp` does not accept a path. This clarifies the command signatures for these two cases.