### PR TITLE
Fix p7zip usage on alpine

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -7,7 +7,7 @@ module PlatformEngines
 using SHA, Downloads, Tar
 import ...Pkg: Pkg, TOML, pkg_server, depots1, can_fancyprint
 using ..MiniProgressBars
-using Base.BinaryPlatforms
+using Base.BinaryPlatforms, p7zip_jll
 
 export probe_platform_engines!, verify, unpack, package, download_verify_unpack
 
@@ -15,11 +15,16 @@ const EXE7Z_LOCK = ReentrantLock()
 const EXE7Z = Ref{String}()
 
 function exe7z()
+    # If the JLL is available, use the wrapper function defined in there
+    if p7zip_jll.is_available()
+        return p7zip_jll.p7zip()
+    end
+
     lock(EXE7Z_LOCK) do
         if !isassigned(EXE7Z)
             EXE7Z[] = find7z()
         end
-        return EXE7Z[]
+        return Cmd([EXE7Z[]])
     end
 end
 


### PR DESCRIPTION
The `p7zip_jll` wrapper defines all sorts of useful environment
variables such as `LD_LIBRARY_PATH` to pick up the `libstdc++` that
Julia bundles with it.  We need to use that if the `7z` we're invoking
comes from that JLL, which it does if we pick it up from the `libexec`
directory of Julia.  So we instead use `p7zip_jll` if it is available on
this platform, and if it's not, we'll pick something up off the `PATH`.