### PR TITLE
Document that dev --local path is not allowed.

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -156,12 +156,16 @@ PSA[:name => "develop",
     :description => "clone the full package repo locally for development",
     :help => md"""
     [dev|develop] [--shared|--local] pkg[=uuid] ...
+    [dev|develop] [--shared] path
 
 Make a package available for development. If `pkg` is an existing local path, that path will be recorded in
 the manifest and used. Otherwise, a full git clone of `pkg` is made. The location of the clone is
 controlled by the `--shared` (default) and `--local` arguments. The `--shared` location defaults to
-`~/.julia/dev`, but can be controlled with the `JULIA_PKG_DEVDIR` environment variable. When `--local` is given,
-the clone is placed in a `dev` folder in the current project.
+`~/.julia/dev`, but can be controlled with the `JULIA_PKG_DEVDIR` environment variable.
+
+When `--local` is given, the clone is placed in a `dev` folder in the current project. This
+is not implemented for paths, only registered packages.
+
 This operation is undone by `free`.
 
 **Examples**


### PR DESCRIPTION
See [discussion](https://discourse.julialang.org/t/pkg-dev-local-some-path-doesnt-make-a-local-clone-in-dev/47316/).

Clarification on whether is just not implemented, or not allowed for some deeper reason, is welcome; then I will update the PR.