### PR TITLE
Auto-precompilation: Remove tip, add env var note to pkg repl help

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -915,8 +915,6 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     # when manually called, unsuspend all packages that were suspended due to precomp errors
     internal_call ? recall_suspended_packages() : precomp_unsuspend!()
 
-    action_help = internal_call ? " (tip: to disable auto-precompilation set ENV[\"JULIA_PKG_PRECOMPILE_AUTO\"]=0)" : ""
-
     direct_deps = [
         Base.PkgId(uuid, name)
         for (name, uuid) in ctx.env.project.deps if !Base.in_sysimage(Base.PkgId(uuid, name))
@@ -1011,7 +1009,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
             wait(first_started)
             (isempty(pkg_queue) || interrupted_or_done.set) && return
             fancyprint && lock(print_lock) do
-                printpkgstyle(io, :Precompiling, "project...$action_help")
+                printpkgstyle(io, :Precompiling, "project...")
                 print(io, ansi_disablecursor)
             end
             t = Timer(0; interval=1/10)
@@ -1103,7 +1101,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
                     iob = IOBuffer()
                     name = is_direct_dep ? pkg.name : string(color_string(pkg.name, :light_black))
                     !fancyprint && lock(print_lock) do
-                        isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...$action_help")
+                        isempty(pkg_queue) && printpkgstyle(io, :Precompiling, "project...")
                     end
                     push!(pkg_queue, pkg)
                     started[pkg] = true

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -308,8 +308,15 @@ PSA[:name => "precompile",
     :help => md"""
     precompile
 
-Precompile all the dependencies of the project by running `import` on all of them in a new process.
+Precompile all the dependencies of the project in parallel.
 The `startup.jl` file is disabled during precompilation unless julia is started with `--startup-file=yes`.
+
+Errors will only throw when precompiling the top-level dependencies, given that
+not all manifest dependencies may be loaded by the top-level dependencies on the given system.
+
+This method is called automatically after any Pkg action that changes the manifest.
+Any packages that have previously errored during precompilation won't be retried in auto mode
+until they have changed. To disable automatic precompilation set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`
 """,
 ],
 PSA[:name => "status",

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -316,7 +316,7 @@ not all manifest dependencies may be loaded by the top-level dependencies on the
 
 This method is called automatically after any Pkg action that changes the manifest.
 Any packages that have previously errored during precompilation won't be retried in auto mode
-until they have changed. To disable automatic precompilation set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`
+until they have changed. To disable automatic precompilation set the environment variable `JULIA_PKG_PRECOMPILE_AUTO=0`
 """,
 ],
 PSA[:name => "status",


### PR DESCRIPTION
Removes the env var tip that was shown each time auto precomp ran. 
Adds a note about it to the pkg repl help