### PR TITLE
Don't use the `@assert` macro

### DIFF
--- a/src/project.jl
+++ b/src/project.jl
@@ -151,7 +151,9 @@ function destructure(project::Project)::Dict
 
     # sanity check for consistency between compat value and string representation
     for (name, compat) in project.compat
-        @assert compat.val == semver_spec(compat.str) "inconsistency between compat values and string representation"
+        if compat.val != semver_spec(compat.str)
+            throw(ErrorException("inconsistency between compat values and string representation"))
+        end
     end
 
     # if a field is set to its default value, don't include it in the write


### PR DESCRIPTION
In the future, we may disable `@assert`s by default. But I think this particular error should always be shown.