### PR TITLE
Travis CI: if the tests fail, automatically retry them one time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,7 @@ stages:
   - name: test
   - name: docs
 
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia test/pkg-uuid.jl
-  - julia --project -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
-  - julia --project --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+script: travis-script.sh
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ stages:
   - name: test
   - name: docs
 
-script: travis-script.sh
+script: ./travis-script.sh
 
 jobs:
   include:

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+julia test/pkg-uuid.jl
+julia --project -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
+try_count=0
+while [ $try_count != 2 ]; do
+    julia --project --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+    if [ $? = 0 ]; then exit 0; fi
+    try_count = `expr $try_count + 1`
+    sleep 60
+done
+exit 1


### PR DESCRIPTION
It is very common for one of the CI jobs to fail because of a network error. For example, a clone from GitHub fails. The solution is to restart the single failed job.

See e.g. this run: https://travis-ci.com/github/JuliaLang/Pkg.jl/builds/188489284

In that run, the first three jobs passed, but the fourth failed due to a sporadic network error.

It's annoying to have to always restart those jobs.

This pull request adds a bounded retry loop. We try at most two times total. We sleep 60 seconds between tries - if GitHub was rate limiting our downloads for some reason, this sleep may give time for the rate limit to reset.