### PR TITLE
Precomp: Halve the default number of precompilation tasks in windows to avoid ReadOnlyMemoryError

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -984,7 +984,12 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
-    num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(Sys.CPU_THREADS::Int + 1)))
+
+    # Windows sometimes hits a ReadOnlyMemoryError, so we halve the default number of tasks. Issue #2323
+    # TODO: Investigate why this happens in windows and restore the full task limit
+    default_num_tasks = Sys.iswindows() ? round(Int, Sys.CPU_THREADS::Int / 2) + 1 : Sys.CPU_THREADS::Int + 1
+
+    num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(default_num_tasks)))
     parallel_limiter = Base.Semaphore(num_tasks)
     io = ctx.io
     fancyprint = can_fancyprint(io)

--- a/src/API.jl
+++ b/src/API.jl
@@ -987,7 +987,7 @@ function precompile(ctx::Context; internal_call::Bool=false, kwargs...)
 
     # Windows sometimes hits a ReadOnlyMemoryError, so we halve the default number of tasks. Issue #2323
     # TODO: Investigate why this happens in windows and restore the full task limit
-    default_num_tasks = Sys.iswindows() ? round(Int, Sys.CPU_THREADS::Int / 2) + 1 : Sys.CPU_THREADS::Int + 1
+    default_num_tasks = Sys.iswindows() ? div(Sys.CPU_THREADS::Int, 2) + 1 : Sys.CPU_THREADS::Int + 1
 
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(default_num_tasks)))
     parallel_limiter = Base.Semaphore(num_tasks)


### PR DESCRIPTION
Hopefully a temporary fix for #2323 

This will mean precomp will be slower on windows, but still a lot faster than <v1.6

Fixes #2323