### PR TITLE
Precomp: Better error handling, hide cursor during print

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1060,18 +1060,18 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 i += 1
                 wait(t)
             end
-            println(io, ansi_enablecursor)
         catch err
             interrupted = true
             show_report = false
             if err isa InterruptException
                 lock(print_lock) do
-                    print(io, ansi_enablecursor)
                     println(io, " Interrupted: Exiting precompilation...")
                 end
             else
                 rethrow(err)
             end
+        finally
+            print(io, ansi_enablecursor)
         end
     end
     @sync for (pkg, deps) in depsmap # precompilation loop

--- a/src/API.jl
+++ b/src/API.jl
@@ -1124,7 +1124,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                         end
                         was_recompiled[pkg] = true
                     catch err
-                        if err isa Base.PrecompileFailedException
+                        if err isa ErrorException
                             failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
                             !fancy_print && lock(print_lock) do
                                 println(io, string(color_string("  ✗ ", Base.error_color()), name))

--- a/src/API.jl
+++ b/src/API.jl
@@ -1071,7 +1071,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 rethrow(err)
             end
         finally
-            print(io, ansi_enablecursor)
+            fancy_print && print(io, ansi_enablecursor)
         end
     end
     @sync for (pkg, deps) in depsmap # precompilation loop

--- a/src/API.jl
+++ b/src/API.jl
@@ -995,6 +995,8 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
     ansi_moveup(n::Int) = string("\e[", n, "A")
     ansi_movecol1 = "\e[1G"
     ansi_cleartoend = "\e[0J"
+    ansi_enablecursor = "\e[?25h"
+    ansi_disablecursor = "\e[?25l"
     show_report::Bool = true
     n_done::Int = 0
     n_already_precomp::Int = 0
@@ -1005,6 +1007,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
             isempty(pkg_queue) && return
             fancy_print && lock(print_lock) do
                 printpkgstyle(io, :Precompiling, "project...$action_help")
+                print(io, ansi_disablecursor)
             end
             t = Timer(0; interval=1/10)
             anim_chars = ["◐","◓","◑","◒"]
@@ -1057,10 +1060,12 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 i += 1
                 wait(t)
             end
+            println(io, ansi_enablecursor)
         catch err
             if err isa InterruptException
                 interrupted = true
                 lock(print_lock) do
+                    print(io, ansi_enablecursor)
                     println(io, " Interrupted: Exiting precompilation...")
                 end
             else

--- a/src/API.jl
+++ b/src/API.jl
@@ -1125,7 +1125,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                         end
                         was_recompiled[pkg] = true
                     catch err
-                        if err isa PrecompileFailedException
+                        if err isa Base.PrecompileFailedException
                             failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
                             !fancy_print && lock(print_lock) do
                                 println(io, string(color_string("  ✗ ", Base.error_color()), name))

--- a/src/API.jl
+++ b/src/API.jl
@@ -1064,6 +1064,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
         catch err
             if err isa InterruptException
                 interrupted = true
+                show_report = false
                 lock(print_lock) do
                     print(io, ansi_enablecursor)
                     println(io, " Interrupted: Exiting precompilation...")
@@ -1086,70 +1087,80 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
         end
 
         @async begin
-            for dep in deps # wait for deps to finish
-                wait(was_processed[dep])
-            end
+            try
+                for dep in deps # wait for deps to finish
+                    wait(was_processed[dep])
+                end
 
-            suspended = if haskey(man, pkg.uuid) # to handle the working environment uuid
-                pkgent = man[pkg.uuid]
-                precomp_suspended(PackageSpec(uuid = pkg.uuid, name = pkgent.name, version = pkgent.version, tree_hash = pkgent.tree_hash))
-            else
-                false
-            end
-            # skip stale checking and force compilation if any dep was recompiled in this session
-            any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
-            is_stale = true
-            if (any_dep_recompiled || (!suspended && (is_stale = _is_stale(paths, sourcepath))))
-                Base.acquire(parallel_limiter)
-                is_direct_dep = pkg in direct_deps
-                iob = IOBuffer()
-                name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
-                !fancy_print && lock(print_lock) do
-                    isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
+                suspended = if haskey(man, pkg.uuid) # to handle the working environment uuid
+                    pkgent = man[pkg.uuid]
+                    precomp_suspended(PackageSpec(uuid = pkg.uuid, name = pkgent.name, version = pkgent.version, tree_hash = pkgent.tree_hash))
+                else
+                    false
                 end
-                push!(pkg_queue, pkg)
-                started[pkg] = true
-                fancy_print && notify(first_started)
-                if interrupted
-                    notify(was_processed[pkg])
-                    return
-                end
-                try
-                    Logging.with_logger(Logging.NullLogger()) do
-                        Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull
-                    end
+                # skip stale checking and force compilation if any dep was recompiled in this session
+                any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
+                is_stale = true
+                if (any_dep_recompiled || (!suspended && (is_stale = _is_stale(paths, sourcepath))))
+                    Base.acquire(parallel_limiter)
+                    is_direct_dep = pkg in direct_deps
+                    iob = IOBuffer()
+                    name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
                     !fancy_print && lock(print_lock) do
