### PR TITLE
Suggest functional API in warning, consistency in docs

### DIFF
--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -34,7 +34,7 @@ function generate()
         This section describes available commands in the Pkg REPL.
         The REPL mode is mostly meant for interactive use,
         and for non-interactive use it is recommended to use the
-        "API mode", see [API Reference](@ref API-Reference).
+        "functional API", see [API Reference](@ref API-Reference).
         """)
     # list commands
     println(io, "## `package` commands")

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -32,7 +32,7 @@ function generate()
         # [**11.** REPL Mode Reference](@id REPL-Mode-Reference)
 
         This section describes available commands in the Pkg REPL.
-        The REPL mode is mostly meant for interactive use,
+        The Pkg REPL mode is mostly meant for interactive use,
         and for non-interactive use it is recommended to use the
         "functional API", see [API Reference](@ref API-Reference).
         """)

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -34,7 +34,7 @@ function generate()
         This section describes available commands in the Pkg REPL.
         The Pkg REPL mode is mostly meant for interactive use,
         and for non-interactive use it is recommended to use the
-        "functional API", see [API Reference](@ref API-Reference).
+        functional API, see [API Reference](@ref API-Reference).
         """)
     # list commands
     println(io, "## `package` commands")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,7 +1,7 @@
 # [**12.** API Reference](@id API-Reference)
 
-This section describes the functional interface,
-for interacting with Pkg.jl. The "functional API" is recommended
+This section describes the functional API for interacting with Pkg.jl.
+It is recommended to use the functional API, rather than the Pkg REPL mode,
 for non-interactive usage, for example in scripts.
 
 ## General API Reference

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -16,7 +16,7 @@ For example, `Pkg.add("Example"; io=devnull)` will discard any output produced b
 
 ## Package API Reference
 
-In the REPL mode, packages (with associated version, UUID, URL etc) are parsed from strings,
+In the Pkg REPL mode, packages (with associated version, UUID, URL etc) are parsed from strings,
 for example `"Package#master"`,`"Package@v0.1"`, `"www.mypkg.com/MyPkg#my/feature"`.
 
 In the functional API, it is possible to use strings as arguments for simple commands (like `Pkg.add(["PackageA", "PackageB"])`,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,7 +1,7 @@
 # [**12.** API Reference](@id API-Reference)
 
-This section describes the function interface,
-for interacting with Pkg.jl. The function API is recommended
+This section describes the functional interface,
+for interacting with Pkg.jl. The "functional API" is recommended
 for non-interactive usage, for example in scripts.
 
 ## General API Reference
@@ -54,7 +54,7 @@ Pkg.redo
 !!! compat "Julia 1.1"
     Pkg's registry handling requires at least Julia 1.1.
 
-The function API for registries uses [`RegistrySpec`](@ref)s, similar to
+The functional API for registries uses [`RegistrySpec`](@ref)s, similar to
 [`PackageSpec`](@ref).
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,6 @@
 # [**12.** API Reference](@id API-Reference)
 
-This section describes the function interface, or "API mode",
+This section describes the function interface,
 for interacting with Pkg.jl. The function API is recommended
 for non-interactive usage, for example in scripts.
 
@@ -19,7 +19,7 @@ For example, `Pkg.add("Example"; io=devnull)` will discard any output produced b
 In the REPL mode, packages (with associated version, UUID, URL etc) are parsed from strings,
 for example `"Package#master"`,`"Package@v0.1"`, `"www.mypkg.com/MyPkg#my/feature"`.
 
-In the API mode, it is possible to use strings as arguments for simple commands (like `Pkg.add(["PackageA", "PackageB"])`,
+In the functional API, it is possible to use strings as arguments for simple commands (like `Pkg.add(["PackageA", "PackageB"])`,
 but more complicated commands, which e.g. specify URLs or version range, require the use of a more structured format over strings.
 This is done by creating an instance of [`PackageSpec`](@ref) which is passed in to functions.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ The documentation covers many things, for example managing package
 installations, developing packages, working with package registries and more.
 
 Throughout the manual the REPL interface to Pkg is used in the examples.
-There is also a functional API interface, which is preferred when not working
+There is also a functional API, which is preferred when not working
 interactively. This API is documented in the [API Reference](@ref) section.
 
 ## Background and Design

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ Welcome to the documentation for Pkg, Julia's package manager.
 The documentation covers many things, for example managing package
 installations, developing packages, working with package registries and more.
 
-Throughout the manual the REPL interface to Pkg is used in the examples.
+Throughout the manual the REPL interface to Pkg ("Pkg REPL mode") is used in the examples.
 There is also a functional API, which is preferred when not working
 interactively. This API is documented in the [API Reference](@ref) section.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ Welcome to the documentation for Pkg, Julia's package manager.
 The documentation covers many things, for example managing package
 installations, developing packages, working with package registries and more.
 
-Throughout the manual the REPL interface to Pkg ("Pkg REPL mode") is used in the examples.
+Throughout the manual the REPL interface to Pkg, the Pkg REPL mode, is used in the examples.
 There is also a functional API, which is preferred when not working
 interactively. This API is documented in the [API Reference](@ref) section.
 

--- a/docs/src/registries.md
+++ b/docs/src/registries.md
@@ -11,7 +11,7 @@ is the default one, and is installed automatically.
     Pkg's registry handling requires at least Julia 1.1.
 
 Registries can be added, removed and updated from either the Pkg REPL
-or by using the function based API. In this section we will describe the
+or by using the functional API. In this section we will describe the
 REPL interface. The registry API is documented in
 the [Registry API Reference](@ref) section.
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -473,7 +473,7 @@ in the vector.
     | `Pkg.add(PackageSpec(url="www.myhost.com/MyPkg")))`                 | `Pkg.add(name = "Package")`                    |
     |` Pkg.add([PackageSpec(name="Package"), PackageSpec(path="/MyPkg"])` | `Pkg.add([(;name="Package"), (;path="MyPkg")])`|
 
-Below is a comparison between the REPL interface and the functional API:
+Below is a comparison between the REPL mode and the functional API:
 
 | `REPL`               | `API`                                                 |
 |:---------------------|:------------------------------------------------------|
@@ -540,7 +540,7 @@ on all the registries in the vector.
 
 # Examples
 
-Below is a comparison between the REPL interface and the functional API::
+Below is a comparison between the REPL mode and the functional API::
 
 | `REPL`               | `API`                                           |
 |:---------------------|:------------------------------------------------|

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -473,7 +473,7 @@ in the vector.
     | `Pkg.add(PackageSpec(url="www.myhost.com/MyPkg")))`                 | `Pkg.add(name = "Package")`                    |
     |` Pkg.add([PackageSpec(name="Package"), PackageSpec(path="/MyPkg"])` | `Pkg.add([(;name="Package"), (;path="MyPkg")])`|
 
-Below is a comparison between the REPL version and the API version:
+Below is a comparison between the REPL interface and the functional API:
 
 | `REPL`               | `API`                                                 |
 |:---------------------|:------------------------------------------------------|
@@ -540,7 +540,7 @@ on all the registries in the vector.
 
 # Examples
 
-Below is a comparison between the REPL version and the API version:
+Below is a comparison between the REPL interface and the functional API::
 
 | `REPL`               | `API`                                           |
 |:---------------------|:------------------------------------------------|

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -374,7 +374,7 @@ end
 #############
 function do_cmd(repl::REPL.AbstractREPL, input::String; do_rethrow=false)
     if !isinteractive() && !TEST_MODE[] && !PRINTED_REPL_WARNING[]
-        @warn "The Pkg REPL mode is intended for interactive use, use with caution from scripts, or use the functional API."
+        @warn "The Pkg REPL mode is intended for interactive use only, and should not be used from scripts. It is recommended to use the functional API instead."
         PRINTED_REPL_WARNING[] = true
     end
     try

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -374,7 +374,7 @@ end
 #############
 function do_cmd(repl::REPL.AbstractREPL, input::String; do_rethrow=false)
     if !isinteractive() && !TEST_MODE[] && !PRINTED_REPL_WARNING[]
-        @warn "The Pkg REPL interface is intended for interactive use, use with caution from scripts."
+        @warn "The Pkg REPL mode is intended for interactive use, use with caution from scripts, or use the functional API."
         PRINTED_REPL_WARNING[] = true
     end
     try


### PR DESCRIPTION
I am guessing the warning is suggesting script writers to anticipate that their scripts might break if the REPL mode asks a question (cf. `apt-get -y`). I thought it would be clearer to indicate what to do that would reduce the need for caution.

I also tried to improve some consistency in terminology in the docs. I was ambivalent about choosing between "REPL mode"  or "REPL interface".