### PR TITLE
Canonicalize repo url when writing manifest.

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -203,7 +203,11 @@ function destructure(manifest::Manifest)::Dict
             path = join(splitpath(path), "/")
         end
         entry!(new_entry, "path", path)
-        entry!(new_entry, "repo-url", entry.repo.source)
+        repo_source = entry.repo.source
+        if repo_source !== nothing && Sys.iswindows() && !isabspath(repo_source) && !isurl(repo_source)
+            repo_source = join(splitpath(repo_source), "/")
+        end
+        entry!(new_entry, "repo-url", repo_source)
         entry!(new_entry, "repo-rev", entry.repo.rev)
         entry!(new_entry, "repo-subdir", entry.repo.subdir)
         if isempty(entry.deps)

--- a/test/new.jl
+++ b/test/new.jl
@@ -681,9 +681,14 @@ end
         # We add the package using a relative path.
         cd(path) do
             Pkg.add(path=".")
+            manifest = Pkg.Types.read_manifest(joinpath(dirname(Base.active_project()), "Manifest.toml"))
+            # Test that the relative path is canonicalized.
+            repo = string("../../../", basename(tempdir), "/EmptyPackage")
+            @test manifest[empty_package].repo.source == repo
         end
         # Now we try to find the package.
         rm(joinpath(DEPOT_PATH[1], "packages"); recursive=true)
+        rm(joinpath(DEPOT_PATH[1], "clones"); recursive=true)
         Pkg.instantiate()
         # Test that Operations.is_instantiated works with relative path
         @test Pkg.Operations.is_instantiated(Pkg.Types.EnvCache())


### PR DESCRIPTION
This solves part 1 of #2247, adds a test for part 1, and modifies a test so that it captures part 2 and would have failed without #2249.
