### PR TITLE
Align all status printing

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1023,7 +1023,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     prune_manifest(ctx.env)
     # update project & manifest
     write_env(ctx.env)
-    show_update(ctx, ignore_indent=false)
+    show_update(ctx)
 end
 
 update_package_add(ctx::Context, pkg::PackageSpec, ::Nothing, is_dep::Bool) = pkg
@@ -1153,7 +1153,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=UUID[];
     download_artifacts(ctx.env, pkgs; platform=platform)
 
     write_env(ctx.env) # write env before building
-    show_update(ctx, ignore_indent=false)
+    show_update(ctx)
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1171,7 +1171,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Vector{UUID};
     new_apply = download_source(ctx, pkgs; readonly=true)
     download_artifacts(ctx.env, pkgs; platform=platform)
     write_env(ctx.env) # write env before building
-    show_update(ctx, ignore_indent=false)
+    show_update(ctx)
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1236,7 +1236,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel)
     new_apply = download_source(ctx, pkgs)
     download_artifacts(ctx.env, pkgs)
     write_env(ctx.env) # write env before building
-    show_update(ctx, ignore_indent=false)
+    show_update(ctx)
     build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git))
 end
 
@@ -1278,7 +1278,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
     new = download_source(ctx, pkgs)
     download_artifacts(ctx.env, pkgs)
     write_env(ctx.env) # write env before building
-    show_update(ctx, ignore_indent=false)
+    show_update(ctx)
     build_versions(ctx, UUID[pkg.uuid for pkg in new])
 end
 
@@ -1315,12 +1315,12 @@ function free(ctx::Context, pkgs::Vector{PackageSpec})
         new = download_source(ctx, pkgs)
         download_artifacts(ctx.env, new)
         write_env(ctx.env) # write env before building
-        show_update(ctx, ignore_indent=false)
+        show_update(ctx)
         build_versions(ctx, UUID[pkg.uuid for pkg in new])
     else
         foreach(pkg -> manifest_info(ctx.env.manifest, pkg.uuid).pinned = false, pkgs)
         write_env(ctx.env)
-        show_update(ctx, ignore_indent=false)
+        show_update(ctx)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 
-function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false)
+function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false; color=:green)
     indent = textwidth(string(:Precompiling)) # "Precompiling" is the longest operation
     ignore_indent && (indent = 0)
-    printstyled(io, lpad(string(cmd), indent), color=:green, bold=true)
+    printstyled(io, lpad(string(cmd), indent), color=color, bold=true)
     println(io, " ", text)
 end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -1933,13 +1933,13 @@ end
         @test occursin(r"Status `.+Project.toml`", readline(io))
         @test occursin(r"→ \[7876af07\] Example v\d\.\d\.\d", readline(io))
         @test occursin(r"\[d6f4376e\] Markdown", readline(io))
-        @test "Info packages marked with → not downloaded, use `instantiate` to download" == readline(io)
+        @test "Info packages marked with → not downloaded, use `instantiate` to download" == strip(readline(io))
         Pkg.status(;io=io, mode=Pkg.PKGMODE_MANIFEST)
         @test occursin(r"Status `.+Manifest.toml`", readline(io))
         @test occursin(r"→ \[7876af07\] Example v\d\.\d\.\d", readline(io))
         @test occursin(r"\[2a0f44e3\] Base64", readline(io))
         @test occursin(r"\[d6f4376e\] Markdown", readline(io))
-        @test "Info packages marked with → not downloaded, use `instantiate` to download" == readline(io)
+        @test "Info packages marked with → not downloaded, use `instantiate` to download" == strip(readline(io))
     end
     # Manifest Status API
     isolate(loaded_depot=true) do


### PR DESCRIPTION
Alignment during printing of status info is inconsistent with the rest of pkg indenting and stands out most when the status prints are embedded within other actions. Notice the two `Updating`'s here

Master
<img width="522" alt="Screen Shot 2021-01-04 at 4 17 00 PM" src="https://user-images.githubusercontent.com/1694067/103580716-b00c4b00-4ea8-11eb-8d56-a6885be346f9.png">

This PR
<img width="480" alt="Screen Shot 2021-01-04 at 4 19 09 PM" src="https://user-images.githubusercontent.com/1694067/103580733-b5699580-4ea8-11eb-9842-0890f44661cd.png">

This PR turns alignment on for all status prints.
That includes for basic `pkg> status` reports, which stood out less given they were the only text printed, which I understand the reasoning for, but it seems better to be consistent?

Master
<img width="362" alt="Screen Shot 2020-12-31 at 12 41 56 AM" src="https://user-images.githubusercontent.com/1694067/103396388-02441980-4b01-11eb-81f2-8d9ac3485619.png">

This PR
<img width="394" alt="Screen Shot 2020-12-31 at 12 41 25 AM" src="https://user-images.githubusercontent.com/1694067/103396391-05d7a080-4b01-11eb-81ed-b7c849c8946e.png">
