### PR TITLE
Revert "Use Sys.isexecutable() to calculate git hashes"

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -175,7 +175,8 @@ function gitmode(path::AbstractString)
         return mode_symlink
     elseif isdir(path)
         return mode_dir
-    elseif Sys.isexecutable(path)
+    # We cannot use `Sys.isexecutable()` because on Windows, that simply calls `isfile()`
+    elseif !iszero(filemode(path) & 0o100)
         return mode_executable
     else
         return mode_normal

--- a/test/new.jl
+++ b/test/new.jl
@@ -2311,7 +2311,6 @@ tree_hash(root::AbstractString) = bytes2hex(@inferred Pkg.GitTools.tree_hash(roo
         open(file, write=true) do io
             println(io, "Hello, world.")
         end
-        chmod(file, 0o644)
         # reference hash generated with command-line git
         @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
         # test with various executable bits set
@@ -2320,7 +2319,11 @@ tree_hash(root::AbstractString) = bytes2hex(@inferred Pkg.GitTools.tree_hash(roo
         chmod(file, 0o654) # group x bit doesn't matter
         @test "0a890bd10328d68f6d85efd2535e3a4c588ee8e6" == tree_hash(dir)
         chmod(file, 0o744) # user x bit matters
-        @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
+        if Sys.iswindows()
+            @test_broken "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
+        else
+            @test "952cfce0fb589c02736482fa75f9f9bb492242f8" == tree_hash(dir)
+        end
     end
 
     # Test for empty directory hashing


### PR DESCRIPTION
Reverts JuliaLang/Pkg.jl#2253

This caused hashes to not give the correct result anymore (even on non-Windows systems) which of course causes a bunch of errors (https://github.com/jheinen/GR.jl/issues/360). I added some debug prints to `gitmode` when adding `GR_jll` (which fails on nightly) and it showed that for example for the file

```
"~/.julia/artifacts/jl_LIRHTe/Applications/GKSTerm.app/Contents/Resources/English.lproj/InfoPlist.strings"
```

`Sys.isexecutable` and `!iszero(filemode(path) & 0o100)` does not give the same result causing the hash to change.

The permission of the file is `555` octal.

cc @staticfloat 