### PR TITLE
Registry: Change update from `cp` to `mv`

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -186,7 +186,12 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
                         "`$(Base.contractuser(joinpath(depot, "registries", registry.name*"-2")))`."))
                 end
             else
-                mv(tmp, regpath)
+                try
+                    mv(tmp, regpath)
+                catch e
+                    isdir(regpath) && rm(regpath, recursive=true, force=true) # don't leave an incomplete registry
+                    rethrow()
+                end
                 printpkgstyle(io, :Added, "registry `$(registry.name)` to `$(Base.contractuser(regpath))`")
             end
         end

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -186,12 +186,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
                         "`$(Base.contractuser(joinpath(depot, "registries", registry.name*"-2")))`."))
                 end
             else
-                try
-                    mv(tmp, regpath)
-                catch e
-                    isdir(regpath) && rm(regpath, recursive=true, force=true) # don't leave an incomplete registry
-                    rethrow()
-                end
+                mv(tmp, regpath)
                 printpkgstyle(io, :Added, "registry `$(registry.name)` to `$(Base.contractuser(regpath))`")
             end
         end

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -298,7 +298,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=DEFAULT_IO[]
                 if url !== nothing && (new_hash = pkg_server_url_hash(url)) != old_hash
                     let new_hash = new_hash
                         # TODO: update faster by using a diff, if available
-                        mktempdir() do tmp
+                        mktempdir(cleanup=false) do tmp # no cleanup since we mv it
                             try
                                 download_verify_unpack(url, nothing, tmp, ignore_existence = true)
                             catch err
@@ -307,7 +307,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=DEFAULT_IO[]
                             tree_info_file = joinpath(tmp, ".tree_info.toml")
                             hash = pkg_server_url_hash(url)
                             write(tree_info_file, "git-tree-sha1 = " * repr(string(new_hash)))
-                            cp(tmp, reg.path, force=true)
+                            mv(tmp, reg.path, force=true)
                         end
                     end
                 end

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -298,17 +298,16 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=DEFAULT_IO[]
                 if url !== nothing && (new_hash = pkg_server_url_hash(url)) != old_hash
                     let new_hash = new_hash
                         # TODO: update faster by using a diff, if available
-                        mktempdir(cleanup=false) do tmp # no cleanup since we mv it
-                            try
-                                download_verify_unpack(url, nothing, tmp, ignore_existence = true)
-                            catch err
-                                @error "could not download $url" exception=err
-                            end
-                            tree_info_file = joinpath(tmp, ".tree_info.toml")
-                            hash = pkg_server_url_hash(url)
-                            write(tree_info_file, "git-tree-sha1 = " * repr(string(new_hash)))
-                            mv(tmp, reg.path, force=true)
+                        tmp = mktempdir(cleanup=false) # no cleanup since we mv it
+                        try
+                            download_verify_unpack(url, nothing, tmp, ignore_existence = true)
+                        catch err
+                            @error "could not download $url" exception=err
                         end
+                        tree_info_file = joinpath(tmp, ".tree_info.toml")
+                        hash = pkg_server_url_hash(url)
+                        write(tree_info_file, "git-tree-sha1 = " * repr(string(new_hash)))
+                        mv(tmp, reg.path, force=true)
                     end
                 end
             elseif isdir(joinpath(reg.path, ".git"))


### PR DESCRIPTION
- ~~Don't leave an incomplete registry if mv fails or is interrupted
An attempt to reduce the chances of https://github.com/JuliaLang/Pkg.jl/issues/1667 happening.
Might be a fix, although the move from `cp` to `mv` may have made the likelihood much smaller already?~~

- Use `mv` rather than `cp` when updating the registry. 
`cp` seems A LOT slower on windows than `mv` https://github.com/JuliaLang/Pkg.jl/issues/2348#issuecomment-763346086
