### PR TITLE
Throw an error if the Julia version requirement is not satisfied

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -287,7 +287,7 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
     if julia_version !== nothing
         v = intersect(julia_version, project_compatibility(env, "julia"))
         if isempty(v)
-            @warn "julia version requirement for project not satisfied" _module=nothing _file=nothing
+            Types.pkgerror("julia version requirement for project not satisfied")
         end
     end
     names = Dict{UUID, String}(uuid => stdlib for (uuid, stdlib) in stdlibs())


### PR DESCRIPTION
In all other cases, if the `[compat]` entry is not satisfiable, we throw an exception.

Therefore, for consistency, I think it makes sense that if the `[compat]` entry for `julia` is not satisfiable, we should throw an exception.

---

See also: https://discourse.julialang.org/t/resolve-mismatch-between-running-julia-and-the-compatibility-section/52064