### PR TITLE
more structured Registry handling

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ end
 
 # setup for doctesting
 DocMeta.setdocmeta!(Pkg.BinaryPlatforms, :DocTestSetup, :(using Base.BinaryPlatforms); recursive=true)
+DocMeta.setdocmeta!(Pkg.LazilyInitializedFields, :DocTestSetup, :(using Pkg.LazilyInitializedFields))
 
 # Run doctests first and disable them in makedocs
 Documenter.doctest(joinpath(@__DIR__, "src"), [Pkg])

--- a/ext/LazilyInitializedFields/LazilyInitializedFields.jl
+++ b/ext/LazilyInitializedFields/LazilyInitializedFields.jl
@@ -1,0 +1,328 @@
+"""
+A package for handling lazily initialized fields.
+
+### Exports:
+* macros: `@lazy`, `@init!`, `@uninit!`, `@isinit`.
+* functions: `init!` `uninit!`, `isinit`.
+* objects: `uninit`.
+* exceptions: `NonLazyFieldException`, `UninitializedFieldException`, `AlreadyInitializedException`
+
+### Example usage:
+
+```julia-repl
+julia> @lazy struct Foo{T}
+           a::T
+           @lazy b::Int
+           @lazy c::Union{Float64, Nothing}
+           @lazy d::Union{Int, Nothing}
+           e::Float64
+       end
+
+julia> f = Foo(2, uninit, 2.0, nothing, 3.0)
+Foo{Int64}(2, uninit, 2.0, nothing, 3.0)
+
+julia> @isinit f.b
+false
+
+julia> @isinit f.c
+true
+
+julia> f.b
+ERROR: field `b` in struct of type `Foo{Int64}` is not initialized
+[...]
+
+julia> @init! f.b = 4
+4
+
+julia> f.b
+4
+
+julia> @init! f.a=2
+ERROR: field `a` in struct of type `Foo{Int64}` is not lazy, lazy fields are `b` ,`c` ,`d`.
+[...]
+
+julia> @uninit! f.b
+uninit
+
+julia> @isinit f.b
+false
+```
+
+"""
+module LazilyInitializedFields
+
+export @lazy, uninit,
+       @init!, @isinit, @uninit!,
+        init!,  isinit,  uninit!,
+        NonLazyFieldException, UninitializedFieldException, AlreadyInitializedException
+
+
+"""
+    Uninitialized
+
+A type with no fields that is the type of [`uninit`](@ref).
+"""
+struct Uninitialized end
+
+"""
+    uninit
+
+The singleton instance of the type [`Uninitialized`](@ref), used
+for fields that are currently uninitialized.
+"""
+const uninit = Uninitialized()
+Base.show(io::IO, u::Uninitialized) = print(io, "uninit")
+
+# The @lazy macro will extended this function
+# for the struct getting defined so that we can use
+# it to check if a field is lazy, for example:
+# islazyfield(::Type{Foo}, s::Symbol) = s === :a || s === :b
+function islazyfield end
+
+
+struct NonLazyFieldException <: Exception
+    T::DataType
+    s::Symbol
+end
+
+Base.showerror(io::IO, err::NonLazyFieldException) =
+    print(io, "field `$(err.s)` in struct of type `$(err.T)` is not lazy, lazy fields are ",
+          join("`" .* string.(filter(x->islazyfield(err.T, x), fieldnames(err.T))) .* "`", ", "), ".")
+
+struct UninitializedFieldException <: Exception
+    T::DataType
+    s::Symbol
+end
+Base.showerror(io::IO, err::UninitializedFieldException) =
+    print(io, "field `", err.s, "` in struct of type `$(err.T)` is not initialized")
+
+struct AlreadyInitializedException <: Exception
+    T::DataType
+    s::Symbol
+end
+Base.showerror(io::IO, err::AlreadyInitializedException) =
+    print(io, "field `", err.s, "` in struct of type `$(err.T)` already initialized")
+
+
+"""
+    init!(a, s::Symbol)
+
+Function version of [@init!](@ref).
+"""
+@inline function init!(x::T, s::Symbol, v) where {T}
+    islazyfield(T, s) || throw(NonLazyFieldException(T, s))
+    old = getfield(x, s)
+    old isa Uninitialized || throw(AlreadyInitializedException(T, s))
+    return setfield!(x, s, v)
+end
+
+_check_setproperty_expr(expr, s) =
+    (expr isa Expr && expr.head === :(=) && expr.args[1].head === :.) || error("invalid usage of $s")
+"""
+    @init! a.b = v
+
+Initialize the lazy field `b` in object `a` to `v`.
+Throw a `NonLazyFieldException` if `b` is not a lazy field
+of `a`. Throw an `AlreadyInitializedException` if `b` is already
+initialized.
+Macro version of `init!(a, :b, v)`
+
+```jldoctest
+julia> @lazy struct Foo
+           @lazy b::Int
+       end
+
+julia> f = Foo(uninit)
+Foo(uninit)
+
+julia> f.b
+ERROR: field `b` in struct of type `Foo` is not initialized
+[...]
+
+julia> @init! f.b = 3
+3
+
+julia> f.b
+3
+
+julia> @init! f.b = 2
+ERROR: field `b` in struct of type `Foo` already initialized
+[...]
+```
+"""
+macro init!(expr)
+    _check_setproperty_expr(expr, "@init!")
+    v = expr.args[2]
+    body, sym = expr.args[1].args
+    return :(init!($(esc(body)), $(esc(sym)), $(esc(v))))
+end
+
+
+_check_getproperty_expr(expr, s) =
+    (expr isa Expr && expr.head === :.) || error("invalid usage of $s")
+
+"""
+    isinit(a, s::Symbol)
+
+Function version of [@isinit](@ref).
+"""
+@inline function isinit(x::T, s) where {T}
+    islazyfield(T, s) || throw(NonLazyFieldException(T, s))
+    !(getfield(x, s) isa Uninitialized)
+end
+"""
+    @isinit a.b
+
+Check if the lazy field `b` in the object `a` is initialized.
+Throw a `NonLazyFieldException` if `b` is not a lazy field
+of `a`.
+Macro version of [`isinit(a, :b)`](@ref)
+
+```jldoctest
+julia> @lazy struct Foo
+           @lazy b::Int
+       end
+
+julia> f = Foo(uninit)
+Foo(uninit)
+
+julia> @isinit f.b
+false
+
+julia> @init! f.b = 5
+5
+
+julia> @isinit f.b
+true
+```
+"""
+macro isinit(expr)
+    _check_getproperty_expr(expr, "@isinit")
+    return :(isinit($(esc.(expr.args)...)))
+end
+
+"""
+    uninit!(a, s::Symbol)
+
+Function version of [`@uninit!`](@ref).
+"""
+
+@inline function uninit!(x::T, s::Symbol) where {T}
+    islazyfield(T, s) || throw(NonLazyFieldException(T, s))
+    return setfield!(x, s, uninit)
+end
+
+"""
+    @uninit! f.b
+
+Uninitialize the field `b` in the object `f`
+Throw a `NonLazyFieldException` if `b` is not a lazy field
+of `a`.
+Macro version of [`uninit`](@ref)
+
+```jldoctest
+julia> @lazy struct Foo
+           @lazy b::Int
+       end
+
+julia> f = Foo(uninit)
+Foo(uninit)
+
+julia> @isinit f.b
+false
+
+julia> @init! f.b = 5
+5
+
+julia> @isinit f.b
+true
+```
+"""
+macro uninit!(expr)
+    _check_getproperty_expr(expr, "@uninit!")
+    return :(uninit!($(esc.(expr.args)...)))
+end
+
+global in_lazy_struct
+"""
+    @lazy struct Foo
+        a::Int
+        @lazy b::Int
+        @lazy c::Float64
+    end
+
+Make a struct `Foo` with the lazy fields `b` and `c`.
+"""
+macro lazy(expr)
+    if expr isa Expr && expr.head === :struct
+        try
+            global in_lazy_struct = true
+            return lazy_struct(expr)
+        finally
+            global in_lazy_struct = false
+        end
+    elseif expr isa Expr && expr.head === :(::) && length(expr.args) == 2
+        return lazy_field(expr)
+    else
+        _throw_invalid_usage()
+    end
+end
+
+function lazy_field(expr)
+    # expr is checked for correct form in @lazy
+    in_lazy_struct || error("@lazy macro use outside of @lazy struct")
+    name, T = expr.args
+    :($(esc(name))::Union{$Uninitialized, $(esc(T))})
+end
+
+function lazy_struct(expr)
+    mutable, structdef, body = expr.args
+    structname = if structdef isa Symbol
+        structdef
+    elseif structdef isa Expr && structdef.head === :curly
+        structdef.args[1]
+    else
+        error("internal error: unhandled expression $expr")
+    end
+
+    expr.args[1] = true # make mutable
+    lazyfield = QuoteNode[]
+    for (i, arg) in enumerate(body.args)
+        if arg isa Expr && arg.head === :macrocall && arg.args[1] === Symbol("@lazy")
+            body.args[i] = macroexpand(@__MODULE__, arg)
+            name = body.args[i].args[1]
+            @assert name isa Symbol
+            push!(lazyfield, QuoteNode(name))
+        end
+    end
+
+    if length(lazyfield) == 0
+        error("expected a @lazy field inside the struct")
+    end
+
+    checks = foldr((a,b)->:(s === $a || $b), lazyfield[1:end-1]; init=:(s === $(lazyfield[end])))
+    ret = Expr(:block)
+    push!(ret.args, quote
+        $(esc(expr))
+        # is @pure overkill?
+        Base.@pure $(LazilyInitializedFields).islazyfield(::Type{<:$(esc(structname))}, s::Symbol) = $checks
+        function Base.getproperty(x::$(esc(structname)), s::Symbol)
+            if $(LazilyInitializedFields).islazyfield($(esc(structname)), s)
+                r = Base.getfield(x, s)
+                r isa $Uninitialized && throw(UninitializedFieldException(typeof(x), s))
+                return r
+            end
+            return Base.getfield(x, s)
+        end
+    end)
+    if !mutable
+        push!(ret.args, quote
+            function Base.setproperty!(x::$(esc(structname)), s::Symbol, v)
+                error("setproperty! for struct of type `", $(esc(structname)), "` has been disabled")
+            end
+        end)
+    end
+    return ret
+end
+
+end

