### PR TITLE
Cache registry data for PkgServer registries over Pkg invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Pkg v1.7 Release Notes
 ======================
 
+- Registries downloaded from Pkg Server (not git) is now assumed to be immutable. Manual changes to their files might not be picked up by a running Pkg session.
 - Adding packages by folder name in the REPL mode now requires a prepending a `./` to the folder name package folder is in the current folder, e.g. `add ./Package` is required instead of `add Pacakge`. This is to avoid confusion between the package name `Package` and the local directory `Package`.
 - `rm`, `pin`, and `free` now support the `--all` option, and the api variants gain the `all_pkgs::Bool` kwarg, to perform the operation on all packages within the project or manifest, depending on the mode of the operation.

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -174,13 +174,13 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
         mktempdir() do tmp
             url, registry_urls = pkg_server_registry_url(reg.uuid, registry_urls)
             if reg.path !== nothing && reg.linked == true # symlink to local source
-                registry = Registry.RegistryInstance(reg.path; parse_packages=false)
+                registry = Registry.RegistryInstance(reg.path)
                 regpath = joinpath(depot, "registries", registry.name)
                 printpkgstyle(io, :Symlinking, "registry from `$(Base.contractuser(reg.path))`")
                 isdir(dirname(regpath)) || mkpath(dirname(regpath))
                 symlink(reg.path, regpath)
                 isfile(joinpath(regpath, "Registry.toml")) || Pkg.Types.pkgerror("no `Registry.toml` file in linked registry.")
-                registry = Registry.RegistryInstance(regpath; parse_packages=false)
+                registry = Registry.RegistryInstance(regpath)
                 printpkgstyle(io, :Symlinked, "registry `$(Base.contractuser(registry.name))` to `$(Base.contractuser(regpath))`")
                 return
             elseif registry_use_pkg_server(url)
@@ -196,7 +196,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             elseif reg.path !== nothing # copy from local source
                 printpkgstyle(io, :Copying, "registry from `$(Base.contractuser(reg.path))`")
                 isfile(joinpath(reg.path, "Registry.toml")) || Pkg.Types.pkgerror("no `Registry.toml` file in source directory.")
-                registry = Registry.RegistryInstance(reg.path; parse_packages=false)
+                registry = Registry.RegistryInstance(reg.path)
                 regpath = joinpath(depot, "registries", registry.name)
                 cp(reg.path, regpath; force=true) # has to be cp given we're copying
                 printpkgstyle(io, :Copied, "registry `$(Base.contractuser(registry.name))` to `$(Base.contractuser(regpath))`")
@@ -211,12 +211,12 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             if !isfile(joinpath(tmp, "Registry.toml"))
                 Pkg.Types.pkgerror("no `Registry.toml` file in cloned registry.")
             end
-            registry = Registry.RegistryInstance(tmp; parse_packages=false)
+            registry = Registry.RegistryInstance(tmp)
             regpath = joinpath(depot, "registries", registry.name)
             # copy to `depot`
             ispath(dirname(regpath)) || mkpath(dirname(regpath))
             if isfile(joinpath(regpath, "Registry.toml"))
-                existing_registry = Registry.RegistryInstance(regpath; parse_packages=false)
+                existing_registry = Registry.RegistryInstance(regpath)
                 if registry.uuid == existing_registry.uuid
                     println(io,
                             "registry `$(registry.name)` already exist in `$(Base.contractuser(regpath))`.")
@@ -264,7 +264,7 @@ end
 # Search for the input registries among installed ones
 function find_installed_registries(io::IO,
                                    needles::Union{Vector{Registry.RegistryInstance}, Vector{RegistrySpec}})
-    haystack = reachable_registries(; parse_packages=false)
+    haystack = reachable_registries()
     output = Registry.RegistryInstance[]
     for needle in needles
         if needle.name === nothing && needle.uuid === nothing

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -182,10 +182,10 @@ struct RegistryInstance
     name_to_uuids::Dict{String, Vector{UUID}}
 end
 
-const REGISTRY_CACHE = Dict{UUID, Tuple{Base.SHA1, RegistryInstance}}()
+const REGISTRY_CACHE = Dict{Tuple{String, UUID}, Tuple{Base.SHA1, RegistryInstance}}()
 
-function get_cached_registry(uuid::UUID, tree_info::Base.SHA1)
-    v = get(REGISTRY_CACHE, uuid, nothing)
+function get_cached_registry(path, uuid::UUID, tree_info::Base.SHA1)
+    v = get(REGISTRY_CACHE, (path, uuid), nothing)
     if v !== nothing
         cached_tree_info, reg = v
         if cached_tree_info == tree_info
@@ -210,7 +210,7 @@ function RegistryInstance(path::AbstractString)
     
     # Reuse an existing cached registry if it exists for this content
     if tree_info !== nothing
-        reg = get_cached_registry(reg_uuid, tree_info)
+        reg = get_cached_registry(path, reg_uuid, tree_info)
         if reg isa RegistryInstance
             return reg
         end
@@ -236,7 +236,7 @@ function RegistryInstance(path::AbstractString)
         Dict{String, UUID}(),
     )
     if tree_info !== nothing
-        REGISTRY_CACHE[reg_uuid] = (tree_info, reg)
+        REGISTRY_CACHE[(path, reg_uuid)] = (tree_info, reg)
     end
     return reg
 end

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -182,29 +182,52 @@ struct RegistryInstance
     name_to_uuids::Dict{String, Vector{UUID}}
 end
 
