### PR TITLE
get rid of the mode field in PackageSpec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# Pkg v1.7 release notes
+
+- The `mode` keyword for `PackageSpec` has been removed.

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1070,17 +1070,18 @@ end
 ##############
 # Operations #
 ##############
-function rm(ctx::Context, pkgs::Vector{PackageSpec})
+function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
     drop = UUID[]
     # find manifest-mode drops
-    for pkg in pkgs
-        pkg.mode == PKGMODE_MANIFEST || continue
-        info = manifest_info(ctx, pkg.uuid)
-        if info !== nothing
-            pkg.uuid in drop || push!(drop, pkg.uuid)
-        else
-            str = has_name(pkg) ? pkg.name : string(pkg.uuid)
-            @warn("`$str` not in manifest, ignoring")
+    if mode == PKGMODE_MANIFEST
+        for pkg in pkgs
+            info = manifest_info(ctx, pkg.uuid)
+            if info !== nothing
+                pkg.uuid in drop || push!(drop, pkg.uuid)
+            else
+                str = has_name(pkg) ? pkg.name : string(pkg.uuid)
+                @warn("`$str` not in manifest, ignoring")
+            end
         end
     end
     # drop reverse dependencies
@@ -1096,22 +1097,23 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
         clean && break
     end
     # find project-mode drops
-    for pkg in pkgs
-        pkg.mode == PKGMODE_PROJECT || continue
-        found = false
-        for (name::String, uuid::UUID) in ctx.env.project.deps
-            pkg.name == name || pkg.uuid == uuid || continue
-            pkg.name == name ||
-                error("project file name mismatch for `$uuid`: $(pkg.name) ≠ $name")
-            pkg.uuid == uuid ||
-                error("project file UUID mismatch for `$name`: $(pkg.uuid) ≠ $uuid")
-            uuid in drop || push!(drop, uuid)
-            found = true
-            break
+    if mode == PKGMODE_PROJECT
+        for pkg in pkgs
+            found = false
+            for (name::String, uuid::UUID) in ctx.env.project.deps
+                pkg.name == name || pkg.uuid == uuid || continue
+                pkg.name == name ||
+                    error("project file name mismatch for `$uuid`: $(pkg.name) ≠ $name")
+                pkg.uuid == uuid ||
+                    error("project file UUID mismatch for `$name`: $(pkg.uuid) ≠ $uuid")
+                uuid in drop || push!(drop, uuid)
+                found = true
+                break
+            end
+            found && continue
+            str = has_name(pkg) ? pkg.name : string(pkg.uuid)
+            @warn("`$str` not in project, ignoring")
         end
-        found && continue
-        str = has_name(pkg) ? pkg.name : string(pkg.uuid)
-        @warn("`$str` not in project, ignoring")
     end
     # delete drops from project
     n = length(ctx.env.project.deps)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -64,7 +64,7 @@ An enum with the instances
   * `PKGMODE_PROJECT`
 
 Determines if operations should be made on a project or manifest level.
-Used as an argument to  [`PackageSpec`](@ref) or as an argument to [`Pkg.rm`](@ref).
+Used as an argument to [`Pkg.rm`](@ref), [`Pkg.update`](@ref) and [`Pkg.status`](@ref).
 """
 const PackageMode = Types.PackageMode
 
@@ -148,10 +148,10 @@ Pkg.precompile()
 const precompile = API.precompile
 
 """
-    Pkg.rm(pkg::Union{String, Vector{String}})
-    Pkg.rm(pkg::Union{PackageSpec, Vector{PackageSpec}})
+    Pkg.rm(pkg::Union{String, Vector{String}}; mode::PackageMode = PKGMODE_PROJECT)
+    Pkg.rm(pkg::Union{PackageSpec, Vector{PackageSpec}}; mode::PackageMode = PKGMODE_PROJECT)
 
-Remove a package from the current project. If the `mode` of `pkg` is
+Remove a package from the current project. If `mode` is equal to
 `PKGMODE_MANIFEST` also remove it from the manifest including all
 recursive dependencies of `pkg`.
 
@@ -443,8 +443,6 @@ This includes:
   * A `url` and an optional git `rev`ision. `rev` can be a branch name or a git commit SHA1.
   * A local `path`. This is equivalent to using the `url` argument but can be more descriptive.
   * A `subdir` which can be used when adding a package that is not in the root of a repository.
-  * A `mode`, which is an instance of the enum [`PackageMode`](@ref), with possible values `PKGMODE_PROJECT`
-   (the default) or `PKGMODE_MANIFEST`. Used in e.g. [`Pkg.rm`](@ref).
 
 Most functions in Pkg take a `Vector` of `PackageSpec` and do the operation on all the packages
 in the vector.
@@ -468,7 +466,6 @@ Below is a comparison between the REPL version and the API version:
 | `Package#master`     | `PackageSpec(name="Package", rev="master")`           |
 | `local/path#feature` | `PackageSpec(path="local/path"; rev="feature")`       |
 | `www.mypkg.com`      | `PackageSpec(url="www.mypkg.com")`                    |
-| `--manifest Package` | `PackageSpec(name="Package", mode=PKGSPEC_MANIFEST)`  |
 | `--major Package`    | `PackageSpec(name="Package", version=PKGLEVEL_MAJOR)` |
 
 """


### PR DESCRIPTION
This is never used in Pkg individually, but always as something applied to all packages. Pretty pointless to store that in every PackageSpec.