--- a/ext/update.jl
+++ b/ext/update.jl
@@ -1,0 +1,5 @@
+lazy_dir = joinpath(@__DIR__, "LazilyInitializedFields")
+lazy_file = joinpath(lazy_dir, "LazilyInitializedFields.jl")
+mkpath(lazy_dir)
+download("https://raw.githubusercontent.com/KristofferC/LazilyInitializedFields.jl/master/src/LazilyInitializedFields.jl",
+         lazy_file)

--- a/src/API.jl
+++ b/src/API.jl
@@ -69,6 +69,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
         $f(pkgs::Vector{<:AbstractString}; kwargs...)          = $f([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
         function $f(pkgs::Vector{PackageSpec}; kwargs...)
             ctx = Context()
+            Types.clone_default_registries(ctx)
             ret = $f(ctx, pkgs; kwargs...)
             $(f in (:develop, :add, :up, :pin, :free, :build)) && _auto_precompile(ctx)
             return ret
@@ -309,7 +310,6 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     manifest_resolve!(ctx, pkgs)
     ensure_resolved(ctx, pkgs)
 
-    find_registered!(ctx, UUID[pkg.uuid for pkg in pkgs])
     Operations.free(ctx, pkgs)
     return
 end
@@ -1258,6 +1258,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
                      update_registry::Bool=true, verbose::Bool=false,
                      platform::AbstractPlatform=HostPlatform(), allow_autoprecomp::Bool=true, kwargs...)
     Context!(ctx; kwargs...)
+    Types.clone_default_registries(ctx)
     if !isfile(ctx.env.project_file) && isfile(ctx.env.manifest_file)
         _manifest = Pkg.Types.read_manifest(ctx.env.manifest_file)
         deps = Dict{String,String}()

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -162,84 +162,23 @@ end
 # Registry Loading #
 ####################
 
-function load_versions(ctx, path::String; include_yanked=false)
-    toml = parse_toml(ctx, joinpath(path, "Versions.toml"); fakeit=true)
-    versions = Dict{VersionNumber, SHA1}(
-        VersionNumber(ver) => SHA1(info["git-tree-sha1"]) for (ver, info) in toml
-            if !get(info, "yanked", false) || include_yanked)
-    if Pkg.OFFLINE_MODE[] # filter out all versions that are not already downloaded
-        pkg = parse_toml(joinpath(path, "Package.toml"))
-        filter!(versions) do (v, sha)
-            pkg_spec = PackageSpec(name=pkg["name"]::String, uuid=UUID(pkg["uuid"]::String), version=v, tree_hash=sha)
-            return is_package_downloaded(ctx, pkg_spec)
+function load_tree_hash!(ctx::Context, pkg::PackageSpec)
+    tracking_registered_version(pkg) || return pkg
+    hash = nothing
+    for reg in ctx.env.registries
+        reg_pkg = get(reg, pkg.uuid, nothing)
+        reg_pkg === nothing && continue
+        pkg_info = Pkg.RegistryHandling.registry_info(reg_pkg)
+        version_info = get(pkg_info.version_info, pkg.version, nothing)
+        version_info === nothing && continue
+        hash′ = version_info.git_tree_sha1
+        if hash !== nothing
+            hash == hash′ || pkgerror("hash mismatch in registries for $(pkg.name) at version $(pkg.version)")
         end
+        hash = hash′
     end
-    return versions
-end
-
-load_package_data(ctx::Context, ::Type{T}, path::String, version::VersionNumber) where {T} =
-    get(load_package_data(ctx, T, path, [version]), version, nothing)
-
-# TODO: This function is very expensive. Optimize it
-function load_package_data(ctx::Context, ::Type{T}, path::String, versions::Vector{VersionNumber}) where {T}
-    compressed = parse_toml(ctx, path; fakeit=true)
-    compressed = convert(Dict{String, Dict{String, Union{String, Vector{String}}}}, compressed)
-    uncompressed = Dict{VersionNumber, Dict{String,T}}()
-    # Many of the entries are repeated so we keep a cache so there is no need to re-create
-    # a bunch of identical objects
-    cache = Dict{String, T}()
-    vsorted = sort(versions)
-    for (vers, data) in compressed
-        vs = VersionRange(vers)
-        first = length(vsorted) + 1
-        # We find the first and last version that are in the range
-        # and since the versions are sorted, all versions in between are sorted
-        for i in eachindex(vsorted)
-            v = vsorted[i]
-            v in vs && (first = i; break)
-        end
-        last = 0
-        for i in reverse(eachindex(vsorted))
-            v = vsorted[i]
-            v in vs && (last = i; break)
-        end
-        for i in first:last
-            v = vsorted[i]
-            uv = get!(() -> Dict{String, T}(), uncompressed, v)
-            for (key, value) in data
-                if haskey(uv, key)
-                    @warn "Overlapping ranges for $(key) in $(repr(path)) for version $v."
-                else
-                    Tvalue = if value isa String
-                        Tvalue = get!(()->T(value), cache, value)
-                    else
-                        Tvalue = T(value)
-                    end
-                    uv[key] = Tvalue
-                end
-            end
-        end
-    end
-    return uncompressed
-end
-
-function load_tree_hash(ctx::Context, pkg::PackageSpec)
-    hashes = SHA1[]
-    for path in registered_paths(ctx, pkg.uuid)
-        vers = load_versions(ctx, path; include_yanked=true)
-        hash = get(vers, pkg.version, nothing)
-        hash !== nothing && push!(hashes, hash)
-    end
-    isempty(hashes) && return nothing
-    length(unique!(hashes)) == 1 || pkgerror("hash mismatch")
-    return hashes[1]
-end
-
-function load_tree_hashes!(ctx::Context, pkgs::Vector{PackageSpec})
-    for pkg in pkgs
-        tracking_registered_version(pkg) || continue
-        pkg.tree_hash = load_tree_hash(ctx, pkg)
-    end
+    pkg.tree_hash = hash
+    return pkg
 end
 
 #######################################
@@ -389,7 +328,6 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
     Resolve.simplify_graph!(graph)
     vers = Resolve.resolve(graph)
 
-    find_registered!(ctx, collect(keys(vers)))
     # update vector of package versions
     for (uuid, ver) in vers
         idx = findfirst(p -> p.uuid == uuid, pkgs)
@@ -402,11 +340,9 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
             push!(pkgs, PackageSpec(;name=name, uuid=uuid, version=ver))
         end
     end
-    # TODO: We already parse the Versions.toml file for each package in deps_graph but this
-    # function ends up reparsing it. Consider caching the earlier result.
-    load_tree_hashes!(ctx, pkgs)
     final_deps_map = Dict{UUID, Dict{String, UUID}}()
     for pkg in pkgs
+        load_tree_hash!(ctx, pkg)
         deps = begin
             if pkg.uuid in keys(fixed)
                 deps_fixed = Dict{String, UUID}()
@@ -428,8 +364,14 @@ end
 get_or_make!(d::Dict{K,V}, k::K) where {K,V} = get!(d, k) do; V() end
 
 function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve.Requires, fixed::Dict{UUID,Resolve.Fixed})