-function RegistryInstance(path::AbstractString; parse_packages::Bool=true)
-    d = parsefile(joinpath(path, "Registry.toml"))
-    pkgs = Dict{UUID, PkgEntry}()
-    if parse_packages
-        for (uuid, info) in d["packages"]::Dict{String, Any}
-            uuid = UUID(uuid::String)
-            info::Dict{String, Any}
-            name = info["name"]::String
-            pkgpath = info["path"]::String
-            pkg = PkgEntry(pkgpath, path, name, uuid, uninit)
-            pkgs[uuid] = pkg
+const REGISTRY_CACHE = Dict{UUID, Tuple{Base.SHA1, RegistryInstance}}()
+
+function get_cached_registry(uuid::UUID, tree_info::Base.SHA1)
+    v = get(REGISTRY_CACHE, uuid, nothing)
+    if v !== nothing
+        cached_tree_info, reg = v
+        if cached_tree_info == tree_info
+            return reg
         end
     end
+    # Prevent hogging up memory indefinitely
+    length(REGISTRY_CACHE) > 20 && empty!(REGISTRY_CACHE)
+    return nothing
+end
+    
+
+function RegistryInstance(path::AbstractString)
+    d = parsefile(joinpath(path, "Registry.toml"))
     tree_info_file = joinpath(path, ".tree_info.toml")
     tree_info = if isfile(tree_info_file)
         Base.SHA1(parsefile(tree_info_file)["git-tree-sha1"]::String)
     else
         nothing
     end
-    return RegistryInstance(
+    reg_uuid = UUID(d["uuid"]::String)
+    
+    # Reuse an existing cached registry if it exists for this content
+    if tree_info !== nothing
+        reg = get_cached_registry(reg_uuid, tree_info)
+        if reg isa RegistryInstance
+            return reg
+        end
+    end
+    pkgs = Dict{UUID, PkgEntry}()
+    for (uuid, info) in d["packages"]::Dict{String, Any}
+        uuid = UUID(uuid::String)
+        info::Dict{String, Any}
+        name = info["name"]::String
+        pkgpath = info["path"]::String
+        pkg = PkgEntry(pkgpath, path, name, uuid, uninit)
+        pkgs[uuid] = pkg
+    end
+    reg = RegistryInstance(
         path,
         d["name"]::String,
-        UUID(d["uuid"]::String),
+        reg_uuid,
         get(d, "url", nothing)::Union{String, Nothing},
         get(d, "repo", nothing)::Union{String, Nothing},
         get(d, "description", nothing)::Union{String, Nothing},
@@ -212,6 +235,10 @@ function RegistryInstance(path::AbstractString; parse_packages::Bool=true)
         tree_info,
         Dict{String, UUID}(),
     )
+    if tree_info !== nothing
+        REGISTRY_CACHE[reg_uuid] = (tree_info, reg)
+    end
+    return reg
 end
 
 function Base.show(io::IO, ::MIME"text/plain", r::RegistryInstance)
@@ -238,7 +265,7 @@ function create_name_uuid_mapping!(r::RegistryInstance)
     return
 end
 
-function reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH, parse_packages::Bool=true)
+function reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT_PATH)
     # collect registries
     if depots isa String
         depots = [depots]
@@ -251,7 +278,7 @@ function reachable_registries(; depots::Union{String, Vector{String}}=Base.DEPOT
         for name in readdir(reg_dir)
             file = joinpath(reg_dir, name, "Registry.toml")
             isfile(file) || continue
-            push!(registries, RegistryInstance(joinpath(reg_dir, name); parse_packages))
+            push!(registries, RegistryInstance(joinpath(reg_dir, name)))
         end
     end
     return registries

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -182,10 +182,10 @@ struct RegistryInstance
     name_to_uuids::Dict{String, Vector{UUID}}
 end
 
-const REGISTRY_CACHE = Dict{Tuple{String, UUID}, Tuple{Base.SHA1, RegistryInstance}}()
+const REGISTRY_CACHE = Dict{String, Tuple{Base.SHA1, RegistryInstance}}()
 
-function get_cached_registry(path, uuid::UUID, tree_info::Base.SHA1)
-    v = get(REGISTRY_CACHE, (path, uuid), nothing)
+function get_cached_registry(path::AbstractString, tree_info::Base.SHA1)
+    v = get(REGISTRY_CACHE, path, nothing)
     if v !== nothing
         cached_tree_info, reg = v
         if cached_tree_info == tree_info
@@ -196,7 +196,7 @@ function get_cached_registry(path, uuid::UUID, tree_info::Base.SHA1)
     length(REGISTRY_CACHE) > 20 && empty!(REGISTRY_CACHE)
     return nothing
 end
-    
+
 
 function RegistryInstance(path::AbstractString)
     d = parsefile(joinpath(path, "Registry.toml"))
@@ -207,10 +207,10 @@ function RegistryInstance(path::AbstractString)
         nothing
     end
     reg_uuid = UUID(d["uuid"]::String)
-    
+
     # Reuse an existing cached registry if it exists for this content
     if tree_info !== nothing
-        reg = get_cached_registry(path, reg_uuid, tree_info)
+        reg = get_cached_registry(path, tree_info)
         if reg isa RegistryInstance
             return reg
         end
@@ -236,7 +236,7 @@ function RegistryInstance(path::AbstractString)
         Dict{String, UUID}(),
     )
     if tree_info !== nothing
-        REGISTRY_CACHE[(path, reg_uuid)] = (tree_info, reg)
+        REGISTRY_CACHE[path] = (tree_info, reg)
     end
     return reg
 end


### PR DESCRIPTION
There was already a cache in place that cached parsing of TOML files.
However, many other parts of the registry handling (like uncompressing the version ranges) were not. In the future, we want to move to keep the registry in its tarred form which means that re-reading it will be expensive, so let's cache it instead.

This takes for example the time to add Plots over and over from 234ms to 150ms.

Ref https://github.com/JuliaLang/Pkg.jl/issues/2435, https://github.com/JuliaLang/Pkg.jl/pull/2431