### PR TITLE
Set `force_latest_compat=true` by default on Dependabot/CompatHelper PRs, and set `force_latest_compat=false` by default otherwise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ docs/build
 /docs/src/repl.md
 .DS_Store
 /test/registries/*
+/test/registry_depot/*
 /test/loaded_depot/*

--- a/src/API.jl
+++ b/src/API.jl
@@ -320,6 +320,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, test_fn=nothing,
               julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
               test_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
+              force_latest_compat::Bool=false,
               kwargs...)
     julia_args = Cmd(julia_args)
     test_args = Cmd(test_args)
@@ -334,7 +335,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx.env.manifest, pkgs)
     end
-    Operations.test(ctx, pkgs; coverage=coverage, test_fn=test_fn, julia_args=julia_args, test_args=test_args)
+    Operations.test(ctx, pkgs; coverage=coverage, test_fn=test_fn, julia_args=julia_args, test_args=test_args, force_latest_compat=force_latest_compat)
     return
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -320,7 +320,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, test_fn=nothing,
               julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
               test_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
-              force_latest_compat::Bool=false,
+              force_latest_compat::Union{Bool, Symbol}=:autodetect,
               kwargs...)
     julia_args = Cmd(julia_args)
     test_args = Cmd(test_args)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -10,7 +10,7 @@ import REPL
 using REPL.TerminalMenus
 using ..Types, ..Resolve, ..PlatformEngines, ..GitTools, ..MiniProgressBars
 import ..depots, ..depots1, ..devdir, ..set_readonly, ..Types.PackageEntry
-import ..Types.latest_compat, ..Types.force_latest_compat
+import ..Types.latest_compat, ..Types.force_latest_compat, ..Types.decide_force_latest_compat
 import ..Artifacts: ensure_all_artifacts_installed, artifact_names, extract_all_hashes, artifact_exists
 using Base.BinaryPlatforms
 import ...Pkg
@@ -1391,7 +1391,7 @@ end
 
 # ctx + pkg used to compute parent dep graph
 function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::String,
-                 sandbox_path::String, sandbox_project_override; force_latest_compat::Bool=false)
+                 sandbox_path::String, sandbox_project_override; force_latest_compat::Union{Bool, Symbol}=:autodetect)
     active_manifest = manifestfile_path(dirname(ctx.env.project_file))
     sandbox_project = projectfile_path(sandbox_path)
 
@@ -1406,7 +1406,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
             cp(sandbox_project, tmp_project)
             chmod(tmp_project, 0o600)
         end
-        if force_latest_compat
+        if Types.decide_force_latest_compat(force_latest_compat)
             Types.force_latest_compat(tmp_project)
             chmod(tmp_project, 0o600)
         end
@@ -1526,7 +1526,7 @@ testdir(source_path::String) = joinpath(source_path, "test")
 testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, julia_args::Cmd=``, test_args::Cmd=``,
-              test_fn=nothing, force_latest_compat::Bool=false)
+              test_fn=nothing, force_latest_compat::Union{Bool, Symbol}=:autodetect)
     Pkg.instantiate(ctx; allow_autoprecomp = false)
 
     # load manifest data

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -187,9 +187,13 @@ const update = API.up
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
+  - `force_latest_compat::Bool=false`: for each `[compat]` entry in the active project, only allow the latest compatible version of each dependency
 
 !!! compat "Julia 1.3"
     `julia_args` and `test_args` requires at least Julia 1.3.
+
+!!! compat "Julia 1.7"
+    `force_latest_compat` requires at least Julia 1.7.
 
 Run the tests for package `pkg`, or for the current project (which thus needs to be a package) if no
 positional argument is given to `Pkg.test`. A package is tested by running its
@@ -542,7 +546,6 @@ Below is a comparison between the REPL version and the API version:
 | `www.myregistry.com` | `RegistrySpec(url="www.myregistry.com")`        |
 """
 const RegistrySpec = Types.RegistrySpec
-
 
 function __init__()
     DEFAULT_IO[] = stderr

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -187,7 +187,7 @@ const update = API.up
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
-  - `force_latest_compat::Bool=false`: for each `[compat]` entry in the active project, only allow the latest compatible version of each dependency
+  - `force_latest_compat::Union{Bool, Symbol}=:autodetect`: for each `[compat]` entry in the active project, only allow the latest compatible version of each dependency
 
 !!! compat "Julia 1.3"
     `julia_args` and `test_args` requires at least Julia 1.3.

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1308,4 +1308,6 @@ parse_toml(path::String; fakeit::Bool=false) = parse_toml(TOML.Parser(), path; f
 parse_toml(parser::TOML.Parser, path::String; fakeit::Bool=false) =
     !fakeit || isfile(path) ? TOML.parsefile(parser, path) : Dict{String,Any}()
 
+include("force-latest-compat.jl")
+
 end # module

--- a/src/force-latest-compat.jl
+++ b/src/force-latest-compat.jl
@@ -1,0 +1,54 @@
+using TOML
+
+function latest_compat(range::VersionRange)
+    lower = range.lower
+    upper = range.upper
+    t_lower = Int.(lower.t[1:lower.n])
+    t_upper = Int.(upper.t[1:upper.n])
+    # `t_lower` is a tuple of integers
+    # `t_upper` is a tuple of integers
+    # `t_lower` and `t_upper` do not necessarily have the same length
+    if VersionNumber(t_lower) > VersionNumber(t_upper)
+        return t_lower
+    else
+        return t_upper
+    end
+end
+
+function latest_compat(s::VersionSpec)
+    ts = latest_compat.(s.ranges)
+    # `ts` is a vector of tuples of integers
+    # the tuples in `ts` may have different lengths
+    vers = VersionNumber.(ts)
+    i = argmax(vers)
+    t = ts[i]
+    new_compat_entry = join(string.(t), ".")
+    return new_compat_entry
+end
+
+function latest_compat(compat_entry::AbstractString)
+    s = semver_spec(compat_entry)
+    return latest_compat(s)
+end
+
+function force_latest_compat(compat_old::AbstractDict{<:AbstractString, <:Any})
+    compat_new = Dict{String,Any}()
+    for (pkg_name, old_compat_entry) in pairs(compat_old)
+        compat_new[pkg_name] = latest_compat(old_compat_entry)
+    end
+    return compat_new
+end
+
+function force_latest_compat(filename::AbstractString)
+    _filename = abspath(filename)
+    project = TOML.parsefile(_filename)
+    compat_old = get(project, "compat", Dict{String,Any}())
+    if !isempty(compat_old)
+        project["compat"] = force_latest_compat(compat_old)
+        rm(_filename; force = true)
+        open(_filename, "w") do io
+            TOML.print(io, project)
+        end
+    end
+    return nothing
+end

--- a/src/force-latest-compat.jl
+++ b/src/force-latest-compat.jl
@@ -83,12 +83,10 @@ function is_dependabot_job()
     return any(is_dependabot_branch.(chop_refs_head.(possible_branch_names)))
 end
 
-function decide_force_latest_compat(force_latest_compat_value::Union{Bool, Symbol})
-    if force_latest_compat_value === true
-        return true
-    elseif force_latest_compat_value === false
-        return false
-    elseif force_latest_compat_value === :autodetect
+decide_force_latest_compat(force_latest_compat_value::Bool) = force_latest_compat_value
+
+function decide_force_latest_compat(force_latest_compat_value::Symbol)
+    if force_latest_compat_value === :autodetect
         return is_dependabot_job()
     else
         msg = "Invalid value for force_latest_compat: $(force_latest_compat_value)"

--- a/test/force-latest-compat.jl
+++ b/test/force-latest-compat.jl
@@ -1,0 +1,82 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module ForceLatestCompatTests
+
+import ..Pkg # ensure we are using the correct Pkg
+import ..Utils
+using Test
+
+@testset "ForceLatestCompatTests" begin
+    @testset "`Types.latest_compat`" begin
+        @test Pkg.Types.latest_compat("1, 3.4, 5.6.7") == "5.6.7"
+        @test Pkg.Types.latest_compat("1, 4.5.6, 2.3") == "4.5.6"
+        @test Pkg.Types.latest_compat("1, 4.5, 2.3") == "4.5.0"
+        @test Pkg.Types.latest_compat("1, 4.5, 2.3.6") == "4.5.0"
+        @test Pkg.Types.latest_compat("1.5.7, 4, 2.3.6") == "4"
+    end
+
+    @testset "`Types.force_latest_compat`" begin
+        before = """
+        [compat]
+        PkgA = "1, 4.5.6, 2.3"
+        """
+        expected_after = """
+        [compat]
+        PkgA = "4.5.6"
+        """
+        tmp_dir = mktempdir(; cleanup = true)
+        project_file = joinpath(tmp_dir, "Project.toml")
+        open(project_file, "w") do io
+            println(io, before)
+        end
+        @test strip(read(project_file, String)) == strip(before)
+        Pkg.Types.force_latest_compat(project_file)
+        @test strip(read(project_file, String)) == strip(expected_after)
+        rm(tmp_dir; force = true, recursive = true)
+    end
+
+    @testset "`force_latest_compat` kwarg to `Pkg.test`" begin
+        parent_dir = joinpath(@__DIR__, "test_packages", "force-latest-compat")
+        @testset "OldOnly: `SomePkg = \"0.1\"`" begin
+            tmp_dir = mktempdir(; cleanup = true)
+            test_package = joinpath(tmp_dir, "OldOnly")
+            cp(joinpath(parent_dir, "OldOnly"), test_package; force = true)
+            Utils.isolate() do
+                Pkg.activate(test_package)
+                Pkg.instantiate()
+                Pkg.build()
+                @test Pkg.test(; force_latest_compat = false) == nothing
+                @test Pkg.test(; force_latest_compat = false) == nothing
+            end
+            rm(tmp_dir; force = true, recursive = true)
+        end
+        @testset "BothOldAndNew: `SomePkg = \"0.1, 0.2\"`" begin
+            tmp_dir = mktempdir(; cleanup = true)
+            test_package = joinpath(tmp_dir, "BothOldAndNew")
+            cp(joinpath(parent_dir, "BothOldAndNew"), test_package; force = true)
+            Utils.isolate() do
+                Pkg.activate(test_package)
+                Pkg.instantiate()
+                Pkg.build()
+                @test Pkg.test(; force_latest_compat = false) == nothing
+                @test_throws Pkg.Resolve.ResolverError Pkg.test(; force_latest_compat = true)
+            end
+            rm(tmp_dir; force = true, recursive = true)
+        end
+        @testset "NewOnly: `SomePkg = \"0.2\"`" begin
+            tmp_dir = mktempdir(; cleanup = true)
+            test_package = joinpath(tmp_dir, "NewOnly")
+            cp(joinpath(parent_dir, "NewOnly"), test_package; force = true)
+            Utils.isolate() do
+                Pkg.activate(test_package)
+                Pkg.instantiate()
+                Pkg.build()
+                @test_throws Pkg.Resolve.ResolverError Pkg.test(; force_latest_compat = false)
+                @test_throws Pkg.Resolve.ResolverError Pkg.test(; force_latest_compat = true)
+            end
+            rm(tmp_dir; force = true, recursive = true)
+        end
+    end
+end
+
+end # end module ForceLatestCompatTests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ include("binaryplatforms.jl")
 include("platformengines.jl")
 include("sandbox.jl")
 include("resolve.jl")
+include("force-latest-compat.jl")
 
 # clean up locally cached registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)

--- a/test/test_packages/force-latest-compat/BothOldAndNew/.gitignore
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/test/test_packages/force-latest-compat/BothOldAndNew/Project.toml
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/Project.toml
@@ -1,0 +1,18 @@
+name = "BothOldAndNew"
+uuid = "ebb7d249-15d2-4389-abff-d529bd2cf37c"
+authors = ["Dilum Aluthge <dilum@aluthge.com>"]
+version = "0.1.0"
+
+[deps]
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+
+[compat]
+MLJModelInterface = "0.1, 0.2"
+ScientificTypes = "0.6"
+
+[extras]
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ScientificTypes", "Test"]

--- a/test/test_packages/force-latest-compat/BothOldAndNew/src/BothOldAndNew.jl
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/src/BothOldAndNew.jl
@@ -1,0 +1,7 @@
+module BothOldAndNew
+
+import MLJModelInterface
+
+f(x) = x + x
+
+end # module

--- a/test/test_packages/force-latest-compat/BothOldAndNew/test/runtests.jl
+++ b/test/test_packages/force-latest-compat/BothOldAndNew/test/runtests.jl
@@ -1,0 +1,7 @@
+import BothOldAndNew
+import ScientificTypes
+import Test
+
+Test.@testset "BothOldAndNew.jl" begin
+    Test.@test BothOldAndNew.f(1) == 2
+end

--- a/test/test_packages/force-latest-compat/NewOnly/.gitignore
+++ b/test/test_packages/force-latest-compat/NewOnly/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/test/test_packages/force-latest-compat/NewOnly/Project.toml
+++ b/test/test_packages/force-latest-compat/NewOnly/Project.toml
@@ -1,0 +1,18 @@
+name = "NewOnly"
+uuid = "2c7b3c3b-62b6-437a-a36e-3d5963db0b1f"
+authors = ["Dilum Aluthge <dilum@aluthge.com>"]
+version = "0.1.0"
+
+[deps]
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+
+[compat]
+MLJModelInterface = "0.2"
+ScientificTypes = "0.6"
+
+[extras]
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ScientificTypes", "Test"]

--- a/test/test_packages/force-latest-compat/NewOnly/src/NewOnly.jl
+++ b/test/test_packages/force-latest-compat/NewOnly/src/NewOnly.jl
@@ -1,0 +1,7 @@
+module NewOnly
+
+import MLJModelInterface
+
+f(x) = x + x
+
+end # module

--- a/test/test_packages/force-latest-compat/NewOnly/test/runtests.jl
+++ b/test/test_packages/force-latest-compat/NewOnly/test/runtests.jl
@@ -1,0 +1,7 @@
+import NewOnly
+import ScientificTypes
+import Test
+
+Test.@testset "NewOnly.jl" begin
+    Test.@test NewOnly.f(1) == 2
+end

--- a/test/test_packages/force-latest-compat/OldOnly/.gitignore
+++ b/test/test_packages/force-latest-compat/OldOnly/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/test/test_packages/force-latest-compat/OldOnly/Project.toml
+++ b/test/test_packages/force-latest-compat/OldOnly/Project.toml
@@ -1,0 +1,18 @@
+name = "OldOnly"
+uuid = "abc047b9-6ad4-4533-a374-d50ae908e3e9"
+authors = ["Dilum Aluthge <dilum@aluthge.com>"]
+version = "0.1.0"
+
+[deps]
+MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+
+[compat]
+MLJModelInterface = "0.1"
+ScientificTypes = "0.6"
+
+[extras]
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ScientificTypes", "Test"]

--- a/test/test_packages/force-latest-compat/OldOnly/src/OldOnly.jl
+++ b/test/test_packages/force-latest-compat/OldOnly/src/OldOnly.jl
@@ -1,0 +1,7 @@
+module OldOnly
+
+import MLJModelInterface
+
+f(x) = x + x
+
+end # module

--- a/test/test_packages/force-latest-compat/OldOnly/test/runtests.jl
+++ b/test/test_packages/force-latest-compat/OldOnly/test/runtests.jl
@@ -1,0 +1,7 @@
+import OldOnly
+import ScientificTypes
+import Test
+
+Test.@testset "OldOnly.jl" begin
+    Test.@test OldOnly.f(1) == 2
+end


### PR DESCRIPTION
This pull request is made against #2176 

You can view the correct diff (#2234 against #2176) at this link: https://github.com/DilumAluthge/Pkg.jl/compare/dpa/force-latest-compat...dpa/autodetect-dependabot