### PR TITLE
Avoid invalidations related to * string concat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
       - uses: julia-actions/julia-processcoverage@v1
+        env:
+            JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info

--- a/src/API.jl
+++ b/src/API.jl
@@ -112,15 +112,17 @@ function project(env::EnvCache)::ProjectInfo
     )
 end
 
-function check_package_name(x::AbstractString, mode=nothing)
+function check_package_name(x::AbstractString, mode::Union{Nothing,String,Symbol}=nothing)
     if !Base.isidentifier(x)
-        message = "`$x` is not a valid package name"
-        if endswith(lowercase(x), ".jl")
-            message *= ". Perhaps you meant `$(chop(x; tail=3))`"
-        end
-        if mode !== nothing && any(occursin.(['\\','/'], x)) # maybe a url or a path
-            message *= "\nThe argument appears to be a URL or path, perhaps you meant " *
-                "`Pkg.$mode(url=\"...\")` or `Pkg.$mode(path=\"...\")`."
+        message = sprint() do iostr
+            print(iostr, "`$x` is not a valid package name")
+            if endswith(lowercase(x), ".jl")
+                print(iostr, ". Perhaps you meant `$(chop(x; tail=3))`")
+            end
+            if mode !== nothing && any(occursin.(['\\','/'], x)) # maybe a url or a path
+                print(iostr, "\nThe argument appears to be a URL or path, perhaps you meant ",
+                    "`Pkg.$mode(url=\"...\")` or `Pkg.$mode(path=\"...\")`.")
+            end
         end
         pkgerror(message)
     end
@@ -1011,12 +1013,13 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
     end
     depsmap = Dict{Base.PkgId, Vector{Base.PkgId}}(Iterators.filter(!isnothing, deps_pair_or_nothing)) #flat map of each dep and its deps
 
