### PR TITLE
Add the `Pkg.Versions.to_semver_spec` function for converting `VersionSpec`s to strings, with the property that `Pkg.Versions.semver_spec(Pkg.Versions.to_semver_spec(spec::VersionSpec)) == spec`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ include("sandbox.jl")
 include("resolve.jl")
 include("misc.jl")
 include("force_latest_compatible_version.jl")
+include("versions.jl")
 
 # clean up locally cached registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)

--- a/test/versions.jl
+++ b/test/versions.jl
@@ -12,7 +12,7 @@ function roundtrip_to_semver_spec(str_1::AbstractString)
     spec_2 = Pkg.Versions.semver_spec(str_2)
     str_3 = Pkg.Versions.to_semver_spec(spec_2)
     spec_3 = Pkg.Versions.semver_spec(str_3)
-    result = (spec_1 == spec_1) && (spec_1 == spec_2) && (spec_2 == spec_3)
+    result = (spec_1 == spec_2) && (spec_1 == spec_3) && (spec_2 == spec_3)
     if !result
         @info("", spec_1, spec_2, spec_3, str_1, str_2, str_3)
     end

--- a/test/versions.jl
+++ b/test/versions.jl
@@ -1,0 +1,82 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module VersionsTests
+
+import ..Pkg # ensure we are using the correct Pkg
+import ..Utils
+using Test
+
+function roundtrip_to_semver_spec(str_1::AbstractString)
+    spec_1 = Pkg.Versions.semver_spec(str_1)
+    str_2 = Pkg.Versions.to_semver_spec(spec_1)
+    spec_2 = Pkg.Versions.semver_spec(str_2)
+    str_3 = Pkg.Versions.to_semver_spec(spec_2)
+    spec_3 = Pkg.Versions.semver_spec(str_3)
+    result = (spec_1 == spec_1) && (spec_1 == spec_2) && (spec_2 == spec_3)
+    if !result
+        @info("", spec_1, spec_2, spec_3, str_1, str_2, str_3)
+    end
+    return result
+end
+
+@testset "Pkg.Versions.to_semver_spec" begin
+    @testset begin
+        bases = ["0.0.3", "0.2.3", "1.2.3", "0.0", "0.2", "1.2", "0", "1"]
+        specifiers = ["", "^", "~", "= ", ">= ", "≥ "]
+        for specifier in specifiers
+            for base in bases
+                @test roundtrip_to_semver_spec("$(specifier)$(base)")
+            end
+            @test roundtrip_to_semver_spec(join(string.(Ref(specifier), bases), ", "))
+        end
+    end
+
+    @testset begin
+        bases = ["0.0.3", "0.2.3", "1.2.3", "0.2", "1.2", "1"]
+        specifiers = ["< "]
+        for specifier in specifiers
+            for base in bases
+                @test roundtrip_to_semver_spec("$(specifier)$(base)")
+            end
+            @test roundtrip_to_semver_spec(join(string.(Ref(specifier), bases), ", "))
+        end
+    end
+
+    @testset begin
+        strs = [
+            # ranges
+            "1.2.3 - 4.5.6",
+            "0.2.3 - 4.5.6",
+            "1.2 - 4.5.6",
+            "1 - 4.5.6",
+            "0.2 - 4.5.6",
+            "0.2 - 0.5.6",
+            "1.2.3 - 4.5",
+            "1.2.3 - 4",
+            "1.2 - 4.5",
+            "1.2 - 4",
+            "1 - 4.5",
+            "1 - 4",
+            "0.2.3 - 4.5",
+            "0.2.3 - 4",
+            "0.2 - 4.5",
+            "0.2 - 4",
+            "0.2 - 0.5",
+            "0.2 - 0",
+
+            # multiple ranges
+            "1 - 2.3, 4.5.6 - 7.8.9",
+
+            # other stuff
+            "1 - 0",
+            "2 - 1",
+            ">= 0",
+        ]
+
+        for str in strs
+            @test roundtrip_to_semver_spec(str)
+        end
+    end
+end
+
+end # module


### PR DESCRIPTION
## Summary

This pull request adds the `Pkg.Versions.to_semver_spec` function, which has the following signature:
```
Pkg.Versions.to_semver_spec(spec::Pkg.Versions.VersionSpec) -> String
```

For `VersionSpec`s in its domain, the `to_semver_spec` function has the following property:
```
Pkg.Versions.semver_spec(Pkg.Versions.to_semver_spec(spec)) == spec
```

That is, if `spec::VersionSpec` is in the domain of `to_semver_spec`, then `to_semver_spec` is the inverse function of `semver_spec`.

## Motivation

I think this is a useful feature in general, but also I would specifically like to use this functionality to simplify #2468.

Here is an example use case from #2468:
```julia
julia> original_compat_entry_string = "1.2.3 - 4.5.6, 7.8.9 - 10.11.12"
"1.2.3 - 4.5.6, 7.8.9 - 10.11.12"

julia> latest_compatible_version = v"10.11.12" # the result of getting all registered versions from the registry, checking them against the compat entry, and taking the maximum
v"10.11.12"

julia> earliest_backwards_compatible_version = Pkg.Operations.get_earliest_backwards_compatible_version(latest_compatible_version)
v"10.0.0"

julia> original_compat_spec = Pkg.Versions.semver_spec(original_compat_entry_string)
VersionSpec("[1.2.3-4.5.6, 7.8.9-10.11.12]")

julia> new_compat_spec = intersect(original_compat_spec, Pkg.Versions.semver_spec("^$(earliest_backwards_compatible_version)"))
VersionSpec("10.0.0-10.11.12")

julia> new_compat_entry_string = Pkg.Versions.to_semver_spec(new_compat_spec)
"10.0.0 - 10.11.12"
```

## Domain of `to_semver_spec`

Almost all `VersionSpec`s are in the domain of `to_semver_spec`. However, there is one type of `VersionSpec` that I cannot figure out how to represent using the SemVer notation:
```julia
julia> lower = Pkg.Versions.VersionBound()
Pkg.Versions.VersionBound((0x00000000, 0x00000000, 0x00000000), 0)

julia> upper = Pkg.Versions.VersionBound(1)
Pkg.Versions.VersionBound((0x00000001, 0x00000000, 0x00000000), 1)

julia> r = Pkg.Types.VersionRange(lower, upper)
VersionRange("0-1.0.0")

julia> r.lower.n
0

julia> r.upper.n
1

julia> spec = Pkg.Types.VersionSpec([r])
VersionSpec("0-1.0.0")
```

I simply cannot figure out how to write a string `str` such that `semver_spec(str)` returns the above `VersionSpec`.

The specific issue here is that `r.lower.n` is zero and `r.upper.n` is nonzero. I can't figure out how to write a range `r` that has this property in SemVer notation.