### PR TITLE
Remove `resolve` from `test/testgroups`

### DIFF
--- a/test/testgroups
+++ b/test/testgroups
@@ -1,2 +1,1 @@
 pkg
-resolve


### PR DESCRIPTION
This prevents the `resolve` tests from being run during base julia's `make testall`.

@KristofferC do you know why we were running the `resolve` tests by themselves during `make testall`?  Alternatively, should we fix Base's `testall` so that these modules can actually find `Pkg`?  Without this, we get the very strange errors of:

```
Error in testset Pkg/resolve:
Error During Test at /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.6/Pkg/test/resolve.jl:428
  Got exception outside of a @test
  UndefVarError: Pkg not defined
  Stacktrace:
    [1] temp_pkg_dir(fn::Main.Test33Main_Pkg_resolve.ResolveTest.var"#1#3"; rm::Bool)
      @ Main.Test33Main_Pkg_resolve.ResolveTest.Utils /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.6/Pkg/test/utils.jl:81
    [2] temp_pkg_dir(fn::Function)
      @ Main.Test33Main_Pkg_resolve.ResolveTest.Utils /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.6/Pkg/test/utils.jl:77
    [3] top-level scope
      @ /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.6/Pkg/test/resolve.jl:429
    [4] top-level scope
      @ /buildworker/worker/package_linux32/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1113
    [5] top-level scope
      @ /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.6/Pkg/test/resolve.jl:429
    [6] include(mod::Module, _path::String)
      @ Base ./Base.jl:389
    [7] include
      @ /buildworker/worker/tester_linux32/build/share/julia/test/testdefs.jl:13 [inlined]
    [8] macro expansion
      @ /buildworker/worker/tester_linux32/build/share/julia/test/testdefs.jl:25 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux32/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1113 [inlined]
   [10] macro expansion
      @ /buildworker/worker/tester_linux32/build/share/julia/test/testdefs.jl:24 [inlined]
   [11] macro expansion
      @ ./timing.jl:310 [inlined]
   [12] top-level scope
      @ /buildworker/worker/tester_linux32/build/share/julia/test/testdefs.jl:22
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] runtests(name::String, path::String, isolate::Bool; seed::UInt128)
      @ Main /buildworker/worker/tester_linux32/build/share/julia/test/testdefs.jl:28
   [15] (::Distributed.var"#106#108"{Distributed.CallMsg{:call_fetch}})()
      @ Distributed /buildworker/worker/package_linux32/build/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:294
   [16] run_work_thunk(thunk::Distributed.var"#106#108"{Distributed.CallMsg{:call_fetch}}, print_error::Bool)
      @ Distributed /buildworker/worker/package_linux32/build/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:79
   [17] macro expansion
      @ /buildworker/worker/package_linux32/build/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:294 [inlined]
   [18] (::Distributed.var"#105#107"{Distributed.CallMsg{:call_fetch}, Distributed.MsgHeader, Sockets.TCPSocket})()
      @ Distributed ./task.jl:392
```