### PR TITLE
send Pkg server value itself as a header to the Pkg server

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -639,6 +639,7 @@ function get_metadata_headers(url::AbstractString)
     server_dir = get_server_dir(url, server)
     server_dir === nothing && return headers
     push!(headers, "Julia-Pkg-Protocol" => "1.0")
+    push!(headers, "Julia-Pkg-Server" => server)
     push!(headers, "Julia-Version" => string(VERSION))
     system = triplet(HostPlatform())
     push!(headers, "Julia-System" => system)


### PR DESCRIPTION
This is useful because there may be redirection going on and it may not be clear how someone got to a particular pkg server. Setting this header is not a risk even though it captures the content of the `JULIA_PKG_SERVER` environment variable, because if the content of the variable happens to be something sensitive instead of the address of a package server, then the request will never reach the package server in the first place, let alone the header.