### PR TITLE
Precompile: Throw errors properly, disable auto during `Pkg.test`, remove trailing new line, remember suspensions for projects and after restart

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -1058,6 +1058,9 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
         catch err
             if err isa InterruptException
                 interrupted = true
+                lock(print_lock) do
+                    println(io, " Interrupted: Exiting precompilation...")
+                end
             end
         end
     end
@@ -1106,6 +1109,9 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                             interrupted = true
                             show_report = false
                             notify(was_processed[pkg])
+                            lock(print_lock) do
+                                println(io, " Interrupted: Exiting precompilation...")
+                            end
                         else
                             !fancy_print && lock(print_lock) do 
                                 str = string(color_string("  ✗ ", Base.error_color()), pkg.name)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1127,14 +1127,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
     finished = true
     notify(first_started) # in cases of no-op or !fancy_print
     wait(t_print)
-    failed_direct = filter(in(direct_deps), failed_deps)
-    if !isempty(failed_direct)
-        failed_list = ""
-        for d in failed_direct
-            failed_list *= "  $d\n"
-        end
-        pkgerror("The following direct dependencies failed to precompile:\n$(failed_list)")
-    end
+    
     nothing
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -1143,7 +1143,7 @@ end
 instantiate(; kwargs...) = instantiate(Context(); kwargs...)
 function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
                      update_registry::Bool=true, verbose::Bool=false,
-                     platform::AbstractPlatform=HostPlatform(), kwargs...)
+                     platform::AbstractPlatform=HostPlatform(), allow_autoprecomp::Bool=true, kwargs...)
     Context!(ctx; kwargs...)
     if !isfile(ctx.env.project_file) && isfile(ctx.env.manifest_file)
         _manifest = Pkg.Types.read_manifest(ctx.env.manifest_file)
@@ -1178,7 +1178,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Operations.download_artifacts(ctx, [dirname(ctx.env.manifest_file)]; platform=platform, verbose=verbose)
     # check if all source code and artifacts are downloaded to exit early
     if Operations.is_instantiated(ctx) 
-        _auto_precompile(ctx)
+        allow_autoprecomp && _auto_precompile(ctx)
         return
     end
 
@@ -1233,7 +1233,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Run build scripts
     Operations.build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git); verbose=verbose)
     
-    _auto_precompile(ctx)
+    allow_autoprecomp && _auto_precompile(ctx)
 end
 
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -1053,7 +1053,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 str *= ")"
             end
             show_report && lock(print_lock) do
-                println(io, str, "\n")
+                println(io, str)
             end
         catch err
             if err isa InterruptException

--- a/src/API.jl
+++ b/src/API.jl
@@ -1083,7 +1083,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                             return
                         end
                         Logging.with_logger(Logging.NullLogger()) do
-                            Base.compilecache(pkg, sourcepath, iob) # don't print errors from indirect deps
+                            Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull 
                         end
                         !fancy_print && lock(print_lock) do 
                             str = string(color_string("  ✓ ", :green), pkg.name)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1135,16 +1135,17 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
     show_report && lock(print_lock) do
         println(io, str)
     end
-
-    err_str = ""
-    for (dep, err) in failed_deps
-        if dep in direct_deps
-            err_str *= "\n" * "$dep" * "\n\n" * err * "\n"
+    if !internal_call
+        err_str = ""
+        for (dep, err) in failed_deps
+            if dep in direct_deps
+                err_str *= "\n" * "$dep" * "\n\n" * err * "\n"
+            end
         end
-    end
-    if err_str != ""
-        println(io, "")
-        pkgerror("The following direct dependencies failed to precompile:\n$(err_str)")
+        if err_str != ""
+            println(io, "")
+            pkgerror("The following direct dependencies failed to precompile:\n$(err_str)")
+        end
     end
     
     nothing

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1565,7 +1565,7 @@ testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, julia_args::Cmd=``, test_args::Cmd=``,
               test_fn=nothing)
-    Pkg.instantiate(ctx)
+    Pkg.instantiate(ctx; allow_autoprecomp = false)
 
     # load manifest data
     for pkg in pkgs

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -26,12 +26,9 @@ pkg_scratchpath() = joinpath(depots1(), "scratchspaces", PkgUUID)
 function save_suspended_packages()
     path = pkg_scratchpath()
     fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project())))
-    try
-        mkpath(path); rm(fpath, force=true)
-        open(fpath, "w") do io
-            serialize(io, pkgs_precompile_suspended)
-        end
-    catch
+    mkpath(path); rm(fpath, force=true)
+    open(fpath, "w") do io
+        serialize(io, pkgs_precompile_suspended)
     end
     return nothing
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -26,7 +26,7 @@ pkg_scratchpath() = joinpath(depots1(), "scratchspaces", PkgUUID)
 function save_suspended_packages()
     path = pkg_scratchpath()
     fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project())))
-    mkpath(path); rm(fpath, force=true)
+    mkpath(path); Base.Filesystem.rm(fpath, force=true)
     open(fpath, "w") do io
         serialize(io, pkgs_precompile_suspended)
     end
@@ -40,7 +40,6 @@ function recall_suspended_packages()
         end
     catch
         empty!(pkgs_precompile_suspended)
-        Base.Filesystem.rm(fpath, force=true)
     end
     return nothing
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -21,8 +21,9 @@ using Serialization
 #########
 
 const PkgUUID = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-const pkgs_precompile_suspended = Base.PkgId[]
 pkg_scratchpath() = joinpath(depots1(), "scratchspaces", PkgUUID)
+
+const pkgs_precompile_suspended = Base.PkgId[]
 function save_suspended_packages()
     path = pkg_scratchpath()
     fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project())))

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -34,11 +34,16 @@ function save_suspended_packages()
 end
 function recall_suspended_packages()
     fpath = joinpath(pkg_scratchpath(), string("suspend_cache_", hash(Base.active_project())))
-    try
-        open(fpath) do io
-            append!(empty!(pkgs_precompile_suspended), deserialize(io))
+    if isfile(fpath) 
+        v = open(fpath) do io
+            try 
+                return deserialize(io)
+            catch
+                return Base.PkgId[]
+            end
         end
-    catch
+        append!(empty!(pkgs_precompile_suspended), v)
+    else
         empty!(pkgs_precompile_suspended)
     end
     return nothing

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -38,9 +38,9 @@ function recall_suspended_packages()
     if isfile(fpath) 
         v = open(fpath) do io
             try 
-                return deserialize(io)
+                deserialize(io)
             catch
-                return Base.PkgId[]
+                Base.PkgId[]
             end
         end
         append!(empty!(pkgs_precompile_suspended), v)
@@ -171,7 +171,6 @@ function update_manifest!(ctx::Context, pkgs::Vector{PackageSpec}, deps_map)
         ctx.env.manifest[pkg.uuid] = entry
     end
     prune_manifest(ctx)
-    Operations.save_suspended_packages()
 end
 
 # TODO: Should be included in Base


### PR DESCRIPTION
Two things:
- This changes `Pkg.precompile()` to not throw. The error messages presented are high-level success or failure, hence I don't think they are informative enough to own the throw. The user or script should go-on to code loading and get the nicer stack trace.

@simonbyrne, it was mentioned by @KristofferC that you changed `precompile` to throw in the past. Is there a particular reason we should be aware of?

- Fixes an unintended auto precomp call during `Pkg.test` #2110 

Fixes #2110 
Fixes #2112 
Fixes #2118
Fixes #2116