### PR TITLE
Add the public `Pkg.active_pkg_server` function, and (only if on CI) print the active Pkg server once

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -543,6 +543,19 @@ Below is a comparison between the REPL version and the API version:
 """
 const RegistrySpec = Types.RegistrySpec
 
+"""
+active_pkg_server()
+
+Get the active Pkg server.
+
+## Example
+
+```julia
+julia> Pkg.active_pkg_server()
+"https://us-east.pkg.julialang.org/"
+```
+"""
+const active_pkg_server = Types.active_pkg_server
 
 function __init__()
     DEFAULT_IO[] = stderr


### PR DESCRIPTION
It's pretty common for people to share Pkg logs when they are trying to figure out whether or not their problem is a Pkg server problem or something else. Sometimes people share logs from their local machines, and other times people share logs from one or more CI providers.

It can be difficult to figure out which Pkg server is actually being used. If the user is on their local machine, we can try to guess based on the user's geographic location. If this is a log from CI, then we have to figure out whether the particular CI job was using the CI-specific Pkg server or one of the regular Pkg servers.

This pull request tries to fix this problem. One time per Julia session, if you are running on CI, Pkg will print the active Pkg server.

Example output looks like this:
```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.0-DEV.1275 (2020-10-18)
 _/ |\__'_|_|_|\__'_|  |  Commit 44b55d1584 (0 days old master)
|__/                   |

julia> import Pkg

julia> Pkg.update()
        Info The active Pkg server is: https://us-east2.pkg.julialang.org/
    Updating registry at `~/.julia/registries/General`
No Changes to `~/Downloads/Pkg.jl/Project.toml`
No Changes to `~/Downloads/Pkg.jl/Manifest.toml`

julia> Pkg.update()
    Updating registry at `~/.julia/registries/General`
No Changes to `~/Downloads/Pkg.jl/Project.toml`
No Changes to `~/Downloads/Pkg.jl/Manifest.toml`

julia> Pkg.update()
    Updating registry at `~/.julia/registries/General`
No Changes to `~/Downloads/Pkg.jl/Project.toml`
No Changes to `~/Downloads/Pkg.jl/Manifest.toml`
```