### PR TITLE
Clarify REPL errors for add/dev

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -861,6 +861,14 @@ end
         @test args == [Pkg.PackageSpec(;path=".")]
         @test isempty(opts)
     end end
+    isolate() do; cd_tempdir() do dir
+        # adding a nonexistent directory
+        @test_throws PkgError("`some/really/random/Dir` appears to be a local path, but directory does not exist"
+                              ) Pkg.pkg"add some/really/random/Dir"
+        # warn if not explicit about adding directory
+        mkdir("Example")
+        @test_logs (:info, r"Use `./Example` to add or develop the local directory at `.*`.") Pkg.pkg"add Example"
+    end end
 end
 
 #


### PR DESCRIPTION
fix #2406

The current error message is pretty cryptic. It would be more clear if we detect if a user is trying to add a local path and let the user know early if we can not carry the operation out.

Example:
```
(jl_CLaIt8) pkg> add path/does/not/Exist
ERROR: `path/does/not/Exist` appears to be a local path, but directory does not exist
````