### PR TITLE
WIP: Implement new manifest format with top-level metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          # - macOS-latest
+          # - windows-latest
         julia-arch:
           - 'x64'
-          - 'x86'
+          # - 'x86'
         pkg-server:
-          - ""
+          # - ""
           - "pkg.julialang.org"
         julia-version:
           # - '1.6'
@@ -41,9 +41,10 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - name: Install Julia from URL
+        uses: julia-actions/install-julia-from-url@main
         with:
-          version: ${{ matrix.julia-version }}
+          url: https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.7/julia-88274cb9c2-linux64.tar.gz
       - name: Fix TEMP on windows
         if: matrix.os == 'windows-latest'
         run: |
@@ -67,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - name: Install Julia from URL
+        uses: julia-actions/install-julia-from-url@main
         with:
-          # version: '1.6'
-          version: 'nightly'
+          url: https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.7/julia-88274cb9c2-linux64.tar.gz
       - name: Generate docs
         run: |
           julia --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\"\n"));'

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -103,7 +103,7 @@ function complete_installed_packages(options, partial)
     mode = get(options, :mode, PKGMODE_PROJECT)
     return mode == PKGMODE_PROJECT ?
         collect(keys(env.project.deps)) :
-        unique!([entry.name for (uuid, entry) in env.manifest])
+        unique!([entry.name for (uuid, entry) in env.manifest.deps])
 end
 
 function complete_add_dev(options, partial, i1, i2)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -221,7 +221,7 @@ Base.@kwdef mutable struct Project
     compat::Dict{String,Compat} = Dict{String,Compat}()
 end
 Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Project))
