### PR TITLE
Precompile: handle when source file is missing

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1153,7 +1153,11 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     for (pkg, deps) in depsmap # precompilation loop
         paths = Base.find_all_in_cache_path(pkg)
         sourcepath = Base.locate_package(pkg)
-        sourcepath === nothing && continue
+        if sourcepath === nothing
+            failed_deps[pkg] = "Error: Missing source file for $(pkg)"
+            notify(was_processed[pkg])
+            continue
+        end
         # Heuristic for when precompilation is disabled
         if occursin(r"\b__precompile__\(\s*false\s*\)", read(sourcepath, String))
             notify(was_processed[pkg])


### PR DESCRIPTION
If the source file couldn't be found some status messaging was missing, resulting in a deadlock.
I think this is the deadlock we've been seeing, like @simeonschaub's case in #2321 and #2331 

Fixes #2331 

```
(Pkg) pkg> activate --temp
  Activating new environment at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_m94iSi/Project.toml`

(jl_m94iSi) pkg> add Literate
    Updating registry at `~/.julia/registries/General`
   Resolving package versions...
Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_m94iSi/Project.toml`
  [98b081ad] + Literate v2.7.0
Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_m94iSi/Manifest.toml`
  [682c06a0] + JSON v0.21.1
  [98b081ad] + Literate v2.7.0
  [69de0a69] + Parsers v1.0.15
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [b77e0a4c] + InteractiveUtils
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [6462fe0b] + Sockets
  Progress [========================================>]  2/2
2 dependencies successfully precompiled in 2 seconds (1 already precompiled)

(jl_m94iSi) pkg> dev JSON
     Cloning git-repo `https://github.com/JuliaIO/JSON.jl.git`
   Resolving package versions...
Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_m94iSi/Project.toml`
  [682c06a0] + JSON v0.21.1 `~/.julia/dev/JSON`
Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_m94iSi/Manifest.toml`
  [682c06a0] ~ JSON v0.21.1 ⇒ v0.21.1 `~/.julia/dev/JSON`

shell> rm -rf ~/.julia/dev/JSON

shell> rm -rf ~/.julia/compiled/v1.7

(jl_m94iSi) pkg> precompile
  Progress [===========================>             ]  2/3
  ✗ Literate
1 dependency successfully precompiled in 3 seconds

ERROR: The following 2 direct dependencies failed to precompile:

Literate [98b081ad-f1c9-55d3-8b20-4c87d4299306]

ERROR: LoadError: ArgumentError: Package JSON [682c06a0-de6a-54ab-a142-c8b1cf79cde6] is required but does not seem to be installed:
 - Run `Pkg.instantiate()` to install all recorded dependencies.

Stacktrace:
 [1] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:986
 [2] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:910
 [3] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:897
 [4] include
   @ ./Base.jl:386 [inlined]
 [5] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
   @ Base ./loading.jl:1209
 [6] top-level scope
   @ none:1
 [7] eval
   @ ./boot.jl:369 [inlined]
 [8] eval(x::Expr)
   @ Base.MainInclude ./client.jl:453
 [9] top-level scope
   @ none:1
in expression starting at /Users/ian/.julia/packages/Literate/TWhmv/src/Literate.jl:1

JSON [682c06a0-de6a-54ab-a142-c8b1cf79cde6]

Error: Missing source file for JSON [682c06a0-de6a-54ab-a142-c8b1cf79cde6]
```