### PR TITLE
Docstrings: add references from `Pkg.add` to `Pkg.develop` and vice versa

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -128,7 +128,7 @@ Pkg.add(url="/remote/mycompany/juliapackages/OurPackage") # From path to local g
 Pkg.add(url="https://github.com/Company/MonoRepo", subdir="juliapkgs/Package.jl)") # With subdir
 ```
 
-See also [`PackageSpec`](@ref).
+See also [`PackageSpec`](@ref), [`Pkg.develop`](@ref).
 """
 const add = API.add
 
@@ -301,7 +301,7 @@ Pkg.develop(url="https://github.com/JuliaLang/Compat.jl")
 Pkg.develop(path="MyJuliaPackages/Package.jl")
 ```
 
-See also [`PackageSpec`](@ref)
+See also [`PackageSpec`](@ref), [`Pkg.add`](@ref).
 
 """
 const develop = API.develop


### PR DESCRIPTION
These two docstrings are right next to each other in the manual. However, if you are just looking at the `Pkg.add` docstring in the REPL (e.g. `?Pkg.add`), you won't see any mention of `Pkg.develop`. This PR fixes that.

The motivation is as follows: sometimes, users will try to `Pkg.add` a path that is not a Git repo. This throws an error. The solution is to instead `Pkg.develop` the desired path. However, currently, the `Pkg.add` docstring does not mention `Pkg.develop`.