### PR TITLE
Precomp: safer recall_precompile_state

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1328,14 +1328,14 @@ function recall_precompile_state()
     for (prefix, store) in (("suspend_cache_", pkgs_precompile_suspended), ("pending_cache_", pkgs_precompile_pending))
         fpath = joinpath(Operations.pkg_scratchpath(), string(prefix, hash(string(Base.active_project(), Base.VERSION))))
         if isfile(fpath)
-            v = open(fpath) do io
+            open(fpath) do io
                 try
-                    deserialize(io)
+                    pkgspecs = deserialize(io)
+                    append!(empty!(store), pkgspecs)
                 catch
-                    PackageSpec[]
+                    empty!(store)
                 end
             end
-            append!(empty!(store), v)
         else
             empty!(store)
         end


### PR DESCRIPTION
In testing https://github.com/JuliaLang/Pkg.jl/pull/2425 locally I hit a state where the cache deserialized successfully, but somehow the type was invalid.. 
I didn't get to the bottom of it, but the logical thing to do is to make this function safer. It's much better to just forget this cache than to error.

