### PR TITLE
Test suite: print a message with info on the current Pkg server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - osx
 
 env:
-- JULIA_PKG_SERVER="https://pkg.julialang.org"
+- JULIA_PKG_SERVER="https://pkg.julialang.org" # please note: on CI, this will redirect to "https://us-east-ci.pkg.julialang.org"
 - JULIA_PKG_SERVER=""
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - osx
 
 env:
-- JULIA_PKG_SERVER="https://pkg.julialang.org" # please note: on CI, this will redirect to "https://us-east-ci.pkg.julialang.org"
+- JULIA_PKG_SERVER="https://pkg.julialang.org"
 - JULIA_PKG_SERVER=""
 
 notifications:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+if (server = Pkg.pkg_server()) !== nothing && Sys.which("curl") !== nothing
+    s = read(`curl -sLI $(server)`, String);
+    @info "Pkg Server metadata:\n$s"
+end
+
 module PkgTests
 
 import Pkg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module PkgTests
+
+import Pkg
+
 if (server = Pkg.pkg_server()) !== nothing && Sys.which("curl") !== nothing
     s = read(`curl -sLI $(server)`, String);
     @info "Pkg Server metadata:\n$s"
 end
-
-module PkgTests
-
-import Pkg
 
 # Make sure to not start with an outdated registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)


### PR DESCRIPTION
This prints a message so that if someone is having a hard time diagnosing test failures on CI, they can see exactly which Pkg server CI uses.

cc: @staticfloat 

---

E.g. on my machine:
```julia
julia> if (server = Pkg.pkg_server()) !== nothing && Sys.which("curl") !== nothing
           s = read(`curl -sLI $(server)`, String);
           @info "Pkg Server metadata:\n$s"
       end
┌ Info: Pkg Server metadata:
│ HTTP/2 301
│ server: Varnish
│ retry-after: 0
│ location: https://us-east2.pkg.julialang.org/
│ x-geo-continent: NA
│ x-geo-country: US
│ x-geo-region: RI
│ accept-ranges: bytes
│ date: Wed, 07 Oct 2020 08:07:58 GMT
│ via: 1.1 varnish
│ x-served-by: cache-ewr18161-EWR
│ x-cache: HIT
│ x-cache-hits: 0
│ x-timer: S1602058078.462363,VS0,VE0
│ content-length: 0
│
│ HTTP/1.1 200 OK
│ Server: nginx/1.19.2
│ Date: Wed, 07 Oct 2020 08:07:58 GMT
│ Content-Type: text/html
│ Content-Length: 401
│ Connection: keep-alive
│ Accept-Ranges: bytes
└
```