-    if ctx.env.pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", ctx.env.pkg.name * ".jl") )
-        depsmap[Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name)] = [
+    ctx_env_pkg = ctx.env.pkg
+    if ctx_env_pkg !== nothing && isfile( joinpath( dirname(ctx.env.project_file), "src", "$(ctx_env_pkg.name).jl") )
+        depsmap[Base.PkgId(ctx_env_pkg.uuid, ctx_env_pkg.name)] = [
             Base.PkgId(last(x), first(x))
             for x in ctx.env.project.deps if !Base.in_sysimage(Base.PkgId(last(x), first(x)))
         ]
-        push!(direct_deps, Base.PkgId(ctx.env.pkg.uuid, ctx.env.pkg.name))
+        push!(direct_deps, Base.PkgId(ctx_env_pkg.uuid, ctx_env_pkg.name))
     end
 
     started = Dict{Base.PkgId,Bool}()
@@ -1108,34 +1111,35 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                     else
                         pkg_queue
                     end
-                    str = ""
-                    if i > 1
-                        str *= string(ansi_moveup(last_length+1), ansi_movecol1, ansi_cleartoend)
-                    end
-                    bar.current = n_done - n_already_precomp
-                    bar.max = n_total - n_already_precomp
-                    str *= sprint(io -> show_progress(io, bar); context=io) * '\n'
-                    for dep in pkg_queue_show
-                        name = dep in direct_deps ? dep.name : string(color_string(dep.name, :light_black))
-                        if dep in precomperr_deps
-                            str *= string(color_string("  ? ", Base.warn_color()), name, "\n")
-                        elseif haskey(failed_deps, dep)
-                            str *= string(color_string("  ✗ ", Base.error_color()), name, "\n")
-                        elseif was_recompiled[dep]
-                            interrupted_or_done.set && continue
-                            str *= string(color_string("  ✓ ", :green), name, "\n")
-                            @async begin # keep successful deps visible for short period
-                                sleep(1);
-                                filter!(!isequal(dep), pkg_queue)
+                    str = sprint() do iostr
+                        if i > 1
+                            print(iostr, ansi_moveup(last_length+1), ansi_movecol1, ansi_cleartoend)
+                        end
+                        bar.current = n_done - n_already_precomp
+                        bar.max = n_total - n_already_precomp
+                        print(iostr, sprint(io -> show_progress(io, bar); context=io), "\n")
+                        for dep in pkg_queue_show
+                            name = dep in direct_deps ? dep.name : string(color_string(dep.name, :light_black))
+                            if dep in precomperr_deps
+                                print(iostr, color_string("  ? ", Base.warn_color()), name, "\n")
+                            elseif haskey(failed_deps, dep)
+                                print(iostr, color_string("  ✗ ", Base.error_color()), name, "\n")
+                            elseif was_recompiled[dep]
+                                interrupted_or_done.set && continue
+                                print(iostr, color_string("  ✓ ", :green), name, "\n")
+                                @async begin # keep successful deps visible for short period
+                                    sleep(1);
+                                    filter!(!isequal(dep), pkg_queue)
+                                end
+                            elseif started[dep]
+                                # Offset each spinner animation using the first character in the package name as the seed.
+                                # If not offset, on larger terminal fonts it looks odd that they all sync-up
+                                anim_char = anim_chars[(i + Int(dep.name[1])) % length(anim_chars) + 1]
+                                anim_char_colored = dep in direct_deps ? anim_char : color_string(anim_char, :light_black)
+                                print(iostr, "  $anim_char_colored $name\n")
+                            else
+                                print(iostr, "    $name\n")
                             end
-                        elseif started[dep]
-                            # Offset each spinner animation using the first character in the package name as the seed.
-                            # If not offset, on larger terminal fonts it looks odd that they all sync-up
-                            anim_char = anim_chars[(i + Int(dep.name[1])) % length(anim_chars) + 1]
-                            anim_char_colored = dep in direct_deps ? anim_char : color_string(anim_char, :light_black)
-                            str *= string("  $anim_char_colored ", name, "\n")
-                        else
-                            str *= "    " * name * "\n"
                         end
                     end
                     last_length = length(pkg_queue_show)
@@ -1257,24 +1261,26 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
     ndeps = count(values(was_recompiled))
     if ndeps > 0 || !isempty(failed_deps)
         plural = ndeps == 1 ? "y" : "ies"
-        str = "$(ndeps) dependenc$(plural) successfully precompiled in $(seconds_elapsed) seconds"
-        if n_already_precomp > 0 || !isempty(skipped_deps)
-            str *= " ("
-            n_already_precomp > 0 && (str *= "$n_already_precomp already precompiled")
-            !isempty(circular_deps) && (str *= ", $(length(circular_deps)) skipped due to circular dependency")
-            !isempty(skipped_deps) && (str *= ", $(length(skipped_deps)) skipped during auto due to previous errors")
-            str *= ")"
-        end
-        if !isempty(precomperr_deps)
-            plural = length(precomperr_deps) == 1 ? "y" : "ies"
-            str *= string("\n",
-                color_string(string(length(precomperr_deps)), Base.warn_color()),
-                " dependenc$(plural) failed but may be precompilable after restarting julia"
-            )
-        end
-        if internal_call && !isempty(failed_deps)
-            plural = length(failed_deps) == 1 ? "y" : "ies"
-            str *= "\n" * color_string("$(length(failed_deps))", Base.error_color()) * " dependenc$(plural) errored"
+        str = sprint() do iostr
+            print(iostr, "$(ndeps) dependenc$(plural) successfully precompiled in $(seconds_elapsed) seconds")
+            if n_already_precomp > 0 || !isempty(skipped_deps)
+                print(iostr, " (")
+                n_already_precomp > 0 && (print(iostr, "$n_already_precomp already precompiled"))
+                !isempty(circular_deps) && (print(iostr, ", $(length(circular_deps)) skipped due to circular dependency"))
+                !isempty(skipped_deps) && (print(iostr, ", $(length(skipped_deps)) skipped during auto due to previous errors"))
+                print(iostr, ")")
+            end
+            if !isempty(precomperr_deps)
+                plural = length(precomperr_deps) == 1 ? "y" : "ies"
+                print(iostr, "\n",
+                    color_string(string(length(precomperr_deps)), Base.warn_color()),
+                    " dependenc$(plural) failed but may be precompilable after restarting julia"
+                )
+            end
+            if internal_call && !isempty(failed_deps)
+                plural = length(failed_deps) == 1 ? "y" : "ies"
+                print(iostr, "\n", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural) errored")
+            end
         end
         lock(print_lock) do
             println(io, str)
@@ -1284,7 +1290,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
             n_direct_errs = 0
             for (dep, err) in failed_deps
                 if strict || (dep in direct_deps)
-                    err_str *= "\n" * "$dep" * "\n\n" * err * (n_direct_errs > 0 ? "\n" : "")
+                    err_str = string(err_str, "\n$dep\n\n$err", (n_direct_errs > 0 ? "\n" : ""))
                     n_direct_errs += 1
                 end
             end
@@ -1302,7 +1308,7 @@ end
 const pkgs_precompile_suspended = PackageSpec[]
 function save_suspended_packages()
     path = Operations.pkg_scratchpath()
-    fpath = joinpath(path, string("suspend_cache_", hash(Base.active_project() * string(Base.VERSION))))
+    fpath = joinpath(path, string("suspend_cache_", hash(string(Base.active_project(), Base.VERSION))))
     mkpath(path); Base.Filesystem.rm(fpath, force=true)
     open(fpath, "w") do io
         serialize(io, pkgs_precompile_suspended)
@@ -1310,7 +1316,7 @@ function save_suspended_packages()
     return nothing
 end
 function recall_suspended_packages()
-    fpath = joinpath(Operations.pkg_scratchpath(), string("suspend_cache_", hash(Base.active_project() * string(Base.VERSION))))
+    fpath = joinpath(Operations.pkg_scratchpath(), string("suspend_cache_", hash(string(Base.active_project(), Base.VERSION))))
     if isfile(fpath)
         v = open(fpath) do io
             try

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -513,7 +513,7 @@ function promptf()
         else
             project_name = projname(project_file)
             if project_name !== nothing
-                prefix = string("(", project_name, ") ")
+                prefix = "($(project_name)) "
                 prev_prefix = prefix
                 prev_project_timestamp = mtime(project_file)
                 prev_project_file = project_file
@@ -521,9 +521,9 @@ function promptf()
         end
     end
     if OFFLINE_MODE[]
-        prefix = prefix * "[offline] "
+        prefix = "$(prefix)[offline] "
     end
-    return prefix * "pkg> "
+    return "$(prefix)pkg> "
 end
 
 # Set up the repl Pkg REPLMode


### PR DESCRIPTION
I noticed that loading Flux was causing Pkg latency, which on investigation seems to be due to `ChainRulesCore`'s necessarily broad `*` methods (https://github.com/JuliaDiff/ChainRulesCore.jl/pull/273) and the use of `*` for string concat in Pkg

Before:
```
julia> using SnoopCompileCore

julia> invalidations = @snoopr using ChainRulesCore;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Tuple where var"#s3") in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Base.UUID, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Base.UUID, String}}, ::Any, ::Int64) (0 children)
                 6: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting *(s, comp::Composite) in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differential_arithmetic.jl:138 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Union{Regex, String}, Any} triggered MethodInstance for *(::Any, ::Char, ::Any) (0 children)

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Dict where var"#s3"<:Dict) in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)

 inserting *(::Zero, ::Any) in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differential_arithmetic.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Pkg.REPLMode.promptf() (0 children)
                 2: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Pkg.API.var"#precompile#195"(::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.precompile), ::Pkg.Types.Context) (15 children)
                 3: signature Tuple{typeof(*), Any, Char} triggered MethodInstance for *(::Any, ::Char, ::Any) (16 children)
   10 mt_cache
```

The `Pkg.API.var"#precompile#195"` invalidation seems most substantial
```
julia> show(last(root); minchildren=0, maxdepth=10)
MethodInstance for Pkg.API.var"#precompile#197"(::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.precompile), ::Pkg.Types.Context) (15 children)
 MethodInstance for (::Pkg.API.var"#precompile##kw")(::NamedTuple{(:internal_call,), Tuple{Bool}}, ::typeof(Pkg.API.precompile), ::Pkg.Types.Context) (14 children)
  MethodInstance for Pkg.API._auto_precompile(::Pkg.Types.Context) (13 children)
   MethodInstance for Pkg.API.var"#instantiate#249"(::Nothing, ::Bool, ::Bool, ::Base.BinaryPlatforms.Platform, ::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.instantiate), ::Pkg.Types.Context) (4 children)
    MethodInstance for (::Pkg.API.var"#instantiate##kw")(::NamedTuple{(:manifest, :update_registry, :verbose), Tuple{Nothing, Bool, Bool}}, ::typeof(Pkg.API.instantiate), ::Pkg.Types.Context) (1 children)
     MethodInstance for Pkg.API.var"#instantiate#249"(::Nothing, ::Bool, ::Bool, ::Base.BinaryPlatforms.Platform, ::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.instantiate), ::Pkg.Types.Context) (0 children)
    MethodInstance for (::Pkg.API.var"#instantiate##kw")(::NamedTuple{(:allow_autoprecomp,), Tuple{Bool}}, ::typeof(Pkg.API.instantiate), ::Pkg.Types.Context) (1 children)
     MethodInstance for Pkg.API.var"#precompile#197"(::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.precompile), ::Pkg.Types.Context) (0 children)
   MethodInstance for Pkg.API.var"#add#24"(::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.add), ::Vector{Pkg.Types.PackageSpec}) (7 children)
    MethodInstance for Pkg.API.add(::Vector{Pkg.Types.PackageSpec}) (6 children)
     MethodInstance for Pkg.API.var"#add#22"(::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.add), ::Pkg.Types.PackageSpec) (1 children)
      MethodInstance for Pkg.API.add(::Pkg.Types.PackageSpec) (0 children)
     MethodInstance for Pkg.API.var"#add#23"(::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.add), ::Vector{String}) (3 children)
      MethodInstance for Pkg.API.add(::Vector{String}) (2 children)
       MethodInstance for Pkg.API.var"#add#22"(::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.add), ::String) (1 children)
        MethodInstance for Pkg.API.add(::String) (0 children)
```

This PR eliminates the `Pkg.REPLMode.promptf()` and `Pkg.API.var"#precompile#195"` invalidations
```
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Tuple where var"#s3") in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting *(s, comp::Composite) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differential_arithmetic.jl:138 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Union{Regex, String}, Any} triggered MethodInstance for *(::Any, ::Char, ::Any) (0 children)
                 2: signature Tuple{typeof(*), String, Any} triggered MethodInstance for Logging.default_metafmt(::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any) (0 children)

 inserting *(::DoesNotExist, ::Any) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differential_arithmetic.jl:28 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Any, Char} triggered MethodInstance for *(::Any, ::Char, ::Any) (16 children)
   8 mt_cache

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Dict where var"#s3"<:Dict) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)
```
