### PR TITLE
Fix `status` output for pin/free

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1636,12 +1636,14 @@ print_single(io::IO, pkg::PackageSpec) = printstyled(io, stat_rep(pkg); color=:w
 
 is_instantiated(::Nothing) = false
 is_instantiated(x::PackageSpec) = x.version != VersionSpec() || is_stdlib(x.uuid)
+# Compare an old and new node of the dependency graph and print a single line to summarize the change
 function print_diff(io::IO, old::Union{Nothing,PackageSpec}, new::Union{Nothing,PackageSpec})
     if !is_instantiated(old) && is_instantiated(new)
         printstyled(io, "+ $(stat_rep(new))"; color=:light_green)
     elseif !is_instantiated(new)
         printstyled(io, "- $(stat_rep(old))"; color=:light_red)
-    elseif is_tracking_registry(old) && is_tracking_registry(new) && new.version isa VersionNumber && old.version isa VersionNumber
+    elseif is_tracking_registry(old) && is_tracking_registry(new) &&
+           new.version isa VersionNumber && old.version isa VersionNumber && new.version != old.version
         if new.version > old.version
             printstyled(io, "↑ $(stat_rep(old)) ⇒ $(stat_rep(new; name=false))"; color=:light_yellow)
         else

--- a/test/new.jl
+++ b/test/new.jl
@@ -1954,6 +1954,21 @@ end
         @test occursin(r"\[7876af07\] - Example v\d\.\d\.\d", output)
         @test occursin(r"Updating `.+Manifest.toml`", output)
         @test occursin(r"\[7876af07\] - Example v\d\.\d\.\d", output)
+
+        # Pinning a registered package
+        Pkg.add("Example")
+        Pkg.pin("Example"; io=io)
+        output = String(take!(io))
+        @test occursin(r"Updating `.+Project.toml`", output)
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d ⇒ v\d\.\d\.\d ⚲", output)
+        @test occursin(r"Updating `.+Manifest.toml`", output)
+
+        # Free a pinned package
+        Pkg.free("Example"; io=io)
+        output = String(take!(io))
+        @test occursin(r"Updating `.+Project.toml`", output)
+        @test occursin(r"\[7876af07\] ~ Example v\d\.\d\.\d ⚲ ⇒ v\d\.\d\.\d", output)
+        @test occursin(r"Updating `.+Manifest.toml`", output)
     end
     # Project Status API
     isolate(loaded_depot=true) do


### PR DESCRIPTION
Fixes #1931

```
(jl_U2Ku8o) pkg> pin Example
   Resolving package versions...
    Updating `/tmp/jl_U2Ku8o/Project.toml`
  [7876af07] ~ Example v0.5.3 ⇒ v0.5.3 ⚲
    Updating `/tmp/jl_U2Ku8o/Manifest.toml`
  [7876af07] ~ Example v0.5.3 ⇒ v0.5.3 ⚲

(jl_U2Ku8o) pkg> free Example
    Updating `/tmp/jl_U2Ku8o/Project.toml`
  [7876af07] ~ Example v0.5.3 ⚲ ⇒ v0.5.3
    Updating `/tmp/jl_U2Ku8o/Manifest.toml`
  [7876af07] ~ Example v0.5.3 ⚲ ⇒ v0.5.3
```