### PR TITLE
Force mv in `create_artifact`

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -55,7 +55,7 @@ function create_artifact(f::Function)
         new_path = artifact_path(artifact_hash; honor_overrides=false)
         if !isdir(new_path)
             # Move this generated directory to its final destination, set it to read-only
-            mv(temp_dir, new_path)
+            mv(temp_dir, new_path; force=true)
             chmod(new_path, filemode(dirname(new_path)))
             set_readonly(new_path)
         end


### PR DESCRIPTION
Over at [ClimateMachine.jl](https://github.com/CliMA/ClimateMachine.jl), we're seeing race conditions when using `create_artifact` on multiple processors (e.g., [here](https://buildkite.com/clima/climatemachine-ci/builds/572#d76710eb-c466-4c30-ad3d-4636e5b33bd6/208-218)). This is likely not the best fix but, based on [this thread](https://github.com/JuliaLang/julia/pull/36638#discussion_r453820564), it seems like it may work. Looping in @kpamnany. I'm hoping that this will partially fix [ClimateMachine's 1678](https://github.com/CliMA/ClimateMachine.jl/issues/1678).

Doing this the "right way" seems ultimately dependent on resolving [cross-platform file locking](https://github.com/JuliaLang/julia/issues/7176). [Pidfile.jl](https://github.com/vtjnash/Pidfile.jl) seems like a promising solution, but I'm not sure what the status is on [moving this into Base](https://github.com/JuliaLang/julia/issues/7176#issuecomment-411102022).