### PR TITLE
precompile: Escape string in toml file

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -656,7 +656,7 @@ function _run_precompilation_script_setup()
     write("registries/Registry/T/TestPkg/Package.toml", """
         name = "TestPkg"
         uuid = "$uuid"
-        repo = "$tmp/TestPkg.jl"
+        repo = "$(escape_string(tmp))/TestPkg.jl"
         """)
     return tmp
 end


### PR DESCRIPTION
Drive by fix for the following issue in the output of the precompile
```
┌ Error: Error in the keymap
│   exception =
│    TOML Parser error:
│    C:\users\keno\Temp\jl_qpEfxR\registries\Registry\T/TestPkg\Package.toml:3:12 error: invalid uncidode scalar
│      repo = "C:\users\keno\Temp\jl_qpEfxR/TestPkg.jl"
│                 ^                                     
│    Stacktrace:
│     [1] parse
│       @ .\toml_parser.jl:441 [inlined]
│     [2] Base.CachedTOMLDict(p::Base.TOML.Parser, path::String)
│       @ Base .\loading.jl:180
│     [3] (::Base.var"#810#811"{String, Base.TOMLCache})()
│       @ Base .\loading.jl:226
└ @ REPL.LineEdit Z:\home\keno\julia-win64\usr\share\julia\stdlib\v1.7\REPL\src\LineEdit.jl:2579
```