### PR TITLE
adjust `activate` feedback and hook up to `io` kwarg

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1496,10 +1496,10 @@ end
 
 function activate(;temp=false, shared=false, io::IO=DEFAULT_IO[])
     shared && pkgerror("Must give a name for a shared environment")
-    temp && return activate(mktempdir())
+    temp && return activate(mktempdir(); io=io)
     Base.ACTIVE_PROJECT[] = nothing
     p = Base.active_project()
-    p === nothing || printpkgstyle(io, :Activating, "environment at $(pathrepr(p))")
+    p === nothing || printpkgstyle(io, :Activating, "project at $(pathrepr(dirname(p)))")
     add_snapshot_to_undo()
     return nothing
 end
@@ -1556,7 +1556,7 @@ function activate(path::AbstractString; shared::Bool=false, temp::Bool=false, io
     p = Base.active_project()
     if p !== nothing
         n = ispath(p) ? "" : "new "
-        printpkgstyle(io, :Activating, "$(n)environment at $(pathrepr(p))")
+        printpkgstyle(io, :Activating, "$(n)project at $(pathrepr(dirname(p)))")
     end
     add_snapshot_to_undo()
     return nothing

--- a/test/new.jl
+++ b/test/new.jl
@@ -326,6 +326,18 @@ end
     end
 end
 
+@testset "activate" begin
+    isolate(loaded_depot=true) do
+        io = IOBuffer()
+        Pkg.activate("Foo"; io=io)
+        output = String(take!(io))
+        @test occursin(r"Activating.*project at.*`.*Foo`", output)
+        Pkg.activate(; io=io, temp=true)
+        output = String(take!(io))
+        @test occursin(r"Activating new project at `.*`", output)
+    end
+end
+
 #
 # # Add
 #


### PR DESCRIPTION
We weren't passing `io` down in `activate` for all cases: this fixes that.
Also adjust `activate` feedback to suggesting in #1761.

Fix #1761, Close #2036