### PR TITLE
Fix how Base.compilecache is called

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -977,7 +977,7 @@ function precompile(ctx::Context; internal_call::Bool=false)
                 try
                     !any(values(was_recompiled)) && printpkgstyle(ctx, :Precompiling, "project...")
                     was_recompiled[pkg] = true
-                    Base.compilecache(pkg, sourcepath, is_direct_dep) # don't print errors from indirect deps
+                    Base.compilecache(pkg, sourcepath, toml_c, is_direct_dep) # don't print errors from indirect deps
                 catch err
                     Operations.precomp_suspend!(pkg)
                     if is_direct_dep # only throw errors for direct dependencies (in Project)


### PR DESCRIPTION
With f1430b5dbbdeb09236a77faf755275a611690a93 and https://github.com/JuliaLang/julia/commit/f6d1032763cfa160c117f0a5de25ba3370a3dca4, I get an error with `Pkg.precompile`:

```
ERROR: TaskFailedException

    nested task error: MethodError: no method matching compilecache(::Base.PkgId, ::String, ::Bool)
    Closest candidates are:
      compilecache(::Base.PkgId, ::Base.TOMLCache, ::Bool) at loading.jl:1247
      compilecache(::Base.PkgId, ::String) at loading.jl:1255
      compilecache(::Base.PkgId, ::String, ::Base.TOMLCache) at loading.jl:1255
      ...
    Stacktrace:
     [1] macro expansion
       @ ~/.julia/dev/Pkg/src/API.jl:985 [inlined]
     [2] (::LatestPkg.Pkg.API.var"#203#211"{LatestPkg.Pkg.Types.Context, Base.TOMLCache, Dict{Base.PkgId, Bool}, Dict{Base.PkgId, Base.Event}, Vector{Base.PkgId}, Base.Semaphore, Vector{Base.PkgId}, Base.PkgId, String, Vector{String}})()
       @ LatestPkg.Pkg.API ./task.jl:392

    caused by: MethodError: no method matching compilecache(::Base.PkgId, ::String, ::Bool)
    Closest candidates are:
      compilecache(::Base.PkgId, ::Base.TOMLCache, ::Bool) at loading.jl:1247
      compilecache(::Base.PkgId, ::String) at loading.jl:1255
      compilecache(::Base.PkgId, ::String, ::Base.TOMLCache) at loading.jl:1255
      ...
    Stacktrace:
     [1] macro expansion
       @ ~/.julia/dev/Pkg/src/API.jl:980 [inlined]
     [2] (::LatestPkg.Pkg.API.var"#203#211"{LatestPkg.Pkg.Types.Context, Base.TOMLCache, Dict{Base.PkgId, Bool}, Dict{Base.PkgId, Base.Event}, Vector{Base.PkgId}, Base.Semaphore, Vector{Base.PkgId}, Base.PkgId, String, Vector{String}})()
       @ LatestPkg.Pkg.API ./task.jl:392

...and 3 more exception(s).

Stacktrace:
 [1] sync_end(c::Channel{Any})
   @ Base ./task.jl:350
 [2] macro expansion
   @ ./task.jl:369 [inlined]
 [3] precompile(ctx::LatestPkg.Pkg.Types.Context; internal_call::Bool)
   @ LatestPkg.Pkg.API ~/.julia/dev/Pkg/src/API.jl:951
 [4] #precompile#195
   @ ~/.julia/dev/Pkg/src/API.jl:913 [inlined]
 [5] precompile()
   @ LatestPkg.Pkg.API ~/.julia/dev/Pkg/src/API.jl:913
 [6] top-level scope
   @ REPL[4]:1
```

(full example: https://github.com/tkf/ThreadsX.jl/pull/155/checks?check_run_id=1180332393#step:5:52)

This is because Pkg.jl tries to call `Base.compilecache(::PkgId, ::String, ::Bool)` which does not exist any more:

```
julia> methods(Base.compilecache)
# 6 methods for generic function "compilecache":
[1] compilecache(pkg::Base.PkgId) in Base at loading.jl:1247
[2] compilecache(pkg::Base.PkgId, cache::Base.TOMLCache) in Base at loading.jl:1247
[3] compilecache(pkg::Base.PkgId, cache::Base.TOMLCache, show_errors::Bool) in Base at loading.jl:1247
[4] compilecache(pkg::Base.PkgId, path::String) in Base at loading.jl:1255
[5] compilecache(pkg::Base.PkgId, path::String, cache::Base.TOMLCache) in Base at loading.jl:1255
[6] compilecache(pkg::Base.PkgId, path::String, cache::Base.TOMLCache, show_errors::Bool) in Base at loading.jl:1255
```

This PR fixes it.


cc @ianshmean