### PR TITLE
Do not set links as read-only with `set_readonly`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,6 +24,12 @@ function set_readonly(path)
     for (root, dirs, files) in walkdir(path)
         for file in files
             filepath = joinpath(root, file)
+            # `chmod` on a link would change the permissions of the target.  If
+            # the link points to a file within the same root, it will be
+            # chmod'ed anyway, but we don't want to make directories read-only.
+            # It's better not to mess with the other cases (links to files
+            # outside of the root, links to non-file/non-directories, etc...)
+            islink(filepath) && continue
             fmode = filemode(filepath)
             try
                 chmod(filepath, fmode & (typemax(fmode) ⊻ 0o222))


### PR DESCRIPTION
`set_readonly` is supposed to set only files as read-only, but in practice if
there is a link to a directory it'll set the target directory as read-only,
causing the files inside it to be unremovable without first fixing permissions
of the directory.

This prevents `set_readonly` from changing the mode of any link.