### PR TITLE
Precompile: Fix and test per-project precomp suspension state retention

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1094,7 +1094,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
             # skip stale checking and force compilation if any dep was recompiled in this session
             any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
             is_stale = true
-            if (any_dep_recompiled || (!suspended && is_stale = _is_stale(paths, sourcepath)))
+            if (any_dep_recompiled || (!suspended && (is_stale = _is_stale(paths, sourcepath))))
                 Base.acquire(parallel_limiter)
                 is_direct_dep = pkg in direct_deps
                 iob = IOBuffer()

--- a/src/API.jl
+++ b/src/API.jl
@@ -1090,6 +1090,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                     Base.acquire(parallel_limiter)
                     is_direct_dep = pkg in direct_deps
                     iob = IOBuffer()
+                    name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
                     try
                         !fancy_print && lock(print_lock) do
                             isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
@@ -1105,8 +1106,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                             Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull
                         end
                         !fancy_print && lock(print_lock) do
-                            str = string(color_string("  ✓ ", :green), pkg.name)
-                            println(io, is_direct_dep ? str : color_string(str, :light_black))
+                            println(io, string(color_string("  ✓ ", :green), name))
                         end
                         was_recompiled[pkg] = true
                     catch err
@@ -1120,8 +1120,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                         else
                             failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
                             !fancy_print && lock(print_lock) do
-                                str = string(color_string("  ✗ ", Base.error_color()), pkg.name)
-                                println(io, is_direct_dep ? str : color_string(str, :light_black))
+                                println(io, string(color_string("  ✗ ", Base.error_color()), name))
                             end
                             Operations.precomp_suspend!(pkg)
                         end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1078,65 +1078,63 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 wait(was_processed[dep])
             end
 
-            proceed = if haskey(man, pkg.uuid) # to handle the working environment uuid
+            suspended = if haskey(man, pkg.uuid) # to handle the working environment uuid
                 pkgent = man[pkg.uuid]
-                !precomp_suspended(PackageSpec(uuid = pkg.uuid, name = pkgent.name, version = pkgent.version, tree_hash = pkgent.tree_hash))
+                precomp_suspended(PackageSpec(uuid = pkg.uuid, name = pkgent.name, version = pkgent.version, tree_hash = pkgent.tree_hash))
             else
-                true
+                false
             end
-            if proceed
-                # skip stale checking and force compilation if any dep was recompiled in this session
-                any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
-                if (any_dep_recompiled || _is_stale(paths, sourcepath))
-                    Base.acquire(parallel_limiter)
-                    is_direct_dep = pkg in direct_deps
-                    iob = IOBuffer()
-                    name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
-                    try
-                        !fancy_print && lock(print_lock) do
-                            isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
-                        end
-                        push!(pkg_queue, pkg)
-                        started[pkg] = true
-                        fancy_print && notify(first_started)
-                        if interrupted
-                            notify(was_processed[pkg])
-                            return
-                        end
-                        Logging.with_logger(Logging.NullLogger()) do
-                            Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull
-                        end
-                        !fancy_print && lock(print_lock) do
-                            println(io, string(color_string("  ✓ ", :green), name))
-                        end
-                        was_recompiled[pkg] = true
-                    catch err
-                        if err isa InterruptException
-                            interrupted = true
-                            show_report = false
-                            notify(was_processed[pkg])
-                            lock(print_lock) do
-                                println(io, " Interrupted: Exiting precompilation...")
-                            end
-                        else
-                            failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
-                            !fancy_print && lock(print_lock) do
-                                println(io, string(color_string("  ✗ ", Base.error_color()), name))
-                            end
-                            if haskey(man, pkg.uuid)
-                                pkgentry = man[pkg.uuid]
-                                precomp_suspend!(PackageSpec(uuid = pkg.uuid, name = pkgentry.name,
-                                                        version = pkgentry.version, tree_hash = pkgentry.tree_hash))
-                            end
-                        end
-                    finally
-                        Base.release(parallel_limiter)
+            # skip stale checking and force compilation if any dep was recompiled in this session
+            any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
+            is_stale = true
+            if (any_dep_recompiled || (!suspended && is_stale = _is_stale(paths, sourcepath)))
+                Base.acquire(parallel_limiter)
+                is_direct_dep = pkg in direct_deps
+                iob = IOBuffer()
+                name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
+                try
+                    !fancy_print && lock(print_lock) do
+                        isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
                     end
