### PR TITLE
Fix treehash generation

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -274,7 +274,7 @@ function tree_hash(::Type{HashType}, root::AbstractString; debug_out::Union{IO,N
     entries = Tuple{String, Vector{UInt8}, GitMode}[]
     for f in sort(readdir(root; join=true); by = f -> isdir(f) ? f*"/" : f)
         # Skip `.git` directories
-        if f == ".git"
+        if basename(f) == ".git"
             continue
         end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -2485,8 +2485,11 @@ tree_hash(root::AbstractString; kwargs...) = bytes2hex(@inferred Pkg.GitTools.tr
         mkdir(joinpath(dir, "FooGit"))
         mkdir(joinpath(dir, "FooGit", ".git"))
         write(joinpath(dir, "Foo", "foo"), "foo")
+        chmod(joinpath(dir, "Foo", "foo"), 0o644)
         write(joinpath(dir, "FooGit", "foo"), "foo")
+        chmod(joinpath(dir, "FooGit", "foo"), 0o644)
         write(joinpath(dir, "FooGit", ".git", "foo"), "foo")
+        chmod(joinpath(dir, "FooGit", ".git", "foo"), 0o644)
         @test tree_hash(joinpath(dir, "Foo")) == 
               tree_hash(joinpath(dir, "FooGit")) ==
               "2f42e2c1c1afd4ef8c66a2aaba5d5e1baddcab33"

--- a/test/new.jl
+++ b/test/new.jl
@@ -2478,6 +2478,19 @@ tree_hash(root::AbstractString; kwargs...) = bytes2hex(@inferred Pkg.GitTools.tr
             @test "8bc80be82b2ae4bd69f50a1a077a81b8678c9024" == tree_hash(dir)
         end
     end
+
+    # Test for directory with .git hashing
+    mktempdir() do dir
+        mkdir(joinpath(dir, "Foo"))
+        mkdir(joinpath(dir, "FooGit"))
+        mkdir(joinpath(dir, "FooGit", ".git"))
+        write(joinpath(dir, "Foo", "foo"), "foo")
+        write(joinpath(dir, "FooGit", "foo"), "foo")
+        write(joinpath(dir, "FooGit", ".git", "foo"), "foo")
+        @test tree_hash(joinpath(dir, "Foo")) == 
+              tree_hash(joinpath(dir, "FooGit")) ==
+              "2f42e2c1c1afd4ef8c66a2aaba5d5e1baddcab33"
+    end
 end
 
 @testset "multiple registries overlapping version ranges for different versions" begin


### PR DESCRIPTION
We missed a `basename()` when comparing `f` to `".git"`, meaning that
embedded `.git` directories get included.