### PR TITLE
Precomp: fix PkgId bug and bad test in circular deps, interrupt faster, add elapsed time, handle missing cache for loaded pkgs, instantiate if not instantiated

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -974,7 +974,9 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         if in_deps([pkg], deps, depsmap)
             push!(circular_deps, pkg)
             notify(was_processed[pkg])
-            precomp_suspend!(pkg)
+            pkgentry = man[pkg.uuid]
+            precomp_suspend!(PackageSpec(uuid = pkg.uuid, name = pkgentry.name,
+                            version = pkgentry.version, tree_hash = pkgentry.tree_hash))
             !internal_call && @warn "Circular dependency detected. Precompilation skipped for $pkg"
         end
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -917,7 +917,7 @@ precompile(; kwargs...) = precompile(Context(); kwargs...)
 function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     if !Operations.is_instantiated(ctx)
-        Pkg.instantiate(ctx)
+        Pkg.instantiate(ctx; allow_autoprecomp=false, kwargs...)
     end
     time_start = time_ns()
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS::Int + 1)))

--- a/src/API.jl
+++ b/src/API.jl
@@ -1020,7 +1020,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     t_print = @async begin # fancy print loop
         try
             wait(first_started)
-            isempty(pkg_queue) && return
+            (isempty(pkg_queue) || interrupted_or_done.set) && return
             fancy_print && lock(print_lock) do
                 printpkgstyle(io, :Precompiling, "project...$action_help")
                 print(io, ansi_disablecursor)
@@ -1172,6 +1172,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         end
         push!(tasks, task)
     end
+    isempty(tasks) && notify(interrupted_or_done)
     try
         wait(interrupted_or_done)
     catch err

--- a/src/API.jl
+++ b/src/API.jl
@@ -1167,7 +1167,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         end
         push!(tasks, task)
     end
-    while !interrupted && any(.!istaskdone.(tasks))
+    while !interrupted && any(!istaskdone, tasks)
         sleep(0.1)
     end
     finished = true

--- a/src/API.jl
+++ b/src/API.jl
@@ -915,8 +915,11 @@ end
 
 precompile(; kwargs...) = precompile(Context(); kwargs...)
 function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
-    time_start = time_ns()
     Context!(ctx; kwargs...)
+    if !Operations.is_instantiated(ctx)
+        Pkg.instantiate(ctx)
+    end
+    time_start = time_ns()
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS::Int + 1)))
     parallel_limiter = Base.Semaphore(num_tasks)
     io = ctx.io

--- a/src/API.jl
+++ b/src/API.jl
@@ -1184,6 +1184,8 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
                 lock(print_lock) do
                     println(io, " Interrupted: Exiting precompilation...")
                 end
+            else
+                throw(err)
             end
         end
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -916,9 +916,7 @@ end
 precompile(; kwargs...) = precompile(Context(); kwargs...)
 function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
-    if !Operations.is_instantiated(ctx)
-        Pkg.instantiate(ctx; allow_autoprecomp=false, kwargs...)
-    end
+    instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS::Int + 1)))
     parallel_limiter = Base.Semaphore(num_tasks)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1203,11 +1203,13 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
             !isempty(skipped_deps) && (str *= ", $(length(skipped_deps)) skipped during auto due to previous errors")
             str *= ")"
         end
-        if !isempty(failed_deps)
-            str *= "\n" * color_string("$(length(failed_deps)) errored", Base.error_color())
-        end
         if !isempty(rec_restart)
-            str *= "\n" * color_string(string(length(rec_restart)), Base.warn_color()) * " may not be precompilable. Try restarting julia"
+            plural = length(rec_restart) == 1 ? "y" : "ies"
+            str *= "\n" * color_string(string(length(rec_restart)), Base.warn_color()) * " dependenc$(plural) may not be precompilable. Try restarting julia"
+        end
+        if internal_call && !isempty(failed_deps)
+            plural = length(failed_deps) == 1 ? "y" : "ies"
+            str *= "\n" * color_string("$(length(failed_deps))", Base.error_color()) * " dependenc$(plural) errored"
         end
         lock(print_lock) do
             println(io, str)
@@ -1224,7 +1226,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
             if err_str != ""
                 println(io, "")
                 plural = n_direct_errs == 1 ? "y" : "ies"
-                pkgerror("The following direct dependenc$(plural) failed to precompile:\n$(err_str)")
+                pkgerror("The following $( n_direct_errs) direct dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
             end
         end
     end

--- a/test/api.jl
+++ b/test/api.jl
@@ -220,20 +220,8 @@ end
 
         Pkg.activate(".")
         Pkg.resolve()
-        precomp_task = @async Pkg.precompile()
+        Pkg.precompile()
 
-        timer = Timer(60*2) # allow 2 minutes before assuming deadlock
-        timed_out = false
-        while true
-            istaskdone(precomp_task) && break
-            if !isopen(timer)
-                timed_out = true
-                Base.throwto(precomp_task, InterruptException())
-                break
-            end
-            sleep(0.5)
-        end
-        @test timed_out == false
     end end
 end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -148,7 +148,7 @@ end
         Pkg.develop(Pkg.PackageSpec(path="packages/Dep4"), io=iob)
         @test occursin("Precompiling", String(take!(iob)))
         Pkg.precompile(io=iob)
-        @test String(take!(iob)) == "" # test that the previous precompile was a no-op
+        @test !occursin("Precompiling", String(take!(iob))) # test that the previous precompile was a no-op
         ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0
         println("Auto precompilation disabled")
         Pkg.develop(Pkg.PackageSpec(path="packages/Dep5"))
@@ -163,7 +163,7 @@ end
         @test length(broken_packages) == 1
         Pkg.activate("newpath")
         Pkg.precompile(io=iob)
-        @test String(take!(iob)) == "" # test that the previous precompile was a no-op
+        @test !occursin("Precompiling", String(take!(iob))) # test that the previous precompile was a no-op
         @test isempty(Pkg.API.pkgs_precompile_suspended)
 
         Pkg.activate(".") # test that going back to the project restores suspension list
@@ -190,7 +190,7 @@ end
         end
         Pkg.update("BrokenDep") # should trigger auto-precomp including the fixed BrokenDep
         Pkg.precompile(io=iob)
-        @test String(take!(iob)) == "" # test that the previous precompile was a no-op
+        @test !occursin("Precompiling", String(take!(iob))) # test that the previous precompile was a no-op
 
         # https://github.com/JuliaLang/Pkg.jl/pull/2142
         Pkg.build(; verbose=true)


### PR DESCRIPTION
- Fixes a bug in the circular dep suspender that wasn't caught in tests because the `@async` circular dep test wasn't checking for failure, just completion..

- Interrupts faster by leaving in-progress compilecache tasks to finish in background (fixes #2149)

- Add seconds elapsed to report (closes #2151)

- Added handling for when the cache is deleted out from underneath a loaded package, and compilecache doesn't error but returns a `Base.PrecompilableError` (closes #2157)

![image](https://user-images.githubusercontent.com/1694067/97025010-84262e00-1525-11eb-88c7-1e9f040e2760.png)

- Instantiate if not instantiated (doesn't noticeably increase no-op, see comment below)