### PR TITLE
Fix multiple print of `precompiling project...`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -976,8 +976,9 @@ function precompile(ctx::Context; internal_call::Bool=false)
                 end
                 is_direct_dep =  pkg in direct_deps
                 try
-                    if !any(values(was_recompiled))
-                        lock(print_lock) do
+                    lock(print_lock) do
+                        if !any(values(was_recompiled))
+                            was_recompiled[pkg] = true # needed to prevent async race
                             printpkgstyle(ctx, :Precompiling, "project...")
                         end
                     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -978,11 +978,10 @@ function precompile(ctx::Context; internal_call::Bool=false)
                 try
                     lock(print_lock) do
                         if !any(values(was_recompiled))
-                            was_recompiled[pkg] = true # needed to prevent async race
                             printpkgstyle(ctx, :Precompiling, "project...")
                         end
+                        was_recompiled[pkg] = true # needs to be in lock to prevent async race on printing
                     end
-                    was_recompiled[pkg] = true
                     Base.compilecache(pkg, sourcepath, is_direct_dep) # don't print errors from indirect deps
                 catch err
                     Operations.precomp_suspend!(pkg)

--- a/src/API.jl
+++ b/src/API.jl
@@ -975,7 +975,10 @@ function precompile(ctx::Context; internal_call::Bool=false)
                 end
                 is_direct_dep =  pkg in direct_deps
                 try
-                    !any(values(was_recompiled)) && printpkgstyle(ctx, :Precompiling, "project...")
+                    if !any(values(was_recompiled))
+                        was_recompiled[pkg] = true # needed to prevent `@async` race, and multiple prints
+                        printpkgstyle(ctx, :Precompiling, "project...")
+                    end
                     was_recompiled[pkg] = true
                     Base.compilecache(pkg, sourcepath, is_direct_dep) # don't print errors from indirect deps
                 catch err

--- a/src/API.jl
+++ b/src/API.jl
@@ -946,6 +946,7 @@ function precompile(ctx::Context; internal_call::Bool=false)
         was_recompiled[pkgid] = false
     end
     
+    print_done = Event()
     errored = false
     toml_c = Base.TOMLCache()
     @sync for (pkg, deps) in depsmap
@@ -978,7 +979,9 @@ function precompile(ctx::Context; internal_call::Bool=false)
                     if !any(values(was_recompiled))
                         was_recompiled[pkg] = true # needed to prevent `@async` race, and multiple prints
                         printpkgstyle(ctx, :Precompiling, "project...")
+                        notify(print_done)
                     end
+                    wait(print_done)
                     was_recompiled[pkg] = true
                     Base.compilecache(pkg, sourcepath, is_direct_dep) # don't print errors from indirect deps
                 catch err


### PR DESCRIPTION
Not seen on my system, but by others. It seems `printpkgstyle` has a yield point or two, so better to set the bool before