### PR TITLE
CI: re-enable testing with Pkg server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           # - windows-latest  # windows has problems and the TEMP fix below doesn't work)
         pkg-server:
           - ""
-          # - "https://pkg.julialang.org"  # pkg server is borken right now)
+          - "pkg.julialang.org"
         exclude:
           - os: macOS-latest
             julia-arch: x86


### PR DESCRIPTION
Let's see if Pkg server is working again.