### PR TITLE
Precomp Tweaks: Don't print precomp message when no-op + Suspend precomp on pkgs that have errored, until they change

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -906,9 +906,7 @@ end
 _do_auto_precompile() = parse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "0")) == 1
 
 precompile() = precompile(Context())
-function precompile(ctx::Context)
-    printpkgstyle(ctx, :Precompiling, "project...")
-    
+function precompile(ctx::Context)    
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS + 1)))
     parallel_limiter = Base.Semaphore(num_tasks)
     
@@ -940,6 +938,7 @@ function precompile(ctx::Context)
         was_recompiled[pkgid] = false
     end
     
+    msg_printed = false
     errored = false
     toml_c = Base.TOMLCache()
     @sync for (pkg, deps) in depsmap
@@ -968,6 +967,10 @@ function precompile(ctx::Context)
                 end
                 is_direct_dep =  pkg in direct_deps
                 try
+                    if !msg_printed 
+                        msg_printed = true
+                        printpkgstyle(ctx, :Precompiling, "project...")
+                    end
                     was_recompiled[pkg] = true
                     Base.compilecache(pkg, sourcepath, is_direct_dep) # don't print errors from indirect deps
                 catch err

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -22,6 +22,7 @@ import ...Pkg: pkg_server
 const pkgs_precompile_suspended = Base.PkgId[]
 precomp_suspend!(pkg) = push!(pkgs_precompile_suspended, pkg)
 precomp_unsuspend!(pkg) = filter!(!isequal(pkg), pkgs_precompile_suspended)
+precomp_unsuspend!() = empty!(pkgs_precompile_suspended)
 precomp_suspended(pkg) = pkg in pkgs_precompile_suspended
 
 function find_installed(name::String, uuid::UUID, sha1::SHA1)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -18,6 +18,12 @@ import ...Pkg: pkg_server
 #########
 # Utils #
 #########
+
+const pkgs_precompile_suspended = Base.PkgId[]
+precomp_suspend!(pkg) = push!(pkgs_precompile_suspended, pkg)
+precomp_unsuspend!(pkg) = filter!(!isequal(pkg), pkgs_precompile_suspended)
+precomp_suspended(pkg) = pkg in pkgs_precompile_suspended
+
 function find_installed(name::String, uuid::UUID, sha1::SHA1)
     slug_default = Base.version_slug(uuid, sha1)
     # 4 used to be the default so look there first
@@ -129,6 +135,7 @@ function update_manifest!(ctx::Context, pkgs::Vector{PackageSpec}, deps_map)
             entry.deps = deps_map[pkg.uuid]
         end
         ctx.env.manifest[pkg.uuid] = entry
+        precomp_unsuspend!(pkg)
     end
     prune_manifest(ctx)
 end


### PR DESCRIPTION
Don't print precomp message when precompile is a no-op.

Makes for a cleaner experience when precompilation is auto-enabled