-    uuids = collect(union(keys(reqs), keys(fixed), map(fx->keys(fx.requires), values(fixed))...))
-    seen = UUID[]
+    uuids = Set{UUID}()
+    union!(uuids, keys(reqs))
+    union!(uuids, keys(fixed))
+    for fixed_uuids in map(fx->keys(fx.requires), values(fixed))
+        union!(uuids, fixed_uuids)
+    end
+
+    seen = Set{UUID}()
 
     all_versions = VersionsDict()
     all_deps     = DepsDict()
@@ -464,7 +406,7 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                 all_deps_u_vr = get_or_make!(all_deps_u, v)
                 for (name, other_uuid) in proj.deps
                     all_deps_u_vr[name] = other_uuid
-                    other_uuid in uuids || push!(uuids, other_uuid)
+                    push!(uuids, other_uuid)
                 end
 
                 # TODO look at compat section for stdlibs?
@@ -473,33 +415,34 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                     all_compat_u_vr[name] = VersionSpec()
                 end
             else
-                for path in registered_paths(ctx, uuid)
-                    version_info = load_versions(ctx, path; include_yanked=false)
-                    versions = sort!(collect(keys(version_info)))
-                    deps_data = load_package_data(ctx, UUID, joinpath(path, "Deps.toml"), versions)
-                    compat_data = load_package_data(ctx, VersionSpec, joinpath(path, "Compat.toml"), versions)
-
-                    union!(all_versions_u, versions)
-
-                    for (vr, dd) in deps_data
-                        all_deps_u_vr = get_or_make!(all_deps_u, vr)
-                        for (name,other_uuid) in dd
-                            # check conflicts??
-                            all_deps_u_vr[name] = other_uuid
-                            other_uuid in uuids || push!(uuids, other_uuid)
+                for reg in ctx.env.registries
+                    pkg = reg[uuid]
+                    info = Pkg.RegistryHandling.registry_info(pkg)
+                    for (v, uncompressed_data) in Pkg.RegistryHandling.uncompressed_data(info)
+                        # Filter yanked and if we are in offline mode also downloaded packages
+                        # TODO, pull this into a function
+                        Pkg.RegistryHandling.isyanked(info, v) && continue
+                        if Pkg.OFFLINE_MODE[]
+                            pkg_spec = PackageSpec(name=pkg.name, uuid=pkg.uuid, version=v, tree_hash=Pkg.RegistryHandling.treehash(info, v))
+                            is_package_downloaded(ctx, pkg_spec) || continue
                         end
