### PR TITLE
If the `JULIA_PKG_SERVER` environment variable is not set, use Git for cloning registries

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -136,7 +136,13 @@ function populate_known_registries_with_urls!(registries::Vector{RegistrySpec})
     end
 end
 
-registry_use_pkg_server() = haskey(ENV, "JULIA_PKG_SERVER")
+function registry_use_pkg_server(url)
+    if url === nothing
+        return false
+    else
+        return haskey(ENV, "JULIA_PKG_SERVER")
+    end
+end
 
 function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=depots1())
     populate_known_registries_with_urls!(regs)
@@ -148,7 +154,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
         # clone to tmpdir first
         mktempdir() do tmp
             url, registry_urls = pkg_server_registry_url(reg.uuid, registry_urls)
-            if url !== nothing && registry_use_pkg_server()
+            if registry_use_pkg_server(url)
                 # download from Pkg server
                 try
                     download_verify_unpack(url, nothing, tmp, ignore_existence = true)

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -136,8 +136,7 @@ function populate_known_registries_with_urls!(registries::Vector{RegistrySpec})
     end
 end
 
-registry_use_pkg_server() =
-    !Sys.iswindows() || haskey(ENV, "JULIA_PKG_SERVER")
+registry_use_pkg_server() = haskey(ENV, "JULIA_PKG_SERVER")
 
 function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=depots1())
     populate_known_registries_with_urls!(regs)


### PR DESCRIPTION
See also: #2175, #2364 

Before this PR:
| OS | `JULIA_PKG_SERVER` environment variable | Registry is obtained via | 
| --- | --- | --- | 
| Windows | not set | Git |
| Windows | set to `""` | Git |
| Windows | set to `"pkg.julialang.org"` (or any other valid Pkg server value) | Pkg server |
| Not Windows | not set | **Pkg server** |
| Not Windows | set to `""` | Git |
| Not Windows | set to `"pkg.julialang.org"` (or any other valid Pkg server value) | Pkg server |

After this PR:
| OS | `JULIA_PKG_SERVER` environment variable | Registry is obtained via | 
| --- | --- | --- | 
| Windows | not set | Git |
| Windows | set to `""` | Git |
| Windows | set to `"pkg.julialang.org"` (or any other valid Pkg server value) | Pkg server |
| Not Windows | not set | **Git** |
| Not Windows | set to `""` | Git |
| Not Windows | set to `"pkg.julialang.org"` (or any other valid Pkg server value) | Pkg server |