### PR TITLE
Allow custom `package` function in `archive_artifact`

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -127,16 +127,22 @@ function verify_artifact(hash::SHA1; honor_overrides::Bool=false)
 end
 
 """
-    archive_artifact(hash::SHA1, tarball_path::String; honor_overrides::Bool=false)
+    archive_artifact(hash::SHA1, tarball_path::String;
+                     honor_overrides::Bool=false,
+                     package::Function=package)
 
 Archive an artifact into a tarball stored at `tarball_path`, returns the SHA256 of the
 resultant tarball as a hexidecimal string. Throws an error if the artifact does not
-exist.  If the artifact is overridden, throws an error unless `honor_overrides` is set.
+exist.  If the artifact is overridden, throws an error unless `honor_overrides` is set.  A
+`package(src_dir, tarball_path)` function may be specified to use a custom compression
+method.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3.
 """
-function archive_artifact(hash::SHA1, tarball_path::String; honor_overrides::Bool=false)
+function archive_artifact(hash::SHA1, tarball_path::String;
+                          honor_overrides::Bool=false,
+                          package::Function=package)
     if !honor_overrides
         if query_override(hash) !== nothing
             error("Will not archive an overridden artifact unless `honor_overrides` is set!")

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -378,13 +378,15 @@ function list_tarball_files(tarball_path::AbstractString)
 end
 
 """
-    package(src_dir::AbstractString, tarball_path::AbstractString)
+    package(src_dir::AbstractString, tarball_path::AbstractString;
+            format::AbstractString="gzip")
 
-Compress `src_dir` into a tarball located at `tarball_path`.
+Compress `src_dir` into a tarball located at `tarball_path` using the `format`.
 """
-function package(src_dir::AbstractString, tarball_path::AbstractString)
+function package(src_dir::AbstractString, tarball_path::AbstractString;
+                 format::AbstractString="gzip")
     rm(tarball_path, force=true)
-    cmd = `$(exe7z()) a -si -tgzip -mx9 $tarball_path`
+    cmd = `$(exe7z()) a -si -t$format -mx9 $tarball_path`
     open(pipeline(cmd, stdout=devnull), write=true) do io
         Tar.create(src_dir, io)
     end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -302,6 +302,13 @@ end
             tarball_path = joinpath(art_dir, "foo.tar.gz")
             archive_artifact(hash, tarball_path)
             @test "foo" in PlatformEngines.list_tarball_files(tarball_path)
+            rm(tarball_path)
+
+            # Test custom `package` function and ensure failure if no `tarball_path` file
+            # is created.
+            package_alt(src_dir, tarball_path) = nothing
+            @test !isfile(tarball_path)
+            @test_throws SystemError archive_artifact(hash, tarball_path, package=package_alt)
 
             # Test archiving something that doesn't exist fails
             remove_artifact(hash)

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -29,17 +29,19 @@ using Test, Pkg.PlatformEngines, Pkg.BinaryPlatforms, SHA
             write(f, "use_julia=true\n")
         end
 
-        # Next, package it up as a .tar.gz file
+        # Next, package it up as a compressed tarball
         mktempdir() do output_dir
-            tarball_path =  joinpath(output_dir, "foo.tar.gz")
-            package(prefix, tarball_path)
-            @test isfile(tarball_path)
+            for (format, ext) in [("gzip", "gz"), ("xz", "xz")]
+                tarball_path =  joinpath(output_dir, "foo.tar.$ext")
+                package(prefix, tarball_path; format=format)
+                @test isfile(tarball_path)
 
-            # Test that we can inspect the contents of the tarball
-            contents = PlatformEngines.list_tarball_files(tarball_path)
-            @test "bin/bar.sh" in contents
-            @test "lib/baz.so" in contents
-            @test "etc/qux.conf" in contents
+                # Test that we can inspect the contents of the tarball
+                contents = PlatformEngines.list_tarball_files(tarball_path)
+                @test "bin/bar.sh" in contents
+                @test "lib/baz.so" in contents
+                @test "etc/qux.conf" in contents
+            end
         end
     end
 


### PR DESCRIPTION
Compressing large artifacts can be [quite time consuming](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/106#issuecomment-769173686) when using 7zip's non-threaded gzip support. In BinaryBuilderBase we're [experimenting with using `pigz`](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/107) as an alternative way of performing threaded gzip compression. Having support for a custom `package` function would avoid having to duplicate the functionality provided in `archive_artifact`.

Possibly `pigz` or another compression format should be used here in the future.

