### PR TITLE
change the way compat is uncompressed

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -404,13 +404,10 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                 v = something(proj.version, VERSION)
                 push!(all_versions_u, v)
 
-                for (name, other_uuid) in proj.deps
-                    push!(uuids, other_uuid)
-                end
-
                 # TODO look at compat section for stdlibs?
                 all_compat_u_vr = get_or_make!(all_compat_u, v)
                 for (_, other_uuid) in proj.deps
+                    push!(uuids, other_uuid)
                     all_compat_u_vr[other_uuid] = VersionSpec()
                 end
             else

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -367,6 +367,7 @@ end
 
 get_or_make!(d::Dict{K,V}, k::K) where {K,V} = get!(d, k) do; V() end
 
+const JULIA_UUID = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
 function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve.Requires, fixed::Dict{UUID,Resolve.Fixed})
     uuids = Set{UUID}()
     union!(uuids, keys(reqs))
@@ -434,6 +435,7 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
     end
 
     for uuid in uuids
+        uuid == JULIA_UUID && continue
         if !haskey(uuid_to_name, uuid)
             name = registered_name(ctx, uuid)
             name === nothing && pkgerror("cannot find name corresponding to UUID $(uuid) in a registry")

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -404,6 +404,9 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                 v = something(proj.version, VERSION)
                 push!(all_versions_u, v)
 
+                for (name, other_uuid) in proj.deps
+                    push!(uuids, other_uuid)
+                end
 
                 # TODO look at compat section for stdlibs?
                 all_compat_u_vr = get_or_make!(all_compat_u, v)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -324,7 +324,7 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
         names[pkg.uuid] = pkg.name
     end
     reqs = Resolve.Requires(pkg.uuid => VersionSpec(pkg.version) for pkg in pkgs)
-    graph, deps_map = deps_graph(ctx, names, reqs, fixed)
+    graph, compat_map = deps_graph(ctx, names, reqs, fixed)
     Resolve.simplify_graph!(graph)
     vers = Resolve.resolve(graph)
 
@@ -351,7 +351,11 @@ function resolve_versions!(ctx::Context, pkgs::Vector{PackageSpec})
                 end
                 deps_fixed
             else
-                deps_map[pkg.uuid][pkg.version]
+                d = Dict{String, UUID}()
+                for (uuid, _) in compat_map[pkg.uuid][pkg.version]
+                    d[names[uuid]]  = uuid
+                end
+                d
             end
         end
         # julia is an implicit dependency
@@ -374,12 +378,10 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
     seen = Set{UUID}()
 
     all_versions = VersionsDict()
-    all_deps     = DepsDict()
     all_compat   = CompatDict()
 
     for (fp, fx) in fixed
         all_versions[fp] = Set([fx.version])
-        all_deps[fp]     = Dict(fx.version => valtype(DepsValDict)())
         all_compat[fp]   = Dict(fx.version => valtype(CompatValDict)())
     end
 
@@ -390,7 +392,6 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
             push!(seen, uuid)
             uuid in keys(fixed) && continue
             all_versions_u = get_or_make!(all_versions, uuid)
-            all_deps_u     = get_or_make!(all_deps,     uuid)
             all_compat_u   = get_or_make!(all_compat,   uuid)
 
             # Collect deps + compat for stdlib
@@ -403,16 +404,11 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                 v = something(proj.version, VERSION)
                 push!(all_versions_u, v)
 
-                all_deps_u_vr = get_or_make!(all_deps_u, v)
-                for (name, other_uuid) in proj.deps
-                    all_deps_u_vr[name] = other_uuid
-                    push!(uuids, other_uuid)
-                end
 
                 # TODO look at compat section for stdlibs?
                 all_compat_u_vr = get_or_make!(all_compat_u, v)
-                for (name, other_uuid) in proj.deps
-                    all_compat_u_vr[name] = VersionSpec()
+                for (_, other_uuid) in proj.deps
+                    all_compat_u_vr[other_uuid] = VersionSpec()
                 end
             else
                 for reg in ctx.registries
