### PR TITLE
If user does e.g. `Pkg.add("Foo.jl")`, instruct them to do `Pkg.add("Foo")` instead

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -50,6 +50,9 @@ end
 function check_package_name(x::AbstractString, mode=nothing)
     if !Base.isidentifier(x)
         message = "`$x` is not a valid package name"
+        if endswith(lowercase(x), ".jl")
+            message *= ". Perhaps you meant `$(chop(x; tail=3))`"
+        end
         if mode !== nothing && any(occursin.(['\\','/'], x)) # maybe a url or a path
             message *= "\nThe argument appears to be a URL or path, perhaps you meant " *
                 "`Pkg.$mode(url=\"...\")` or `Pkg.$mode(path=\"...\")`."

--- a/test/api.jl
+++ b/test/api.jl
@@ -210,4 +210,8 @@ end
     end end
 end
 
+@testset "Pkg.API.check_package_name: Error message if package name ends in .jl" begin
+    @test_throws Pkg.Types.PkgError("`Example.jl` is not a valid package name. Perhaps you meant `Example`") Pkg.API.check_package_name("Example.jl")
+end
+
 end # module APITests


### PR DESCRIPTION
In documentation and other prose, we often refer to Julia packages as "PackageName.jl". So I think it is understandable that a user would try to do `Pkg.add("PackageName.jl")`.

This PR prints an instructive message if a user tries to do that.