### PR TITLE
Precompilation: detect and suspend precomp for circular deps

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -950,7 +950,7 @@ function precompile(ctx::Context; internal_call::Bool=false)
     function in_deps(pkg, deps, dmap)
         isempty(deps) && return false
         pkg in deps && return true
-        return any(map(dep->in_deps(pkg, dmap[dep], dmap), deps))
+        return any(dep->in_deps(pkg, dmap[dep], dmap), deps)
     end
     for (pkg, deps) in depsmap
         if in_deps(pkg, deps, depsmap)

--- a/src/API.jl
+++ b/src/API.jl
@@ -948,7 +948,7 @@ function precompile(ctx::Context; internal_call::Bool=false)
     
     # guarding against circular deps
     function in_deps(pkg, deps, dmap)
-        length(deps) == 0 && return false
+        isempty(deps) && return false
         pkg in deps && return true
         return any(map(dep->in_deps(pkg, dmap[dep], dmap), deps))
     end

--- a/test/api.jl
+++ b/test/api.jl
@@ -115,4 +115,52 @@ import .FakeTerminals.FakeTerminal
     end
 end
 
+@testset "Pkg.precompile" begin
+    # sequential precompile, depth-first
+    cd_tempdir() do tmp
+        path = pwd()
+        Pkg.activate(".")
+        cd(mkdir("packages")) do
+            Pkg.generate("Dep1")
+            Pkg.generate("Dep2")
+            Pkg.generate("Dep3")
+        end
+        Pkg.develop(Pkg.PackageSpec(path="packages/Dep1"))
+        
+        Pkg.activate("Dep1")
+        Pkg.develop(Pkg.PackageSpec(path="packages/Dep2"))
+        Pkg.activate("Dep2")
+        Pkg.develop(Pkg.PackageSpec(path="packages/Dep3"))
+
+        Pkg.activate(".")
+        Pkg.resolve()
+        Pkg.precompile()
+    end
+    
+    # ignoring circular deps, to avoid deadlock
+    cd_tempdir() do tmp
+        path = pwd()
+        Pkg.activate(".")
+        cd(mkdir("packages")) do
+            Pkg.generate("CircularDep1")
+            Pkg.generate("CircularDep2")
+            Pkg.generate("CircularDep3")
+        end
+        Pkg.develop(Pkg.PackageSpec(path="packages/CircularDep1"))
+        Pkg.develop(Pkg.PackageSpec(path="packages/CircularDep2"))
+        Pkg.develop(Pkg.PackageSpec(path="packages/CircularDep3"))
+        
+        Pkg.activate("CircularDep1")
+        Pkg.develop(Pkg.PackageSpec(path="packages/CircularDep2"))
+        Pkg.activate("CircularDep2")
+        Pkg.develop(Pkg.PackageSpec(path="packages/CircularDep3"))
+        Pkg.activate("CircularDep3")
+        Pkg.develop(Pkg.PackageSpec(path="packages/CircularDep1"))
+        
+        Pkg.activate(".")
+        Pkg.resolve()
+        Pkg.precompile()
+    end
+end
+
 end # module APITests

--- a/test/api.jl
+++ b/test/api.jl
@@ -159,7 +159,20 @@ end
         
         Pkg.activate(".")
         Pkg.resolve()
-        Pkg.precompile()
+        precomp_task = @async Pkg.precompile()
+        
+        timer = Timer(60*2) # allow 2 minutes before assuming deadlock
+        timed_out = false
+        while true
+            istaskdone(precomp_task) && break
+            if !isopen(timer)
+                timed_out = true
+                Base.throwto(precomp_task, InterruptException())
+                break
+            end
+            sleep(0.5)
+        end
+        @test timed_out == false
     end
 end
 


### PR DESCRIPTION
Circular deps could deadlock the parallel `Pkg.precompile` process, which may be what was happening in #2057 

This adds a lightweight check to detect and suspend any circular deps within the full dep tree (not just first level, as in the case below)
Warnings are only printed only during  explicit `pkg> precompile` calls, not when `precompile` is automatically called.

These new checks added ~0.006 seconds in my case, for an environment with 333 dependencies in the manifest, which was insignificant even in the no-op case.

```
(@v1.6) pkg> precompile
┌ Warning: Circular dependency detected. Precompilation skipped for CircularDep2 [206312f7-dc9c-4d80-acd8-43a486edfa59]
└ @ Pkg.API ~/Documents/GitHub/Pkg.jl/src/API.jl:959
┌ Warning: Circular dependency detected. Precompilation skipped for CircularDep1 [5f60ae3d-344a-4690-ba7b-6488d0e2fe2e]
└ @ Pkg.API ~/Documents/GitHub/Pkg.jl/src/API.jl:959
Precompiling project...
[ Info: Precompiling Roots [f2b01f46-fcfa-551c-844a-d8ac1e96c665]
[ Info: Precompiling Reexport [189a3867-3050-52da-a836-e630ba90ab69]
[ Info: Precompiling Opus_jll [91d4177d-7536-5919-b921-800302f37372]
[ Info: Precompiling CEnum [fa961155-64e5-5f13-b03f-caf6b980ea82]
[ Info: Precompiling IniFile [83e8ac13-25f8-5344-8a64-a9f2b223428f]
...
```