-                    end
-                    for (vr, cd) in compat_data
-                        all_compat_u_vr = get_or_make!(all_compat_u, vr)
-                        for (name,vs) in cd
+
+                        push!(all_versions_u, v)
+                        all_deps_u_v = get_or_make!(all_deps_u, v)
+                        all_compat_u_v = get_or_make!(all_compat_u, v)
+                        for (name, other_uuid) in uncompressed_data.deps
                             # check conflicts??
-                            all_compat_u_vr[name] = vs
+                            all_deps_u_v[name] = other_uuid
+                            push!(uuids, other_uuid)
+                        end
+                        for (name,vs) in uncompressed_data.compat
+                            # check conflicts??
+                            all_compat_u_v[name] = vs
                         end
                     end
                 end
             end
         end
-        find_registered!(ctx, uuids)
     end
 
     for uuid in uuids
@@ -518,18 +461,19 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
 end
 
 function load_urls(ctx::Context, pkgs::Vector{PackageSpec})
-    urls = Dict{UUID,Vector{String}}()
+    urls = Dict{UUID,Set{String}}()
     for pkg in pkgs
         uuid = pkg.uuid
-        ver = pkg.version::VersionNumber
-        urls[uuid] = String[]
-        for path in registered_paths(ctx, uuid)
-            info = parse_toml(joinpath(path, "Package.toml"))
-            repo = info["repo"]
-            repo in urls[uuid] || push!(urls[uuid], repo)
+        urls[uuid] = Set{String}()
+        for reg in ctx.env.registries
+            reg_pkg = get(reg, pkg.uuid, uuid)
+            reg_pkg === nothing && continue
+            info = Pkg.RegistryHandling.registry_info(reg_pkg)
+            repo = info.repo
+            repo === nothing && continue
+            push!(urls[uuid], repo)
         end
     end
-    foreach(sort!, values(urls))
     return urls
 end
 
@@ -609,7 +553,7 @@ function install_git(
     uuid::UUID,
     name::String,
     hash::SHA1,
-    urls::Vector{String},
+    urls::Set{String},
     version::Union{VersionNumber,Nothing},
     version_path::String
 )::Nothing
