### PR TITLE
Fix download prints respecting IO, and show when downloads fail

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -400,6 +400,7 @@ end
         force::Bool = false,
         verbose::Bool = false,
         quiet_download::Bool = false,
+        io::IO=stdout,
     )
 
 Helper method to download tarball located at `url`, verify it matches the
@@ -434,6 +435,7 @@ function download_verify_unpack(
     force::Bool = false,
     verbose::Bool = false,
     quiet_download::Bool = false,
+    io::IO=stdout,
 )
     # First, determine whether we should keep this tarball around
     remove_tarball = false

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -150,7 +150,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             if !Sys.iswindows() && url !== nothing
                 # download from Pkg server
                 try
-                    download_verify_unpack(url, nothing, tmp, ignore_existence = true)
+                    download_verify_unpack(url, nothing, tmp, ignore_existence = true, io = io)
                 catch err
                     Pkg.Types.pkgerror("could not download $url")
                 end
@@ -295,7 +295,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=DEFAULT_IO[]
                         # TODO: update faster by using a diff, if available
                         mktempdir() do tmp
                             try
-                                download_verify_unpack(url, nothing, tmp, ignore_existence = true)
+                                download_verify_unpack(url, nothing, tmp, ignore_existence = true, io=io)
                             catch err
                                 @error "could not download $url" exception=err
                             end


### PR DESCRIPTION
- Fixes #2328. All download activity printing is passed to the given io (which can be `devnull` to suppress printing)

- Now reports when an artifact download fails. 
Previously Pkg was reporting "Downloaded.." even if an artifact download failed, which looks a bit odd.
If the first download attempt fails for an artifact, I've enabled printing of the domain of both the failure and the subsequent success/failures.
There's an existing todo to only try the pkg server if it knows about the artifact, which would make this all a bit tidier for artifacts that aren't actually served there.
If the first download attempts just work, the printing remains minimal.

## Before
- Download IO isn't suppressed by `io=devnull`
- Download failures are reported as successful downloads, and no detail is provided

<img width="701" alt="Screen Shot 2021-01-23 at 1 34 38 AM" src="https://user-images.githubusercontent.com/1694067/105571112-2f0fd900-5d1b-11eb-84db-bb662dd9d420.png">

## This PR

<img width="755" alt="Screen Shot 2021-01-23 at 3 08 35 AM" src="https://user-images.githubusercontent.com/1694067/105572990-6a64d480-5d28-11eb-9106-c75e73efaa20.png">

