### PR TITLE
Precompile: add debug info

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1233,7 +1233,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
                 end
                 n_done += 1
                 notify(was_processed[pkg])
-                @debug "Precompilation: remaining packages\n$(sprint(show, MIME"text/plain"(), collect(keys(filter(e->!(last(e).set), was_processed)))))"
+                @debug "Precompilation: finished processing $(pkg.name). Remaining packages:\n$(sprint(show, MIME"text/plain"(), collect(keys(filter(e->!(last(e).set), was_processed)))))"
             catch err_outer
                 handle_interrupt(err_outer)
                 notify(was_processed[pkg])

--- a/src/API.jl
+++ b/src/API.jl
@@ -1238,7 +1238,7 @@ function precompile(ctx::Context; internal_call::Bool=false, debugmode::Bool=occ
                 n_done += 1
                 notify(was_processed[pkg])
                 if debugmode
-                    println(io, "Remaining:\n", filter(e->!(last(e).set), was_processed))
+                    println(io, "Remaining:\n", keys(filter(e->!(last(e).set), was_processed)))
                 end
             catch err_outer
                 handle_interrupt(err_outer)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1233,7 +1233,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
                 end
                 n_done += 1
                 notify(was_processed[pkg])
-                @debug "Precompilation: remaining packages\n$(sprint(show, MIME"text/plain"(), keys(filter(e->!(last(e).set), was_processed))))"
+                @debug "Precompilation: remaining packages\n$(sprint(show, MIME"text/plain"(), collect(keys(filter(e->!(last(e).set), was_processed)))))"
             catch err_outer
                 handle_interrupt(err_outer)
                 notify(was_processed[pkg])

--- a/src/API.jl
+++ b/src/API.jl
@@ -1016,11 +1016,12 @@ function precompile(ctx::Context; internal_call::Bool=false, debugmode::Bool=occ
         push!(direct_deps, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
     end
 
-    @debug "List of deps to be precompiled"
-    @debug keys(depsmap)
-
-    @debug "Full depsmap:"
-    @debug depsmap
+    if debugmode
+        str = sprint() do io
+            show(io, MIME"text/plain"(), depsmap)
+        end
+        @debug "Full depsmap:\n$str"
+    end
 
     started = Dict{Base.PkgId,Bool}()
     was_processed = Dict{Base.PkgId,Base.Event}()

--- a/src/API.jl
+++ b/src/API.jl
@@ -1016,6 +1016,12 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         push!(direct_deps, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
     end
 
+    @debug "List of deps to be precompiled"
+    @debug keys(depsmap)
+
+    @debug "Full depsmap:"
+    @debug depsmap
+
     started = Dict{Base.PkgId,Bool}()
     was_processed = Dict{Base.PkgId,Base.Event}()
     was_recompiled = Dict{Base.PkgId,Bool}()
@@ -1045,6 +1051,9 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
             !internal_call && @warn "Circular dependency detected. Precompilation skipped for $pkg"
         end
     end
+
+    @debug "Packages determined to have circular dependency"
+    @debug circular_deps
 
     pkg_queue = Base.PkgId[]
     failed_deps = Dict{Base.PkgId, String}()

--- a/src/API.jl
+++ b/src/API.jl
@@ -989,7 +989,9 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS::Int + 1)))
     parallel_limiter = Base.Semaphore(num_tasks)
     io = ctx.io
-    fancyprint = can_fancyprint(io) && !debugmode
+
+    fancyprint = can_fancyprint(io)
+    @debug fancyprint = false # disable fancy printing in debug mode
 
     # when manually called, unsuspend all packages that were suspended due to precomp errors
     internal_call ? recall_suspended_packages() : precomp_unsuspend!()

--- a/src/API.jl
+++ b/src/API.jl
@@ -1238,7 +1238,7 @@ function precompile(ctx::Context; internal_call::Bool=false, debugmode::Bool=occ
                 n_done += 1
                 notify(was_processed[pkg])
                 if debugmode
-                    println(io, "Remaining:\n", keys(filter(e->!(last(e).set), was_processed)))
+                    println(io, "Remaining: ", keys(filter(e->!(last(e).set), was_processed)))
                 end
             catch err_outer
                 handle_interrupt(err_outer)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1018,7 +1018,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         push!(direct_deps, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
     end
 
-    @debug "Precompilation dependency map" depsmap=sprint(show, MIME"text/plain"(), depsmap)
+    @debug "Precompilation dependency map\n$(sprint(show, MIME"text/plain"(), depsmap))"
     started = Dict{Base.PkgId,Bool}()
     was_processed = Dict{Base.PkgId,Base.Event}()
     was_recompiled = Dict{Base.PkgId,Bool}()
@@ -1049,7 +1049,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
         end
     end
 
-    @debug "Packages determined to have circular dependency" circular_deps
+    @debug "Packages determined to have circular dependency\n$(sprint(show, MIME"text/plain"(), circular_deps))"
 
     pkg_queue = Base.PkgId[]
     failed_deps = Dict{Base.PkgId, String}()
@@ -1233,7 +1233,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
                 end
                 n_done += 1
                 notify(was_processed[pkg])
-                @debug "Precompilation: remaining packages" remaining=keys(filter(e->!(last(e).set), was_processed))
+                @debug "Precompilation: remaining packages\n$(sprint(show, MIME"text/plain"(), keys(filter(e->!(last(e).set), was_processed))))"
             catch err_outer
                 handle_interrupt(err_outer)
                 notify(was_processed[pkg])


### PR DESCRIPTION
When `JULIA_DEBUG` includes `Pkg`, precompile switches to the linear basic plotting, and shows more info about what's left to be done

Here's the end of a successful precompile job
```
Remaining: Base.PkgId[PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883], Graphics [a2bd30eb-e257-5431-a919-1863eab51364], ColorVectorSpace [c3611d14-8923-5661-9e6a-0046d554d3a4], ImageCore [a09fc81d-aa75-5fe9-8630-4744c3626534], Colors [5ae59095-9a9b-59fe-a467-6f913c188581], Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ColorTypes [3da002f7-5984-5a60-b8a6-cbb66c0b333f], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ✓ ColorTypes
Remaining: Base.PkgId[PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883], Graphics [a2bd30eb-e257-5431-a919-1863eab51364], ColorVectorSpace [c3611d14-8923-5661-9e6a-0046d554d3a4], ImageCore [a09fc81d-aa75-5fe9-8630-4744c3626534], Colors [5ae59095-9a9b-59fe-a467-6f913c188581], Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ✓ Colors
Remaining: Base.PkgId[PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883], Graphics [a2bd30eb-e257-5431-a919-1863eab51364], ColorVectorSpace [c3611d14-8923-5661-9e6a-0046d554d3a4], ImageCore [a09fc81d-aa75-5fe9-8630-4744c3626534], Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ✓ Graphics
Remaining: Base.PkgId[PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883], ColorVectorSpace [c3611d14-8923-5661-9e6a-0046d554d3a4], ImageCore [a09fc81d-aa75-5fe9-8630-4744c3626534], Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ? ColorVectorSpace
Remaining: Base.PkgId[PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883], ImageCore [a09fc81d-aa75-5fe9-8630-4744c3626534], Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ✓ ImageCore
Remaining: Base.PkgId[PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883], Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ✓ PNGFiles
Remaining: Base.PkgId[Netpbm [f09324ee-3d7c-5217-9330-fc30815ba969], ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ? Netpbm
Remaining: Base.PkgId[ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]]
  ✓ ImageIO
Remaining: Base.PkgId[]
32 dependencies successfully precompiled in 22 seconds
5 dependencies failed but may be precompilable after restarting julia
```

in the case of hanging precomp, this should allow you to see which packages are remaining, and then looking at the deepest of the remaining deps is a good place to start with strategies like `using Dep` to try and figure out what's going wrong.

In a case with @simeonschaub a corrupted `.julia/packages/Dep` directory was silently preventing a package being installed, which manifested in a hang during precomp. This helped identify which package it was