-                else
-                    n_already_precomp += 1
+                    push!(pkg_queue, pkg)
+                    started[pkg] = true
+                    fancy_print && notify(first_started)
+                    if interrupted
+                        notify(was_processed[pkg])
+                        return
+                    end
+                    Logging.with_logger(Logging.NullLogger()) do
+                        Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull
+                    end
+                    !fancy_print && lock(print_lock) do
+                        println(io, string(color_string("  ✓ ", :green), name))
+                    end
+                    was_recompiled[pkg] = true
+                catch err
+                    if err isa InterruptException
+                        interrupted = true
+                        show_report = false
+                        notify(was_processed[pkg])
+                        lock(print_lock) do
+                            println(io, " Interrupted: Exiting precompilation...")
+                        end
+                    else
+                        failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
+                        !fancy_print && lock(print_lock) do
+                            println(io, string(color_string("  ✗ ", Base.error_color()), name))
+                        end
+                        if haskey(man, pkg.uuid)
+                            pkgentry = man[pkg.uuid]
+                            precomp_suspend!(PackageSpec(uuid = pkg.uuid, name = pkgentry.name,
+                                                    version = pkgentry.version, tree_hash = pkgentry.tree_hash))
+                        end
+                    end
+                finally
+                    Base.release(parallel_limiter)
                 end
             else
-                !in(pkg, circular_deps) && push!(skipped_deps, pkg)
+                !is_stale && (n_already_precomp += 1)
+                suspended && !in(pkg, circular_deps) && push!(skipped_deps, pkg)
             end
             n_done += 1
             notify(was_processed[pkg])

--- a/src/API.jl
+++ b/src/API.jl
@@ -69,7 +69,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
         function $f(pkgs::Vector{PackageSpec}; kwargs...)
             ctx = Context()
             ret = $f(ctx, pkgs; kwargs...)
-            $(f in (:develop, :add, :up, :pin, :free, :build)) && _auto_precompile(ctx)
+            $(f in (:develop, :add, :up, :pin, :free, :build)) && _auto_precompile(ctx; kwargs...)
             return ret
         end
         $f(ctx::Context; kwargs...) = $f(ctx, PackageSpec[]; kwargs...)
@@ -907,9 +907,9 @@ function _is_stale(paths::Vector{String}, sourcepath::String)
     return true
 end
 
-function _auto_precompile(ctx::Context)
+function _auto_precompile(ctx::Context; kwargs...)
     if parse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
-        Pkg.precompile(ctx, internal_call=true)
+        Pkg.precompile(ctx; internal_call=true, kwargs...)
     end
 end
 
@@ -1258,7 +1258,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Operations.download_artifacts(ctx, [dirname(ctx.env.manifest_file)]; platform=platform, verbose=verbose)
     # check if all source code and artifacts are downloaded to exit early
     if Operations.is_instantiated(ctx)
-        allow_autoprecomp && _auto_precompile(ctx)
+        allow_autoprecomp && _auto_precompile(ctx; kwargs...)
         return
     end
 
@@ -1313,7 +1313,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Run build scripts
     Operations.build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git); verbose=verbose)
 
-    allow_autoprecomp && _auto_precompile(ctx)
+    allow_autoprecomp && _auto_precompile(ctx; kwargs...)
 end
 
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -943,6 +943,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
             Base.PkgId(last(x), first(x))
             for x in ctx.env.project.deps if !Base.in_sysimage(Base.PkgId(last(x), first(x)))
         ]
