### PR TITLE
normalize potentially invalid chars in get_server_dir

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -50,7 +50,9 @@ function get_server_dir(url::AbstractString, server=pkg_server())
         @warn "malformed Pkg server value" server
         return
     end
-    joinpath(depots1(), "servers", String(m.captures[1]))
+    # normalize a few characters
+    domain = replace(m.captures[1], r"[\\\/\:\*\?\"\<\>\|]" => "-")
+    joinpath(depots1(), "servers", domain)
 end
 
 const AUTH_ERROR_HANDLERS = Pair{Union{String, Regex},Any}[]

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -215,6 +215,9 @@ end
         test_server_dir("https://foo.bar/baz", "https://foo.bar/baz", "foo.bar")
         test_server_dir("https://foo.bar/baz/a", "https://foo.bar/baz", "foo.bar")
         test_server_dir("https://foo.bar/baz/a", "https://foo.bar/baz", "foo.bar")
+        test_server_dir("https://foo.bar:8080/baz/a", "https://foo.bar:8080/baz", "foo.bar-8080")
+        test_server_dir("https://foo.bar:8080", "https://foo.bar:8080", "foo.bar-8080")
+        @test startswith(PlatformEngines.get_server_dir("https://foo.bar:8080", "https://foo.bar:8080"), Pkg.depots1())
     end
 
     called = 0


### PR DESCRIPTION
`get_server_dir` breaks on Windows if the package server includes a port, because 
```
julia> joinpath("/asd", "foo:20")
"foo:20"
```