### PR TITLE
allow `--preserve` option for `develop` in the REPL

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -155,12 +155,13 @@ PSA[:name => "develop",
         PSA[:name => "strict", :api => :strict => true],
         PSA[:name => "local", :api => :shared => false],
         PSA[:name => "shared", :api => :shared => true],
+        PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
     :completions => complete_add_dev,
     :description => "clone the full package repo locally for development",
     :help => md"""
-    [dev|develop] [--shared|--local] pkg[=uuid] ...
-    [dev|develop] path
+    [dev|develop] [--preserve=<opt>] [--shared|--local] pkg[=uuid] ...
+    [dev|develop] [--preserve=<opt>] path
 
 Make a package available for development. If `pkg` is an existing local path, that path will be recorded in
 the manifest and used. Otherwise, a full git clone of `pkg` is made. The location of the clone is

--- a/test/new.jl
+++ b/test/new.jl
@@ -1217,6 +1217,11 @@ end
         @test api == Pkg.develop
         @test args == [Pkg.PackageSpec(;url="https://github.com/JuliaLang/Example.jl")]
         @test isempty(opts)
+        # develop using preserve option
+        api, args, opts = first(Pkg.pkg"dev --preserve=none Example")
+        @test api == Pkg.develop
+        @test args == [Pkg.PackageSpec(;name="Example")]
+        @test opts == Dict(:preserve => Pkg.PRESERVE_NONE)
     end
 end
 


### PR DESCRIPTION
Someone on slack was trying to set `preserve` while `develop`ing, but it hasn't been hooked up to the REPL yet. I am a little surprised it hasn't been pointed out before.