### PR TITLE
Registry add: Overwrite registry folders that don't contain a Registry.toml

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -174,7 +174,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             # copy to `depot`
             regpath = joinpath(depot, "registries", registry.name)
             ispath(dirname(regpath)) || mkpath(dirname(regpath))
-            if isdir_nothrow(regpath)
+            if isfile(joinpath(regpath, "Registry.toml"))
                 existing_registry = Registry.RegistryInstance(regpath; parse_packages=false)
                 if registry.uuid == existing_registry.uuid
                     println(io,
@@ -186,7 +186,8 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
                         "`$(Base.contractuser(joinpath(depot, "registries", registry.name*"-2")))`."))
                 end
             else
-                mv(tmp, regpath)
+                # if the dir doesn't exist, or exists but doesn't contain a Registry.toml
+                mv(tmp, regpath, force=true)
                 printpkgstyle(io, :Added, "registry `$(registry.name)` to `$(Base.contractuser(regpath))`")
             end
         end


### PR DESCRIPTION
Even though the core reason for #1667 should be fixed on master & 1.6, that error can happen if a registry dir exists that's missing the `Registry.toml` file, which might happen if people are using newer and older julia versions together.

This changes to checking for the `Registry.toml` directly, rather than the existence of the dir.
If it's missing, the dir is replaced by the new cloned registry.