### PR TITLE
Prioritize package name before local directory for REPL add and develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+Pkg v1.7 Release Notes
+======================
+
+- Adding packages by folder name in the REPL mode now requires a prepending a `./` to the folder name package folder is in the current folder, e.g. `add ./Package` is required instead of `add Pacakge`. This is to avoid confusion between the package name `Package` and the local directory `Package`.

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -118,11 +118,14 @@ end
 # additionally valid for add/develop are: local path, url
 function parse_package_identifier(word::AbstractString; add_or_develop=false)::PackageSpec
     if add_or_develop && casesensitive_isdir(expanduser(word))
-        if !occursin(Base.Filesystem.path_separator_re, word)
+        if occursin(name_re, word)
+            @info "Use `./$word` to add or develop the local directory at `$(Base.contractuser(abspath(word)))`."
+        else
             @info "Resolving package identifier `$word` as a directory at `$(Base.contractuser(abspath(word)))`."
+            return PackageSpec(repo=Types.GitRepo(source=normpath(expanduser(word))))
         end
-        return PackageSpec(repo=Types.GitRepo(source=expanduser(word)))
-    elseif occursin(uuid_re, word)
+    end
+    if occursin(uuid_re, word)
         return PackageSpec(uuid=UUID(word))
     elseif occursin(name_re, word)
         return PackageSpec(String(match(name_re, word).captures[1]))

--- a/test/new.jl
+++ b/test/new.jl
@@ -834,13 +834,17 @@ end
     # check casesensitive resolution of paths
     isolate() do; cd_tempdir() do dir
         Pkg.REPLMode.TEST_MODE[] = true
-        # Add using UUID syntax
         mkdir("example")
         api, args, opts = first(Pkg.pkg"add Example")
         @test api == Pkg.add
         @test args == [Pkg.PackageSpec(;name="Example")]
         @test isempty(opts)
         api, args, opts = first(Pkg.pkg"add example")
+        @test api == Pkg.add
+        @test args == [Pkg.PackageSpec(;name="example")]
+        @test isempty(opts)
+        @test_throws PkgError Pkg.pkg"add ./Example"
+        api, args, opts = first(Pkg.pkg"add ./example")
         @test api == Pkg.add
         @test args == [Pkg.PackageSpec(;path="example")]
         @test isempty(opts)
@@ -1086,11 +1090,11 @@ end
             @test pkg.is_tracking_path
         end
     end end
-    # bare directory name
+    # Local directory name. This must be prepended by "./".
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         path = copy_test_package(tempdir, "SimplePackage")
         cd(dirname(path)) do
-            Pkg.pkg"develop SimplePackage"
+            Pkg.pkg"develop ./SimplePackage"
         end
         Pkg.dependencies(simple_package_uuid) do pkg
             @test pkg.name == "SimplePackage"

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -33,21 +33,21 @@ temp_pkg_dir() do project_path
 
         @test_throws PkgError pkg"generate 2019Julia"
         pkg"generate Foo"
-        pkg"dev Foo"
+        pkg"dev ./Foo"
         mv(joinpath("Foo", "src", "Foo.jl"), joinpath("Foo", "src", "Foo2.jl"))
-        @test_throws PkgError pkg"dev Foo"
+        @test_throws PkgError pkg"dev ./Foo"
         ###
         mv(joinpath("Foo", "src", "Foo2.jl"), joinpath("Foo", "src", "Foo.jl"))
         write(joinpath("Foo", "Project.toml"), """
             name = "Foo"
         """
         )
-        @test_throws PkgError pkg"dev Foo"
+        @test_throws PkgError pkg"dev ./Foo"
         write(joinpath("Foo", "Project.toml"), """
             uuid = "b7b78b08-812d-11e8-33cd-11188e330cbe"
         """
         )
-        @test_throws PkgError pkg"dev Foo"
+        @test_throws PkgError pkg"dev ./Foo"
     end
 end
 
@@ -179,7 +179,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
                 with_current_env() do
                     uuid1 = Pkg.generate("SubModule1")["SubModule1"]
                     uuid2 = Pkg.generate("SubModule2")["SubModule2"]
-                    pkg"develop SubModule1"
+                    pkg"develop ./SubModule1"
                     mkdir("tests")
                     cd("tests")
                     pkg"develop ../SubModule2"
@@ -418,10 +418,10 @@ temp_pkg_dir() do project_path; cd(project_path) do
         with_current_env() do
             # the command below also tests multiline input
             pkg"""
-                dev RecursiveDep2
-                dev RecursiveDep
-                dev SubModule
-                dev SubModule2
+                dev ./RecursiveDep2
+                dev ./RecursiveDep
+                dev ./SubModule
+                dev ./SubModule2
                 add Random
                 add Example
                 add JSON


### PR DESCRIPTION
This PR revives #1636, i.e. interpret `pkg> add Example` as a package name also when you have a directory `Example` in your current directory and require `pkg> add ./Example` if you want the local directory. It differs somewhat though:

* Still accepts the name as a local directory if it's not a valid package name.
* Is more chatty in the ambiguous case.
* Uses `normpath` to normalize the local directory name after parsing. This replaces `./Example` with just `Example`.

I'm open for discussion whether these changes are desired.
