### PR TITLE
Precompilation: Limit the default number of tasks to 16

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1009,6 +1009,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
     # Windows sometimes hits a ReadOnlyMemoryError, so we halve the default number of tasks. Issue #2323
     # TODO: Investigate why this happens in windows and restore the full task limit
     default_num_tasks = Sys.iswindows() ? div(Sys.CPU_THREADS::Int, 2) + 1 : Sys.CPU_THREADS::Int + 1
+    default_num_tasks = min(default_num_tasks, 16) # limit for better stability on shared resource systems
 
     num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(default_num_tasks)))
     parallel_limiter = Base.Semaphore(num_tasks)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -144,7 +144,8 @@ Precompile all the dependencies of the project in parallel.
 !!! note
     This method is called automatically after any Pkg action that changes the manifest.
     Any packages that have previously errored during precompilation won't be retried in auto mode
-    until they have changed. To disable automatic precompilation set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`
+    until they have changed. To disable automatic precompilation set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`.
+    To manually control the number of tasks used set `ENV["JULIA_NUM_PRECOMPILE_TASKS"]`.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3. On earlier versions

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -336,7 +336,8 @@ not all manifest dependencies may be loaded by the top-level dependencies on the
 
 This method is called automatically after any Pkg action that changes the manifest.
 Any packages that have previously errored during precompilation won't be retried in auto mode
-until they have changed. To disable automatic precompilation set the environment variable `JULIA_PKG_PRECOMPILE_AUTO=0`
+until they have changed. To disable automatic precompilation set the environment variable `JULIA_PKG_PRECOMPILE_AUTO=0`.
+To manually control the number of tasks used set the environment variable `JULIA_NUM_PRECOMPILE_TASKS`.
 """,
 ],
 PSA[:name => "status",


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/2404

Note that users can still override this via setting `ENV["JULIA_NUM_PRECOMPILE_TASKS"]`