### PR TITLE
Add the `resolver_only` kwarg to `add`, `develop`, `free`, `pin`, and `update`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -171,7 +171,8 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
 end
 
 function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
-                 preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform(), kwargs...)
+                 preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform(),
+                 resolver_only::Bool=false, kwargs...)
     require_not_empty(pkgs, :develop)
     Context!(ctx; kwargs...)
 
@@ -210,12 +211,13 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
         end
     end
 
-    Operations.develop(ctx, pkgs, new_git; preserve=preserve, platform=platform)
+    Operations.develop(ctx, pkgs, new_git; preserve, platform, resolver_only)
     return
 end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PRESERVE_TIERED,
-             platform::AbstractPlatform=HostPlatform(), kwargs...)
+             platform::AbstractPlatform=HostPlatform(), resolver_only::Bool=false,
+             kwargs...)
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)
 
@@ -263,7 +265,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
         end
     end
 
-    Operations.add(ctx, pkgs, new_git; preserve, platform)
+    Operations.add(ctx, pkgs, new_git; preserve, platform, resolver_only)
     return
 end
 
@@ -310,7 +312,7 @@ end
 
 function up(ctx::Context, pkgs::Vector{PackageSpec};
             level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode=PKGMODE_PROJECT,
-            update_registry::Bool=true, kwargs...)
+            update_registry::Bool=true, resolver_only::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     if update_registry
         Registry.download_default_registries(ctx.io)
@@ -327,7 +329,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx.env.manifest, pkgs)
     end
-    Operations.up(ctx, pkgs, level)
+    Operations.up(ctx, pkgs, level; resolver_only)
     return
 end
 
@@ -337,7 +339,8 @@ function resolve(ctx::Context; kwargs...)
     return nothing
 end
 
-function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwargs...)
+function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false,
+             resolver_only::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
@@ -364,11 +367,12 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwar
 
     project_deps_resolve!(ctx.env, pkgs)
     ensure_resolved(ctx.env.manifest, pkgs)
-    Operations.pin(ctx, pkgs)
+    Operations.pin(ctx, pkgs; resolver_only)
     return
 end
 
-function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwargs...)
+function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false,
+              resolver_only::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
@@ -390,7 +394,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwa
     manifest_resolve!(ctx.env.manifest, pkgs)
     ensure_resolved(ctx.env.manifest, pkgs)
 
-    Operations.free(ctx, pkgs)
+    Operations.free(ctx, pkgs; resolver_only)
     return
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -36,6 +36,10 @@ const DEFAULT_IO = Ref{IO}()
 
 can_fancyprint(io::IO) = (io isa Base.TTY) && (get(ENV, "CI", nothing) != "true")
 
+function _auto_precompile_enabled()
+    return (Base.JLOptions().use_compiled_modules == 1) && (tryparse(Bool, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) === true)
+end
+
 include("../ext/LazilyInitializedFields/LazilyInitializedFields.jl")
 
 include("utils.jl")
@@ -607,7 +611,7 @@ end
 ##################
 
 function _auto_precompile(ctx::Types.Context)
-    if Base.JLOptions().use_compiled_modules == 1 && tryparse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
+    if _auto_precompile_enabled()
         Pkg.precompile(ctx; internal_call=true)
     end
 end


### PR DESCRIPTION
Fixes #2503 
See also: #1718 

This pull request adds the `resolver_only::Bool` keyword argument to the following five functions:
1. `Pkg.add`
2. `Pkg.develop`
3. `Pkg.free`
4. `Pkg.pin`
5. `Pkg.update`

The default value is `resolver_only = false`.

When `resolver_only` is `true`, we skip the following steps:
1. Downloading the source code
2. Downloading the artifacts
3. Running the package build scripts

You must disable auto-precompilation for this feature to work. If `resolver_only` is `true` and auto-precompilation is enabled, an error will be thrown.