### PR TITLE
Fix `is_instantiated()`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1371,9 +1371,6 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
                  " Otherwise, remove `$name` with `Pkg.rm(\"$name\")`.",
                  " Finally, run `Pkg.instantiate()` again.")
     end
-    # TODO: seems to be a bug in is_instantiated on the line below so we have to download
-    # artifacts here even though we do the same at the end of this function
-    Operations.download_artifacts([dirname(ctx.env.manifest_file)]; platform=platform, verbose=verbose)
     # check if all source code and artifacts are downloaded to exit early
     if Operations.is_instantiated(ctx.env)
         allow_autoprecomp && _auto_precompile(ctx)
@@ -1426,10 +1423,14 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
 
     # Install all packages
     new_apply = Operations.download_source(ctx, pkgs)
-    # Install all artifacts
-    Operations.download_artifacts(ctx.env, pkgs; platform=platform, verbose=verbose)
+    # Install artifacts for deps and artifacts for current package, if applicable
+    art_pkgs = copy(pkgs)
+    if ctx.env.pkg !== nothing
+        push!(art_pkgs, ctx.env.pkg)
+    end
+    Operations.download_artifacts(ctx.env, art_pkgs; platform, verbose)
     # Run build scripts
-    Operations.build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git); verbose=verbose)
+    Operations.build_versions(ctx, union(UUID[pkg.uuid for pkg in new_apply], new_git); verbose)
 
     allow_autoprecomp && _auto_precompile(ctx; kwargs...)
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -110,7 +110,11 @@ end
 function is_instantiated(env::EnvCache)::Bool
     # Load everything
     pkgs = load_all_deps(env)
-    # Make sure all paths exist
+    # If the top-level project is a package, ensure it is instantiated as well
+    if env.pkg !== nothing
+        push!(pkgs, Types.PackageSpec(name=env.pkg.name, uuid=env.pkg.uuid, version=env.pkg.version, path=dirname(env.project_file)))
+    end
+    # Make sure all paths/artifacts exist
     return all(pkg -> is_package_downloaded(env.project_file, pkg), pkgs)
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -278,6 +278,7 @@ function EnvCache(env::Union{Nothing,String}=nothing)
             name = project.name,
             uuid = project.uuid,
             version = something(project.version, VersionNumber("0.0")),
+            path = project_dir,
         )
     else
         project_package = nothing


### PR DESCRIPTION
Previously, `is_instantiated()` would only check for the presence of
dependencies, which caused artifacts belonging to the top-level project
itself to be missed in its check.  This rectifies that oversight.