### PR TITLE
Prevent github actions CI git from changing \n to \r\n

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,12 @@ jobs:
           - os: macOS-latest
             julia-arch: x86
     steps:
-      - uses: actions/checkout@v1.0.0
+      - name: Set git to use LF
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}


### PR DESCRIPTION
Turns out GitHub actions's Windows runner was changing `\n` to `\r\n` which was breaking hashing

Following the advice from https://github.com/actions/checkout/issues/135 to disable this

@staticfloat takes the prize for finding the bug

Fixes #2380 