### PR TITLE
Improve the implementation of `force_latest_compatible_version`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -311,7 +311,9 @@ end
 
 function up(ctx::Context, pkgs::Vector{PackageSpec};
             level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode=PKGMODE_PROJECT,
-            update_registry::Bool=true, kwargs...)
+            update_registry::Bool=true,
+            skip_writing_project::Bool=false,
+            kwargs...)
     Context!(ctx; kwargs...)
     if update_registry
         Registry.download_default_registries(ctx.io)
@@ -328,13 +330,13 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx.env.manifest, pkgs)
     end
-    Operations.up(ctx, pkgs, level)
+    Operations.up(ctx, pkgs, level; skip_writing_project)
     return
 end
 
 resolve(; io::IO=stderr_f(), kwargs...) = resolve(Context(;io); kwargs...)
-function resolve(ctx::Context; kwargs...)
-    up(ctx; level=UPLEVEL_FIXED, mode=PKGMODE_MANIFEST, update_registry=false, kwargs...)
+function resolve(ctx::Context; skip_writing_project::Bool=false, kwargs...)
+    up(ctx; level=UPLEVEL_FIXED, mode=PKGMODE_MANIFEST, update_registry=false, skip_writing_project, kwargs...)
     return nothing
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -177,6 +177,16 @@ function set_compat(proj::Project, name::String, compat::String)
     proj.compat[name] = Types.Compat(Types.semver_spec(compat), compat)
 end
 
+function reset_all_compat!(proj::Project)
+    for name in keys(proj.compat)
+        compat = proj.compat[name]
+        if compat.val != Types.semver_spec(compat.str)
+            proj.compat[name] = Types.Compat(Types.semver_spec(compat.str), compat.str)
+        end
+    end
+    return nothing
+end
+
 function collect_project!(pkg::PackageSpec, path::String,
                           deps_map::Dict{UUID,Vector{PackageSpec}})
     deps_map[pkg.uuid] = PackageSpec[]
@@ -1218,7 +1228,8 @@ function up_load_manifest_info!(pkg::PackageSpec, entry::PackageEntry)
     # `pkg.version` and `pkg.tree_hash` is set by `up_load_versions!`
 end
 
-function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel)
+function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
+            skip_writing_project::Bool=false)
     new_git = Set{UUID}()
     # TODO check all pkg.version == VersionSpec()
     # set version constraints according to `level`
@@ -1236,7 +1247,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel)
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
     download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)
-    write_env(ctx.env) # write env before building
+    write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env; io=ctx.io)
     build_versions(ctx, union(new_apply, new_git))
 end
@@ -1435,8 +1446,17 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
         with_temp_env(tmp) do
             temp_ctx = Context()
             temp_ctx.env.project.deps[target.name] = target.uuid
+
+            if force_latest_compatible_version
+                apply_force_latest_compatible_version!(
+                    temp_ctx;
+                    target_name = target.name,
+                    allow_earlier_backwards_compatible_versions,
+                )
+            end
+
             try
-                Pkg.resolve(temp_ctx; io=devnull)
+                Pkg.resolve(temp_ctx; io=devnull, skip_writing_project=true)
                 @debug "Using _parent_ dep graph"
             catch err# TODO
                 err isa Resolve.ResolverError || rethrow()
@@ -1444,9 +1464,11 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
                 @debug err
                 @warn "Could not use exact versions of packages in manifest, re-resolving"
                 temp_ctx.env.manifest = Dict(uuid => entry for (uuid, entry) in temp_ctx.env.manifest if isfixed(entry))
-                Pkg.resolve(temp_ctx; io=devnull)
+                Pkg.resolve(temp_ctx; io=devnull, skip_writing_project=true)
                 @debug "Using _clean_ dep graph"
             end
+
+            reset_all_compat!(temp_ctx.env.project)
 
             # Absolutify stdlibs paths
             for (uuid, entry) in temp_ctx.env.manifest
@@ -1455,17 +1477,6 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
                 end
             end
             write_env(temp_ctx.env, update_undo = false)
