### PR TITLE
[BinaryPlatforms]: fix triplet breakage

### DIFF
--- a/src/BinaryPlatforms_compat.jl
+++ b/src/BinaryPlatforms_compat.jl
@@ -9,7 +9,7 @@ export platform_key_abi, platform_dlext, valid_dl_path, arch, libc, compiler_abi
 
 import Base.BinaryPlatforms: libgfortran_version, libstdcxx_version, platform_name,
                              wordsize, platform_dlext, tags, arch, libc, call_abi,
-                             cxxstring_abi, triplet
+                             cxxstring_abi
 
 struct UnknownPlatform <: AbstractPlatform
     UnknownPlatform(args...; kwargs...) = new()
@@ -87,6 +87,20 @@ end
 # Add one-off functions
 MacOS(; kwargs...) = MacOS(:x86_64; kwargs...)
 FreeBSD(; kwargs...) = FreeBSD(:x86_64; kwargs...)
+
+function triplet(p::AbstractPlatform)
+    # We are going to sub off to `Base.BinaryPlatforms.triplet()` here,
+    # with the important exception that we override `os_version` to better
+    # mimic the old behavior of `triplet()`
+    if Sys.isfreebsd(p)
+        p = deepcopy(p)
+        p["os_version"] = "11.1.0"
+    elseif Sys.isapple(p)
+        p = deepcopy(p)
+        p["os_version"] = "14.0.0"
+    end
+    return Base.BinaryPlatforms.triplet(p)
+end
 
 """
     platform_key_abi(machine::AbstractString)

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -79,9 +79,9 @@ const platform = @inferred Platform platform_key_abi()
         @test triplet(Linux(:armv6l; libc=:musl, call_abi=:eabihf)) == "armv6l-linux-musleabihf"
         @test triplet(Linux(:x86_64)) == "x86_64-linux-gnu"
         @test triplet(Linux(:armv6l)) == "armv6l-linux-gnueabihf"
-        @test triplet(MacOS()) == "x86_64-apple-darwin"
-        @test triplet(FreeBSD(:x86_64)) == "x86_64-unknown-freebsd"
-        @test triplet(FreeBSD(:i686)) == "i686-unknown-freebsd"
+        @test triplet(MacOS()) == "x86_64-apple-darwin14"
+        @test triplet(FreeBSD(:x86_64)) == "x86_64-unknown-freebsd11.1"
+        @test triplet(FreeBSD(:i686)) == "i686-unknown-freebsd11.1"
     end
 
     @testset "Valid DL paths" begin


### PR DESCRIPTION
We momentarily broke the MacOS (and FreeBSD, although I'm not sure that
was actually noticed ;P) ecosystem by changing slightly the rules around
`triplet(::Platform)`.  `Base.BinaryPlatforms` keeps track of the
`os_version` and appends it to the end of the triplet for `MacOS` and
`FreeBSD`, but on older versions of julia they are always expected to be
`14` and `11.1`, respectively.  This PR maintains that willful ignorance
when an old package calls `Pkg.BinaryPlatforms.triplet()`, but for new
packages that are ready to wake up and stop living in a simulation, they
can use `Base.BinaryPlatforms.triplet()` to get the full, glorious,
properly-versioned triplet string.