### PR TITLE
async git installs

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -726,7 +726,7 @@ function download_source(ctx::Context; readonly=true)
     ##################################################
     # Use LibGit2 to download any remaining packages #
     ##################################################
-    for (pkg, urls, path) in missed_packages
+    asyncmap(missed_packages) do (pkg, urls, path)
         uuid = pkg.uuid
         install_git(ctx.io, pkg.uuid, pkg.name, pkg.tree_hash, urls, path)
         readonly && set_readonly(path)


### PR DESCRIPTION
When you have dozens of dependencies that are on gitlab the time to git clone them all is annoying.
I think it's completely safe and reasonable to do them async