@@ -620,8 +564,8 @@ function install_git(
         clones_dir = joinpath(depots1(), "clones")
         ispath(clones_dir) || mkpath(clones_dir)
         repo_path = joinpath(clones_dir, string(uuid))
-        repo = GitTools.ensure_clone(ctx, repo_path, urls[1]; isbare=true,
-                                     header = "[$uuid] $name from $(urls[1])")
+        repo = GitTools.ensure_clone(ctx, repo_path, first(urls); isbare=true,
+                                     header = "[$uuid] $name from $(first(urls))")
         git_hash = LibGit2.GitHash(hash.bytes)
         for url in urls
             try LibGit2.with(LibGit2.GitObject, repo, git_hash) do g
@@ -707,7 +651,7 @@ function download_source(ctx::Context, pkgs::Vector{PackageSpec}; readonly=true)
 end
 
 function download_source(ctx::Context, pkgs::Vector{PackageSpec},
-                        urls::Dict{UUID, Vector{String}}; readonly=true)
+                        urls::Dict{UUID, Set{String}}; readonly=true)
     probe_platform_engines!()
     new_pkgs = PackageSpec[]
 
@@ -1123,13 +1067,22 @@ function update_package_add(ctx::Context, pkg::PackageSpec, entry::PackageEntry,
     return pkg
 end
 
-function check_registered(ctx::Context, pkgs::Vector{PackageSpec})
+function is_all_registered(ctx::Context, pkgs::Vector{PackageSpec})
     pkgs = filter(tracking_registered_version, pkgs)
-    find_registered!(ctx, UUID[pkg.uuid for pkg in pkgs])
     for pkg in pkgs
-        isempty(registered_paths(ctx, pkg.uuid)) || continue
+        if !any(r->haskey(r, pkg.uuid), ctx.env.registries)
+            return pkg
+        end
+    end
+    return true
+end
+
+function check_registered(ctx::Context, pkgs::Vector{PackageSpec})
+    pkg = is_all_registered(ctx, pkgs)
+    if pkg isa PackageSpec
         pkgerror("expected package $(err_rep(pkg)) to be registered")
     end
+    return nothing
 end
 
 # Check if the package can be added without colliding/overwriting things
@@ -1319,7 +1272,7 @@ function update_package_pin!(ctx::Context, pkg::PackageSpec, entry::PackageEntry
         if entry.repo.source !== nothing || entry.path !== nothing
             # A pin in this case includes an implicit `free` to switch to tracking registered versions
             # First, make sure the package is registered so we have something to free to
-            if isempty(registered_paths(ctx, pkg.uuid))
+            if is_all_registered(ctx, [pkg]) !== true
                 pkgerror("unable to pin unregistered package $(err_rep(pkg)) to an arbritrary version")
             end
         end
@@ -1333,7 +1286,6 @@ end
 function pin(ctx::Context, pkgs::Vector{PackageSpec})
     foreach(pkg -> update_package_pin!(ctx, pkg, manifest_info(ctx, pkg.uuid)), pkgs)
     pkgs = load_direct_deps(ctx, pkgs)
-    check_registered(ctx, pkgs)
 
     pkgs, deps_map = _resolve(ctx, pkgs, PRESERVE_TIERED)
     update_manifest!(ctx, pkgs, deps_map)
@@ -1356,7 +1308,7 @@ function update_package_free!(ctx::Context, pkg::PackageSpec, entry::PackageEntr
     end
     if entry.path !== nothing || entry.repo.source !== nothing
         # make sure the package is registered so we have something to free to
-        if isempty(registered_paths(ctx, pkg.uuid))
+        if is_all_registered(ctx, [pkg]) !== true
             pkgerror("unable to free unregistered package $(err_rep(pkg))")
         end
         return # -> name, uuid

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -165,7 +165,7 @@ end
 function load_tree_hash!(ctx::Context, pkg::PackageSpec)
     tracking_registered_version(pkg) || return pkg
     hash = nothing
-    for reg in ctx.env.registries
+    for reg in ctx.registries
         reg_pkg = get(reg, pkg.uuid, nothing)
         reg_pkg === nothing && continue
         pkg_info = Pkg.RegistryHandling.registry_info(reg_pkg)
@@ -415,7 +415,7 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                     all_compat_u_vr[name] = VersionSpec()
                 end
             else
-                for reg in ctx.env.registries
+                for reg in ctx.registries
                     pkg = reg[uuid]
                     info = Pkg.RegistryHandling.registry_info(pkg)
                     for (v, uncompressed_data) in Pkg.RegistryHandling.uncompressed_data(info)
@@ -465,7 +465,7 @@ function load_urls(ctx::Context, pkgs::Vector{PackageSpec})
     for pkg in pkgs
         uuid = pkg.uuid
         urls[uuid] = Set{String}()
-        for reg in ctx.env.registries
+        for reg in ctx.registries
             reg_pkg = get(reg, pkg.uuid, uuid)
             reg_pkg === nothing && continue
             info = Pkg.RegistryHandling.registry_info(reg_pkg)
@@ -1070,7 +1070,7 @@ end
 function is_all_registered(ctx::Context, pkgs::Vector{PackageSpec})
     pkgs = filter(tracking_registered_version, pkgs)
     for pkg in pkgs
-        if !any(r->haskey(r, pkg.uuid), ctx.env.registries)
+        if !any(r->haskey(r, pkg.uuid), ctx.registries)
             return pkg
         end
     end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -36,9 +36,13 @@ const DEFAULT_IO = Ref{Union{Nothing,IO}}(nothing)
 
 can_fancyprint(io::IO) = (io isa Base.TTY) && (get(ENV, "CI", nothing) != "true")
 
+include("../ext/LazilyInitializedFields/LazilyInitializedFields.jl")
+
 include("utils.jl")
 include("GitTools.jl")
 include("PlatformEngines.jl")
+include("Versions.jl")
+include("RegistryHandling.jl")
 include("Types.jl")
 include("Resolve/Resolve.jl")
 include("BinaryPlatforms_compat.jl")

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -9,7 +9,7 @@ import REPL: LineEdit, REPLCompletions
 
 import ..casesensitive_isdir
 using ..Types, ..Operations, ..API, ..Registry, ..Resolve
-import ..Pkg: Pkg
+import ..Pkg: Pkg, RegistryHandling
 
 const TEST_MODE = Ref{Bool}(false)
 const PRINTED_REPL_WARNING = Ref{Bool}(false)

--- a/src/RegistryHandling.jl
+++ b/src/RegistryHandling.jl
@@ -1,0 +1,270 @@
+module RegistryHandling
+
+export isyanked, treehash, uncompressed_data, registry_info
+
+using Base: UUID, SHA1, RefValue
+using TOML
+using Pkg.Versions: VersionSpec, VersionRange
+using Pkg.LazilyInitializedFields
+
+# The content of a registry is assumed to be constant during the
+# lifetime of a `Registry`. Create a new `Registry` if you want to have
+# a new view on the current registry.
+
+# See loading.jl
+const TOML_CACHE = Base.TOMLCache(TOML.Parser(), Dict{String, Dict{String, Any}}())
+const TOML_LOCK = ReentrantLock()
+parsefile(project_file::AbstractString) = Base.parsed_toml(project_file, TOML_CACHE, TOML_LOCK)
+
+# Info about each version of a package
+@lazy mutable struct VersionInfo
+    git_tree_sha1::Base.SHA1
+    yanked::Bool
+
+    # This is the uncompressed info and is lazily computed because it is kinda expensive
+    # TODO: Collapse the two dictionaries below into a single dictionary,
+    # we should only need to know the `Dict{UUID, VersionSpec}` mapping
+    # (therebe getting rid of the package names).
+    @lazy uncompressed_compat::Union{Dict{String, VersionSpec}}
+    @lazy uncompressed_deps::Union{Dict{String, UUID}}
+end
+VersionInfo(git_tree_sha1::Base.SHA1, yanked::Bool) = VersionInfo(git_tree_sha1, yanked, uninit, uninit)
+
+# This is the information that exists in e.g. General/A/ACME
+struct PkgInfo
+    # Package.toml:
+    repo::Union{String, Nothing}
+    subdir::Union{String, Nothing}
+
+    # Versions.toml:
+    version_info::Dict{VersionNumber, VersionInfo}
+
+    # Compat.toml
+    compat::Dict{VersionRange, Dict{String, VersionSpec}}
+
+    # Deps.toml
+    deps::Dict{VersionRange, Dict{String, UUID}}
+end
+
+isyanked(pkg::PkgInfo, v::VersionNumber) = pkg.version_info[v].yanked
+treehash(pkg::PkgInfo, v::VersionNumber) = pkg.version_info[v].git_tree_sha1
+
+function uncompress(compressed::Dict{VersionRange, Dict{String, T}}, vsorted::Vector{VersionNumber}) where {T}
+    @assert issorted(vsorted)
+    uncompressed = Dict{VersionNumber, Dict{String, T}}()
+    for (vs, data) in compressed
+        first = length(vsorted) + 1
+        # We find the first and last version that are in the range
+        # and since the versions are sorted, all versions in between are sorted
+        for i in eachindex(vsorted)
+            v = vsorted[i]
+            v in vs && (first = i; break)
+        end
+        last = 0
+        for i in reverse(eachindex(vsorted))
+            v = vsorted[i]
+            v in vs && (last = i; break)
+        end
+        for i in first:last
+            v = vsorted[i]
+            uv = get!(Dict{String, T}, uncompressed, v)
+            for (key, value) in data
+                if haskey(uv, key)
+                    # Change to an error?
+                    error("Overlapping ranges for $(key) in $(repr(path)) for version $v.")
+                else
+                    uv[key] = value
+                end
+            end
+        end
+    end
+    return uncompressed
+end
+
+# Call this before accessing uncompressed data
+function initialize_uncompressed!(pkg::PkgInfo, versions = keys(pkg.version_info))
+
+    # Only valid to call this with existing versions of the package
+    # Remove all versions we have already uncompressed
+    versions = filter!(v -> !isinit(pkg.version_info[v], :uncompressed_compat), collect(versions))
+
+    sort!(versions)
+
+    uncompressed_compat = uncompress(pkg.compat, versions)
+    uncompressed_deps   = uncompress(pkg.deps,   versions)
+
+    for v in versions
+        vinfo = pkg.version_info[v]
+        # TODO: Use when collapsing the two fields in VersionInfo is to be implemented
+        #=
+        JULIA_UUID = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
+        d = Dict{UUID, VersionSpec}()
+        uncompressed_deps_v = uncompressed_deps[v]
+        for (name, compat) in uncompressed_compat[v]
+            is_julia = name == "julia"
+            uuid = get(uncompressed_deps_v, name, nothing)
+            uuid === nothing && @assert is_julia
+            uuid = is_julia ? JULIA_UUID : uuid
+            d[uuid] = compat
+        end
+        =#
+        @init! vinfo.uncompressed_compat = get(Dict{String, VersionSpec}, uncompressed_compat, v)
+        @init! vinfo.uncompressed_deps = get(Dict{String, UUID}, uncompressed_deps, v)
+    end
+    return pkg
+end
+
+function uncompressed_data(pkg::PkgInfo)
+    initialize_uncompressed!(pkg)
+    # This tuple feels like a bad API for some reason...
+    return Dict(v => (; compat = info.uncompressed_compat, deps = info.uncompressed_deps) for (v, info) in pkg.version_info)
+end
+
+@lazy struct PkgEntry
+    # Registry.toml:
+    path::String
+    registry_path::String
+    name::String
+    uuid::UUID
+
+    # Version.toml / (Compat.toml / Deps.toml):
+    @lazy info::PkgInfo
+end
+
+registry_info(pkg::PkgEntry) = init_package_info!(pkg)
+
+function init_package_info!(pkg::PkgEntry)
+    # Already uncompressed the info for this package, return early
+    @isinit(pkg.info) && return pkg.info
+    path = joinpath(pkg.registry_path, pkg.path)
+
+    path_package = joinpath(path, "Package.toml")
+    d_p = parsefile(path_package)
+    name = d_p["name"]::String
+    name != pkg.name && error("inconsistend name in Registry.toml and Package.toml for pkg at $(path)")
+    repo = get(d_p, "repo", nothing)::Union{Nothing, String}
+    subdir = get(d_p, "subdir", nothing)::Union{Nothing, String}
+
+    # Versions.toml
+    path_vers = joinpath(path, "Versions.toml")
+    d_v = isfile(path_vers) ? parsefile(path_vers) : Dict{String, Any}()
+    version_info = Dict{VersionNumber, VersionInfo}(VersionNumber(k) =>
+        VersionInfo(SHA1(v["git-tree-sha1"]::String), get(v, "yanked", false)::Bool) for (k, v) in d_v)
+
+    # Compat.toml
+    compat_file = joinpath(path, "Compat.toml")
+    compat_data_toml = isfile(compat_file) ? parsefile(compat_file) : Dict{String, Any}()
+    # The Compat.toml file might have string or vector values
+    compat_data_toml = convert(Dict{String, Dict{String, Union{String, Vector{String}}}}, compat_data_toml)
+    compat = Dict{VersionRange, Dict{String, VersionSpec}}()
+    for (v, data) in compat_data_toml
+        vr = VersionRange(v)
+        d = Dict{String, VersionSpec}(dep => VersionSpec(vr_dep) for (dep, vr_dep) in data)
+        compat[vr] = d
+    end
+
+    # Deps.toml
+    deps_file = joinpath(path, "Deps.toml")
+    deps_data_toml = isfile(deps_file) ? parsefile(deps_file) : Dict{String, Any}()
+    # But the Deps.toml only have strings as values
+    deps_data_toml = convert(Dict{String, Dict{String, String}}, deps_data_toml)
+    deps = Dict{VersionRange, Dict{String, UUID}}()
+    for (v, data) in deps_data_toml
+        vr = VersionRange(v)
+        d = Dict{String, UUID}(dep => UUID(uuid) for (dep, uuid) in data)
+        deps[vr] = d
+    end
+
+    @init! pkg.info = PkgInfo(repo, subdir, version_info, compat, deps)
+
+    return pkg.info
+end
+
+
+struct Registry
+    path::String
+    name::String
+    uuid::UUID
+    url::Union{String, Nothing}
+    repo::Union{String, Nothing}
+    description::Union{String, Nothing}
+    pkgs::Dict{UUID, PkgEntry}
+    tree_info::Union{Base.SHA1, Nothing}
+    # various caches
+    name_to_uuids::Dict{String, Vector{UUID}}
+end
+
+function Registry(path::AbstractString)
+    d = parsefile(joinpath(path, "Registry.toml"))
+    pkgs = Dict{UUID, PkgEntry}()
+    for (uuid, info) in d["packages"]::Dict{String, Any}
+        uuid = UUID(uuid::String)
+        info::Dict{String, Any}
+        name = info["name"]::String
+        name === "julia" && continue
+        pkgpath = info["path"]::String
+        pkg = PkgEntry(pkgpath, path, name, uuid, uninit)
+        pkgs[uuid] = pkg
+    end
+    tree_info_file = joinpath(path, ".tree_info.toml")
+    tree_info = if isfile(tree_info_file)
+        Base.SHA1(parsefile(tree_info_file)["git-tree-sha1"]::String)
+    else
+        nothing
+    end
+    return Registry(
+        path,
+        d["name"]::String,
+        UUID(d["uuid"]::String),
+        get(d, "url", nothing)::Union{String, Nothing},
+        get(d, "repo", nothing)::Union{String, Nothing},
+        get(d, "description", nothing)::Union{String, Nothing},
+        pkgs,
+        tree_info,
+        Dict{String, UUID}(),
+    )
+end
+
+function Base.show(io::IO, ::MIME"text/plain", r::Registry)
+    println(io, "Registry: $(repr(r.name)) at $(repr(r.path)):")
+    println(io, "  uuid: ", r.uuid)
+    println(io, "  repo: ", r.repo)
+    if r.tree_info !== nothing
+        println(io, "  git-tree-sha1: ", r.tree_info)
+    end
+    println(io, "  packages: ", length(r.pkgs))
+end
+
+function uuids_from_name(r::Registry, name::String)
+    create_name_uuid_mapping!(r)
+    return get(Vector{UUID}, r.name_to_uuids, name)
+end
+
+function create_name_uuid_mapping!(r::Registry)
+    isempty(r.name_to_uuids) || return
+    for (uuid, pkg) in r.pkgs
+        uuids = get!(Vector{UUID}, r.name_to_uuids, pkg.name)
+        push!(uuids, pkg.uuid)
+    end
+    return
+end
+
+# Dict interface
+
+function Base.haskey(r::Registry, uuid::UUID)
+    return haskey(r.pkgs, uuid)
+end
+
+function Base.keys(r::Registry)
+    return keys(r.pkgs)
+end
+
+Base.getindex(r::Registry, uuid::UUID) = r.pkgs[uuid]
+
+Base.get(r::Registry, uuid::UUID, default) = get(r.pkgs, uuid, default)
+
+Base.iterate(r::Registry) = iterate(r.pkgs)
+Base.iterate(r::Registry, state) = iterate(r.pkgs, state)
+
+end # module
+

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -599,6 +599,42 @@ function logstr(pkgID, args...)
     end
 end
 
+"""
+    range_compressed_versionspec(pool, subset=pool)
+
+ - `pool`: all versions that exist (a superset of `subset`)
+ - `subset`: the subset of those versions that we want to include in the spec.
+
+Finds a minimal collection of ranges as a `VersionSpec`, that permits everything in the
+`subset`, but does not permit anything else from the `pool`.
+"""
+function range_compressed_versionspec(pool, subset=pool)
+    length(subset)==1 && return VersionSpec(only(subset))
+    # PREM-OPT: we keep re-sorting these, probably not required.
+    sort!(pool)
+    sort!(subset)
+    @assert subset ⊆ pool
+
+    contiguous_subsets = VersionRange[]
+
+    range_start = first(subset)
+    pool_ii = findfirst(isequal(range_start), pool) + 1  # skip-forward til we have started
+    for s in @view subset[2:end]
+        if s != pool[pool_ii]
+            range_end = pool[pool_ii-1]  # previous element was last in this range
+            push!(contiguous_subsets, VersionRange(range_start, range_end))
+            range_start = s  # start a new range
+            while (s != pool[pool_ii])  # advance til time to start
+                pool_ii+=1
+            end
+        end
+        pool_ii+=1
+    end
+    push!(contiguous_subsets, VersionRange(range_start, last(subset)))
+
+    return VersionSpec(contiguous_subsets)
+end
+
 function init_log!(data::GraphData)
     np = data.np
     pkgs = data.pkgs

--- a/test/new.jl
+++ b/test/new.jl
@@ -6,8 +6,6 @@ using  Pkg.Types: PkgError
 using  Pkg.Resolve: ResolverError
 using  ..Utils
 
-Pkg.DEFAULT_IO[] = IOBuffer()
-
 general_uuid = UUID("23338594-aafe-5451-b93e-139f81909106") # UUID for `General`
 exuuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a") # UUID for `Example.jl`
 json_uuid = UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -831,6 +831,7 @@ end
     end
 end
 
+import Pkg.Resolve.range_compressed_versionspec
 @testset "range_compressed_versionspec" begin
     pool = [v"1.0.0", v"1.1.0", v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0", v"3.1.0"]
     @test (range_compressed_versionspec(pool)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -352,7 +352,6 @@ temp_pkg_dir() do project_path; cd(project_path) do
         mkpath("testdir/foo/bar")
         c, r = test_complete("add ")
         @test Sys.iswindows() ? ("testdir\\\\" in c) : ("testdir/" in c)
-        @test "Example" in c
         @test apply_completion("add tes") == (Sys.iswindows() ? "add testdir\\\\" : "add testdir/")
         @test apply_completion("add ./tes") == (Sys.iswindows() ? "add ./testdir\\\\" : "add ./testdir/")
         c, r = test_complete("dev ./")

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -434,8 +434,10 @@ end
             end
             return versions[idx]
         end
+
         # First, we're going to resolve for specific versions of Julia, ensuring we get the right dep versions:
         ctx = Pkg.Types.Context(;julia_version=v"1.5")
+        Pkg.Types.clone_default_registries(ctx)
         versions, deps = Pkg.Operations._resolve(ctx, [
             Pkg.Types.PackageSpec(name="MPFR_jll", uuid=Base.UUID("3a97d323-0669-5f0c-9066-3539efd106a3")),
         ], Pkg.Types.PRESERVE_TIERED)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,9 @@ end
 # Make sure to not start with an outdated registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)
 
+
+Pkg.DEFAULT_IO[] = IOBuffer()
+
 include("utils.jl")
 include("new.jl")
 include("pkg.jl")


### PR DESCRIPTION
Some background: Pkg is a little bit of spaghetti now and it is hard to know where things for a certain area is done. For example (relevant for this PR) where is the code that handles the registry? Well, it's a bit all over the place, depending on what the function needs, it might even go and parse some files in the registry and get what it wants. I (mostly) blame myself for this but in my defense when I did most of the stuff on Pkg there was little time until 1.0 and a lot of features to implement to get to feature parity with the old package manager. Now when things are calmed down I think it would be good to re-evaluate a bit on how things are structured.

As a start, I want to look exactly at the way we access the information in the registries. As I said, right now, there are callees that parse registry files all over the place, the same TOML file thus gets parsed multiple times, etc. There is an attempt of a caching system in the `EnvCache` struct but it doesn't work properly. Also, https://github.com/JuliaLang/Pkg.jl/issues/2044 is relevant since every time you go and parse a TOML file you lose type information. In addition, we might want to have access to the registry information when we e.g. do `status` so that we can show what packages are being held back. But there is no way to conveniently do that right now.

To start improving this, this PR starts implementing a proper "interface" to query the registry. It is lazy and constructs things as you access them as to not parse and uncompress a bunch of unnecessary data. Right now, only the resolver part has been moved to use the new interface (and there is still some wip there) but I want to start moving all lookups that Pkg does about registry information to it. Also, the information about the registry will be stored in e.g. the `EnvCache` so that information about the registry is available throughout the whole Pkg operation and not only when it is needed.

I'll probably force push to this a lot.