### PR TITLE
Another GHA windows fix: run with bash, fix TEMP fix, add sanity check for correct Pkg under test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
     tags: '*'
+defaults:
+  run:
+    shell: bash
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,8 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           # See https://github.com/actions/virtual-environments/issues/712
-          echo "TMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
-          echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
+          echo "TMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
+          echo "TEMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
       - name: Run tests
         run: |
           julia test/pkg-uuid.jl

--- a/test/new.jl
+++ b/test/new.jl
@@ -17,6 +17,14 @@ unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
 #
+# Sanity Check
+#
+
+@testset "Ensure we're testing the correct Pkg" begin
+    @test realpath(dirname(dirname(Base.pathof(Pkg)))) == realpath(dirname(@__DIR__))
+end
+
+#
 # # Depot Changes
 #
 


### PR DESCRIPTION
I forgot to bring this over from the debug PR #2374

Also added a sanity check that the correct Pkg is being tested, and not the one  from the julia sysimage