### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['nightly']
+        julia-arch: [x64, x86]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        pkg-server: ["https://pkg.julialang.org", ""]
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Run tests
+        run: |
+          julia test/pkg-uuid.jl
+          julia --project --color=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
+          julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+        env:
+          JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
+      - name: Process coverage
+        run: |
+          julia --project=test/coverage --color=yes -e 'using Pkg; Pkg.instantiate();
+          using Coverage; Codecov.submit(Codecov.process_folder())'
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 'nightly'
+      - name: Generate docs
+        run: |
+          julia --color=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"))'
+          julia --project --color=yes -e 'using Pkg; Pkg.activate("docs"); Pkg.instantiate(); Pkg.develop(PackageSpec(path = pwd()))'
+          julia --project=docs --color=yes docs/make.jl pdf
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Run tests
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - name: Fix TEMP on windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          # See https://github.com/actions/virtual-environments/issues/712
+          set TMP=%USERPROFILE%\AppData\Local\Temp
+          set TEMP=%USERPROFILE%\AppData\Local\Temp
       - name: Run tests
         run: |
           julia test/pkg-uuid.jl


### PR DESCRIPTION
I thought it would be worth seeing how CI runs on github actions, given it can be pretty slow on appveyor, and travis has recently been a bit slow to respond

One of the options mentioned in https://github.com/JuliaLang/Pkg.jl/issues/2066

The actions won't appear here until this is merged, or this PR is replicated on a non-fork branch. 
You can see them here https://github.com/ianshmean/Pkg.jl/pull/1 (the coverage processing step will fail on each on that fork)