### PR TITLE
Use a consistent alternative uuid across CI platforms, to help root tree hash checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run tests
         run: |
           julia test/pkg-uuid.jl
-          julia --project --color=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"));'
+          julia --project --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\"\n"));'
           julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
@@ -61,7 +61,7 @@ jobs:
           version: 'nightly'
       - name: Generate docs
         run: |
-          julia --color=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"))'
+          julia --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\"\n"));'
           julia --project --color=yes -e 'using Pkg; Pkg.activate("docs"); Pkg.instantiate(); Pkg.develop(PackageSpec(path = pwd()))'
           julia --project=docs --color=yes docs/make.jl pdf
         env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ build_script:
       using UUIDs;
       before = read(\"Project.toml\", String);
       after = replace(before, \"uuid = \\\"44cfe95a-1eb2-52ea-b672-e2afdf69b78f\\\"\" =>
-                              \"uuid = \\\"4d836010-47a6-11e8-12b2-0918962bae33\\\"\");
+                              \"uuid = \\\"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\\\"\");
       write(\"Project.toml\", after);
       import Pkg; Pkg.build()"
 


### PR DESCRIPTION
Using random/different uuids across platforms isn't helping debugging of tree hash issues