### PR TITLE
Only use `Sys.isexecutable()` on Windows

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -171,11 +171,21 @@ Base.string(mode::GitMode) = string(UInt32(mode); base=8)
 Base.print(io::IO, mode::GitMode) = print(io, string(mode))
 
 function gitmode(path::AbstractString)
+    # Windows doens't deal with executable permissions in quite the same way,
+    # `stat()` gives a different answer than we actually want, so we use
+    # `isexecutable()` which uses `uv_fs_access()` internally.  On other
+    # platforms however, we just want to check via `stat()`.
+    function isexec(p)
+        @static if Sys.iswindows()
+            return Sys.isexecutable(p)
+        end
+        return !iszero(filemode(p) & 0o100)
+    end
     if islink(path)
         return mode_symlink
     elseif isdir(path)
         return mode_dir
-    elseif Sys.isexecutable(path)
+    elseif isexec(path)
         return mode_executable
     else
         return mode_normal


### PR DESCRIPTION
Supercedes #2271

@KristofferC I think this is a better solution; it will keep windows improved (and hopefully allow us to no longer have hash mismatches when users create artifacts on Windows then use them on Linux) while keeping the behavior we have had on Linux/MacOS.  My initial guess right now is that `Sys.isexecutable()` (which uses `access()` internally) has corner cases on MacOS that we don't know about yet, so we should just stay away from using that for now and keep using what we've been using so far.