### PR TITLE
Small documentation update for valid package/project names.

### DIFF
--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -36,8 +36,9 @@ The name of the package/project is determined by the `name` field, for example:
 ```toml
 name = "Example"
 ```
-The name can contain word characters `[a-zA-Z0-9_]`, but can not start with a number. For
-packages it is recommended to follow the
+The name must be a valid [identifier](https://docs.julialang.org/en/v1/base/base/#Base.isidentifier)
+(a sequence of Unicode characters that does not start with a number and is neither `true` nor `false`).
+For packages it is recommended to follow the
 [package naming guidelines](@ref Package-naming-guidelines). The `name` field is mandatory
 for packages.
 


### PR DESCRIPTION
I think we should update this (old?) falsely restrictive information.

I realized this while reading the documentation for another detail, knowing that some personal project names are not limited to ASCII (see this [old error](https://github.com/JuliaLang/Pkg.jl/issues/1846)).