@@ -428,17 +424,8 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                         end
 
                         push!(all_versions_u, v)
-                        all_deps_u_v = get_or_make!(all_deps_u, v)
-                        all_compat_u_v = get_or_make!(all_compat_u, v)
-                        for (name, other_uuid) in uncompressed_data.deps
-                            # check conflicts??
-                            all_deps_u_v[name] = other_uuid
-                            push!(uuids, other_uuid)
-                        end
-                        for (name,vs) in uncompressed_data.compat
-                            # check conflicts??
-                            all_compat_u_v[name] = vs
-                        end
+                        all_compat_u[v] = uncompressed_data
+                        union!(uuids, keys(uncompressed_data))
                     end
                 end
             end
@@ -456,8 +443,8 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
         end
     end
 
-    return Resolve.Graph(all_versions, all_deps, all_compat, uuid_to_name, reqs, fixed, #=verbose=# ctx.graph_verbose, ctx.julia_version),
-           all_deps
+    return Resolve.Graph(all_versions, all_compat, uuid_to_name, reqs, fixed, #=verbose=# ctx.graph_verbose, ctx.julia_version),
+           all_compat
 end
 
 function load_urls(ctx::Context, pkgs::Vector{PackageSpec})

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -412,7 +412,8 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Resolve
                 end
             else
                 for reg in ctx.registries
-                    pkg = reg[uuid]
+                    pkg = get(reg, uuid, nothing)
+                    pkg === nothing && continue
                     info = Pkg.RegistryHandling.registry_info(pkg)
                     for (v, uncompressed_data) in Pkg.RegistryHandling.uncompressed_data(info)
                         # Filter yanked and if we are in offline mode also downloaded packages

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -260,9 +260,8 @@ mutable struct Graph
         data = GraphData(versions, uuid_to_name, verbose)
         pkgs, np, spp, pdict, pvers, vdict, rlog = data.pkgs, data.np, data.spp, data.pdict, data.pvers, data.vdict, data.rlog
 
-        local extended_deps
-        let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
-            extended_deps = [Vector{Dict{Int,BitVector}}(undef, spp[p0]-1) for p0 = 1:np]
+        extended_deps = let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
+            [Vector{Dict{Int,BitVector}}(undef, spp[p0]-1) for p0 = 1:np]
         end
         for p0 = 1:np, v0 = 1:(spp[p0]-1)
             n2u = Dict{String,UUID}()

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -264,7 +264,6 @@ mutable struct Graph
             [Vector{Dict{Int,BitVector}}(undef, spp[p0]-1) for p0 = 1:np]
         end
         for p0 = 1:np, v0 = 1:(spp[p0]-1)
-            n2u = Dict{String,UUID}()
             vn = pvers[p0][v0]
             req = Dict{Int,VersionSpec}()
             uuid = pkgs[p0]
@@ -276,12 +275,6 @@ mutable struct Graph
                 # (intersecting is used by fixed packages though...)
                 req_p1 = get!(VersionSpec, req, p1)
                 req[p1] = req_p1 ∩ vs
-            end
-            # The remaining dependencies do not have compatibility constraints
-            for uuid in values(n2u)
-                p1 = pdict[uuid]
-                p1 == p0 && continue
-                get!(VersionSpec, req, p1)
             end
             # Translate the requirements into bit masks
             # Hot code, measure performance before changing
@@ -299,9 +292,8 @@ mutable struct Graph
 
         gadj = [Int[] for p0 = 1:np]
         gmsk = [BitMatrix[] for p0 = 1:np]
-        local gconstr
-        let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
-            gconstr = [trues(spp[p0]) for p0 = 1:np]
+        gconstr = let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
+            [trues(spp[p0]) for p0 = 1:np]
         end
         adjdict = [Dict{Int,Int}() for p0 = 1:np]
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -33,12 +33,10 @@ export UUID, SHA1, VersionRange, VersionSpec,
     printpkgstyle, isurl,
     projectfile_path, manifestfile_path,
     RegistrySpec
-export DepsValDict, CompatValDict, VersionsDict, DepsDict, CompatDict
+export CompatValDict, VersionsDict, CompatDict
 
-const DepsValDict   = Dict{VersionNumber,Dict{String,UUID}}
-const CompatValDict = Dict{VersionNumber,Dict{String,VersionSpec}}
+const CompatValDict = Dict{VersionNumber,Dict{UUID,VersionSpec}}
 const VersionsDict  = Dict{UUID,Set{VersionNumber}}
-const DepsDict      = Dict{UUID,DepsValDict}
 const CompatDict    = Dict{UUID,CompatValDict}
 
 const URL_regex = r"((file|git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?"x

--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -227,7 +227,8 @@ end
 
 VersionSpec(r::VersionRange) = VersionSpec(VersionRange[r])
 VersionSpec(v::VersionNumber) = VersionSpec(VersionRange(v))
-VersionSpec() = VersionSpec(VersionRange())
+const _all_versionsspec = VersionSpec(VersionRange())
+VersionSpec() = _all_versionsspec
 VersionSpec(s::AbstractString) = VersionSpec(VersionRange(s))
 VersionSpec(v::AbstractVector) = VersionSpec(map(VersionRange, v))
 

--- a/test/resolve_utils.jl
+++ b/test/resolve_utils.jl
@@ -40,8 +40,7 @@ function graph_from_data(deps_data)
     uuid(p) = storeuuid(p, uuid_to_name)
     fixed = Dict{UUID,Fixed}()
     all_versions = Dict{UUID,Set{VersionNumber}}()
-    all_deps = DepsDict()
-    all_compat = Dict{UUID,Dict{VersionNumber,Dict{String,VersionSpec}}}()
+    all_compat = Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}}()
 
     deps = Dict{String,Dict{VersionNumber,Dict{String,VersionSpec}}}()
     for d in deps_data
