### PR TITLE
Fix two `Base.hash` methods and add tests

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -234,7 +234,7 @@ Base.@kwdef mutable struct Project
     compat::Dict{String,Compat} = Dict{String,Compat}()
 end
 Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Project))
-Base.hash(x::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
+Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
 
 
 Base.@kwdef mutable struct PackageEntry

--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -86,7 +86,7 @@ function isjoinable(up::VersionBound, lo::VersionBound)
     return true
 end
 
-Base.hash(r::VersionBound, h::UInt) = hash(hash(r.t, h), convert(UInt64, r.n))
+Base.hash(r::VersionBound, h::UInt) = hash(r.t, hash(r.n, h))
 
 # Hot code
 function VersionBound(s::AbstractString)

--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -86,7 +86,7 @@ function isjoinable(up::VersionBound, lo::VersionBound)
     return true
 end
 
-Base.hash(r::VersionBound, h::UInt) = hash(reinterpret(UInt8, [hash(r.t, h)]), convert(UInt64, r.n))
+Base.hash(r::VersionBound, h::UInt) = hash(hash(r.t, h), convert(UInt64, r.n))
 
 # Hot code
 function VersionBound(s::AbstractString)

--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -86,7 +86,7 @@ function isjoinable(up::VersionBound, lo::VersionBound)
     return true
 end
 
-Base.hash(r::VersionBound, h::UInt) = hash(hash(r.t, h), r.n)
+Base.hash(r::VersionBound, h::UInt) = hash(reinterpret(UInt8, [hash(r.t, h)]), convert(UInt64, r.n))
 
 # Hot code
 function VersionBound(s::AbstractString)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -12,8 +12,7 @@ end
     @test hash(Pkg.Types.Project()) == 0xd4b8cda960e4de88
     @test hash(Pkg.Types.VersionBound()) == 0xdc46ceef40d7ff7f
     @test hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0))) == 0xea3ee20b2c9d6ccb
-    @test hash(Pkg.Types.VersionSpec()) == 0x4245018905bae555
 
-    # hash isn't stable because the internal `repo` field is a mutable struct
-    hash(Pkg.Types.PackageEntry())
+    hash(Pkg.Types.VersionSpec()) # hash isn't stable
+    hash(Pkg.Types.PackageEntry()) # hash isn't stable because the internal `repo` field is a mutable struct
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -12,8 +12,8 @@ end
     @test hash(Pkg.Types.Project()) == 0xd4b8cda960e4de88
     @test hash(Pkg.Types.VersionBound()) == 0xdc46ceef40d7ff7f
     @test hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0))) == 0xea3ee20b2c9d6ccb
+    @test hash(Pkg.Types.VersionSpec()) == 0x4245018905bae555
 
-    # hashes for these empty objects aren't stable
-    hash(Pkg.Types.VersionSpec())
+    # hash isn't stable because the internal `repo` field is a mutable struct
     hash(Pkg.Types.PackageEntry())
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -10,7 +10,7 @@ end
 
 @testset "hashing" begin
     @test hash(Pkg.Types.Project()) == 0xd4b8cda960e4de88
-    @test hash(Pkg.Types.VersionBound()) == 0x873f51b414a315c2
+    @test hash(Pkg.Types.VersionBound()) == 0xdc46ceef40d7ff7f
     @test hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0))) == 0xea3ee20b2c9d6ccb
 
     # hashes for these empty objects aren't stable

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -7,3 +7,13 @@ using Pkg
     f() = Pkg.Types.UNREGISTERED_STDLIBS
     @inferred f()
 end
+
+@testset "hashing" begin
+    @test hash(Pkg.Types.Project()) == 0xd4b8cda960e4de88
+    @test hash(Pkg.Types.VersionBound()) == 0x873f51b414a315c2
+    @test hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0))) == 0xea3ee20b2c9d6ccb
+
+    # hashes for these empty objects aren't stable
+    hash(Pkg.Types.VersionSpec())
+    hash(Pkg.Types.PackageEntry())
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -9,9 +9,9 @@ using Pkg
 end
 
 @testset "hashing" begin
-    @test hash(Pkg.Types.Project()) == 0xd4b8cda960e4de88
-    @test hash(Pkg.Types.VersionBound()) == 0xdc46ceef40d7ff7f
-    @test hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0))) == 0xea3ee20b2c9d6ccb
+    @test hash(Pkg.Types.Project()) == hash(Pkg.Types.Project())
+    @test hash(Pkg.Types.VersionBound()) == hash(Pkg.Types.VersionBound())
+    @test hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0))) == hash(Pkg.Resolve.Fixed(VersionNumber(0,1,0)))
 
     hash(Pkg.Types.VersionSpec()) # hash isn't stable
     hash(Pkg.Types.PackageEntry()) # hash isn't stable because the internal `repo` field is a mutable struct


### PR DESCRIPTION
Fixes what must be unused hash methods and adds explicit tests

```
julia> hash(Pkg.Types.Project())
ERROR: UndefVarError: t not defined
Stacktrace:
 [1] #16
   @ ./none:0 [inlined]
 [2] iterate
   @ ./generator.jl:47 [inlined]
 [3] collect(itr::Base.Generator{NTuple{9, Symbol}, Pkg.Types.var"#16#17"})
   @ Base ./array.jl:678
 [4] hash(x::Pkg.Types.Project, h::UInt64)
   @ Pkg.Types /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Pkg/src/Types.jl:201
 [5] hash(x::Pkg.Types.Project)
   @ Base ./hashing.jl:18
 [6] top-level scope
   @ REPL[3]:1


julia> hash(Pkg.Types.VersionBound())
ERROR: MethodError: no method matching hash(::UInt64, ::Int64)
Closest candidates are:
  hash(::UInt64, ::UInt64) at hashing.jl:72
  hash(::Real, ::UInt64) at float.jl:489
  hash(::Any) at hashing.jl:18
  ...
Stacktrace:
 [1] hash(r::Pkg.Types.VersionBound, h::UInt64)
   @ Pkg.Types /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Pkg/src/versions.jl:88
 [2] hash(x::Pkg.Types.VersionBound)
   @ Base ./hashing.jl:18
 [3] top-level scope
   @ REPL[2]:1
```