### PR TITLE
remove using latest registry version when no version in Project

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -279,16 +279,6 @@ end
 #######################################
 # Dependency gathering and resolution #
 #######################################
-function set_maximum_version_registry!(ctx::Context, pkg::PackageSpec)
-    pkgversions = Set{VersionNumber}()
-    for path in registered_paths(ctx, pkg.uuid)
-        pathvers = keys(load_versions(ctx, path; include_yanked=false))
-        union!(pkgversions, pathvers)
-    end
-    max_version = maximum(pkgversions; init=VersionNumber(0))
-    pkg.version = VersionNumber(max_version.major, max_version.minor, max_version.patch, max_version.prerelease, ("",))
-end
-
 function collect_project!(ctx::Context, pkg::PackageSpec, path::String,
                           deps_map::Dict{UUID,Vector{PackageSpec}})
     deps_map[pkg.uuid] = PackageSpec[]
@@ -308,8 +298,7 @@ function collect_project!(ctx::Context, pkg::PackageSpec, path::String,
     if project.version !== nothing
         pkg.version = project.version
     else
-        # @warn "project file for $(pkg.name) is missing a `version` entry"
-        set_maximum_version_registry!(ctx, pkg)
+        pkgerror("project file for $(pkg.name) is missing a `version` entry")
     end
     return
 end


### PR DESCRIPTION
This doesn't really make sense to me. Why would there be a project without a version that is in the registry? And why would picking the latest version be correct?