### PR TITLE
Only do fancy ansi printing in terminals that support it, specifically not on CI

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -13,6 +13,7 @@ import ..Types: parse_toml, write_env_usage, printpkgstyle
 import ..Pkg
 import ..Pkg: pkg_server
 import ..Pkg: MiniProgressBar, showprogress
+import ..Pkg: can_fancyprint
 using ..PlatformEngines
 using SHA
 
@@ -429,19 +430,21 @@ end
 
 function with_show_download_info(f, name, quiet_download)
     if !quiet_download
+        fancyprint = can_fancyprint(stderr)
         # Should ideally pass ctx::Context as first arg here
-        Pkg.print_progress_bottom(stderr)
+        fancyprint && Pkg.print_progress_bottom(stderr)
         printpkgstyle(stderr, :Downloading, "artifact: $name")
-        print(stderr, "\e[?25l") # disable cursor
+        fancyprint && print(stderr, "\e[?25l") # disable cursor
     end
     try
         return f()
     finally
         if !quiet_download
-            print(stdout, "\033[1A") # move cursor up one line
-            print(stdout, "\033[2K") # clear line
+            fancyprint = can_fancyprint(stdout)
+            fancyprint && print(stdout, "\033[1A") # move cursor up one line
+            fancyprint && print(stdout, "\033[2K") # clear line
             printpkgstyle(stdout, :Downloaded, "artifact: $name")
-            print(stdout, "\e[?25h") # put back cursor
+            fancyprint && print(stdout, "\e[?25h") # put back cursor
         end
     end
 end

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -3,6 +3,7 @@
 module GitTools
 
 using ..Pkg
+import ..Pkg: can_fancyprint
 using SHA
 import Base: SHA1
 import LibGit2
@@ -92,7 +93,9 @@ function clone(ctx, url, source_path; header=nothing, credentials=nothing, kwarg
             transfer_payload,
         )
     )
-    print(stdout, "\e[?25l") # disable cursor
+    io = ctx.io
+    fancyprint = can_fancyprint(io)
+    fancyprint && print(io, "\e[?25l") # disable cursor
     if credentials === nothing
         credentials = LibGit2.CachedCredentials()
     end
@@ -112,8 +115,8 @@ function clone(ctx, url, source_path; header=nothing, credentials=nothing, kwarg
         end
     finally
         Base.shred!(credentials)
-        print(stdout, "\033[2K") # clear line
-        print(stdout, "\e[?25h") # put back cursor
+        fancyprint && print(io, "\033[2K") # clear line
+        fancyprint && print(io, "\e[?25h") # put back cursor
     end
 end
 
@@ -123,6 +126,8 @@ function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, cr
             LibGit2.url(remote)
         end
     end
+    io = ctx.io
+    fancyprint = can_fancyprint(io)
     remoteurl = normalize_url(remoteurl)
     Pkg.Types.printpkgstyle(ctx, :Updating, header === nothing ? "git-repo `$remoteurl`" : header)
     transfer_payload = Pkg.MiniProgressBar(header = "Fetching:", color = Base.info_color())
@@ -132,7 +137,7 @@ function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, cr
             transfer_payload,
         )
     )
-    print(stdout, "\e[?25l") # disable cursor
+    fancyprint && print(io, "\e[?25l") # disable cursor
     if credentials === nothing
         credentials = LibGit2.CachedCredentials()
     end
@@ -147,8 +152,8 @@ function fetch(ctx, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, cr
         end
     finally
         Base.shred!(credentials)
-        print(stdout, "\033[2K") # clear line
-        print(stdout, "\e[?25h") # put back cursor
+        fancyprint && print(io, "\033[2K") # clear line
+        fancyprint && print(io, "\e[?25h") # put back cursor
     end
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -34,6 +34,8 @@ const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 const OFFLINE_MODE = Ref(false)
 const DEFAULT_IO = Ref{Union{Nothing,IO}}(nothing)
 
+can_fancyprint(io::IO) = (io isa Base.TTY) && (get(ENV, "CI", nothing) != "true")
+
 include("utils.jl")
 include("GitTools.jl")
 include("PlatformEngines.jl")
@@ -128,12 +130,12 @@ const add = API.add
 
 Precompile all the dependencies of the project in parallel.
 !!! note
-    Errors will only throw when precompiling the top-level dependencies, given that 
+    Errors will only throw when precompiling the top-level dependencies, given that
     not all manifest dependencies may be loaded by the top-level dependencies on the given system.
 
 !!! note
     This method is called automatically after any Pkg action that changes the manifest.
-    Any packages that have previously errored during precompilation won't be retried in auto mode 
+    Any packages that have previously errored during precompilation won't be retried in auto mode
     until they have changed. To disable automatic precompilation set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`
 
 !!! compat "Julia 1.3"


### PR DESCRIPTION
I've noticed ansi cursor codes being printed as text in CI, and it may be happening in IJulia etc.

This introduces a general setting for whether ansi overprinting and more advance cursor movements should be used, based on the heuristic:
```
(io isa Base.TTY) && (get(ENV, "CI", nothing) != "true")
```