### PR TITLE
add `@debug` logs for artifact download failures

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -317,13 +317,13 @@ function download_artifact(
         try
             download_verify_unpack(tarball_url, tarball_hash, dest_dir, ignore_existence=true,
                                    verbose=verbose, quiet_download=quiet_download, io=io)
-        catch e
-            @debug "download_artifact error" tree_hash tarball_url tarball_hash e
+        catch err
+            @debug "download_artifact error" tree_hash tarball_url tarball_hash err
             # Clean that destination directory out if something went wrong
             rm(dest_dir; force=true, recursive=true)
 
-            if isa(e, InterruptException)
-                rethrow(e)
+            if isa(err, InterruptException)
+                rethrow(err)
             end
             return false
         end
@@ -340,10 +340,10 @@ function download_artifact(
                 download_verify_unpack(tarball_url, tarball_hash, dir, ignore_existence=true, verbose=verbose,
                     quiet_download=quiet_download, io=io)
             end
-        catch e
-            @debug "download_artifact error" tree_hash tarball_url tarball_hash e
-            if isa(e, InterruptException)
-                rethrow(e)
+        catch err
+            @debug "download_artifact error" tree_hash tarball_url tarball_hash err
+            if isa(err, InterruptException)
+                rethrow(err)
             end
             # If something went wrong during download, return false
             return false

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -318,6 +318,7 @@ function download_artifact(
             download_verify_unpack(tarball_url, tarball_hash, dest_dir, ignore_existence=true,
                                    verbose=verbose, quiet_download=quiet_download, io=io)
         catch e
+            @debug "download_artifact error" tree_hash tarball_url tarball_hash e
             # Clean that destination directory out if something went wrong
             rm(dest_dir; force=true, recursive=true)
 
@@ -340,6 +341,7 @@ function download_artifact(
                     quiet_download=quiet_download, io=io)
             end
         catch e
+            @debug "download_artifact error" tree_hash tarball_url tarball_hash e
             if isa(e, InterruptException)
                 rethrow(e)
             end


### PR DESCRIPTION
I don't think there's a good way currently to identify which errors the artifact downloads should report/throw, so this is a stop-gap to allow debugging errors in the wild.