### PR TITLE
Refactor: do not use double constructor for PackageSpec

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -496,7 +496,7 @@ Below is a comparison between the REPL mode and the functional API:
 | `--major Package`    | `PackageSpec(name="Package", version=PKGLEVEL_MAJOR)` |
 
 """
-const PackageSpec = API.Package
+const PackageSpec = Types.PackageSpec
 
 """
     setprotocol!(;

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -11,6 +11,10 @@ function parse_package(args::Vector{QString}, options; add_or_dev=false)::Vector
     return parse_package_args(args; add_or_dev=add_or_dev)
 end
 
+struct VersionToken
+    version::String
+end
+
 struct Rev
     rev::String
 end
@@ -20,7 +24,7 @@ struct Subdir
 end
 
 const PackageIdentifier = String
-const PackageToken = Union{PackageIdentifier, VersionRange, Rev, Subdir}
+const PackageToken = Union{PackageIdentifier, VersionToken, Rev, Subdir}
 
     # Match a git repository URL. This includes uses of `@` and `:` but
     # requires that it has `.git` at the end.
@@ -64,7 +68,7 @@ function package_lex(qwords::Vector{QString})::Vector{String}
 end
 
 PackageToken(word::String)::PackageToken =
-    first(word) == '@' ? VersionRange(word[2:end]) :
+    first(word) == '@' ? VersionToken(word[2:end]) :
     first(word) == '#' ? Rev(word[2:end]) :
     first(word) == ':' ? Subdir(word[2:end]) :
     String(word)
@@ -75,15 +79,15 @@ function parse_package_args(args::Vector{PackageToken}; add_or_dev=false)::Vecto
         (isempty(args) || args[1] isa PackageIdentifier) && return
         modifier = popfirst!(args)
         if modifier isa Subdir
-            pkg.repo.subdir = modifier.dir
+            pkg.subdir = modifier.dir
             (isempty(args) || args[1] isa PackageIdentifier) && return
             modifier = popfirst!(args)
         end
 
-        if modifier isa VersionRange
-            pkg.version = VersionSpec(modifier)
+        if modifier isa VersionToken
+            pkg.version = modifier.version
         elseif modifier isa Rev
-            pkg.repo.rev = modifier.rev
+            pkg.rev = modifier.rev
         else
             pkgerror("Package name/uuid must precede subdir specifier `[$arg]`.")
         end
@@ -98,7 +102,7 @@ function parse_package_args(args::Vector{PackageToken}; add_or_dev=false)::Vecto
             push!(pkgs, pkg)
         # Modifiers without a corresponding package identifier -- this is a user error
         else
-            arg isa VersionRange ?
+            arg isa VersionToken ?
                 pkgerror("Package name/uuid must precede version specifier `@$arg`.") :
             arg isa Rev ?
                 pkgerror("Package name/uuid must precede revision specifier `#$(arg.rev)`.") :
@@ -119,10 +123,10 @@ end
 function parse_package_identifier(word::AbstractString; add_or_develop=false)::PackageSpec
     if add_or_develop
         if isurl(word)
-            return PackageSpec(repo=Types.GitRepo(source=word))
+            return PackageSpec(; url=word)
         elseif any(occursin.(['\\','/'], word)) || word == "." || word == ".."
             if casesensitive_isdir(expanduser(word))
-                return PackageSpec(repo=Types.GitRepo(source=normpath(expanduser(word))))
+                return PackageSpec(; path=normpath(expanduser(word)))
             else
                 pkgerror("`$word` appears to be a local path, but directory does not exist")
             end
@@ -132,7 +136,7 @@ function parse_package_identifier(word::AbstractString; add_or_develop=false)::P
         end
     end
     if occursin(uuid_re, word)
-        return PackageSpec(uuid=UUID(word))
+        return PackageSpec(;uuid=UUID(word))
     elseif occursin(name_re, word)
         return PackageSpec(String(match(name_re, word).captures[1]))
     elseif occursin(name_uuid_re, word)

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -316,12 +316,12 @@ end
     # the global artifact namespace and package list, but it should be harmless.
     mktempdir() do project_path
         with_pkg_env(project_path) do
-            copy_test_package(project_path, "ArtifactInstallation")
+            path = git_init_package(project_path, joinpath(@__DIR__, "test_packages", "ArtifactInstallation"))
             add_this_pkg()
             Pkg.add(Pkg.Types.PackageSpec(
                 name="ArtifactInstallation",
                 uuid=Base.UUID("02111abe-2050-1119-117e-b30112b5bdc4"),
-                path=joinpath(project_path, "ArtifactInstallation"),
+                path=path,
             ))
 
             # Run test harness
@@ -635,6 +635,7 @@ end
         # loads overridden package artifacts.
         Pkg.activate(depot_container) do
             copy_test_package(depot_container, "ArtifactOverrideLoading")
+            git_init_and_commit(joinpath(depot_container, "ArtifactOverrideLoading"))
             add_this_pkg()
             Pkg.add(Pkg.Types.PackageSpec(
                 name="ArtifactOverrideLoading",

--- a/test/test_packages/ArtifactOverrideLoading/Project.toml
+++ b/test/test_packages/ArtifactOverrideLoading/Project.toml
@@ -1,5 +1,5 @@
 name = "ArtifactOverrideLoading"
-uuid = "9f5278ee-142d-5d9a-9723-c4aebaa272e1"
+uuid = "7b879065-7f74-5fa4-bdd5-9b7a15df8941"
 version = "0.1.0"
 
 [deps]


### PR DESCRIPTION
Fix #2282 

I admit that messing with the constructor was a thoroughly terrible idea. The check could be circumvented anyway by manually setting the fields after the constructor call. The checking should be done inside the API.
