### PR TITLE
only use git on Windows for default pkg server

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -136,6 +136,9 @@ function populate_known_registries_with_urls!(registries::Vector{RegistrySpec})
     end
 end
 
+registry_use_pkg_server() =
+    !Sys.iswindows() || haskey(ENV, "JULIA_PKG_SERVER")
+
 function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=depots1())
     populate_known_registries_with_urls!(regs)
     registry_urls = nothing
@@ -146,8 +149,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
         # clone to tmpdir first
         mktempdir() do tmp
             url, registry_urls = pkg_server_registry_url(reg.uuid, registry_urls)
-            # on Windows we prefer git cloning because untarring is so slow
-            if !Sys.iswindows() && url !== nothing
+            if url !== nothing && registry_use_pkg_server()
                 # download from Pkg server
                 try
                     download_verify_unpack(url, nothing, tmp, ignore_existence = true)


### PR DESCRIPTION
Using git for registries on Windows was definitely a big improvement for the vast majority of Windows users, but for Windows users behind firewalls that can't access github.com, it's a problem. This changes the heuristic to using git when on Windows if the pkg server isn't explicitly set. If someone explicitly sets their pkg server then we get the registry from there instead of trying to git clone it. This can be overridden by explicitly git cloning the registry once, after which it will always be git updated. But a very small number of people should need to do that.