-Base.hash(x::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
+Base.hash(p::Project, h::UInt) = foldr(hash, [getfield(p, x) for x in fieldnames(Project)], init=h)
 
 
 Base.@kwdef mutable struct PackageEntry

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -85,14 +85,14 @@ struct Stage1
     deps::Union{Vector{String}, Dict{String,UUID}}
 end
 
-normalize_deps(name, uuid, deps, manifest) = deps
-function normalize_deps(name, uuid, deps::Vector{String}, manifest::Dict{String,Vector{Stage1}})
+normalize_deps(name, uuid, deps, raw_manifest) = deps
+function normalize_deps(name, uuid, deps::Vector{String}, raw_manifest::Dict{String,Vector{Stage1}})
     if length(deps) != length(unique(deps))
         pkgerror("Duplicate entry in `$name=$uuid`'s `deps` field.")
     end
     final = Dict{String,UUID}()
     for dep in deps
-        infos = get(manifest, dep, nothing)
+        infos = get(raw_manifest, dep, nothing)
         if infos === nothing
             pkgerror("`$name=$uuid` depends on `$dep`, ",
                      "but no such entry exists in the manifest.")
@@ -105,19 +105,19 @@ function normalize_deps(name, uuid, deps::Vector{String}, manifest::Dict{String,
     return final
 end
 
-function validate_manifest(stage1::Dict{String,Vector{Stage1}})
+function validate_manifest(stage1::Dict{String,Vector{Stage1}}, julia_version, project_hash::Union{String,Nothing})
     # expand vector format deps
     for (name, infos) in stage1, info in infos
         info.entry.deps = normalize_deps(name, info.uuid, info.deps, stage1)
     end
     # invariant: all dependencies are now normalized to Dict{String,UUID}
-    manifest = Dict{UUID, PackageEntry}()
+    deps = Dict{UUID, PackageEntry}()
     for (name, infos) in stage1, info in infos
-        manifest[info.uuid] = info.entry
+        deps[info.uuid] = info.entry
     end
     # now just verify the graph structure
-    for (entry_uuid, entry) in manifest, (name, uuid) in entry.deps
-        dep_entry = get(manifest, uuid, nothing)
+    for (entry_uuid, entry) in deps, (name, uuid) in entry.deps
+        dep_entry = get(deps, uuid, nothing)
         if dep_entry === nothing
             pkgerror("`$(entry.name)=$(entry_uuid)` depends on `$name=$uuid`, ",
                      "but no such entry exists in the manifest.")
@@ -127,38 +127,46 @@ function validate_manifest(stage1::Dict{String,Vector{Stage1}})
                      "but entry with UUID `$uuid` has name `$(dep_entry.name)`.")
         end
     end
-    return manifest
+    return Manifest(julia_version = julia_version, project_hash = project_hash, deps = deps)
+end
+
+function check_manifest_format_compat(raw::Dict)
+    return haskey(raw, "julia_version") && haskey(raw, "project_hash")
 end
 
 function Manifest(raw::Dict)::Manifest
+    julia_version = raw["julia_version"] == "nothing" ? nothing : VersionNumber(raw["julia_version"])
+    project_hash = raw["project_hash"] == "nothing" ? nothing : raw["project_hash"]
     stage1 = Dict{String,Vector{Stage1}}()
-    for (name, infos) in raw, info in infos
-        entry = PackageEntry()
-        entry.name = name
-        uuid = nothing
-        deps = nothing
-        try
-            entry.pinned      = read_pinned(get(info, "pinned", nothing))
-            uuid              = read_field("uuid",          nothing, info, safe_uuid)::UUID
-            entry.version     = read_field("version",       nothing, info, safe_version)
-            entry.path        = read_field("path",          nothing, info, safe_path)
-            entry.repo.source = read_field("repo-url",      nothing, info, identity)
-            entry.repo.rev    = read_field("repo-rev",      nothing, info, identity)
-            entry.repo.subdir = read_field("repo-subdir",   nothing, info, identity)
-            entry.tree_hash   = read_field("git-tree-sha1", nothing, info, safe_SHA1)
-            entry.uuid        = uuid
-            deps = read_deps(get(info::Dict, "deps", nothing))
-        catch
-            # TODO: Should probably not unconditionally log something
-            @error "Could not parse entry for `$name`"
-            rethrow()
+    if haskey(raw, "deps")
+        for (name, infos) in raw["deps"], info in infos
+            entry = PackageEntry()
+            entry.name = name
+            uuid = nothing
+            deps = nothing
+            try
+                entry.pinned      = read_pinned(get(info, "pinned", nothing))
+                uuid              = read_field("uuid",          nothing, info, safe_uuid)::UUID
+                entry.version     = read_field("version",       nothing, info, safe_version)
+                entry.path        = read_field("path",          nothing, info, safe_path)
+                entry.repo.source = read_field("repo-url",      nothing, info, identity)
+                entry.repo.rev    = read_field("repo-rev",      nothing, info, identity)
+                entry.repo.subdir = read_field("repo-subdir",   nothing, info, identity)
+                entry.tree_hash   = read_field("git-tree-sha1", nothing, info, safe_SHA1)
+                entry.uuid        = uuid
+                deps = read_deps(get(info::Dict, "deps", nothing))
+            catch
+                # TODO: Should probably not unconditionally log something
+                @error "Could not parse entry for `$name`"
+                rethrow()
+            end
+            entry.other = info::Union{Dict,Nothing}
+            stage1[name] = push!(get(stage1, name, Stage1[]), Stage1(uuid, entry, deps))
         end
-        entry.other = info::Union{Dict,Nothing}
-        stage1[name] = push!(get(stage1, name, Stage1[]), Stage1(uuid, entry, deps))
+        # by this point, all the fields of the `PackageEntry`s have been type casted
+        # but we have *not* verified the _graph_ structure of the manifest
     end
-    # by this point, all the fields of the `PackageEntry`s have been type casted
-    # but we have *not* verified the _graph_ structure of the manifest
-    return validate_manifest(stage1)
+    return validate_manifest(stage1, julia_version, project_hash)
 end
 
 function read_manifest(f_or_io::Union{String, IO})
@@ -166,13 +174,20 @@ function read_manifest(f_or_io::Union{String, IO})
         if f_or_io isa IO
             TOML.parse(read(f_or_io, String))
         else
-            isfile(f_or_io) ? parse_toml(f_or_io) : return Manifest()
+            if isfile(f_or_io)
+                parse_toml(f_or_io)
+            else
+                return Manifest()
+            end
         end
     catch e
         if e isa TOML.ParserError
             pkgerror("Could not parse manifest: ", sprint(showerror, e))
         end
         rethrow()
+    end
+    if check_manifest_format_compat(raw) == false
+        raw = update_old_format_raw_manifest(raw)
     end
     return Manifest(raw)
 end
@@ -190,12 +205,15 @@ function destructure(manifest::Manifest)::Dict
     end
 
     unique_name = Dict{String,Bool}()
-    for (uuid, entry) in manifest
+    for (uuid, entry) in manifest.deps
         unique_name[entry.name] = !haskey(unique_name, entry.name)
     end
 
     raw = Dict{String,Any}()
-    for (uuid, entry) in manifest
+    raw["julia_version"] = manifest.julia_version
+    raw["project_hash"] = manifest.project_hash
+    raw["deps"] = Dict{String,Vector{Dict{String,Any}}}()
+    for (uuid, entry) in manifest.deps
         new_entry = something(entry.other, Dict{String,Any}())
         new_entry["uuid"] = string(uuid)
         entry!(new_entry, "version", entry.version)
@@ -225,7 +243,7 @@ function destructure(manifest::Manifest)::Dict
                 end
             end
         end
-        push!(get!(raw, entry.name, Dict{String,Any}[]), new_entry)
+        push!(get!(raw["deps"], entry.name, Dict{String,Any}[]), new_entry)
     end
     return raw
 end
@@ -236,13 +254,30 @@ function write_manifest(env::EnvCache)
 end
 write_manifest(manifest::Manifest, manifest_file::AbstractString) =
     write_manifest(destructure(manifest), manifest_file)
-function write_manifest(manifest::Dict, manifest_file::AbstractString)
+function write_manifest(raw_manifest::Dict, manifest_file::AbstractString)
     str = sprint() do io
         print(io, "# This file is machine-generated - editing it directly is not advised\n\n")
-        TOML.print(io, manifest, sorted=true) do x
-            (x isa UUID || x isa SHA1 || x isa VersionNumber) && return string(x)
+        TOML.print(io, raw_manifest, sorted=true) do x
+            (typeof(x) in [String, Nothing, UUID, SHA1, VersionNumber]) && return string(x)
             error("unhandled type `$(typeof(x))`")
         end
     end
     write(manifest_file, str)
+end
+
+function update_old_format_raw_manifest(old_raw_manifest::Dict)
+    new_raw_manifest = Dict{String,Any}()
+    new_raw_manifest["julia_version"] = "nothing"
+    new_raw_manifest["project_hash"] = "nothing"
+    new_raw_manifest["deps"] = Dict{String,Vector{Any}}()
+    for (key, value) in old_raw_manifest
+        new_raw_manifest["deps"][key] = value
+    end
+    return new_raw_manifest
+end
+
+function update_old_format_manifest(manifest_path::String)
+    old_raw_manifest = Types.parse_toml(manifest_path)
+    new_raw_manifest = update_old_format_raw_manifest(old_raw_manifest)
+    Types.write_manifest(new_raw_manifest, manifest_path)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -142,6 +142,8 @@ function read_project(f_or_io::Union{String, IO})
     return Project(raw)
 end
 
+project_hash(project::Project) = bytes2hex(reinterpret(UInt8, [hash(project)]))
+
 
 ###########
 # WRITING #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -79,3 +79,4 @@ end
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value
 end
+

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -588,7 +588,7 @@ end
             version = "0.1.0"
             """)
         manifest = Pkg.Types.read_manifest("Manifest.toml")
-        package = manifest[Base.UUID("824dc81a-29a7-11e9-3958-fba342a32644")]
+        package = manifest.deps[Base.UUID("824dc81a-29a7-11e9-3958-fba342a32644")]
         @test package.path == (Sys.iswindows() ? "bar\\Foo" : "bar/Foo")
         Pkg.Types.write_manifest(manifest, "Manifest.toml")
         @test occursin("path = \"bar/Foo\"", read("Manifest.toml", String))
@@ -660,10 +660,10 @@ end
         Pkg.activate(joinpath(tmp, "Unpruned"))
         Pkg.update()
         manifest = Pkg.Types.Context().env.manifest
-        package_example = get(manifest, example_uuid, nothing)
+        package_example = get(manifest.deps, example_uuid, nothing)
         @test package_example !== nothing
         @test package_example.version > v"0.4.0"
-        @test get(manifest, unicode_uuid, nothing) === nothing
+        @test get(manifest.deps, unicode_uuid, nothing) === nothing
     end end
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -187,8 +187,8 @@ temp_pkg_dir() do project_path; cd(project_path) do
                     @test Pkg.dependencies()[uuid2].version == v"0.1.0"
                     # make sure paths to SubModule1 and SubModule2 are relative
                     manifest = Pkg.Types.Context().env.manifest
-                    @test manifest[uuid1].path == "SubModule1"
-                    @test manifest[uuid2].path == "SubModule2"
+                    @test manifest.deps[uuid1].path == "SubModule1"
+                    @test manifest.deps[uuid2].path == "SubModule2"
                 end
             end
             cp("HelloWorld", joinpath(other_dir, "HelloWorld"))

--- a/test/sandbox.jl
+++ b/test/sandbox.jl
@@ -16,7 +16,7 @@ test_test(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
         proj = joinpath(tmp, "SandboxFallback2")
         Pkg.activate(proj)
         withenv("JULIA_PROJECT" => proj) do; test_test("Unregistered") do
-            json = get(Pkg.Types.Context().env.manifest, UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6"), nothing)
+            json = get(Pkg.Types.Context().env.manifest.deps, UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6"), nothing)
             @test json !== nothing
             @test json.version == v"0.20.0"
             # test that the active project is the tmp one even though
@@ -32,7 +32,7 @@ test_test(fn; kwargs...)       = Pkg.test(;test_fn=fn, kwargs...)
         copy_test_package(tmp, "Sandbox_PreserveTestDeps")
         Pkg.activate(joinpath(tmp, "Sandbox_PreserveTestDeps"))
         test_test("Foo") do
-            x = get(Pkg.Types.Context().env.manifest, UUID("7876af07-990d-54b4-ab0e-23690620f79a"), nothing)
+            x = get(Pkg.Types.Context().env.manifest.deps, UUID("7876af07-990d-54b4-ab0e-23690620f79a"), nothing)
             @test x !== nothing
             @test x.version == v"0.4.0"
         end

--- a/test/test_packages/BuildProjectFixedDeps/deps/build.jl
+++ b/test/test_packages/BuildProjectFixedDeps/deps/build.jl
@@ -4,7 +4,7 @@ isfile(build_artifact) && rm(build_artifact)
 project = TOML.parsefile(Base.active_project())
 @assert get(project["deps"], "JSON", nothing) === nothing
 manifest = TOML.parsefile(joinpath(dirname(Base.active_project()), "Manifest.toml"))
-json = manifest["JSON"][1]
+json = manifest["deps"]["JSON"][1]
 @assert json["uuid"] == "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 @assert json["version"] == "0.19.0"
 touch(build_artifact)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -250,7 +250,8 @@ end
 
 function copy_test_package(tmpdir::String, name::String; use_pkg=true)
     target = joinpath(tmpdir, name)
-    cp(joinpath(@__DIR__, "test_packages", name), target)
+    test_pkg_dir = joinpath(@__DIR__, "test_packages", name)
+    cp(test_pkg_dir, target)
     use_pkg || return target
 
     # The known Pkg UUID, and whatever UUID we're currently using for testing
@@ -258,7 +259,7 @@ function copy_test_package(tmpdir::String, name::String; use_pkg=true)
     pkg_uuid = TOML.parsefile(joinpath(dirname(@__DIR__), "Project.toml"))["uuid"]
 
     # We usually want this test package to load our pkg, so update its Pkg UUID:
-    test_pkg_dir = joinpath(@__DIR__, "test_packages", name)
+
     for f in ("Manifest.toml", "Project.toml")
         fpath = joinpath(tmpdir, name, f)
         if isfile(fpath)


### PR DESCRIPTION
A WIP go at implementing a new manifest format that:
- Adds `julia_version` and `project_hash` metadata fields
- Moves the packages from top-level to a `deps` field

Dependent on:
- https://github.com/JuliaLang/julia/pull/40765 - CI has been limited to linux 64, and that PR's binary is used (ignore appveyor)
- If the project_hash is going to be implemented, the hash method needs fixing https://github.com/JuliaLang/Pkg.jl/pull/2556

Example manifest:
```
# This file is machine-generated - editing it directly is not advised

julia_version = "1.7.0-DEV.1077"
project_hash = "nothing"

[[deps.Base64]]
uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

[[deps.Distributed]]
deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
```

Notes:
- Backward compatible with the old manifest format. When an old manifest format is detected, the `julia_version` is set to `nothing`
- Needs new format manifest tests added
- The hash checking isn't implemented properly yet. Needs some thought about when the project is hashed and saved to the manifest. Also if/when the user should be warned
- Should version warnings be just for major+minor julia version mismatches?
- Tests passing - Ignore appveyor