### PR TITLE
Use Sys.isexecutable() to calculate git hashes

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -174,8 +174,7 @@ function gitmode(path::AbstractString)
         return mode_symlink
     elseif isdir(path)
         return mode_dir
-    # We cannot use `Sys.isexecutable()` because on Windows, that simply calls `isfile()`
-    elseif !iszero(filemode(path) & 0o100)
+    elseif Sys.isexecutable(path)
         return mode_executable
     else
         return mode_normal

--- a/test/new.jl
+++ b/test/new.jl
@@ -2311,6 +2311,7 @@ tree_hash(root::AbstractString) = bytes2hex(@inferred Pkg.GitTools.tree_hash(roo
         open(file, write=true) do io
             println(io, "Hello, world.")
         end
+        chmod(file, 0o644)
         # reference hash generated with command-line git
         @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
         # test with various executable bits set

--- a/test/new.jl
+++ b/test/new.jl
@@ -2319,11 +2319,7 @@ tree_hash(root::AbstractString) = bytes2hex(@inferred Pkg.GitTools.tree_hash(roo
         chmod(file, 0o654) # group x bit doesn't matter
         @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
         chmod(file, 0o744) # user x bit matters
-        if Sys.iswindows()
-            @test_broken "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
-        else
-            @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
-        end
+        @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
     end
 
     # Test for empty directory hashing


### PR DESCRIPTION
Since our libuv now understands file permissions better on windows, we can finally use `Sys.isexecutable()` on Windows.  :)