@@ -65,18 +64,15 @@ function graph_from_data(deps_data)
         for (vn,vreq) in deps[p], rp in keys(vreq)
             push!(get!(Set{VersionNumber}, deps_pkgs, rp), vn)
         end
-        all_deps[u] = Dict{VersionNumber,Dict{String,UUID}}()
-        all_compat[u] = Dict{VersionNumber,Dict{String,VersionSpec}}()
+        all_compat[u] = Dict{VersionNumber,Dict{UUID,VersionSpec}}()
         for (vn,vreq) in preq
-            all_deps[u][vn] = Dict{String,UUID}()
-            all_compat[u][vn] = Dict{String,VersionSpec}()
+            all_compat[u][vn] = Dict{UUID,VersionSpec}()
             for (rp,rvs) in vreq
-                all_deps[u][vn][rp] = uuid(rp)
-                all_compat[u][vn][rp] = rvs
+                all_compat[u][vn][uuid(rp)] = rvs
             end
         end
     end
-    return Graph(all_versions, all_deps, all_compat, uuid_to_name, Requires(), fixed, VERBOSE)
+    return Graph(all_versions, all_compat, uuid_to_name, Requires(), fixed, VERBOSE)
 end
 function reqs_from_data(reqs_data, graph::Graph)
     reqs = Dict{UUID,VersionSpec}()


### PR DESCRIPTION

The registry has two files `Deps.toml` and `Compat.toml`. This is (I presume!) to make it easier for a human to read the `Compat.toml` file since one can read package names and mostly ignore UUIDs. However, this has also "leaked" into the implementation in Pkg where two dictionaries are created and passed along, and then finally in the Resolver the mapping is done to achieve the finally desired `UUID => VersionRange` compat. This changes it so that the uncompression creates this final data structure at once instead of having the resolver do that work.