### PR TITLE
Windows: prefer git cloning registries (close #2014)

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -974,7 +974,8 @@ function clone_or_cp_registries(ctx::Context, regs::Vector{RegistrySpec}, depot:
         # clone to tmpdir first
         mktempdir() do tmp
             url, registry_urls = pkg_server_registry_url(reg.uuid, registry_urls)
-            if url !== nothing
+            # on Windows we prefer git cloning because untarring is so slow
+            if !Sys.iswindows() && url !== nothing
                 # download from Pkg server
                 try
                     download_verify_unpack(url, nothing, tmp, ignore_existence = true)


### PR DESCRIPTION
Since untarring a tarball like the registry is so slow on Windows,
we prefer to git clone registries instead. Git is slow on Windows
as well, but git updates are faster since git only updates the
files that need to be modified, which is much faster than unpacking
a whole new registry.