### PR TITLE
Work around precompiling packages with no `version` entry

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -952,7 +952,10 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         was_recompiled[pkgid] = false
         if haskey(man, pkgid.uuid)
             pkgent = man[pkgid.uuid]
-            push!(pkg_specs, PackageSpec(uuid = pkgid.uuid, name = pkgent.name, version = pkgent.version, tree_hash = pkgent.tree_hash))
+            # If we have an unusual situation such as an un-versioned package (like an stdlib that
+            # is being overridden) its `version` may be `nothing`.
+            pkgver = something(pkgent.version, VersionSpec())
+            push!(pkg_specs, PackageSpec(uuid = pkgid.uuid, name = pkgent.name, version = pkgver, tree_hash = pkgent.tree_hash))
         end
     end
     precomp_prune_suspended!(pkg_specs)


### PR DESCRIPTION
While experimenting with non-precompiled stdlibs, I found that a
`Project.toml` that has no `version` entry set will cause `precompile()`
to fail in a nasty way.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/2146