### PR TITLE
Precompile: Add precomp to Pkg.test

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -141,7 +141,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
             Registry.download_default_registries(DEFAULT_IO[])
             ctx = Context()
             ret = $f(ctx, pkgs; kwargs...)
-            $(f in (:add, :up, :pin, :free, :build)) && _auto_precompile(ctx)
+            $(f in (:add, :up, :pin, :free, :build)) && Pkg._auto_precompile(ctx)
             return ret
         end
         $f(ctx::Context; kwargs...) = $f(ctx, PackageSpec[]; kwargs...)
@@ -967,12 +967,6 @@ function _is_stale(paths::Vector{String}, sourcepath::String)
     return true
 end
 
-function _auto_precompile(ctx::Context)
-    if parse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
-        Pkg.precompile(ctx; internal_call=true)
-    end
-end
-
 function make_pkgspec(man, uuid)
     pkgent = man[uuid]
     # If we have an unusual situation such as an un-versioned package (like an stdlib that
@@ -1372,7 +1366,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Operations.download_artifacts([dirname(ctx.env.manifest_file)]; platform=platform, verbose=verbose)
     # check if all source code and artifacts are downloaded to exit early
     if Operations.is_instantiated(ctx.env)
-        allow_autoprecomp && _auto_precompile(ctx)
+        allow_autoprecomp && Pkg._auto_precompile(ctx)
         return
     end
 
@@ -1427,7 +1421,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Run build scripts
     Operations.build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git); verbose=verbose)
 
-    allow_autoprecomp && _auto_precompile(ctx; kwargs...)
+    allow_autoprecomp && Pkg._auto_precompile(ctx; kwargs...)
 end
 
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1429,6 +1429,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
         # sandbox
         with_temp_env(tmp) do
             temp_ctx = Context()
+            original_io = ctx.io
             temp_ctx.env.project.deps[target.name] = target.uuid
 
             try
@@ -1451,6 +1452,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
             end
             write_env(temp_ctx.env, update_undo = false)
 
+            temp_ctx.io = original_io # restore given resolve step suppresses io
             allow_autoprecomp && Pkg._auto_precompile(temp_ctx)
 
             # Run sandboxed code

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1451,7 +1451,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
             end
             write_env(temp_ctx.env, update_undo = false)
 
-            allow_autoprecomp && _auto_precompile(temp_ctx)
+            allow_autoprecomp && Pkg._auto_precompile(temp_ctx)
 
             # Run sandboxed code
             path_sep = Sys.iswindows() ? ';' : ':'
@@ -1535,7 +1535,7 @@ testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 function test(ctx::Context, pkgs::Vector{PackageSpec};
               coverage=false, julia_args::Cmd=``, test_args::Cmd=``,
               test_fn=nothing, allow_autoprecomp::Bool=true)
-    Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later in sandbox
+    Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
 
     # load manifest data
     for pkg in pkgs

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -597,6 +597,12 @@ end
 # Precompilation #
 ##################
 
+function _auto_precompile(ctx::Types.Context)
+    if parse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
+        Pkg.precompile(ctx; internal_call=true)
+    end
+end
+
 using LibGit2: LibGit2
 function _run_precompilation_script_setup()
     tmp = mktempdir()

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -186,7 +186,6 @@ const update = API.up
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
-  - `allow_autoprecomp::Bool=true`: allow auto-precompilation to be done in test environment, if not disabled globally
 
 !!! compat "Julia 1.3"
     `julia_args` and `test_args` requires at least Julia 1.3.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -186,6 +186,7 @@ const update = API.up
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
+  - `allow_autoprecomp::Bool=true`: allow auto-precompilation to be done in test environment, if not disabled globally
 
 !!! compat "Julia 1.3"
     `julia_args` and `test_args` requires at least Julia 1.3.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -598,7 +598,7 @@ end
 ##################
 
 function _auto_precompile(ctx::Types.Context)
-    if parse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
+    if tryparse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
         Pkg.precompile(ctx; internal_call=true)
     end
 end


### PR DESCRIPTION
Auto-precompilation is currently not run during `Pkg.test`, which means if a CI test just relies on `Pkg.test` to install the deps it currently won't benefit from parallel precomp. 

Now that error reporting in `Pkg.precompile` has improved to properly error and show stacktraces the issues around lack of information that led to it being disabled https://github.com/JuliaLang/Pkg.jl/issues/2110 should have been cleared.

Things to note:
 - This precomp is done within the correct test sandbox context (not where it was previously done, as discussed in https://github.com/JuliaLang/Pkg.jl/issues/2110)
 - It can be disabled either by settting `Pkg.test(... allow_autoprecomp = false)` or `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`, and the kwarg could be exposed by the github action