### PR TITLE
Add pc as short name for Pkg.precompile

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -303,10 +303,11 @@ Create a project called `pkgname` in the current folder.
 """,
 ],
 PSA[:name => "precompile",
+    :short_name => "pc",
     :api => API.precompile,
     :description => "precompile all the project dependencies",
     :help => md"""
-    precompile
+    [pc|precompile]
 
 Precompile all the dependencies of the project in parallel.
 The `startup.jl` file is disabled during precompilation unless julia is started with `--startup-file=yes`.


### PR DESCRIPTION
Adds `pkg> pc` as short form of `pkg> precompile`. 

Should be nicer for those who don't want auto precomp after each Pkg change, but want to manually invoke precompile routinely, for instance just before leaving Pkg REPL mode. i.e. https://github.com/JuliaLang/Pkg.jl/issues/2221

```
(jl_dyzBJC) pkg> pc
Precompiling project...
  Progress [========================================>]  9/9
9 dependencies successfully precompiled in 8 seconds
```