### PR TITLE
Catch errors during `recursive_dir_size()`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -839,15 +839,19 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
 
     function recursive_dir_size(path)
         size = 0
-        for (root, dirs, files) in walkdir(path)
-            for file in files
-                path = joinpath(root, file)
-                try
-                    size += lstat(path).size
-                catch
-                    @warn "Failed to calculate size of $path"
+        try
+            for (root, dirs, files) in walkdir(path)
+                for file in files
+                    path = joinpath(root, file)
+                    try
+                        size += lstat(path).size
+                    catch ex
+                        @warn("Failed to calculate size of $path", ex)
+                    end
                 end
             end
+        catch ex
+            @warn("Failed to calculate size of $path", ex)
         end
         return size
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -846,12 +846,12 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
                     try
                         size += lstat(path).size
                     catch ex
-                        @warn("Failed to calculate size of $path", ex)
+                        @error("Failed to calculate size of $path", exception=ex)
                     end
                 end
             end
         catch ex
-            @warn("Failed to calculate size of $path", ex)
+            @error("Failed to calculate size of $path", exception=ex)
         end
         return size
     end


### PR DESCRIPTION
While trying to clean up artifacts on Yggdrasil's CI bots, we found that some malformed artifacts (that had things like extremely-deeply-nested directories) would cause `ENAMETOOLONG` in a `stat()` within `walkdir()` itself.  Let's catch these kinds of issues and report them to the user properly.