### PR TITLE
stop running AV without pkg server

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
   # - julia_version: "1.6"
   #   JULIA_PKG_SERVER: "pkg.julialang.org"
   - julia_version: "nightly"
-    JULIA_PKG_SERVER: ""
-  - julia_version: "nightly"
     JULIA_PKG_SERVER: "pkg.julialang.org"
 
 platform:


### PR DESCRIPTION
It is too slow and has too limited parallelism. 