### PR TITLE
only use the stdlib version cache if a custom version is given to the resolver

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -367,6 +367,11 @@ is_stdlib(uuid::UUID) = uuid in keys(stdlibs())
 
 # Allow asking if something is an stdlib for a particular version of Julia
 function is_stdlib(uuid::UUID, julia_version::Union{VersionNumber, Nothing})
+    # Only use the cache if we are asking for stdlibs in a custom Julia version
+    if julia_version == VERSION
+        return is_stdlib(uuid)
+    end
+
     # If this UUID is known to be unregistered, always return `true`
     if haskey(UNREGISTERED_STDLIBS, uuid)
         return true


### PR DESCRIPTION
some workflows require the ability to inject custom stdlibs when
building Julia, the stdlib cache breaks that. The stdlib cache is now
only used when one wants to resolve something for a custom Julia version
(for example BinaryBuilder).