### PR TITLE
Clarify `Pkg.add` docstring

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -102,11 +102,11 @@ Add a package to the current project. This package will be available by using th
 `import` and `using` keywords in the Julia REPL, and if the current project is
 a package, also inside that package.
 
-## Resolution Tiers
-`Pkg` resolves the set of packages in your environment using an algorithm that operates in one of four
-tiers, or modes. Which of these is used can be controlled by the `preserve` keyword argument,
-which should take one of the values shown below (starting with the strictest). The command will fail if
-there is no solution preserving what you request.
+## Tiered Resolution
+`Pkg.add` resolves the set of packages in your environment using an algorithm that treats previously installed 
+packages in one of four ways. Which of these is used is chosen automatically by default, and can be controlled
+with the `preserve` keyword argument, which takes the values shown below.
+The command will fail if there is no solution preserving what you request.
 
 | Value             | Description                                                                         |
 |:------------------|:------------------------------------------------------------------------------------|
@@ -114,7 +114,7 @@ there is no solution preserving what you request.
 | `PRESERVE_DIRECT` | Preserve the state of all existing direct dependencies                              |
 | `PRESERVE_SEMVER` | Preserve semver-compatible versions of direct dependencies                          |
 | `PRESERVE_NONE`   | Do not attempt to preserve any version information                                  |
-| `PRESERVE_TIERED` | Select from the above tiers the one which preserves the most version information, while still allowing a solution. (This is the default.) |
+| `PRESERVE_TIERED` | Select from the above four the one which preserves the most version information, while allowing a solution. (This is the default.) |
 
 !!! compat "Julia 1.4"
     The `preserve` keyword argument requires at least Julia 1.4. 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -103,23 +103,22 @@ Add a package to the current project. This package will be available by using th
 a package, also inside that package.
 
 ## Resolution Tiers
-`Pkg` resolves the set of packages in your environment using an algorithm that operates in one of several
+`Pkg` resolves the set of packages in your environment using an algorithm that operates in one of four
 tiers, or modes. Which of these is used can be controlled by the `preserve` keyword argument,
 which should take one of the following values (in order of decreasing strictness):
 
 | Value             | Description                                                                         |
 |:------------------|:------------------------------------------------------------------------------------|
 | `PRESERVE_ALL`    | Preserve the state of all existing dependencies (including recursive dependencies)  |
-| `PRESERVE_DIRECT` | Preserve the state of all existing direct dependencies                              |
+| `PRESERVE_DIRECT` | Preserve the state of all existing direct dependencies. Error if this is impossible.|
 | `PRESERVE_SEMVER` | Preserve semver-compatible versions of direct dependencies                          |
 | `PRESERVE_NONE`   | Do not attempt to preserve any version information                                  |
-| `PRESERVE_TIERED` | Use the tier which will preserve the most version information (this is the default) |
+| `PRESERVE_TIERED` | Select from the above tiers the one which preserves the most version information, while still alowing a solution. (This is the default.) |
 
 !!! compat "Julia 1.4"
     The `preserve` keyword argument requires at least Julia 1.4. 
-
     When `Pkg.test` adds test dependencies, the resolver's behaviour on Julia 1.3 and earlier
-    is equivalent to `PRESERVE_ALL`, rather than `PRESERVE_TIERED`. This may fail if a recursive dependency 
+    is equivalent to `PRESERVE_ALL`, rather than `PRESERVE_TIERED`. This may fail if a direct or recursive dependency 
     has already been added, before testing, at a version incompatable with a test dependency.
 
 # Examples

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -105,15 +105,16 @@ a package, also inside that package.
 ## Resolution Tiers
 `Pkg` resolves the set of packages in your environment using an algorithm that operates in one of four
 tiers, or modes. Which of these is used can be controlled by the `preserve` keyword argument,
-which should take one of the following values (in order of decreasing strictness):
+which should take one of the values shown below (starting with the strictest). The command will fail if
+there is no solution preserving what you request.
 
 | Value             | Description                                                                         |
 |:------------------|:------------------------------------------------------------------------------------|
 | `PRESERVE_ALL`    | Preserve the state of all existing dependencies (including recursive dependencies)  |
-| `PRESERVE_DIRECT` | Preserve the state of all existing direct dependencies. Error if this is impossible.|
+| `PRESERVE_DIRECT` | Preserve the state of all existing direct dependencies                              |
 | `PRESERVE_SEMVER` | Preserve semver-compatible versions of direct dependencies                          |
 | `PRESERVE_NONE`   | Do not attempt to preserve any version information                                  |
-| `PRESERVE_TIERED` | Select from the above tiers the one which preserves the most version information, while still alowing a solution. (This is the default.) |
+| `PRESERVE_TIERED` | Select from the above tiers the one which preserves the most version information, while still allowing a solution. (This is the default.) |
 
 !!! compat "Julia 1.4"
     The `preserve` keyword argument requires at least Julia 1.4. 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -103,9 +103,9 @@ Add a package to the current project. This package will be available by using th
 a package, also inside that package.
 
 ## Resolution Tiers
-`Pkg` resolves the set of packages in your environment using a tiered algorithm.
-The `preserve` keyword argument allows you to key into a specific tier in the resolve algorithm.
-The following table describes the argument values for `preserve` (in order of strictness):
+`Pkg` resolves the set of packages in your environment using an algorithm that operates in one of several
+tiers, or modes. Which of these is used can be controlled by the `preserve` keyword argument,
+which should take one of the following values (in order of decreasing strictness):
 
 | Value             | Description                                                                         |
 |:------------------|:------------------------------------------------------------------------------------|
@@ -115,12 +115,21 @@ The following table describes the argument values for `preserve` (in order of st
 | `PRESERVE_NONE`   | Do not attempt to preserve any version information                                  |
 | `PRESERVE_TIERED` | Use the tier which will preserve the most version information (this is the default) |
 
+!!! compat "Julia 1.4"
+    The `preserve` keyword argument requires at least Julia 1.4. 
+
+    When `Pkg.test` adds test dependencies, the resolver's behaviour on Julia 1.3 and earlier
+    is equivalent to `PRESERVE_ALL`, rather than `PRESERVE_TIERED`. This may fail if a recursive dependency 
+    has already been added, before testing, at a version incompatable with a test dependency.
+
 # Examples
 ```julia
 Pkg.add("Example") # Add a package from registry
 Pkg.add("Example"; preserve=Pkg.PRESERVE_ALL) # Add the `Example` package and preserve existing dependencies
+
 Pkg.add(name="Example", version="0.3") # Specify version; latest release in the 0.3 series
 Pkg.add(name="Example", version="0.3.1") # Specify version; exact release
+
 Pkg.add(url="https://github.com/JuliaLang/Example.jl", rev="master") # From url to remote gitrepo
 Pkg.add(url="/remote/mycompany/juliapackages/OurPackage") # From path to local gitrepo
 Pkg.add(url="https://github.com/Company/MonoRepo", subdir="juliapkgs/Package.jl)") # With subdir


### PR DESCRIPTION
This wasn't clear to me, and didn't include mention of what version of Julia it applies to.

I'm still not completely sure what the noun "tier" is meant to refer to here:
* One possibility is that it means the mode in which the resolver operates. I think there are there 4 such modes.
* Another is that it refers to a subset of packages, to be treated differently. Such as those already installed, vs. those being installed by this command. Then there are exactly 2 tiers, always?

So I picked one, but would be happy to re-write if this is wrong. 

It's possible that the story about how test deps are added should be referenced / explained a bit in the `Pkg.test` docstring, too. But I haven't done that here.