### PR TITLE
Replace `throw(ErrorException(message))` with `pkgerror(message)`

### DIFF
--- a/src/project.jl
+++ b/src/project.jl
@@ -152,7 +152,7 @@ function destructure(project::Project)::Dict
     # sanity check for consistency between compat value and string representation
     for (name, compat) in project.compat
         if compat.val != semver_spec(compat.str)
-            throw(ErrorException("inconsistency between compat values and string representation"))
+            pkgerror("inconsistency between compat values and string representation")
         end
     end
 


### PR DESCRIPTION
In the Pkg.jl codebase, `pkgerror(message)` is a more idiomatic way of throwing exceptions.