### PR TITLE
Precompile: add `strict` kwarg to control whether indirect deps throw

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -980,7 +980,7 @@ function make_pkgspec(man, uuid)
 end
 
 precompile(; kwargs...) = precompile(Context(); kwargs...)
-function precompile(ctx::Context; internal_call::Bool=false, throw_indirect_deps::Bool=false, kwargs...)
+function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
@@ -1209,7 +1209,7 @@ function precompile(ctx::Context; internal_call::Bool=false, throw_indirect_deps
                         end
                     catch err
                         if err isa ErrorException
-                            failed_deps[pkg] = (throw_indirect_deps || is_direct_dep) ? String(take!(iob)) : ""
+                            failed_deps[pkg] = (strict || is_direct_dep) ? String(take!(iob)) : ""
                             !fancyprint && lock(print_lock) do
                                 println(io, string(color_string("  ✗ ", Base.error_color()), name))
                             end
@@ -1278,7 +1278,7 @@ function precompile(ctx::Context; internal_call::Bool=false, throw_indirect_deps
             err_str = ""
             n_direct_errs = 0
             for (dep, err) in failed_deps
-                if throw_indirect_deps || (dep in direct_deps)
+                if strict || (dep in direct_deps)
                     err_str *= "\n" * "$dep" * "\n\n" * err * (n_direct_errs > 0 ? "\n" : "")
                     n_direct_errs += 1
                 end
@@ -1286,7 +1286,7 @@ function precompile(ctx::Context; internal_call::Bool=false, throw_indirect_deps
             if err_str != ""
                 println(io, "")
                 plural = n_direct_errs == 1 ? "y" : "ies"
-                direct = throw_indirect_deps ? "" : "direct "
+                direct = strict ? "" : "direct "
                 pkgerror("The following $n_direct_errs $(direct)dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
             end
         end

--- a/src/API.jl
+++ b/src/API.jl
@@ -980,7 +980,7 @@ function make_pkgspec(man, uuid)
 end
 
 precompile(; kwargs...) = precompile(Context(); kwargs...)
-function precompile(ctx::Context; internal_call::Bool=false, fail_indirect_deps::Bool=false, kwargs...)
+function precompile(ctx::Context; internal_call::Bool=false, throw_indirect_deps::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
@@ -1209,7 +1209,7 @@ function precompile(ctx::Context; internal_call::Bool=false, fail_indirect_deps:
                         end
                     catch err
                         if err isa ErrorException
-                            failed_deps[pkg] = (fail_indirect_deps || is_direct_dep) ? String(take!(iob)) : ""
+                            failed_deps[pkg] = (throw_indirect_deps || is_direct_dep) ? String(take!(iob)) : ""
                             !fancyprint && lock(print_lock) do
                                 println(io, string(color_string("  ✗ ", Base.error_color()), name))
                             end
@@ -1278,7 +1278,7 @@ function precompile(ctx::Context; internal_call::Bool=false, fail_indirect_deps:
             err_str = ""
             n_direct_errs = 0
             for (dep, err) in failed_deps
-                if fail_indirect_deps || (dep in direct_deps)
+                if throw_indirect_deps || (dep in direct_deps)
                     err_str *= "\n" * "$dep" * "\n\n" * err * (n_direct_errs > 0 ? "\n" : "")
                     n_direct_errs += 1
                 end
@@ -1286,7 +1286,7 @@ function precompile(ctx::Context; internal_call::Bool=false, fail_indirect_deps:
             if err_str != ""
                 println(io, "")
                 plural = n_direct_errs == 1 ? "y" : "ies"
-                direct = fail_indirect_deps ? "" : "direct"
+                direct = throw_indirect_deps ? "" : "direct"
                 pkgerror("The following $n_direct_errs $direct dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
             end
         end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1286,8 +1286,8 @@ function precompile(ctx::Context; internal_call::Bool=false, throw_indirect_deps
             if err_str != ""
                 println(io, "")
                 plural = n_direct_errs == 1 ? "y" : "ies"
-                direct = throw_indirect_deps ? "" : "direct"
-                pkgerror("The following $n_direct_errs $direct dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
+                direct = throw_indirect_deps ? "" : "direct "
+                pkgerror("The following $n_direct_errs $(direct)dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
             end
         end
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1286,7 +1286,8 @@ function precompile(ctx::Context; internal_call::Bool=false, fail_indirect_deps:
             if err_str != ""
                 println(io, "")
                 plural = n_direct_errs == 1 ? "y" : "ies"
-                pkgerror("The following $( n_direct_errs) direct dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
+                direct = fail_indirect_deps ? "" : "direct"
+                pkgerror("The following $n_direct_errs $direct dependenc$(plural) failed to precompile:\n$(err_str[1:end-1])")
             end
         end
     end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -136,7 +136,7 @@ Precompile all the dependencies of the project in parallel.
 !!! note
     Errors will only throw when precompiling the top-level dependencies, given that
     not all manifest dependencies may be loaded by the top-level dependencies on the given system.
-    This can be overridden by setting `throw_indirect_deps=true`
+    This can be overridden by setting the kwarg `throw_indirect_deps` to `true`
 
 !!! note
     This method is called automatically after any Pkg action that changes the manifest.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -130,13 +130,13 @@ See also [`PackageSpec`](@ref).
 const add = API.add
 
 """
-    Pkg.precompile(; fail_indirect_deps::Bool=false)
+    Pkg.precompile(; throw_indirect_deps::Bool=false)
 
 Precompile all the dependencies of the project in parallel.
 !!! note
     Errors will only throw when precompiling the top-level dependencies, given that
     not all manifest dependencies may be loaded by the top-level dependencies on the given system.
-    This can be overridden by setting `fail_indirect_deps=true`
+    This can be overridden by setting `throw_indirect_deps=true`
 
 !!! note
     This method is called automatically after any Pkg action that changes the manifest.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -130,13 +130,13 @@ See also [`PackageSpec`](@ref).
 const add = API.add
 
 """
-    Pkg.precompile(; throw_indirect_deps::Bool=false)
+    Pkg.precompile(; strict::Bool=false)
 
 Precompile all the dependencies of the project in parallel.
 !!! note
     Errors will only throw when precompiling the top-level dependencies, given that
     not all manifest dependencies may be loaded by the top-level dependencies on the given system.
-    This can be overridden by setting the kwarg `throw_indirect_deps` to `true`
+    This can be overridden to make errors in all dependencies throw by setting the kwarg `strict` to `true`
 
 !!! note
     This method is called automatically after any Pkg action that changes the manifest.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -130,12 +130,13 @@ See also [`PackageSpec`](@ref).
 const add = API.add
 
 """
-    Pkg.precompile()
+    Pkg.precompile(; fail_indirect_deps::Bool=false)
 
 Precompile all the dependencies of the project in parallel.
 !!! note
     Errors will only throw when precompiling the top-level dependencies, given that
     not all manifest dependencies may be loaded by the top-level dependencies on the given system.
+    This can be overridden by setting `fail_indirect_deps=true`
 
 !!! note
     This method is called automatically after any Pkg action that changes the manifest.


### PR DESCRIPTION
By default we prevent failures when precompiling indirect dependencies to throw, with the expectation that if they are used by direct dependencies the failure will be caught then and throw.

However, there seems to be some use cases where there is a need to force failures from indirect dependencies.
Fixes https://github.com/JuliaLang/Pkg.jl/issues/2358