### PR TITLE
Make a <return> keypress on an empty line return to julia REPL via precomp

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -547,10 +547,16 @@ function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
         ok || return REPL.transition(s, :abort)
         input = String(take!(buf))
         REPL.reset(repl)
-        do_cmd(repl, input)
+        if isempty(input)
+            Pkg.precompile()
+        else
+            do_cmd(repl, input)
+        end
         REPL.prepare_next(repl)
         REPL.reset_state(s)
-        s.current_mode.sticky || REPL.transition(s, main)
+        if isempty(input) || !s.current_mode.sticky
+            REPL.transition(s, main)
+        end
     end
 
     mk = REPL.mode_keymap(main)


### PR DESCRIPTION
A proposal to provide an optional exit back to julia repl via precompilation, as per https://github.com/JuliaLang/Pkg.jl/issues/2221

(This is with `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`)

With this, on an empty line:
`<backspace>` remains the same and returns to julia repl promptly
`<return>` no longer just prints another empty prompt, it _returns_ to julia repl via `Pkg.precompile()`

```
pkg> add Foo
...
pkg> dev Bar
...
pkg> up
...
pkg> <return>
Precompiling project...
...
julia> 
```

That way, the precomp only takes place once the project is stable.