### PR TITLE
Test suite: change permissions before removing directories

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,9 +22,12 @@ Pkg.DEFAULT_IO[] = IOBuffer()
 include("utils.jl")
 
 # Clean slate. Make sure to not start with an outdated registry
-rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)
-rm(Utils.LOADED_DEPOT; force = true, recursive = true)
-rm(Utils.REGISTRY_DEPOT; force = true, recursive = true)
+paths_to_remove = String[
+    joinpath(@__DIR__, "registries"),
+    Utils.LOADED_DEPOT,
+    Utils.REGISTRY_DEPOT,
+]
+Utils.force_rm.(paths_to_remove)
 
 include("new.jl")
 include("pkg.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -279,4 +279,22 @@ function add_this_pkg(; platform=Base.BinaryPlatforms.HostPlatform())
     Pkg.develop(spec; platform)
 end
 
+function force_rm(path::AbstractString)
+    if isdir(path)
+        chmod(path, 0o700)
+        for (root, dirs, files) in walkdir(path)
+            for dir in dirs
+                chmod(joinpath(root, dir), 0o700)
+            end
+            for file in files
+                chmod(joinpath(root, file), 0o600)
+            end
+        end
+    elseif isfile(path)
+        chmod(path, 0o600)
+    end
+    rm(path; force = true, recursive = true)
+    return nothing
 end
+
+end # module


### PR DESCRIPTION
If the registry is read-only, then (at least on my machine) the `rm` may sometimes fail even if you pass `force = true`.