### PR TITLE
Read the registry straight from the tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 Pkg v1.7 Release Notes
 ======================
 
+- Registries downloaded from the Pkg Server (not git) are no longer uncompressed into files but instead read directly from the compressed tarball into memory. This improves performance on
+  filesystems which do not handle a large number of files well. To turn this feature off, set the environment variable `JULIA_PKG_UNPACK_REGISTRY=true`.
 - It is now possible to use an external `git` executable instead of the default libgit2 library for 
   the downloads that happen via the Git protocol by setting the environment variable `JULIA_PKG_USE_CLI_GIT=true`.
-- Registries downloaded from Pkg Server (not git) is now assumed to be immutable. Manual changes to their files might not be picked up by a running Pkg session.
+- Registries downloaded from the Pkg Server (not git) is now assumed to be immutable. Manual changes to their files might not be picked up by a running Pkg session.
 - Adding packages by folder name in the REPL mode now requires a prepending a `./` to the folder name package folder is in the current folder, e.g. `add ./Package` is required instead of `add Pacakge`. This is to avoid confusion between the package name `Package` and the local directory `Package`.
 - `rm`, `pin`, and `free` now support the `--all` option, and the api variants gain the `all_pkgs::Bool` kwarg, to perform the operation on all packages within the project or manifest, depending on the mode of the operation.
 - The `mode` keyword for `PackageSpec` has been removed.

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -344,7 +344,6 @@ function reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT
         end
 
         for candidate in candidate_registries
-            candidate = joinpath(reg_dir, candidate)
             # candidate can be either a folder or a TOML file
             if isfile(joinpath(candidate, "Registry.toml")) || isfile(candidate)
                 push!(registries, RegistryInstance(candidate))

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -65,7 +65,6 @@ function with_depot2(f)
     Base.DEPOT_PATH[1:2] .= Base.DEPOT_PATH[2:-1:1]
 end
 
-
 @testset "registries" begin
     temp_pkg_dir() do depot; mktempdir() do depot2
         insert!(Base.DEPOT_PATH, 2, depot2)
@@ -318,6 +317,41 @@ end
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.1"
         end
     end
+end
+
+if Pkg.Registry.registry_use_pkg_server()
+@testset "compressed registry" begin
+    for unpack in (true, nothing)
+        withenv("JULIA_PKG_UNPACK_REGISTRY" => unpack) do
+            temp_pkg_dir(;linked_reg=false) do depot
+                # These get restored by temp_pkg_dir
+                Pkg.Registry.DEFAULT_REGISTRIES[1].path = nothing
+                Pkg.Registry.DEFAULT_REGISTRIES[1].url = "https://github.com/JuliaRegistries/General.git"
+                
+                # This should not uncompress the registry
+                Registry.add(RegistrySpec(uuid = UUID("23338594-aafe-5451-b93e-139f81909106")))
+                @test isfile(joinpath(DEPOT_PATH[1], "registries", "General", "General.tar.gz")) != something(unpack, false)
+                Pkg.add("Example")
+                
+                # Write some bad git-tree-sha1 here so that Pkg.update will have to update the registry
+                if unpack == true
+                    write(joinpath(DEPOT_PATH[1], "registries", "General", ".tree_info.toml"),
+                        """
+                        git-tree-sha1 = "179182faa6a80b3cf24445e6f55c954938d57941"
+                        """)
+                else
+                    write(joinpath(DEPOT_PATH[1], "registries", "General", ".registry_info.toml"),
+                        """
+                        git-tree-sha1 = "179182faa6a80b3cf24445e6f55c954938d57941"
+                        uuid = "23338594-aafe-5451-b93e-139f81909106"
+                        filename = "General.tar.gz"
+                        """)
+                end
+                Pkg.update()
+            end
+        end
+    end
+end
 end
 
 end # module

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -330,7 +330,7 @@ if Pkg.Registry.registry_use_pkg_server()
                 
                 # This should not uncompress the registry
                 Registry.add(RegistrySpec(uuid = UUID("23338594-aafe-5451-b93e-139f81909106")))
-                @test isfile(joinpath(DEPOT_PATH[1], "registries", "General", "General.tar.gz")) != something(unpack, false)
+                @test isfile(joinpath(DEPOT_PATH[1], "registries", "General.tar.gz")) != something(unpack, false)
                 Pkg.add("Example")
                 
                 # Write some bad git-tree-sha1 here so that Pkg.update will have to update the registry
@@ -340,11 +340,11 @@ if Pkg.Registry.registry_use_pkg_server()
                         git-tree-sha1 = "179182faa6a80b3cf24445e6f55c954938d57941"
                         """)
                 else
-                    write(joinpath(DEPOT_PATH[1], "registries", "General", ".registry_info.toml"),
+                    write(joinpath(DEPOT_PATH[1], "registries", "General.toml"),
                         """
                         git-tree-sha1 = "179182faa6a80b3cf24445e6f55c954938d57941"
                         uuid = "23338594-aafe-5451-b93e-139f81909106"
-                        filename = "General.tar.gz"
+                        path = "General.tar.gz"
                         """)
                 end
                 Pkg.update()

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -20,7 +20,7 @@ const GENERAL_UUID = UUID("23338594-aafe-5451-b93e-139f81909106")
 function init_reg()
     url, _ = Pkg.Registry.pkg_server_registry_url(GENERAL_UUID, nothing)
     mkpath(REGISTRY_DIR)
-    if Pkg.Registry.registry_use_pkg_server(url)
+    if Pkg.Registry.registry_use_pkg_server()
         @info "Downloading General registry from $url"
         Pkg.PlatformEngines.download_verify_unpack(url, nothing, REGISTRY_DIR, ignore_existence = true, io = stderr)
         tree_info_file = joinpath(REGISTRY_DIR, ".tree_info.toml")


### PR DESCRIPTION
Example:

```
julia> readdir(joinpath(homedir(), ".julia/registries")) # empty
String[]

(Pkg) pkg> add Example
  Installing known registries into `~/.julia`
   Resolving package versions...
   Installed Example ─ v0.5.3

julia> readdir(joinpath(homedir(), ".julia/registries/General"))  # only the tar file and an info file with uuid, filename, tree hash
2-element Vector{String}:
 ".registry_info.toml"
 "General.tar.gz"
``` 


## TODO
- Discuss possible implications of not having the registry files available.
