### PR TITLE
Add the `force_latest_compat` keyword argument to `Pkg.test`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -410,6 +410,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, test_fn=nothing,
               julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
               test_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
+              force_latest_compat::Bool=false,
               kwargs...)
     julia_args = Cmd(julia_args)
     test_args = Cmd(test_args)
@@ -424,7 +425,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx.env.manifest, pkgs)
     end
-    Operations.test(ctx, pkgs; coverage=coverage, test_fn=test_fn, julia_args=julia_args, test_args=test_args)
+    Operations.test(ctx, pkgs; coverage=coverage, test_fn=test_fn, julia_args=julia_args, test_args=test_args, force_latest_compat=force_latest_compat)
     return
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -187,9 +187,13 @@ const update = API.up
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
+  - `force_latest_compat::Bool=false`: for each `[compat]` entry in the active project, only allow the latest compatible version of each dependency
 
 !!! compat "Julia 1.3"
     `julia_args` and `test_args` requires at least Julia 1.3.
+
+!!! compat "Julia 1.7"
+    `force_latest_compat` requires at least Julia 1.7.
 
 Run the tests for package `pkg`, or for the current project (which thus needs to be a package) if no
 positional argument is given to `Pkg.test`. A package is tested by running its
@@ -550,7 +554,6 @@ Below is a comparison between the REPL mode and the functional API::
 | `www.myregistry.com` | `RegistrySpec(url="www.myregistry.com")`        |
 """
 const RegistrySpec = Registry.RegistrySpec
-
 
 function __init__()
     DEFAULT_IO[] = stderr

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -930,4 +930,6 @@ end
 
 
 
+include("force-latest-compat.jl")
+
 end # module

--- a/src/force-latest-compat.jl
+++ b/src/force-latest-compat.jl
@@ -1,0 +1,54 @@
+using TOML
+
+function latest_compat(range::VersionRange)
+    lower = range.lower
+    upper = range.upper
+    t_lower = Int.(lower.t[1:lower.n])
+    t_upper = Int.(upper.t[1:upper.n])
+    # `t_lower` is a tuple of integers
+    # `t_upper` is a tuple of integers
+    # `t_lower` and `t_upper` do not necessarily have the same length
+    if VersionNumber(t_lower) > VersionNumber(t_upper)
+        return t_lower
+    else
+        return t_upper
+    end
+end
+
+function latest_compat(s::VersionSpec)
+    ts = latest_compat.(s.ranges)
+    # `ts` is a vector of tuples of integers
+    # the tuples in `ts` may have different lengths
+    vers = VersionNumber.(ts)
+    i = argmax(vers)
+    t = ts[i]
+    new_compat_entry = join(string.(t), ".")
+    return new_compat_entry
+end
+
+function latest_compat(compat_entry::AbstractString)
+    s = semver_spec(compat_entry)
+    return latest_compat(s)
+end
+
+function force_latest_compat(compat_old::AbstractDict{<:AbstractString, <:Any})
+    compat_new = Dict{String,Any}()
+    for (pkg_name, old_compat_entry) in pairs(compat_old)
+        compat_new[pkg_name] = latest_compat(old_compat_entry)
+    end
+    return compat_new
+end
+
+function force_latest_compat(filename::AbstractString)
+    _filename = abspath(filename)
+    project = TOML.parsefile(_filename)
+    compat_old = get(project, "compat", Dict{String,Any}())
+    if !isempty(compat_old)
+        project["compat"] = force_latest_compat(compat_old)
+        rm(_filename; force = true)
+        open(_filename, "w") do io
+            TOML.print(io, project)
+        end
+    end
+    return nothing
+end

--- a/test/force-latest-compat.jl
+++ b/test/force-latest-compat.jl
@@ -1,0 +1,82 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module ForceLatestCompatTests
+
+import ..Pkg # ensure we are using the correct Pkg
+import ..Utils
+using Test
+
+@testset "ForceLatestCompatTests" begin
+    @testset "`Types.latest_compat`" begin
+        @test Pkg.Types.latest_compat("1, 3.4, 5.6.7") == "5.6.7"
+        @test Pkg.Types.latest_compat("1, 4.5.6, 2.3") == "4.5.6"
+        @test Pkg.Types.latest_compat("1, 4.5, 2.3") == "4.5.0"
+        @test Pkg.Types.latest_compat("1, 4.5, 2.3.6") == "4.5.0"
+        @test Pkg.Types.latest_compat("1.5.7, 4, 2.3.6") == "4"
+    end
+
+    @testset "`Types.force_latest_compat`" begin
+        before = """
+        [compat]
+        PkgA = "1, 4.5.6, 2.3"
+        """
+        expected_after = """
+        [compat]
+        PkgA = "4.5.6"
+        """
+        tmp_dir = mktempdir(; cleanup = true)
+        project_file = joinpath(tmp_dir, "Project.toml")
+        open(project_file, "w") do io
+            println(io, before)
+        end
+        @test strip(read(project_file, String)) == strip(before)
+        Pkg.Types.force_latest_compat(project_file)
+        @test strip(read(project_file, String)) == strip(expected_after)
+        rm(tmp_dir; force = true, recursive = true)
+    end
+
+    @testset "`force_latest_compat` kwarg to `Pkg.test`" begin
+        parent_dir = joinpath(@__DIR__, "test_packages", "force-latest-compat")
+        @testset "OldOnly: `SomePkg = \"0.1\"`" begin
+            tmp_dir = mktempdir(; cleanup = true)
+            test_package = joinpath(tmp_dir, "OldOnly")
+            cp(joinpath(parent_dir, "OldOnly"), test_package; force = true)
+            Utils.isolate() do
+                Pkg.activate(test_package)
+                Pkg.instantiate()
+                Pkg.build()
+                @test Pkg.test(; force_latest_compat = false) == nothing
+                @test Pkg.test(; force_latest_compat = false) == nothing
+            end
+            rm(tmp_dir; force = true, recursive = true)
+        end
+        @testset "BothOldAndNew: `SomePkg = \"0.1, 0.2\"`" begin
+            tmp_dir = mktempdir(; cleanup = true)
+            test_package = joinpath(tmp_dir, "BothOldAndNew")
+            cp(joinpath(parent_dir, "BothOldAndNew"), test_package; force = true)
+            Utils.isolate() do
+                Pkg.activate(test_package)
+                Pkg.instantiate()
+                Pkg.build()
+                @test Pkg.test(; force_latest_compat = false) == nothing
+                @test_throws Pkg.Resolve.ResolverError Pkg.test(; force_latest_compat = true)
+            end
+            rm(tmp_dir; force = true, recursive = true)
+        end
+        @testset "NewOnly: `SomePkg = \"0.2\"`" begin
+            tmp_dir = mktempdir(; cleanup = true)
+            test_package = joinpath(tmp_dir, "NewOnly")
+            cp(joinpath(parent_dir, "NewOnly"), test_package; force = true)
+            Utils.isolate() do
+                Pkg.activate(test_package)
+                Pkg.instantiate()
+                Pkg.build()
+                @test_throws Pkg.Resolve.ResolverError Pkg.test(; force_latest_compat = false)
+                @test_throws Pkg.Resolve.ResolverError Pkg.test(; force_latest_compat = true)
+            end
+            rm(tmp_dir; force = true, recursive = true)
+        end
+    end
+end
+
+end # end module ForceLatestCompatTests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ include("binaryplatforms.jl")
 include("platformengines.jl")
 include("sandbox.jl")
 include("resolve.jl")
+include("force-latest-compat.jl")
 include("misc.jl")
 
 # clean up locally cached registry

--- a/test/test_packages/force-latest-compat/BothOldAndNew/.gitignore
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/test/test_packages/force-latest-compat/BothOldAndNew/Project.toml
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/Project.toml
@@ -1,0 +1,18 @@
+name = "BothOldAndNew"
+uuid = "ebb7d249-15d2-4389-abff-d529bd2cf37c"
+authors = ["Dilum Aluthge <dilum@aluthge.com>"]
+version = "0.1.0"
+
+[deps]
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+
+[compat]
+MLJModelInterface = "0.1, 0.2"
+ScientificTypes = "0.6"
+
+[extras]
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ScientificTypes", "Test"]

--- a/test/test_packages/force-latest-compat/BothOldAndNew/src/BothOldAndNew.jl
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/src/BothOldAndNew.jl
@@ -1,0 +1,7 @@
+module BothOldAndNew
+
+import MLJModelInterface
+
+f(x) = x + x
+
+end # module

--- a/test/test_packages/force-latest-compat/BothOldAndNew/test/runtests.jl
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/test/runtests.jl
@@ -1,0 +1,7 @@
+import BothOldAndNew
+import ScientificTypes
+import Test
+
+Test.@testset "BothOldAndNew.jl" begin
+    Test.@test BothOldAndNew.f(1) == 2
+end

--- a/test/test_packages/force-latest-compat/NewOnly/.gitignore
+++ b/test/test_packages/force-latest-compat/NewOnly/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/test/test_packages/force-latest-compat/NewOnly/Project.toml
+++ b/test/test_packages/force-latest-compat/NewOnly/Project.toml
@@ -1,0 +1,18 @@
+name = "NewOnly"
+uuid = "2c7b3c3b-62b6-437a-a36e-3d5963db0b1f"
+authors = ["Dilum Aluthge <dilum@aluthge.com>"]
+version = "0.1.0"
+
+[deps]
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+
+[compat]
+MLJModelInterface = "0.2"
+ScientificTypes = "0.6"
+
+[extras]
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ScientificTypes", "Test"]

--- a/test/test_packages/force-latest-compat/NewOnly/src/NewOnly.jl
+++ b/test/test_packages/force-latest-compat/NewOnly/src/NewOnly.jl
@@ -1,0 +1,7 @@
+module NewOnly
+
+import MLJModelInterface
+
+f(x) = x + x
+
+end # module

--- a/test/test_packages/force-latest-compat/NewOnly/test/runtests.jl
+++ b/test/test_packages/force-latest-compat/NewOnly/test/runtests.jl
@@ -1,0 +1,7 @@
+import NewOnly
+import ScientificTypes
+import Test
+
+Test.@testset "NewOnly.jl" begin
+    Test.@test NewOnly.f(1) == 2
+end

--- a/test/test_packages/force-latest-compat/OldOnly/.gitignore
+++ b/test/test_packages/force-latest-compat/OldOnly/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/test/test_packages/force-latest-compat/OldOnly/Project.toml
+++ b/test/test_packages/force-latest-compat/OldOnly/Project.toml
@@ -1,0 +1,18 @@
+name = "OldOnly"
+uuid = "abc047b9-6ad4-4533-a374-d50ae908e3e9"
+authors = ["Dilum Aluthge <dilum@aluthge.com>"]
+version = "0.1.0"
+
+[deps]
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+
+[compat]
+MLJModelInterface = "0.1"
+ScientificTypes = "0.6"
+
+[extras]
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ScientificTypes", "Test"]

--- a/test/test_packages/force-latest-compat/OldOnly/src/OldOnly.jl
+++ b/test/test_packages/force-latest-compat/OldOnly/src/OldOnly.jl
@@ -1,0 +1,7 @@
+module OldOnly
+
+import MLJModelInterface
+
+f(x) = x + x
+
+end # module

--- a/test/test_packages/force-latest-compat/OldOnly/test/runtests.jl
+++ b/test/test_packages/force-latest-compat/OldOnly/test/runtests.jl
@@ -1,0 +1,7 @@
+import OldOnly
+import ScientificTypes
+import Test
+
+Test.@testset "OldOnly.jl" begin
+    Test.@test OldOnly.f(1) == 2
+end


### PR DESCRIPTION
This pull request adds the `force_latest_compat` keyword argument to the `Pkg.test` function.

When `force_latest_compat` is `true`, then, for each `[compat]` entry in the active project, only the latest compatible version will be allowed.

The default value is `force_latest_compat = false`.

### Motivation

Suppose that you have a bot (e.g. CompatHelper or Dependabot) that opens pull requests to widen your `[compat]` entries whenever one of your dependencies makes a new breaking release. 

And suppose that originally your package's `Project.toml` file looks like this:
```toml
[compat]
SomePackage = "1"
```

The bot opens a PR to change your package's `Project.toml` file to this:
```toml
[compat]
SomePackage = "1, 2"
```

Now, your CI runs your test suite with this new `Project.toml` file. The problem is that, during the test suite, `Pkg.test` might choose to run your package's tests with version 1 of SomePackage.jl. Therefore, even if your CI tests pass, you don't know whether or not your package is compatible with version 2 of SomePackage.jl.

The solution is to modify your CI test script. Instead of using this as your test script (in Travis CI, AppVeyor CI, GitHub Actions CI, etc.):
```julia
Pkg.test(coverage=true)
```

You would have this as your CI test script instead:
```julia
Pkg.test(coverage=true, force_latest_compat=true)
```

This will guarantee that your tests will run with version 2 of SomePackage.jl.