### PR TITLE
Fix the test suite when run locally with `include("test/runtests.jl")`

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -454,7 +454,7 @@ end
         end
 
         # Next, set up our depot path, with `depot1` as the "innermost" depot.
-        old_depot_path = DEPOT_PATH
+        old_depot_path = copy(DEPOT_PATH)
         empty!(DEPOT_PATH)
         append!(DEPOT_PATH, [depot1, depot2, depot3])
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -725,7 +725,7 @@ end
 @testset "subdir functionality" begin
     temp_pkg_dir() do project_path; with_temp_env() do
         mktempdir() do tmp
-            repodir = git_init_package(tmp, "test_packages/MainRepo")
+            repodir = git_init_package(tmp, joinpath(@__DIR__, "test_packages", "MainRepo"))
             # Add with subdir
             subdir_uuid = UUID("6fe4e069-dcb0-448a-be67-3a8bf3404c58")
             Pkg.add(url = repodir, subdir = "SubDir")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,18 +14,26 @@ end
 # Make sure to not start with an outdated registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)
 
-include("utils.jl")
-include("new.jl")
-include("pkg.jl")
-include("repl.jl")
-include("api.jl")
-include("registry.jl")
-include("subdir.jl")
-include("artifacts.jl")
-include("binaryplatforms.jl")
-include("platformengines.jl")
-include("sandbox.jl")
-include("resolve.jl")
+testfiles = [
+    "utils",
+    "new",
+    "pkg",
+    "repl",
+    "api",
+    "registry",
+    "subdir",
+    "artifacts",
+    "binaryplatforms",
+    "platformengines",
+    "sandbox",
+    "resolve",
+]
+original_project = Base.active_project()
+for testfile in testfiles
+    @info "Running test/$(testfile).jl"
+    include("$(testfile).jl")
+    Pkg.activate(original_project)
+end
 
 # clean up locally cached registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)


### PR DESCRIPTION
This pull request fixes three small bugs in the test suite that only occur when you run the tests locally by using `include("test/runtests.jl")`.

1. The change of `old_depot_path = DEPOT_PATH` to `old_depot_path = copy(DEPOT_PATH)` is necessary to correctly restore the original depot path. If the original depot path is not restored, subsequent tests may fail.

2. The change of `git_init_package(tmp, "test_packages/MainRepo")` to `git_init_package(tmp, joinpath(@__DIR__, "test_packages", "MainRepo"))` is necessary for the Pkg tests to pass if you are not inside the `test` directory when you run the tests. If this change is not made, then the Pkg tests may fail if you are not inside the `test` directory when you run `include("runtests.jl")`.

3. Several of the test files call `Pkg.activate` and do not restore the original active project. If this happens, then, when a subsequent file calls `import ..Pkg`, this might accidentally import the built-in Pkg, instead of the copy of Pkg that we are trying to develop and test. Therefore, after each test file, we should activate the original active project. The easiest way to do this is a for-loop that loops over each test file and resets the active project after running each test file. If this change is not made, then the `import ..Pkg` statement at the top of `test/registry.jl` will actually import the built-in Pkg, instead of the locally developed copy of Pkg.

On this branch, Pkg tests pass for me locally when run with `include("test/runtests.jl")` with both:
1. `export JULIA_PKG_SERVER="https://pkg.julialang.org"`
2. `export JULIA_PKG_SERVER=""`.