### PR TITLE
Add `tree_hash()` debugging output

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -291,7 +291,7 @@ function tree_hash(::Type{HashType}, root::AbstractString; debug_out::Union{IO,N
                 println(debug_out, "$(indent_str)[$(mode_str)] $(basename(filepath)) - $(bytes2hex(hash))")
             end
         end
-        push!(entries, (f, hash, mode))
+        push!(entries, (basename(filepath), hash, mode))
     end
 
     content_size = 0

--- a/test/new.jl
+++ b/test/new.jl
@@ -2306,7 +2306,7 @@ end
     end
 end
 
-tree_hash(root::AbstractString) = bytes2hex(@inferred Pkg.GitTools.tree_hash(root))
+tree_hash(root::AbstractString; kwargs...) = bytes2hex(@inferred Pkg.GitTools.tree_hash(root; kwargs...))
 
 @testset "git tree hash computation" begin
     mktempdir() do dir


### PR DESCRIPTION
Since tree hashes cause us so much grief, make it easier for us to
figure out what _exactly_ is different between two trees.