### PR TITLE
CI: Re-enable testing on Pkg server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           # - windows-latest  # windows has problems and the TEMP fix below doesn't work)
         pkg-server:
           - ""
-          # - "https://pkg.julialang.org"  # pkg server is borken right now)
+          - "pkg.julialang.org"
         exclude:
           - os: macOS-latest
             julia-arch: x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 environment:
   matrix:
   # - julia_version: "1.6"
+  #   JULIA_PKG_SERVER: ""
+  # - julia_version: "1.6"
+  #   JULIA_PKG_SERVER: "pkg.julialang.org"
   - julia_version: "nightly"
-  - JULIA_PKG_SERVER: ""
-  - JULIA_PKG_SERVER: "pkg.julialang.org"
+    JULIA_PKG_SERVER: ""
+  - julia_version: "nightly"
+    JULIA_PKG_SERVER: "pkg.julialang.org"
 
 platform:
   - x64 # 64-bit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
   matrix:
-  # - julia_version: 1.0
-  - julia_version: nightly
+  # - julia_version: "1.6"
+  - julia_version: "nightly"
+  - JULIA_PKG_SERVER: ""
+  - JULIA_PKG_SERVER: "pkg.julialang.org"
 
 platform:
   - x64 # 64-bit


### PR DESCRIPTION
Closes #2237 

This pull request re-enables testing both with and without Pkg server.

This applies to:
- Linux (GitHub Actions)
- macOS (GitHub Actions)
- Windows (AppVeyor)