### PR TITLE
CI: make registry available in temp_pkg_dir

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,7 +11,8 @@ export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
 
 const LOADED_DEPOT = joinpath(@__DIR__, "loaded_depot")
 
-const REGISTRY_DIR = joinpath(@__DIR__, "registries", "General")
+const REGISTRY_DEPOT = joinpath(@__DIR__, "registry_depot")
+const REGISTRY_DIR = joinpath(REGISTRY_DEPOT, "registries", "General")
 
 
 function isolate(fn::Function; loaded_depot=false)
@@ -102,6 +103,7 @@ function temp_pkg_dir(fn::Function;rm=true)
             try
                 push!(LOAD_PATH, "@", "@v#.#", "@stdlib")
                 push!(DEPOT_PATH, depot_dir)
+                push!(DEPOT_PATH, REGISTRY_DEPOT)
                 fn(env_dir)
             finally
                 try


### PR DESCRIPTION
Takes off another chunk on mac builder CI time. Let's see how it does on Windows.