### PR TITLE
Travis CI: test that the Pkg UUID has not been changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ stages:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia test/pkg-uuid.jl
   - julia --project -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
   - julia --project --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
 

--- a/test/pkg-uuid.jl
+++ b/test/pkg-uuid.jl
@@ -1,0 +1,10 @@
+using Pkg
+using Test
+
+@testset "Pkg UUID" begin 
+    project_filename = joinpath(dirname(@__DIR__), "Project.toml")
+    project = Pkg.TOML.parsefile(project_filename)
+    uuid = project["uuid"]
+    correct_uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+    @test uuid == correct_uuid
+end


### PR DESCRIPTION
Fixes #2064 

This pull request adds a test to make sure that the UUID in the Pkg.jl `Project.toml` file has not changed. The test only runs on Travis CI.