### PR TITLE
some performance improvements to uncompressing registry data

### DIFF
--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -61,7 +61,7 @@ function complete_remote_package(partial)
                 path = pkginfo["path"]
                 version_info = Operations.load_versions(ctx, path; include_yanked=false)
                 versions = sort!(collect(keys(version_info)))
-                compat_data = Operations.load_package_data(
+                compat_data = Operations.load_package_data(ctx,
                     VersionSpec, joinpath(reg.path, path, "Compat.toml"), versions)
                 supported_julia_versions = VersionSpec()
                 found_julia_compat = false
@@ -69,7 +69,7 @@ function complete_remote_package(partial)
                     for (compat, v) in compats
                         if compat == "julia"
                             found_julia_compat = true
-                            union!(supported_julia_versions, VersionSpec(v))
+                            supported_julia_versions = union(supported_julia_versions, VersionSpec(v))
                         end
                     end
                 end


### PR DESCRIPTION
Takes the benchmark of

```jl
using TOML
using Pkg
using UUIDs
using Pkg.Operations: load_package_data, VersionSpec, load_versions

const ctx = Pkg.Types.Context()
function bench_load_package()
    reg = joinpath(homedir(), ".julia/registries/General/")
    d = TOML.parsefile(joinpath(reg, "Registry.toml"))
    for (uuid, pkg) in d["packages"]
        pkgpath = pkg["path"] #
        path = joinpath(reg, pkgpath)
        version_info = load_versions(ctx, path)
        versions = sort!(collect(keys(version_info)))
        deps_data = load_package_data(UUID, joinpath(path, "Deps.toml"), versions)
        compat_data = load_package_data(VersionSpec, joinpath(path, "Compat.toml"), versions)
    end
end
```

from 407 ms, 339 Mib, to 330 ms, 248 Mib. For `Pkg.add("DifferentialEquations")` the impact is around 10-13% improvement.,