### PR TITLE
Use `xz` as package compression format

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -384,7 +384,7 @@ Compress `src_dir` into a tarball located at `tarball_path`.
 """
 function package(src_dir::AbstractString, tarball_path::AbstractString)
     rm(tarball_path, force=true)
-    cmd = `$(exe7z()) a -si -tgzip -mx9 $tarball_path`
+    cmd = `$(exe7z()) a -si -txz -mx9 $tarball_path`
     open(pipeline(cmd, stdout=devnull), write=true) do io
         Tar.create(src_dir, io)
     end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -299,7 +299,7 @@ end
     mktempdir() do art_dir
         with_artifacts_directory(art_dir) do
             hash = create_artifact(p -> touch(joinpath(p, "foo")))
-            tarball_path = joinpath(art_dir, "foo.tar.gz")
+            tarball_path = joinpath(art_dir, "foo.tar.xz")
             archive_artifact(hash, tarball_path)
             @test "foo" in PlatformEngines.list_tarball_files(tarball_path)
 

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -29,9 +29,9 @@ using Test, Pkg.PlatformEngines, Pkg.BinaryPlatforms, SHA
             write(f, "use_julia=true\n")
         end
 
-        # Next, package it up as a .tar.gz file
+        # Next, package it up as a .tar.xz file
         mktempdir() do output_dir
-            tarball_path =  joinpath(output_dir, "foo.tar.gz")
+            tarball_path =  joinpath(output_dir, "foo.tar.xz")
             package(prefix, tarball_path)
             @test isfile(tarball_path)
 


### PR DESCRIPTION
Threading is supported on p7zip with the `xz` format (unlink `gzip`) and the compression ratios are better than `gzip` and comparable to `7z`. It appears that Pkg has has support for handling `xz` since artifacts were introduced so this should be a backwards compatible change.

See these compression [benchmarks](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/106#issuecomment-769173686) for runtime and compression size differences. 