### PR TITLE
Fix: capture all `test` printing

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1558,7 +1558,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         printpkgstyle(ctx.io, :Testing, pkg.name)
         sandbox(ctx, pkg, source_path, testdir(source_path), test_project_override) do
             test_fn !== nothing && test_fn()
-            sandbox_ctx = Context()
+            sandbox_ctx = Context(;io=ctx.io)
             status(sandbox_ctx.env; mode=PKGMODE_COMBINED, io=sandbox_ctx.io)
             Pkg._auto_precompile(sandbox_ctx)
             printpkgstyle(ctx.io, :Testing, "Running tests...")

--- a/test/new.jl
+++ b/test/new.jl
@@ -140,6 +140,20 @@ end
 inside_test_sandbox(fn, name; kwargs...) = Pkg.test(name; test_fn=fn, kwargs...)
 inside_test_sandbox(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
 
+@testset "test: printing" begin
+    isolate(loaded_depot=true) do
+        Pkg.add(name="Example")
+        io = IOBuffer()
+        Pkg.test("Example"; io=io)
+        output = String(take!(io))
+        @test occursin(r"Testing Example", output)
+        @test occursin(r"Status `.+Project\.toml`", output)
+        @test occursin(r"Status `.+Manifest\.toml`", output)
+        @test occursin(r"Testing Running tests...", output)
+        @test occursin(r"Testing Example tests passed", output)
+    end
+end
+
 @testset "test: sandboxing" begin
     # explicit test dependencies and the tested project are available within the test sandbox
     isolate(loaded_depot=true) do; mktempdir() do tempdir


### PR DESCRIPTION
Pass the `io` flag to the test context, otherwise we will not capture the complete output