### PR TITLE
remove duplicated tests and move registry into place instead of copying

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1011,7 +1011,7 @@ function clone_or_cp_registries(io::IO, regs::Vector{RegistrySpec}, depot::Strin
                         "`$(Base.contractuser(joinpath(depot, "registries", registry["name"]*"-2")))`."))
                 end
             else
-                cp(tmp, regpath)
+                mv(tmp, regpath)
                 printpkgstyle(io, :Added, "registry `$(registry["name"])` to `$(Base.contractuser(regpath))`")
             end
         end
@@ -1110,7 +1110,7 @@ function update_registries(io::IO, regs::Vector{RegistrySpec} = collect_registri
                             registry_file = joinpath(tmp, "Registry.toml")
                             registry = read_registry(registry_file; cache=false)
                             verify_registry(registry)
-                            cp(tmp, reg.path, force=true)
+                            mv(tmp, reg.path, force=true)
                         end
                     end
                 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -45,21 +45,6 @@ using ..Utils
     end
 end
 
-@testset "Pkg.test" begin
-    temp_pkg_dir() do tmp
-        copy_test_package(tmp, "TestArguments")
-        Pkg.activate(joinpath(tmp, "TestArguments"))
-        # test the old code path (no test/Project.toml)
-        Pkg.test("TestArguments"; test_args=`a b`, julia_args=`--quiet --check-bounds=no`)
-        Pkg.test("TestArguments"; test_args=["a", "b"], julia_args=["--quiet", "--check-bounds=no"])
-        # test new code path
-        touch(joinpath(tmp, "TestArguments", "test", "Project.toml"))
-        Pkg.test("TestArguments"; test_args=`a b`, julia_args=`--quiet --check-bounds=no`)
-        Pkg.test("TestArguments"; test_args=["a", "b"], julia_args=["--quiet", "--check-bounds=no"])
-    end
-end
-
-
 include("FakeTerminals.jl")
 import .FakeTerminals.FakeTerminal
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -1822,10 +1822,6 @@ end
         @test api == Pkg.precompile
         @test isempty(opts)
     end
-    # smoke test
-    isolate() do
-        Pkg.precompile()
-    end
 end
 
 #


### PR DESCRIPTION
Makes a significant impact on CI time (and probably on user time) on especially Windows.