### PR TITLE
show the exception when download fails in artifact downloading

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -313,6 +313,11 @@ function download_artifact(
     calc_hash = try
         create_artifact() do dir
             download_verify_unpack(tarball_url, tarball_hash, dir, ignore_existence=true, verbose=verbose, quiet_download=quiet_download)
+            f = joinpath(dir, "lib", "libc_simple.dll")
+            if isfile(f)
+                @info("immediate post-extraction")
+                run(`icacls $(f)`)
+            end
         end
     catch e
         if isa(e, InterruptException)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -55,14 +55,14 @@ function create_artifact(f::Function)
         # unless the user has been very unwise, but let's be cautious.
         new_path = artifact_path(artifact_hash; honor_overrides=false)
         if !isdir(new_path)
-            f = joinpath(temp_dir, "lib", "libc_simple.dll")
+            f = joinpath(temp_dir, "bin", "libc_simple.dll")
             if isfile(f)
                 @info("pre-move")
                 run(`icacls $(f)`)
             end
             # Move this generated directory to its final destination, set it to read-only
             mv(temp_dir, new_path)
-            f = joinpath(new_path, "lib", "libc_simple.dll")
+            f = joinpath(new_path, "bin", "libc_simple.dll")
             if isfile(f)
                 @info("post-move")
                 run(`icacls $(f)`)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -313,7 +313,7 @@ function download_artifact(
     calc_hash = try
         create_artifact() do dir
             download_verify_unpack(tarball_url, tarball_hash, dir, ignore_existence=true, verbose=verbose, quiet_download=quiet_download)
-            f = joinpath(dir, "lib", "libc_simple.dll")
+            f = joinpath(dir, "bin", "libc_simple.dll")
             if isfile(f)
                 @info("immediate post-extraction")
                 run(`icacls $(f)`)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -55,10 +55,28 @@ function create_artifact(f::Function)
         # unless the user has been very unwise, but let's be cautious.
         new_path = artifact_path(artifact_hash; honor_overrides=false)
         if !isdir(new_path)
+            f = joinpath(temp_dir, "lib", "libc_simple.dll")
+            if isfile(f)
+                @info("pre-move")
+                run(`icacls $(f)`)
+            end
             # Move this generated directory to its final destination, set it to read-only
             mv(temp_dir, new_path)
+            f = joinpath(new_path, "lib", "libc_simple.dll")
+            if isfile(f)
+                @info("post-move")
+                run(`icacls $(f)`)
+            end
             chmod(new_path, filemode(dirname(new_path)))
+            if isfile(f)
+                @info("post-parent-dir-chmod")
+                run(`icacls $(f)`)
+            end
             set_readonly(new_path)
+            if isfile(f)
+                @info("post-set_readonly")
+                run(`icacls $(f)`)
+            end
         end
 
         # Give the people what they want

--- a/test/test_packages/ArtifactInstallation/src/ArtifactInstallation.jl
+++ b/test/test_packages/ArtifactInstallation/src/ArtifactInstallation.jl
@@ -31,6 +31,10 @@ function do_test()
         joinpath(artifact"c_simple", "lib", "libc_simple.so")
     end
 
+    run(`ls -la $(dirname(libc_simple_path))`)
+    if Sys.iswindows()
+        run(`icacls $(libc_simple_path)`)
+    end
     libc_simple = dlopen(libc_simple_path)
     @test libc_simple != nothing
     @test ccall(dlsym(libc_simple, :my_add), Cint, (Cint, Cint), 2, 3) == 5


### PR DESCRIPTION
also, verify the tree hash on windows which I think (correct me if I am wrong @staticfloat) should be ok now.

Might have a bit of overlap with https://github.com/JuliaLang/Pkg.jl/pull/2355.