-
-            if force_latest_compatible_version
-                result = check_force_latest_compatible_version(
-                    temp_ctx;
-                    target_name = target.name,
-                    allow_earlier_backwards_compatible_versions,
-                )
-                if !result
-                    pkgerror("One or more direct dependencies is not at the latest compatible version")
-                end
-            end
 
             # Run sandboxed code
             path_sep = Sys.iswindows() ? ';' : ':'
@@ -1814,26 +1825,27 @@ function status(env::EnvCache, pkgs::Vector{PackageSpec}=PackageSpec[];
     end
 end
 
-function check_force_latest_compatible_version(ctx::Types.Context;
-                                               target_name = nothing,
-                                               allow_earlier_backwards_compatible_versions::Bool = true)
+function apply_force_latest_compatible_version!(ctx::Types.Context;
+                                                target_name = nothing,
+                                                allow_earlier_backwards_compatible_versions::Bool = true)
     direct_deps = load_direct_deps(ctx.env)
     direct_deps_uuids = [dep.uuid for dep in direct_deps]
     uuid_list = filter(!is_stdlib, direct_deps_uuids)
-    isempty(uuid_list) && return true
-    results = check_force_latest_compatible_version.(
-        Ref(ctx),
-        uuid_list;
-        target_name,
-        allow_earlier_backwards_compatible_versions,
-    )
-    return all(results)
+    for uuid in uuid_list
+        apply_force_latest_compatible_version!(
+            ctx,
+            uuid;
+            target_name,
+            allow_earlier_backwards_compatible_versions,
+        )
+    end
+    return nothing
 end
 
-function check_force_latest_compatible_version(ctx::Types.Context,
-                                               uuid::Base.UUID;
-                                               target_name= nothing,
-                                               allow_earlier_backwards_compatible_versions::Bool = true)
+function apply_force_latest_compatible_version!(ctx::Types.Context,
+                                                uuid::Base.UUID;
+                                                target_name= nothing,
+                                                allow_earlier_backwards_compatible_versions::Bool = true)
     dep = ctx.env.manifest[uuid]
     name = dep.name
     active_version = dep.version
@@ -1841,37 +1853,32 @@ function check_force_latest_compatible_version(ctx::Types.Context,
     if !has_compat
         if name != target_name
             @warn(
-                "Package does not have a [compat] entry",
+                "Dependency does not have a [compat] entry",
                 name, uuid, active_version, target_name,
             )
         end
-        return true
+        return nothing
     end
-    compat_entry = ctx.env.project.compat[name].val
+    old_compat_spec = ctx.env.project.compat[name].val
     latest_compatible_version = get_latest_compatible_version(
         ctx,
         uuid,
-        compat_entry,
+        old_compat_spec,
     )
     earliest_backwards_compatible_version = get_earliest_backwards_compatible_version(latest_compatible_version)
     if allow_earlier_backwards_compatible_versions
-        result = active_version >= earliest_backwards_compatible_version
+        version_for_intersect = only_major_minor_patch(earliest_backwards_compatible_version)
     else
-        result = active_version >= latest_compatible_version
+        version_for_intersect = only_major_minor_patch(latest_compatible_version)
     end
-    if !result
-        @error(
-            "Package is not at the latest compatible version",
-            name,
-            uuid,
-            compat_entry,
-            active_version,
-            latest_compatible_version,
-            earliest_backwards_compatible_version,
-            allow_earlier_backwards_compatible_versions,
-        )
-    end
-    return result
+    compat_for_intersect = Pkg.Types.semver_spec("≥ $(version_for_intersect)")
+    new_compat_spec = Base.intersect(old_compat_spec, compat_for_intersect)
+    ctx.env.project.compat[name].val = new_compat_spec
+    return nothing
+end
+
+function only_major_minor_patch(ver::Base.VersionNumber)
+    return Base.VersionNumber(ver.major, ver.minor, ver.patch)
 end
 
 function get_earliest_backwards_compatible_version(ver::Base.VersionNumber)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -932,8 +932,9 @@ manifest_info(::Manifest, uuid::Nothing) = nothing
 function manifest_info(manifest::Manifest, uuid::UUID)::Union{PackageEntry,Nothing}
     return get(manifest, uuid, nothing)
 end
-function write_env(env::EnvCache; update_undo=true)
-    if env.project != env.original_project
+function write_env(env::EnvCache; update_undo=true,
+                   skip_writing_project::Bool=false)
+    if (env.project != env.original_project) && (!skip_writing_project)
         write_project(env)
     end
     if env.manifest != env.original_manifest


### PR DESCRIPTION
This pull request improves the behavior of the following two keyword arguments to the `Pkg.test` function:
1. `force_latest_compatible_version::Bool`
2. `allow_earlier_backwards_compatible_versions::Bool`

These two keyword arguments are:
1. Not part of the public API
2. Only intended for use by CI services that implement auto-detection of CompatHelper/Dependabot pull requests (see e.g. https://github.com/julia-actions/julia-runtest/pull/20 and https://github.com/JuliaRegistries/CompatHelper.jl/issues/298)

## Before this PR

Here is the current behavior:
1. `Pkg.test` creates the temporary sandbox environment.
2. `Pkg.test` runs the resolver.
3. We iterate over each direct dependency that has a `[compat]` entry and check that the direct dependency is at its latest compatible version. If at least one direct dependency is not at its latest compatible version, we throw an error. (For a direct dependency that does not have a `[compat]` entry, we print a warning and do nothing.)
4. `Pkg.test` runs the `test/runtests.jl` file.

This implementation works pretty well, but it does have some flaws:
1. The error message only tells the user that the dependency is not at its latest compatible version. It does not tell the user **why** `Pkg.test` was not able to use the latest compatible version of the dependency. The user will need to clone the repo and run e.g. `] add Foo@0.2` locally in order to figure out why the dependency is being held back.
2. If the package has checked a `Manifest.toml` file into source control, and if the manifest file uses an older version of the dependency, and if `Pkg.test` is able to use the exact same versions as the manifest file, then `Pkg.test` will use the older version of the dependency, and thus the error will be thrown.

## After this PR

This PR changes the implementation as follows:
1. `Pkg.test` creates the temporary sandbox environment.
2. **We iterate over each direct dependency. For each direct dependency, if the dependency has a `[compat]` entry, we modify the `[compat]` entry so that it only includes the latest registered version of the dependency that is compatible with the original `[compat]` entry. If a direct dependency does not have a `[compat]` entry, we print a warning and do nothing.**
3. `Pkg.test` runs the resolver. **At this point, if the resolver is not able to use the latest compatible version of all dependencies, it throws a `ResolveError`.**
4. **We reset all of the `[compat]` entries back to their original values.**
5. `Pkg.test` runs the `test/runtests.jl` file.

Here is an example to illustrate step 2. Suppose that your package has a direct dependency on `Foo.jl`. And suppose that `Foo` has the following registered versions:
- `0.1.0`
- `0.1.1`
- `0.2.0`
- `0.2.1`

Suppose that currently, your package has a `[compat]` entry that looks like this:
```toml
[compat]
Foo = "0.1"
```

And suppose that a bot (e.g. CompatHelper or Dependabot) opens a PR to change your package's `[compat]` entry to this:
```toml
[compat]
Foo = "0.1, 0.2"
```

During step 2, we (roughly speaking) modify the `[compat]` entry to look like this:
```toml
[compat]
Foo = "0.2"
```

This ensures that the resolver uses `Foo` version `0.2.x`.

This new implementation solves the previously mentioned flaws:
1. Instead of printing an error that only tells you that a dependency is not at its latest version, this implementation will cause the resolver to print an error message that details exactly why the resolver was not able to install the latest compatible version of the dependency.
2. This implementation guarantees that `Pkg.test` will use the latest compatible version of each dependency, even if there is a `Manifest.toml` file that uses an older version of a dependency.
