### PR TITLE
Precompilation: Tidy report at end

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1121,6 +1121,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
             n_total = length(depsmap)
             bar.max = n_total - n_already_precomp
             final_loop = false
+            n_print_rows = 0
             while !printloop_should_exit
                 lock(print_lock) do
                     term_size = Base.displaysize(stdout)::Tuple{Int,Int}
@@ -1132,11 +1133,11 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                     end
                     str = sprint() do iostr
                         if i > 1
-                            print(iostr, ansi_moveup(last_length+1), ansi_movecol1, ansi_cleartoend)
+                            print(iostr, ansi_moveup(n_print_rows), ansi_movecol1, ansi_cleartoend)
                         end
                         bar.current = n_done - n_already_precomp
                         bar.max = n_total - n_already_precomp
-                        print(iostr, sprint(io -> show_progress(io, bar); context=io), "\n")
+                        final_loop || print(iostr, sprint(io -> show_progress(io, bar); context=io), "\n")
                         for dep in pkg_queue_show
                             name = dep in direct_deps ? dep.name : string(color_string(dep.name, :light_black))
                             if dep in precomperr_deps
@@ -1162,6 +1163,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                         end
                     end
                     last_length = length(pkg_queue_show)
+                    n_print_rows = count("\n", str)
                     print(io, str)
                 end
                 printloop_should_exit = interrupted_or_done.set && final_loop

--- a/src/API.jl
+++ b/src/API.jl
@@ -1288,7 +1288,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
     if ndeps > 0 || !isempty(failed_deps)
         plural = ndeps == 1 ? "y" : "ies"
         str = sprint() do iostr
-            print(iostr, "$(ndeps) dependenc$(plural) successfully precompiled in $(seconds_elapsed) seconds")
+            print(iostr, "  $(ndeps) dependenc$(plural) successfully precompiled in $(seconds_elapsed) seconds")
             if n_already_precomp > 0 || !isempty(skipped_deps)
                 print(iostr, " (")
                 n_already_precomp > 0 && (print(iostr, "$n_already_precomp already precompiled"))
@@ -1298,14 +1298,14 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
             end
             if !isempty(precomperr_deps)
                 plural = length(precomperr_deps) == 1 ? "y" : "ies"
-                print(iostr, "\n",
+                print(iostr, "\n  ",
                     color_string(string(length(precomperr_deps)), Base.warn_color()),
                     " dependenc$(plural) failed but may be precompilable after restarting julia"
                 )
             end
             if internal_call && !isempty(failed_deps)
                 plural = length(failed_deps) == 1 ? "y" : "ies"
-                print(iostr, "\n", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural) errored")
+                print(iostr, "\n  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural) errored")
             end
         end
         lock(print_lock) do


### PR DESCRIPTION
- Hides the progress bar after precomp has finished
- Indents the precomp report to align better as children of the `Precompiling project...` title

Hopefully helps https://github.com/JuliaLang/Pkg.jl/issues/2456 cc. @nickrobinson251

During
<img width="446" alt="Screen Shot 2021-03-27 at 1 15 17 AM" src="https://user-images.githubusercontent.com/1694067/112710796-1a2a0000-8e9a-11eb-9faf-3d74c1ac17f7.png">

After
<img width="405" alt="Screen Shot 2021-03-27 at 1 15 27 AM" src="https://user-images.githubusercontent.com/1694067/112710795-1a2a0000-8e9a-11eb-943b-a4661f57360e.png">

Previously the progress bar sticks around at 100%