### PR TITLE
Delete the `bors.toml` file

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-  "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch",
-]
-delete-merged-branches = true
-timeout-sec = 7200
-cut_body_after = "---"


### PR DESCRIPTION
We no longer use Bors, so this file is unnecessary.