+        push!(direct_deps, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
     end
 
     started = Dict{Base.PkgId,Bool}()

--- a/src/API.jl
+++ b/src/API.jl
@@ -1099,17 +1099,17 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 is_direct_dep = pkg in direct_deps
                 iob = IOBuffer()
                 name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
+                !fancy_print && lock(print_lock) do
+                    isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
+                end
+                push!(pkg_queue, pkg)
+                started[pkg] = true
+                fancy_print && notify(first_started)
+                if interrupted
+                    notify(was_processed[pkg])
+                    return
+                end
                 try
-                    !fancy_print && lock(print_lock) do
-                        isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
-                    end
-                    push!(pkg_queue, pkg)
-                    started[pkg] = true
-                    fancy_print && notify(first_started)
-                    if interrupted
-                        notify(was_processed[pkg])
-                        return
-                    end
                     Logging.with_logger(Logging.NullLogger()) do
                         Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull
                     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1184,7 +1184,7 @@ end
 const pkgs_precompile_suspended = PackageSpec[]
 function save_suspended_packages()
     path = Operations.pkg_scratchpath()
-    fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project())))
+    fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project() * string(Base.VERSION))))
     mkpath(path); Base.Filesystem.rm(fpath, force=true)
     open(fpath, "w") do io
         serialize(io, pkgs_precompile_suspended)
@@ -1192,7 +1192,7 @@ function save_suspended_packages()
     return nothing
 end
 function recall_suspended_packages()
-    fpath = joinpath(Operations.pkg_scratchpath(), string("suspend_cache_", hash(Base.active_project())))
+    fpath = joinpath(Operations.pkg_scratchpath(), string("suspend_cache_", hash(Base.active_project() * string(Base.VERSION))))
     if isfile(fpath)
         v = open(fpath) do io
             try

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -171,7 +171,6 @@ function update_manifest!(ctx::Context, pkgs::Vector{PackageSpec}, deps_map)
         ctx.env.manifest[pkg.uuid] = entry
     end
     prune_manifest(ctx)
-    Operations.save_suspended_packages()
 end
 
 # TODO: Should be included in Base

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -14,7 +14,6 @@ import ..Artifacts: ensure_all_artifacts_installed, artifact_names, extract_all_
 using Base.BinaryPlatforms
 import ...Pkg
 import ...Pkg: pkg_server
-using Serialization
 
 #########
 # Utils #
@@ -22,39 +21,6 @@ using Serialization
 
 const PkgUUID = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 pkg_scratchpath() = joinpath(depots1(), "scratchspaces", PkgUUID)
-
-const pkgs_precompile_suspended = Base.PkgId[]
-function save_suspended_packages()
-    @debug "Saving precompile suspensions: $pkgs_precompile_suspended"
-    path = pkg_scratchpath()
-    fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project())))
-    mkpath(path); Base.Filesystem.rm(fpath, force=true)
-    open(fpath, "w") do io
-        serialize(io, pkgs_precompile_suspended)
-    end
-    return nothing
-end
-function recall_suspended_packages()
-    fpath = joinpath(pkg_scratchpath(), string("suspend_cache_", hash(Base.active_project())))
-    if isfile(fpath)
-        v = open(fpath) do io
-            try
-                deserialize(io)
-            catch
-                Base.PkgId[]
-            end
-        end
-        append!(empty!(pkgs_precompile_suspended), v)
-    else
-        empty!(pkgs_precompile_suspended)
-    end
-    @debug "Restored precompile suspensions: $pkgs_precompile_suspended"
-    return nothing
-end
-precomp_suspend!(pkg::Base.PkgId) = push!(pkgs_precompile_suspended, pkg)
-precomp_unsuspend!(pkg::Base.PkgId) = filter!(!isequal(pkg), pkgs_precompile_suspended)
-precomp_unsuspend!() = empty!(pkgs_precompile_suspended)
-precomp_suspended(pkg::Base.PkgId) = pkg in pkgs_precompile_suspended
 
 function find_installed(name::String, uuid::UUID, sha1::SHA1)
     slug_default = Base.version_slug(uuid, sha1)
@@ -166,9 +132,6 @@ function update_manifest!(ctx::Context, pkgs::Vector{PackageSpec}, deps_map)
             entry.deps = ctx.env.project.deps
         else
             entry.deps = deps_map[pkg.uuid]
-        end
-        if !haskey(manifest_before, pkg.uuid) || manifest_before[pkg.uuid] != entry
-            precomp_unsuspend!(Base.PkgId(pkg.uuid, pkg.name))
         end
         ctx.env.manifest[pkg.uuid] = entry
     end


### PR DESCRIPTION
The project-specific retention of auto-precompile suspended packages wasn't quite right, and was missing tests

As for burden, the addition of `recall_suspended_packages` to the first Pkg API call adds very little on my system: `0.000206 seconds (92 allocations: 6.750 KiB)` on my machine