### PR TITLE
Use repo_source when cloning.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1330,11 +1330,11 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
             pkgerror("Did not find path `$(repo_source)` for $(err_rep(pkg))")
         end
         repo_path = Types.add_repo_cache_path(repo_source)
-        LibGit2.with(GitTools.ensure_clone(ctx.io, repo_path, pkg.repo.source; isbare=true)) do repo
+        LibGit2.with(GitTools.ensure_clone(ctx.io, repo_path, repo_source; isbare=true)) do repo
             # We only update the clone if the tree hash can't be found
             tree_hash_object = tree_hash(repo, string(pkg.tree_hash))
             if tree_hash_object === nothing
-                GitTools.fetch(ctx.io, repo, pkg.repo.source; refspecs=Types.refspecs)
+                GitTools.fetch(ctx.io, repo, repo_source; refspecs=Types.refspecs)
                 tree_hash_object = tree_hash(repo, string(pkg.tree_hash))
             end
             if tree_hash_object === nothing


### PR DESCRIPTION
This solves part 2 of #2247 and looks like an obvious correction. Possibly `repo_source` was inadvertently changed back to `pkg.repo.source` in #1419.
