### PR TITLE
Don't error if a package does not have a `version`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -263,7 +263,8 @@ function collect_project!(ctx::Context, pkg::PackageSpec, path::String,
     if project.version !== nothing
         pkg.version = project.version
     else
-        pkgerror("project file for $(pkg.name) is missing a `version` entry")
+        @warn("project file for $(pkg.name) is missing a `version` entry")
+        pkg.version = VersionNumber(0)
     end
     return
 end


### PR DESCRIPTION
Fixes #2154 
Closes #2161 

@KristofferC Would this be sufficient to fix #2154?