### PR TITLE
Fix module reference typo in #2307

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -681,7 +681,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         rethrow()
     end
     if lowercase(resp) in ["y", "yes"]
-        Pkg.add(string.(available_pkgs))
+        API.add(string.(available_pkgs))
         if length(available_pkgs) < length(pkgs)
             return false # declare that some pkgs couldn't be installed
         else

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -668,8 +668,17 @@ end
 end
 
 @testset "REPL missing package install hook" begin
-    @test Pkg.REPLMode.try_prompt_pkg_add(Symbol[:notapackage]) == false
-    # cannot test installation of findable packages given requires user input to stdin on the prompt
+    isolate(loaded_depot=true) do
+        @test Pkg.REPLMode.try_prompt_pkg_add(Symbol[:notapackage]) == false
+
+        println(stdin.buffer, "n") # simulate rejecting prompt with `n\n`
+        @test Pkg.REPLMode.try_prompt_pkg_add(Symbol[:Example]) == false
+        flush(stdin.buffer)
+
+        println(stdin.buffer, "y") # simulate accepting prompt with `y\n`
+        @test Pkg.REPLMode.try_prompt_pkg_add(Symbol[:Example]) == true
+        flush(stdin.buffer)
+    end
 end
 
 end # module


### PR DESCRIPTION
This typo slipped into #2307 :/ 

It would be nice to be able to test  more of the prompt by passing `y/n` into stdin, but I don't know how to do that in CI.