### PR TITLE
Don't do autoprecomp after Pkg.dev

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1185,7 +1185,10 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         end
         if !isempty(precomperr_deps)
             plural = length(precomperr_deps) == 1 ? "y" : "ies"
-            str *= "\n" * color_string(string(length(precomperr_deps)), Base.warn_color()) * " dependenc$(plural) may not be precompilable. Try restarting julia"
+            str *= string("\n",
+                color_string(string(length(precomperr_deps)), Base.warn_color()),
+                " dependenc$(plural) failed but may be precompilable after restarting julia"
+            )
         end
         if internal_call && !isempty(failed_deps)
             plural = length(failed_deps) == 1 ? "y" : "ies"

--- a/src/API.jl
+++ b/src/API.jl
@@ -73,7 +73,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
             ctx = Context()
             Types.clone_default_registries(ctx)
             ret = $f(ctx, pkgs; kwargs...)
-            $(f in (:develop, :add, :up, :pin, :free, :build)) && _auto_precompile(ctx)
+            $(f in (:add, :up, :pin, :free, :build)) && _auto_precompile(ctx)
             return ret
         end
         $f(ctx::Context; kwargs...) = $f(ctx, PackageSpec[]; kwargs...)


### PR DESCRIPTION
Fixes #2195 

I also tweaked the message for `?` precomp errors, which are usually because the package is loaded and thus not in a precompilable state, but that's not the only reason.. so the advice is to try restarting julia which will usually fix it.