### PR TITLE
Debugging CI download failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           - os: macOS-latest
             julia-arch: x86
     steps:
+      - run: curl https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714
       - uses: actions/checkout@v1.0.0
       - uses: julia-actions/setup-julia@latest
         with:

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -506,6 +506,7 @@ function install_archive(
             PlatformEngines.download(url, path; verbose=false)
         catch e
             e isa InterruptException && rethrow()
+            @error "failed to download $url" exception=e
             url_success = false
         end
         url_success || continue
@@ -516,7 +517,7 @@ function install_archive(
             unpack(path, dir; verbose=false)
         catch e
             e isa InterruptException && rethrow()
-            @warn "failed to extract archive downloaded from $(url)"
+            @error "failed to extract archive downloaded from $(url)" exception=e
             url_success = false
         end
         url_success || continue

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -506,7 +506,7 @@ function install_archive(
             PlatformEngines.download(url, path; verbose=false)
         catch e
             e isa InterruptException && rethrow()
-            @error "failed to download $url" exception=e
+            @warn "failed to download archive from $(url)" exception=e
             url_success = false
         end
         url_success || continue
@@ -517,7 +517,7 @@ function install_archive(
             unpack(path, dir; verbose=false)
         catch e
             e isa InterruptException && rethrow()
-            @error "failed to extract archive downloaded from $(url)" exception=e
+            @warn "failed to extract archive downloaded from $(url)" exception=e
             url_success = false
         end
         url_success || continue

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -503,7 +503,7 @@ function install_archive(
         push!(tmp_objects, path) # for cleanup
         url_success = true
         try
-            PlatformEngines.download(url, path; verbose=false)
+            PlatformEngines.download(url, path; verbose=true)
         catch e
             e isa InterruptException && rethrow()
             @warn "failed to download archive from $(url)" exception=e

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -710,7 +710,7 @@ function download_source(ctx::Context, pkgs::Vector{PackageSpec},
                             set_readonly(path) # In add mode, files should be read-only
                         end
                         if ctx.use_only_tarballs_for_downloads && !success
-                            pkgerror("failed to get tarball from $(urls[pkg.uuid])")
+                            pkgerror("failed to get tarball for $(urls[pkg.uuid]) from $(first.(archive_urls))")
                         end
                         put!(results, (pkg, success, path))
                     catch err

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -263,7 +263,6 @@ function download(
     end
     @show url, dest, headers
     try
-        println(@which Downloads.download(url, dest; headers, progress))
         @time Downloads.download(url, dest; headers, progress)
     finally
         do_fancy && end_progress(stderr, bar)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -263,7 +263,7 @@ function download(
     end
     @show url, dest, headers
     try
-        @time Downloads.download(url, dest; headers, progress)
+        Downloads.download(url, dest; headers, progress, verbose)
     finally
         do_fancy && end_progress(stderr, bar)
     end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -261,6 +261,7 @@ function download(
     else
         (total, now) -> nothing
     end
+    @show url, dest, headers
     try
         Downloads.download(url, dest; headers, progress)
     finally

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -263,7 +263,8 @@ function download(
     end
     @show url, dest, headers
     try
-        Downloads.download(url, dest; headers, progress)
+        println(@which Downloads.download(url, dest; headers, progress))
+        @time Downloads.download(url, dest; headers, progress)
     finally
         do_fancy && end_progress(stderr, bar)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -21,19 +21,19 @@ testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c7
 
 precompile(Pkg.add, (String,))
 
-for i in 1:10
+for i in 1:1
     @testset "Debugging: Downloads.download. Rep $i" begin
         dest, io = mktemp()
         Downloads.download(testurl, dest; headers = Pair{String, String}[], progress = (total, now) -> nothing, verbose = true)
     end
 end
-for i in 1:10
+for i in 1:1
     @testset "Debugging: PlatformEngines.download. Rep $i" begin
         dest, io = mktemp()
         Pkg.PlatformEngines.download(testurl, dest, verbose = true)
     end
 end
-for i in 1:10
+for i in 1:1
     @testset "Debugging: PlatformEngines.download, isolated. Rep $i" begin
         isolate() do
             dest, io = mktemp()
@@ -42,7 +42,7 @@ for i in 1:10
     end
 end
 
-for i in 1:10
+for i in 1:1
     @testset "Debugging: downloads. Rep $i" begin
         isolate() do
             @testset "tarball downloads" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -18,8 +18,12 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
 using Downloads
 testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714"
-@testset "Debugging: Downloads.download" begin
-    Downloads.download(testurl)
+for i in 1:10
+    @testset "Debugging: Downloads.download. Rep $i" begin
+        path, io = mktemp()
+        progress = (total, now) -> nothing
+        Downloads.download(testurl, path; headers = Pair{String, String}[], progress = progress)
+    end
 end
 for i in 1:10
     @testset "Debugging: PlatformEngines.download. Rep $i" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -17,8 +17,30 @@ unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
 using Downloads
-@testset "Basic download" begin
+@testset "Debugging: Basic download" begin
     Downloads.download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
+end
+@testset "Debugging: downloads" begin
+    # libgit2 downloads
+    isolate() do
+        Pkg.add("Example"; use_libgit2_for_all_downloads=true)
+        @test haskey(Pkg.dependencies(), exuuid)
+        @eval import $(Symbol(TEST_PKG.name))
+        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
+        Pkg.rm(TEST_PKG.name)
+    end
+    isolate() do
+        @testset "libgit2 downloads" begin
+            Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
+            @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+            Pkg.rm(TEST_PKG.name)
+        end
+        @testset "tarball downloads" begin
+            Pkg.add("JSON"; use_only_tarballs_for_downloads=true)
+            @test "JSON" in [pkg.name for (uuid, pkg) in Pkg.dependencies()]
+            Pkg.rm("JSON")
+        end
+    end
 end
 
 #

--- a/test/new.jl
+++ b/test/new.jl
@@ -41,6 +41,16 @@ end
     dest, io = mktemp()
     Pkg.PlatformEngines.download(testurl1, dest, verbose = true)
 end
+@testset "Debugging: PlatformEngines.download, multiple async." begin
+    Base.Experimental.@sync begin
+        dest1, io = mktemp()
+        @async Pkg.PlatformEngines.download(testurl1, dest1, verbose = true)
+        dest2, io = mktemp()
+        @async Pkg.PlatformEngines.download(testurl2, dest2, verbose = true)
+    end
+end
+
+
 @testset "Debugging: PlatformEngines.download, isolated" begin
     isolate() do
         dest, io = mktemp()

--- a/test/new.jl
+++ b/test/new.jl
@@ -24,20 +24,20 @@ precompile(Pkg.add, (String,))
 for i in 1:10
     @testset "Debugging: Downloads.download. Rep $i" begin
         dest, io = mktemp()
-        Downloads.download(testurl, dest; headers = Pair{String, String}[], progress = (total, now) -> nothing)
+        Downloads.download(testurl, dest; headers = Pair{String, String}[], progress = (total, now) -> nothing, verbose = true)
     end
 end
 for i in 1:10
     @testset "Debugging: PlatformEngines.download. Rep $i" begin
         dest, io = mktemp()
-        Pkg.PlatformEngines.download(testurl, dest)
+        Pkg.PlatformEngines.download(testurl, dest, verbose = true)
     end
 end
 for i in 1:10
     @testset "Debugging: PlatformEngines.download, isolated. Rep $i" begin
         isolate() do
             dest, io = mktemp()
-            Pkg.PlatformEngines.download(testurl, dest)
+            Pkg.PlatformEngines.download(testurl, dest, verbose = true)
         end
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -20,25 +20,27 @@ using Downloads
 @testset "Debugging: Basic download" begin
     Downloads.download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
 end
-@testset "Debugging: downloads" begin
-    # libgit2 downloads
-    isolate() do
-        Pkg.add("Example"; use_libgit2_for_all_downloads=true)
-        @test haskey(Pkg.dependencies(), exuuid)
-        @eval import $(Symbol(TEST_PKG.name))
-        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
-        Pkg.rm(TEST_PKG.name)
-    end
-    isolate() do
-        @testset "libgit2 downloads" begin
-            Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
-            @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+for i in 1:10
+    @testset "Debugging: downloads. Rep $i" begin
+        # libgit2 downloads
+        isolate() do
+            Pkg.add("Example"; use_libgit2_for_all_downloads=true)
+            @test haskey(Pkg.dependencies(), exuuid)
+            @eval import $(Symbol(TEST_PKG.name))
+            @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
             Pkg.rm(TEST_PKG.name)
         end
-        @testset "tarball downloads" begin
-            Pkg.add("JSON"; use_only_tarballs_for_downloads=true)
-            @test "JSON" in [pkg.name for (uuid, pkg) in Pkg.dependencies()]
-            Pkg.rm("JSON")
+        isolate() do
+            @testset "libgit2 downloads" begin
+                Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
+                @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                Pkg.rm(TEST_PKG.name)
+            end
+            @testset "tarball downloads" begin
+                Pkg.add("JSON"; use_only_tarballs_for_downloads=true)
+                @test "JSON" in [pkg.name for (uuid, pkg) in Pkg.dependencies()]
+                Pkg.rm("JSON")
+            end
         end
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -22,8 +22,7 @@ testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c7
     Downloads.download(testurl)
 end
 for i in 1:10
-    @testset "Debugging: PlatformEngines.download" begin
-        @show Pkg.PlatformEngines.get_auth_header(testurl, verbose=true)
+    @testset "Debugging: PlatformEngines.download. Rep $i" begin
         path, io = mktemp()
         Pkg.PlatformEngines.download(testurl, path; verbose=true)
     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -16,6 +16,10 @@ unicode_uuid = UUID("4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5")
 unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
+@testset "Basic download" begin
+    download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
+end
+
 #
 # # Depot Changes
 #

--- a/test/new.jl
+++ b/test/new.jl
@@ -16,8 +16,9 @@ unicode_uuid = UUID("4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5")
 unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
+using Downloads
 @testset "Basic download" begin
-    download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
+    Downloads.download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
 end
 
 #

--- a/test/new.jl
+++ b/test/new.jl
@@ -30,19 +30,19 @@ end
 for i in 1:10
     @testset "Debugging: downloads. Rep $i" begin
         # libgit2 downloads
+        # isolate() do
+        #     Pkg.add("Example"; use_libgit2_for_all_downloads=true)
+        #     @test haskey(Pkg.dependencies(), exuuid)
+        #     @eval import $(Symbol(TEST_PKG.name))
+        #     @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
+        #     Pkg.rm(TEST_PKG.name)
+        # end
         isolate() do
-            Pkg.add("Example"; use_libgit2_for_all_downloads=true)
-            @test haskey(Pkg.dependencies(), exuuid)
-            @eval import $(Symbol(TEST_PKG.name))
-            @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
-            Pkg.rm(TEST_PKG.name)
-        end
-        isolate() do
-            @testset "libgit2 downloads" begin
-                Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
-                @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                Pkg.rm(TEST_PKG.name)
-            end
+            # @testset "libgit2 downloads" begin
+            #     Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
+            #     @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+            #     Pkg.rm(TEST_PKG.name)
+            # end
             @testset "tarball downloads" begin
                 Pkg.add("JSON"; use_only_tarballs_for_downloads=true)
                 @test "JSON" in [pkg.name for (uuid, pkg) in Pkg.dependencies()]

--- a/test/new.jl
+++ b/test/new.jl
@@ -18,6 +18,9 @@ simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
 using Downloads
 testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714"
+
+precompile(Pkg.add, (String,))
+
 for i in 1:10
     @testset "Debugging: Downloads.download. Rep $i" begin
         dest, io = mktemp()

--- a/test/new.jl
+++ b/test/new.jl
@@ -17,27 +17,41 @@ unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
 using Downloads
-testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714"
+testurl1 = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714"
+testurl2 = "https://api.github.com/repos/JuliaIO/JSON.jl/tarball/81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 
 precompile(Pkg.add, (String,))
 
 for i in 1:1
     @testset "Debugging: Downloads.download. Rep $i" begin
         dest, io = mktemp()
-        Downloads.download(testurl, dest; headers = Pair{String, String}[], progress = (total, now) -> nothing, verbose = true)
+        Downloads.download(testurl1, dest; headers = Pair{String, String}[], progress = (total, now) -> nothing, verbose = true)
     end
 end
 for i in 1:1
     @testset "Debugging: PlatformEngines.download. Rep $i" begin
         dest, io = mktemp()
-        Pkg.PlatformEngines.download(testurl, dest, verbose = true)
+        Pkg.PlatformEngines.download(testurl1, dest, verbose = true)
     end
 end
 for i in 1:1
     @testset "Debugging: PlatformEngines.download, isolated. Rep $i" begin
         isolate() do
             dest, io = mktemp()
-            Pkg.PlatformEngines.download(testurl, dest, verbose = true)
+            Pkg.PlatformEngines.download(testurl1, dest, verbose = true)
+        end
+    end
+end
+
+for i in 1:1
+    @testset "Debugging: PlatformEngines.download, isolated, multiple in scope. Rep $i" begin
+        isolate() do
+            Base.Experimental.@sync begin
+                dest1, io = mktemp()
+                @async Pkg.PlatformEngines.download(testurl1, dest1, verbose = true)
+                dest2, io = mktemp()
+                @async Pkg.PlatformEngines.download(testurl2, dest2, verbose = true)
+            end
         end
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -20,15 +20,22 @@ using Downloads
 testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714"
 for i in 1:10
     @testset "Debugging: Downloads.download. Rep $i" begin
-        path, io = mktemp()
-        progress = (total, now) -> nothing
-        Downloads.download(testurl, path; headers = Pair{String, String}[], progress = progress)
+        dest, io = mktemp()
+        Downloads.download(testurl, dest; headers = Pair{String, String}[], progress = (total, now) -> nothing)
     end
 end
 for i in 1:10
     @testset "Debugging: PlatformEngines.download. Rep $i" begin
-        path, io = mktemp()
-        Pkg.PlatformEngines.download(testurl, path; verbose=true)
+        dest, io = mktemp()
+        Pkg.PlatformEngines.download(testurl, dest)
+    end
+end
+for i in 1:10
+    @testset "Debugging: PlatformEngines.download, isolated. Rep $i" begin
+        isolate() do
+            dest, io = mktemp()
+            Pkg.PlatformEngines.download(testurl, dest)
+        end
     end
 end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -21,28 +21,17 @@ testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c7
 @testset "Debugging: Downloads.download" begin
     Downloads.download(testurl)
 end
-@testset "Debugging: PlatformEngines.download" begin
-    @show Pkg.PlatformEngines.get_auth_header(testurl, verbose=true)
-    path, io = mktemp()
-    Pkg.PlatformEngines.download(testurl, path; verbose=true)
+for i in 1:10
+    @testset "Debugging: PlatformEngines.download" begin
+        @show Pkg.PlatformEngines.get_auth_header(testurl, verbose=true)
+        path, io = mktemp()
+        Pkg.PlatformEngines.download(testurl, path; verbose=true)
+    end
 end
 
 for i in 1:10
     @testset "Debugging: downloads. Rep $i" begin
-        # libgit2 downloads
-        # isolate() do
-        #     Pkg.add("Example"; use_libgit2_for_all_downloads=true)
-        #     @test haskey(Pkg.dependencies(), exuuid)
-        #     @eval import $(Symbol(TEST_PKG.name))
-        #     @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
-        #     Pkg.rm(TEST_PKG.name)
-        # end
         isolate() do
-            # @testset "libgit2 downloads" begin
-            #     Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
-            #     @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-            #     Pkg.rm(TEST_PKG.name)
-            # end
             @testset "tarball downloads" begin
                 Pkg.add("JSON"; use_only_tarballs_for_downloads=true)
                 @test "JSON" in [pkg.name for (uuid, pkg) in Pkg.dependencies()]

--- a/test/new.jl
+++ b/test/new.jl
@@ -17,9 +17,15 @@ unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
 using Downloads
-@testset "Debugging: Basic download" begin
-    Downloads.download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
+testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714"
+@testset "Debugging: Downloads.download" begin
+    Downloads.download(testurl)
 end
+@testset "Debugging: PlatformEngines.download" begin
+    path, io = mktemp()
+    Pkg.PlatformEngines.download(testurl, path; verbose=true)
+end
+
 for i in 1:10
     @testset "Debugging: downloads. Rep $i" begin
         # libgit2 downloads

--- a/test/new.jl
+++ b/test/new.jl
@@ -22,6 +22,7 @@ testurl = "https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c7
     Downloads.download(testurl)
 end
 @testset "Debugging: PlatformEngines.download" begin
+    @show Pkg.PlatformEngines.get_auth_header(testurl, verbose=true)
     path, io = mktemp()
     Pkg.PlatformEngines.download(testurl, path; verbose=true)
 end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -23,10 +23,6 @@ const PackageSpec = Pkg.Types.PackageSpec
 
 import Pkg.Types: semver_spec, VersionSpec
 
-@testset "Basic download" begin
-    download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
-end
-
 @testset "semver notation" begin
     @test semver_spec("^1.2.3") == VersionSpec("1.2.3-1")
     @test semver_spec("^1.2")   == VersionSpec("1.2.0-1")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -22,6 +22,11 @@ const TEST_PKG = (name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-2369062
 const PackageSpec = Pkg.Types.PackageSpec
 
 import Pkg.Types: semver_spec, VersionSpec
+
+@testset "Basic download" begin
+    download("https://api.github.com/repos/JuliaData/Parsers.jl/tarball/50c9a9ed8c714945e01cd53a21007ed3865ed714")
+end
+
 @testset "semver notation" begin
     @test semver_spec("^1.2.3") == VersionSpec("1.2.3-1")
     @test semver_spec("^1.2")   == VersionSpec("1.2.0-1")


### PR DESCRIPTION
There's a repeatable error during tarball download on ubuntu without the package server, and the error message is currently a little unhelpful. 
This adds the actual tarball urls being tried