-                        println(io, string(color_string("  ✓ ", :green), name))
+                        isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
                     end
-                    was_recompiled[pkg] = true
-                catch err
-                    if err isa InterruptException
-                        interrupted = true
-                        show_report = false
+                    push!(pkg_queue, pkg)
+                    started[pkg] = true
+                    fancy_print && notify(first_started)
+                    if interrupted
                         notify(was_processed[pkg])
-                        lock(print_lock) do
-                            println(io, " Interrupted: Exiting precompilation...")
-                        end
-                    else
-                        failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
-                        !fancy_print && lock(print_lock) do
-                            println(io, string(color_string("  ✗ ", Base.error_color()), name))
-                        end
-                        if haskey(man, pkg.uuid)
-                            pkgentry = man[pkg.uuid]
-                            precomp_suspend!(PackageSpec(uuid = pkg.uuid, name = pkgentry.name,
-                                                    version = pkgentry.version, tree_hash = pkgentry.tree_hash))
-                        end
+                        return
                     end
-                finally
-                    Base.release(parallel_limiter)
+                    try
+                        Logging.with_logger(Logging.NullLogger()) do
+                            Base.compilecache(pkg, sourcepath, iob, devnull) # capture stderr, send stdout to devnull
+                        end
+                        !fancy_print && lock(print_lock) do
+                            println(io, string(color_string("  ✓ ", :green), name))
+                        end
+                        was_recompiled[pkg] = true
+                    catch err
+                        if err isa PrecompileFailedException
+                            failed_deps[pkg] = is_direct_dep ? String(take!(iob)) : ""
+                            !fancy_print && lock(print_lock) do
+                                println(io, string(color_string("  ✗ ", Base.error_color()), name))
+                            end
+                            if haskey(man, pkg.uuid)
+                                pkgentry = man[pkg.uuid]
+                                precomp_suspend!(PackageSpec(uuid = pkg.uuid, name = pkgentry.name,
+                                                        version = pkgentry.version, tree_hash = pkgentry.tree_hash))
+                            end
+                        else
+                            rethrow(err)
+                        end
+                    finally
+                        Base.release(parallel_limiter)
+                    end
+                else
+                    !is_stale && (n_already_precomp += 1)
+                    suspended && !in(pkg, circular_deps) && push!(skipped_deps, pkg)
                 end
-            else
-                !is_stale && (n_already_precomp += 1)
-                suspended && !in(pkg, circular_deps) && push!(skipped_deps, pkg)
+                n_done += 1
+                notify(was_processed[pkg])
+            catch err_outer
+                if err_outer isa InterruptException
+                    interrupted = true
+                    show_report = false
+                    notify(was_processed[pkg])
+                    lock(print_lock) do
+                        println(io, " Interrupted: Exiting precompilation...")
+                    end
+                else
+                    interrupted = true
+                    notify(was_processed[pkg])
+                    rethrow(err_outer)
+                end
             end
-            n_done += 1
-            notify(was_processed[pkg])
         end
     end
     finished = true

--- a/src/API.jl
+++ b/src/API.jl
@@ -1062,17 +1062,15 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
             end
             println(io, ansi_enablecursor)
         catch err
+            interrupted = true
+            show_report = false
             if err isa InterruptException
-                interrupted = true
-                show_report = false
                 lock(print_lock) do
                     print(io, ansi_enablecursor)
                     println(io, " Interrupted: Exiting precompilation...")
                 end
             else
-                # Comment this out if developing this code
-                # @show err
-                # rethrow(err)
+                rethrow(err)
             end
         end
     end
@@ -1148,16 +1146,14 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                 n_done += 1
                 notify(was_processed[pkg])
             catch err_outer
+                interrupted = true
+                show_report = false
+                notify(was_processed[pkg])
                 if err_outer isa InterruptException
-                    interrupted = true
-                    show_report = false
-                    notify(was_processed[pkg])
                     lock(print_lock) do
                         println(io, " Interrupted: Exiting precompilation...")
                     end
                 else
-                    interrupted = true
-                    notify(was_processed[pkg])
                     rethrow(err_outer)
                 end
             end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1112,6 +1112,7 @@ function precompile(ctx::Context; internal_call::Bool=false, io::IO=stderr)
                     fancy_print && notify(first_started)
                     if interrupted
                         notify(was_processed[pkg])
+                        Base.release(parallel_limiter)
                         return
                     end
                     try


### PR DESCRIPTION
- Improves specificity of error handling ~~with a new `Base.PrecompileFailedException` type thrown by `Base.compilecache`. Dependent on https://github.com/JuliaLang/julia/pull/38109~~

- Hides cursor during pretty printing

