### PR TITLE
Make a <return> on an empty line return to julia REPL

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -549,7 +549,9 @@ function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
         do_cmd(repl, input)
         REPL.prepare_next(repl)
         REPL.reset_state(s)
-        s.current_mode.sticky || REPL.transition(s, main)
+        if isempty(input) || !s.current_mode.sticky
+            REPL.transition(s, main)
+        end
     end
 
     mk = REPL.mode_keymap(main)


### PR DESCRIPTION
This lets you type `] add This, That` and press return *twice*,  then immediately paste in the code you wanted to try, and leave that window alone until it's finished downloading, precompiling, loading, etc. 

For some reason I frequently want to do this, but there seems to be no way at present -- the backspace key to exit the `pkg>` mode isn't cached. I don't know how to change the backspace; the change here is simply half of #2248. 