### PR TITLE
allow changing stdlib dir

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "Pkg"
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+uuid = "54cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."

--- a/src/API.jl
+++ b/src/API.jl
@@ -1376,12 +1376,12 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=
 end
 
 
-function activate(;temp=false,shared=false)
+function activate(;temp=false,shared=false, stdlib_dir::String=Types.default_stdlib_dir())
     shared && pkgerror("Must give a name for a shared environment")
     temp && return activate(mktempdir())
     Base.ACTIVE_PROJECT[] = nothing
     p = Base.active_project()
-    p === nothing || printpkgstyle(DEFAULT_IO[], :Activating, "environment at $(pathrepr(p))")
+    p === nothing || printpkgstyle(DEFAULT_IO[], :Activating, "environment at $(pathrepr(p, stdlib_dir))")
     add_snapshot_to_undo()
     return nothing
 end
@@ -1402,7 +1402,7 @@ function _activate_dep(dep_name::AbstractString)
         end
     end
 end
-function activate(path::AbstractString; shared::Bool=false, temp::Bool=false)
+function activate(path::AbstractString; shared::Bool=false, temp::Bool=false, stdlib_dir::String=Types.default_stdlib_dir())
     temp && pkgerror("Can not give `path` argument when creating a temporary environment")
     if !shared
         # `pkg> activate path`/`Pkg.activate(path)` does the following
@@ -1438,7 +1438,7 @@ function activate(path::AbstractString; shared::Bool=false, temp::Bool=false)
     p = Base.active_project()
     if p !== nothing
         n = ispath(p) ? "" : "new "
-        printpkgstyle(DEFAULT_IO[], :Activating, "$(n)environment at $(pathrepr(p))")
+        printpkgstyle(DEFAULT_IO[], :Activating, "$(n)environment at $(pathrepr(p, stdlib_dir))")
     end
     add_snapshot_to_undo()
     return nothing

--- a/src/Registry.jl
+++ b/src/Registry.jl
@@ -24,10 +24,10 @@ Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/General.
 add(reg::Union{String,RegistrySpec}; kwargs...) = add([reg]; kwargs...)
 add(regs::Vector{String}; kwargs...) = add([RegistrySpec(name = name) for name in regs]; kwargs...)
 add(regs::Vector{RegistrySpec}; kwargs...) = add(Context(), regs; kwargs...)
-function add(ctx::Context, regs::Vector{RegistrySpec}; kwargs...)
+function add(ctx::Context, regs::Vector{RegistrySpec};kwargs...)
     Context!(ctx; kwargs...)
     if isempty(regs)
-        Types.clone_default_registries(ctx, only_if_empty = false)
+        Types.clone_default_registries(ctx; only_if_empty = false)
     else
         Types.clone_or_cp_registries(ctx.io, regs)
     end
@@ -83,7 +83,7 @@ function update(ctx::Context,
                 kwargs...)
     isempty(regs) && (regs = Types.collect_registries(depots1()))
     Context!(ctx; kwargs...)
