### PR TITLE
Explicitly set User-Agent for downloads.

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -247,6 +247,7 @@ function download(
     for header in get_metadata_headers(url)
         push!(headers, header)
     end
+    push!(headers, "User-Agent" => Downloads.Curl.USER_AGENT)
 
     io = stderr
     do_fancy = verbose && can_fancyprint(io)


### PR DESCRIPTION
It is possible defaults should be reused for multiplexed connections and that this is a bug in Downloads/libcurl but it seems like a good idea to explicitly set it here anyway.