### PR TITLE
Precompilation: add tip to auto-precomp for getting error details

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1307,7 +1307,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                 plural1 = length(failed_deps) == 1 ? "y" : "ies"
                 plural2 = length(failed_deps) == 1 ? "" : "s"
                 print(iostr, "\n  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural1) errored. ")
-                print(iostr, "To see a full report either call `pkg> precompile` or load the package$(plural2)")
+                print(iostr, "To see a full report either call `import Pkg; Pkg.precompile()` or load the package$(plural2)")
             end
         end
         lock(print_lock) do

--- a/src/API.jl
+++ b/src/API.jl
@@ -1307,7 +1307,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                 plural1 = length(failed_deps) == 1 ? "y" : "ies"
                 plural2 = length(failed_deps) == 1 ? "" : "s"
                 print(iostr, "\n  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural1) errored. ")
-                print(iostr, "To see a full report either call `import Pkg; Pkg.precompile()` or load the package$(plural2)")
+                print(iostr, "To see a full report either run `import Pkg; Pkg.precompile()` or load the package$(plural2)")
             end
         end
         lock(print_lock) do

--- a/src/API.jl
+++ b/src/API.jl
@@ -1304,8 +1304,10 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                 )
             end
             if internal_call && !isempty(failed_deps)
-                plural = length(failed_deps) == 1 ? "y" : "ies"
-                print(iostr, "\n  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural) errored")
+                plural1 = length(failed_deps) == 1 ? "y" : "ies"
+                plural2 = length(failed_deps) == 1 ? "" : "s"
+                print(iostr, "\n  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural1) errored. ")
+                print(iostr, "To see a full report either call `pkg> precompile` or load the package$(plural2)")
             end
         end
         lock(print_lock) do


### PR DESCRIPTION
There's been some confusion about how to get information on the errors that are counted during auto-precomp but that aren't thrown or detailed.

This adds a helper tip `To see a full report either call 'pkg> precompile' or load the package(s)` that's seen at the top here

(I added an `error()` to FileIO)

![image](https://user-images.githubusercontent.com/1694067/112744078-be7b7780-8f6a-11eb-8012-c8dcb4c9611b.png)