-    Types.update_registries(ctx.io, regs; force=true)
+    Types.update_registries(ctx.io, regs; force=true, ctx.stdlib_dir)
 end
 
 """

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -361,7 +361,7 @@ is_project_uuid(env::EnvCache, uuid::UUID) = project_uuid(env) == uuid
 # Context #
 ###########
 default_stdlib_dir() = normpath(joinpath(Sys.BINDIR::String, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"))
-stdlib_path(stdlib::String, stdlib_dir::String) = joinpath(stdlib_dir, stdlib)
+stdlib_path(stdlib::String, stdlib_dir::String=default_stdlib_dir()) = joinpath(stdlib_dir, stdlib)
 
 const STDLIB = Ref{Dict{UUID,String}}()
 function load_stdlib(stdlib_dir::String)
@@ -549,7 +549,7 @@ function set_repo_source_from_registry!(ctx::Context, pkg)
     registry_resolve!(ctx.registries, pkg)
     # Didn't find the package in the registry, but maybe it exists in the updated registry
     if !isresolved(pkg)
-        update_registries(ctx.io, ctx.stdlib_dir)
+        update_registries(ctx.io; stdlib_dir=ctx.stdlib_dir)
         registry_resolve!(ctx.registries, pkg)
     end
     ensure_resolved(ctx.env.manifest, [pkg]; registry=true)
@@ -790,7 +790,7 @@ function registry_resolve!(registries::Vector{RegistryHandling.Registry}, pkgs::
     return pkgs
 end
 
-function stdlib_resolve!(pkgs::AbstractVector{PackageSpec}, stdlib_dir::String)
+function stdlib_resolve!(pkgs::AbstractVector{PackageSpec}, stdlib_dir::String=default_stdlib_dir())
     for pkg in pkgs
         @assert has_name(pkg) || has_uuid(pkg)
         if has_name(pkg) && !has_uuid(pkg)
@@ -1269,7 +1269,7 @@ function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=fa
 end
 
 
-function pathrepr(path::String, stdlib_dir)
+function pathrepr(path::String, stdlib_dir::String=default_stdlib_dir())
     # print stdlib paths as @stdlib/Name
     if startswith(path, stdlib_dir)
         path = "@stdlib/" * basename(path)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -377,13 +377,13 @@ function load_stdlib(stdlib_dir::String)
     return stdlib
 end
 
-function stdlibs(stdlib_dir::String)
+function stdlibs(stdlib_dir::String=default_stdlib_dir())
     if !isassigned(STDLIB)
         STDLIB[] = load_stdlib(stdlib_dir)
     end
     return STDLIB[]
 end
-is_stdlib(uuid::UUID, stdlib_dir::String) = uuid in keys(stdlibs(stdlib_dir))
+is_stdlib(uuid::UUID, stdlib_dir::String=default_stdlib_dir()) = uuid in keys(stdlibs(stdlib_dir))
 
 Context!(kw_context::Vector{Pair{Symbol,Any}})::Context =
     Context!(Context(); kw_context...)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -342,6 +342,8 @@ Base.@kwdef mutable struct Context
 
     # The Julia Version to resolve with respect to
     julia_version::Union{VersionNumber,Nothing} = VERSION
+    # The stdlib dir to resolve with respect to
+    stdlib_dir::String = default_stdlib_dir()
     # test instrumenting
     status_io::Union{IO,Nothing} = nothing
 end
@@ -358,14 +360,14 @@ is_project_uuid(env::EnvCache, uuid::UUID) = project_uuid(env) == uuid
 ###########
 # Context #
 ###########
-stdlib_dir() = normpath(joinpath(Sys.BINDIR::String, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"))
-stdlib_path(stdlib::String) = joinpath(stdlib_dir(), stdlib)
+default_stdlib_dir() = normpath(joinpath(Sys.BINDIR::String, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"))
+stdlib_path(stdlib::String, stdlib_dir::String) = joinpath(stdlib_dir, stdlib)
 
 const STDLIB = Ref{Dict{UUID,String}}()
-function load_stdlib()
+function load_stdlib(stdlib_dir::String)
     stdlib = Dict{UUID,String}()
-    for name in readdir(stdlib_dir())
-        projfile = projectfile_path(stdlib_path(name); strict=true)
+    for name in readdir(stdlib_dir)
+        projfile = projectfile_path(stdlib_path(name, stdlib_dir); strict=true)
         nothing === projfile && continue
         project = parse_toml(projfile)
         uuid = get(project, "uuid", nothing)
@@ -375,13 +377,13 @@ function load_stdlib()
     return stdlib
 end
 
-function stdlibs()
+function stdlibs(stdlib_dir::String)
     if !isassigned(STDLIB)
-        STDLIB[] = load_stdlib()
+        STDLIB[] = load_stdlib(stdlib_dir)
     end
     return STDLIB[]
 end
-is_stdlib(uuid::UUID) = uuid in keys(stdlibs())
+is_stdlib(uuid::UUID, stdlib_dir::String) = uuid in keys(stdlibs(stdlib_dir))
 
 Context!(kw_context::Vector{Pair{Symbol,Any}})::Context =
     Context!(Context(); kw_context...)
@@ -543,11 +545,11 @@ end
 
 add_repo_cache_path(url::String) = joinpath(depots1(), "clones", string(hash(url)))
 
-function set_repo_source_from_registry!(ctx, pkg)
+function set_repo_source_from_registry!(ctx::Context, pkg)
     registry_resolve!(ctx.registries, pkg)
     # Didn't find the package in the registry, but maybe it exists in the updated registry
     if !isresolved(pkg)
-        update_registries(ctx.io)
+        update_registries(ctx.io, ctx.stdlib_dir)
         registry_resolve!(ctx.registries, pkg)
     end
     ensure_resolved(ctx.env.manifest, [pkg]; registry=true)
@@ -645,7 +647,7 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
 
             # If we already resolved a uuid, we can bail early if this package is already installed at the current tree_hash
             if has_uuid(pkg)
-                version_path = Pkg.Operations.source_path(ctx.env.project_file, pkg)
+                version_path = Pkg.Operations.source_path(ctx.env.project_file, pkg, ctx.stdlib_dir)
                 isdir(version_path) && return false
             end
 
@@ -655,7 +657,7 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
 
             # Now that we are fully resolved (name, UUID, tree_hash, repo.source, repo.rev), we can finally
             # check to see if the package exists at its canonical path.
-            version_path = Pkg.Operations.source_path(ctx.env.project_file, pkg)
+            version_path = Pkg.Operations.source_path(ctx.env.project_file, pkg, ctx.stdlib_dir)
             isdir(version_path) && return false
 
             # Otherwise, move the temporary path into its correct place and set read only
@@ -788,16 +790,16 @@ function registry_resolve!(registries::Vector{RegistryHandling.Registry}, pkgs::
     return pkgs
 end
 
-function stdlib_resolve!(pkgs::AbstractVector{PackageSpec})
+function stdlib_resolve!(pkgs::AbstractVector{PackageSpec}, stdlib_dir::String)
     for pkg in pkgs
         @assert has_name(pkg) || has_uuid(pkg)
         if has_name(pkg) && !has_uuid(pkg)
-            for (uuid, name) in stdlibs()
+            for (uuid, name) in stdlibs(stdlib_dir)
                 name == pkg.name && (pkg.uuid = uuid)
             end
         end
         if !has_name(pkg) && has_uuid(pkg)
-            name = get(stdlibs(), pkg.uuid, nothing)
+            name = get(stdlibs(stdlib_dir), pkg.uuid, nothing)
             nothing !== name && (pkg.name = name)
         end
     end
@@ -873,7 +875,7 @@ function clone_default_registries(ctx::Context; only_if_empty = true)
     # Only clone if there are no installed registries, unless called
     # with false keyword argument.
     if isempty(installed_registries) || !only_if_empty
-        printpkgstyle(ctx.io, :Installing, "known registries into $(pathrepr(depots1()))")
+        printpkgstyle(ctx.io, :Installing, "known registries into $(pathrepr(depots1(), ctx.stdlib_dir))")
         registries = copy(DEFAULT_REGISTRIES)
         for uuid in keys(pkg_server_registry_urls())
             if !(uuid in (reg.uuid for reg in registries))
@@ -1102,14 +1104,14 @@ end
 
 # entry point for `registry up`
 function update_registries(io::IO, regs::Vector{RegistrySpec} = collect_registries(depots1());
-                           force::Bool=false)
+                           force::Bool=false, stdlib_dir::String)
     Pkg.OFFLINE_MODE[] && return
     !force && UPDATED_REGISTRY_THIS_SESSION[] && return
     errors = Tuple{String, String}[]
     registry_urls = nothing
     for reg in unique(r -> r.uuid, find_installed_registries(io, regs); seen=Set{Union{UUID,Nothing}}())
         let reg=reg
-            regpath = pathrepr(reg.path)
+            regpath = pathrepr(reg.path, stdlib_dir)
             if isfile(joinpath(reg.path, ".tree_info.toml"))
                 printpkgstyle(io, :Updating, "registry at " * regpath)
                 tree_info = parse_toml(joinpath(reg.path, ".tree_info.toml"))
@@ -1267,9 +1269,9 @@ function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=fa
 end
 
 
-function pathrepr(path::String)
+function pathrepr(path::String, stdlib_dir)
     # print stdlib paths as @stdlib/Name
-    if startswith(path, stdlib_dir())
+    if startswith(path, stdlib_dir)
         path = "@stdlib/" * basename(path)
     end
     return "`" * Base.contractuser(path) * "`"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -206,7 +206,7 @@ end
 function git_init_package(tmp, path)
     base = basename(path)
     pkgpath = joinpath(tmp, base)
-    cp(path, pkgpath)
+    cp(pkgpath, path)
     git_init_and_commit(pkgpath)
     return pkgpath
 end


### PR DESCRIPTION
Tho in most cases we can assume `Pkg` ships with a complete installation of Julia, but when one generates a standalone app with PackageCompiler, this might not be true, and not all the files in stdlibs will be shipped with such kind of app. But there are cases that packages might depend on `Pkg`:

- they might be an enhancement tool on julia's package/project, e.g PkgTemplates
- the user may use Julia's Pkg system as a hot plugin loading system since Julia is dynamic and can actually load packages in runtime, and update methods table by requirements.

This PR make `stdlib_dir` available to change in `Context`, so this won't prevent developers to ship their own standalone app with certain stdlib files (or alternative stdlib files located other places).