### PR TITLE
Refactor: use `VersionSpec` as the canonical compat representation

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -195,6 +195,11 @@ function find_project_file(env::Union{Nothing,String}=nothing)
     return Pkg.safe_realpath(project_file)
 end
 
+Base.@kwdef mutable struct Compat
+    val::VersionSpec
+    str::String
+end
+
 Base.@kwdef mutable struct Project
     other::Dict{String,Any} = Dict{String,Any}()
     # Fields
@@ -206,7 +211,7 @@ Base.@kwdef mutable struct Project
     deps::Dict{String,UUID} = Dict{String,UUID}()
     extras::Dict{String,UUID} = Dict{String,UUID}()
     targets::Dict{String,Vector{String}} = Dict{String,Vector{String}}()
-    compat::Dict{String,String} = Dict{String,String}()# TODO Dict{String, VersionSpec}
+    compat::Dict{String,Compat} = Dict{String,Compat}()
 end
 Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Project))
 Base.hash(x::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)

--- a/src/project.jl
+++ b/src/project.jl
@@ -58,15 +58,17 @@ end
 read_project_targets(raw, project::Project) =
     pkgerror("Expected `targets` section to be a key-value list")
 
-read_project_compat(::Nothing, project::Project) = Dict{String,Any}()
+read_project_compat(::Nothing, project::Project) = Dict{String,Compat}()
 function read_project_compat(raw::Dict{String,Any}, project::Project)
+    compat = Dict{String,Compat}()
     for (name, version) in raw
-        try VersionSpec(semver_spec(version))
+        try
+            compat[name] = Compat(semver_spec(version), version)
         catch err
             pkgerror("Could not parse compatibility version for dependency `$name`")
         end
     end
-    return raw
+    return compat
 end
 read_project_compat(raw, project::Project) =
     pkgerror("Expected `compat` section to be a key-value list")
@@ -147,6 +149,12 @@ end
 function destructure(project::Project)::Dict
     raw = deepcopy(project.other)
 
+    # sanity check for consistency between compat value and string representation
+    for (name, compat) in project.compat
+        @assert compat.val == semver_spec(compat.str) "inconsistency between compat values and string representation"
+    end
+
+    # if a field is set to its default value, don't include it in the write
     should_delete(x::Dict) = isempty(x)
     should_delete(x)       = x === nothing
     entry!(key::String, src) = should_delete(src) ? delete!(raw, key) : (raw[key] = src)
@@ -157,7 +165,7 @@ function destructure(project::Project)::Dict
     entry!("manifest", project.manifest)
     entry!("deps",     project.deps)
     entry!("extras",   project.extras)
-    entry!("compat",   project.compat)
+    entry!("compat",   Dict(name => x.str for (name, x) in project.compat))
     entry!("targets",  project.targets)
     return raw
 end


### PR DESCRIPTION
Inspired by the discussion in #2469. As stated in the discussion. a VersionSpec is a much more desirable representation because it can be modified more easily.

Changes:
- immediately convert to `VersionSpec` when reading project file
- keep raw string representation to write back out when operations complete