### PR TITLE
New Manifest.toml format: Pt 1. Teach Pkg new format, but default to old format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,10 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         julia-arch:
           - 'x64'
-          - 'x86'
         pkg-server:
-          - ""
           - "pkg.julialang.org"
-        julia-version:
-          # - '1.6'
-          - 'nightly'
         exclude:
           - os: macOS-latest
             julia-arch: x86
@@ -41,9 +34,10 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - name: Install Julia from URL
+        uses: julia-actions/install-julia-from-url@main
         with:
-          version: ${{ matrix.julia-version }}
+          url: https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.7/julia-4c13026cc7-linux64.tar.gz
       - name: Fix TEMP on windows
         if: matrix.os == 'windows-latest'
         run: |
@@ -67,10 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - name: Install Julia from URL
+        uses: julia-actions/install-julia-from-url@main
         with:
-          # version: '1.6'
-          version: 'nightly'
+          url: https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.7/julia-4c13026cc7-linux64.tar.gz
       - name: Generate docs
         run: |
           julia --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\"\n"));'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,17 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         julia-arch:
           - 'x64'
+          - 'x86'
         pkg-server:
+          - ""
           - "pkg.julialang.org"
+        julia-version:
+          # - '1.6'
+          - 'nightly'
         exclude:
           - os: macOS-latest
             julia-arch: x86
@@ -34,10 +41,9 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v2
-      - name: Install Julia from URL
-        uses: julia-actions/install-julia-from-url@main
+      - uses: julia-actions/setup-julia@latest
         with:
-          url: https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.7/julia-4c13026cc7-linux64.tar.gz
+          version: ${{ matrix.julia-version }}
       - name: Fix TEMP on windows
         if: matrix.os == 'windows-latest'
         run: |
@@ -61,10 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1.0.0
-      - name: Install Julia from URL
-        uses: julia-actions/install-julia-from-url@main
+      - uses: julia-actions/setup-julia@latest
         with:
-          url: https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.7/julia-4c13026cc7-linux64.tar.gz
+          # version: '1.6'
+          version: 'nightly'
       - name: Generate docs
         run: |
           julia --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\"\n"));'

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -250,6 +250,7 @@ Base.@kwdef mutable struct Manifest
     julia_version::Union{Nothing,VersionNumber} = Base.VERSION
     manifest_format::VersionNumber = v"1.0.0" # default to older flat format
     deps::Dict{UUID,PackageEntry} = Dict{UUID,PackageEntry}()
+    other::Dict{String,Any} = Dict{String,Any}()
 end
 Base.:(==)(t1::Manifest, t2::Manifest) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Manifest))
 Base.hash(m::Manifest, h::UInt) = foldr(hash, [getfield(m, x) for x in fieldnames(Manifest)], init=h)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -245,7 +245,24 @@ Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
     t1.uuid == t2.uuid
     # omits `other`
 Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps, x.uuid], init=h)  # omits `other`
-const Manifest = Dict{UUID,PackageEntry}
+
+Base.@kwdef mutable struct Manifest
+    julia_version::Union{Nothing,VersionNumber} = Base.VERSION
+    manifest_format::VersionNumber = v"2.0.0"
+    deps::Dict{UUID,PackageEntry} = Dict{UUID,PackageEntry}()
+end
+Base.:(==)(t1::Manifest, t2::Manifest) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Manifest))
+Base.hash(m::Manifest, h::UInt) = foldr(hash, [getfield(m, x) for x in fieldnames(Manifest)], init=h)
+Base.getindex(m::Manifest, i_or_key) = getindex(m.deps, i_or_key)
+Base.get(m::Manifest, key, default) = get(m.deps, key, default)
+Base.setindex!(m::Manifest, i_or_key, value) = setindex!(m.deps, i_or_key, value)
+Base.iterate(m::Manifest) = iterate(m.deps)
+Base.iterate(m::Manifest, i::Int) = iterate(m.deps, i)
+Base.length(m::Manifest) = length(m.deps)
+Base.empty!(m::Manifest) = empty!(m.deps)
+Base.values(m::Manifest) = values(m.deps)
+Base.keys(m::Manifest) = keys(m.deps)
+Base.haskey(m::Manifest, key) = haskey(m.deps, key)
 
 function Base.show(io::IO, pkg::PackageEntry)
     f = []

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -248,7 +248,7 @@ Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.
 
 Base.@kwdef mutable struct Manifest
     julia_version::Union{Nothing,VersionNumber} = Base.VERSION
-    manifest_format::VersionNumber = v"2.0.0"
+    manifest_format::VersionNumber = v"1.0.0" # default to older flat format
     deps::Dict{UUID,PackageEntry} = Dict{UUID,PackageEntry}()
 end
 Base.:(==)(t1::Manifest, t2::Manifest) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Manifest))

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -137,7 +137,7 @@ function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
         if f_or_io isa IO
             @warn "Unknown Manifest.toml format version detected in streamed manifest. Unexpected behavior may occur" manifest_format maxlog = 1
         else
-            @warn "Unknown Manifest.toml format version detected in file `$(path)`. Unexpected behavior may occur" manifest_format maxlog = 1
+            @warn "Unknown Manifest.toml format version detected in file `$(f_or_io)`. Unexpected behavior may occur" manifest_format maxlog = 1
         end
     end
     stage1 = Dict{String,Vector{Stage1}}()

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -283,15 +283,18 @@ end
 function write_manifest(manifest::Manifest, manifest_file::AbstractString)
     return write_manifest(destructure(manifest), manifest_file)
 end
-function write_manifest(io::IO, manifest::Dict)
+function write_manifest(io::IO, manifest::Manifest)
+    return write_manifest(io, destructure(manifest))
+end
+function write_manifest(io::IO, raw_manifest::Dict)
     print(io, "# This file is machine-generated - editing it directly is not advised\n\n")
-    TOML.print(io, manifest, sorted=true) do x
+    TOML.print(io, raw_manifest, sorted=true) do x
         (typeof(x) in [String, Nothing, UUID, SHA1, VersionNumber]) && return string(x)
         error("unhandled type `$(typeof(x))`")
     end
     return nothing
 end
-function write_manifest(manifest::Dict, manifest_file::AbstractString)
-    str = sprint(write_manifest, manifest)
+function write_manifest(raw_manifest::Dict, manifest_file::AbstractString)
+    str = sprint(write_manifest, raw_manifest)
     write(manifest_file, str)
 end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -133,6 +133,9 @@ end
 function Manifest(raw::Dict)::Manifest
     julia_version = isnothing(raw["julia_version"]) ? nothing : VersionNumber(raw["julia_version"])
     manifest_format = VersionNumber(raw["manifest_format"])
+    if !in(manifest_format.major, 1:2)
+        @warn "Unknown Manifest.toml format version detected. Unexpected behavior may occur" manifest_format maxlog = 1
+    end
     stage1 = Dict{String,Vector{Stage1}}()
     if haskey(raw, "deps") # deps field doesn't exist if there are no deps
         for (name, infos) in raw["deps"], info in infos

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -264,12 +264,6 @@ function write_manifest(env::EnvCache)
     write_manifest(env.manifest, env.manifest_file)
 end
 function write_manifest(manifest::Manifest, manifest_file::AbstractString)
-    if manifest.manifest_format.major == 1
-        @warn """The active manifest file has an old format that is being maintained.
-            To update to the new format:
-                1. Delete the manifest file at `$(manifest_file)`
-                2. Run `import Pkg; Pkg.resolve()`""" maxlog = 1
-    end
     return write_manifest(destructure(manifest), manifest_file)
 end
 function write_manifest(io::IO, manifest::Dict)

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -219,7 +219,7 @@ function destructure(manifest::Manifest)::Dict
     elseif manifest.manifest_format.major == 2
         raw = Dict{String,Any}()
         raw["julia_version"] = manifest.julia_version
-        raw["manifest_format"] = manifest.manifest_format
+        raw["manifest_format"] = string(manifest.manifest_format.major, ".", manifest.manifest_format.minor)
         raw["deps"] = Dict{String,Vector{Dict{String,Any}}}()
     end
 

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -191,7 +191,7 @@ function convert_flat_format_manifest(old_raw_manifest::Dict)
     new_raw_manifest = Dict{String, Any}(
             "deps" => old_raw_manifest,
             "julia_version" => nothing,
-            "manifest_format" => v"1"
+            "manifest_format" => "1.0.0" # must be a string here to match raw dict
         )
     return new_raw_manifest
 end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -178,20 +178,18 @@ function read_manifest(f_or_io::Union{String, IO})
         end
         rethrow()
     end
-    if !isempty(raw) && Base.is_v1_format_manifest(raw)
+    if Base.is_v1_format_manifest(raw)
         raw = convert_flat_format_manifest(raw)
     end
     return Manifest(raw)
 end
 
 function convert_flat_format_manifest(old_raw_manifest::Dict)
-    new_raw_manifest = Dict{String,Any}()
-    new_raw_manifest["deps"] = Dict{String,Vector{Any}}()
-    for (key, value) in old_raw_manifest
-        new_raw_manifest["deps"][key] = value
-    end
-    new_raw_manifest["julia_version"] = nothing
-    new_raw_manifest["manifest_format"] = "1"
+    new_raw_manifest = Dict{String, Any}(
+            "deps" => old_raw_manifest,
+            "julia_version" => nothing,
+            "manifest_format" => v"1"
+        )
     return new_raw_manifest
 end
 

--- a/test/manifest/formats/v1.0/Manifest.toml
+++ b/test/manifest/formats/v1.0/Manifest.toml
@@ -1,0 +1,11 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/manifest/formats/v1.0/Project.toml
+++ b/test/manifest/formats/v1.0/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/manifest/formats/v2.0/Manifest.toml
+++ b/test/manifest/formats/v2.0/Manifest.toml
@@ -1,0 +1,14 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.0-DEV.1199"
+manifest_format = "2.0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/manifest/formats/v2.0/Manifest.toml
+++ b/test/manifest/formats/v2.0/Manifest.toml
@@ -2,6 +2,8 @@
 
 julia_version = "1.7.0-DEV.1199"
 manifest_format = "2.0"
+some_other_field = "other"
+some_other_data = [1,2,3,4]
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -12,3 +14,4 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+

--- a/test/manifest/formats/v2.0/Project.toml
+++ b/test/manifest/formats/v2.0/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/manifest/formats/v3.0_unknown/Manifest.toml
+++ b/test/manifest/formats/v3.0_unknown/Manifest.toml
@@ -1,0 +1,14 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.0-DEV.1199"
+manifest_format = "3.0" # NOT ACTUALLY v3.0 format. Just here to test a warning!
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/manifest/formats/v3.0_unknown/Project.toml
+++ b/test/manifest/formats/v3.0_unknown/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -28,7 +28,7 @@ using  ..Utils
             io = IOBuffer()
             Pkg.activate(env_dir; io=io)
             output = String(take!(io))
-            @test occursin(r"Activating.*project at.*`.*formats/v1.0`", output)
+            @test occursin(r"Activating.*project at.*`.*v1.0`", output)
             @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
 
             Pkg.add("Profile")
@@ -50,7 +50,7 @@ using  ..Utils
             io = IOBuffer()
             Pkg.activate(env_dir; io=io)
             output = String(take!(io))
-            @test occursin(r"Activating.*project at.*`.*formats/v2.0`", output)
+            @test occursin(r"Activating.*project at.*`.*v2.0`", output)
             @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
 
             Pkg.add("Profile")

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -68,7 +68,7 @@ using  ..Utils
         isfile(env_manifest) || error("Reference manifest is missing")
         isolate(loaded_depot=true) do
             io = IOBuffer()
-            @test_logs (:warn, "Unknown Manifest.toml format version detected. Unexpected behavior may occur") Pkg.activate(env_dir; io=io)
+            @test_logs (:warn,) Pkg.activate(env_dir; io=io)
         end
     end
 end

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -1,0 +1,66 @@
+module ManifestTests
+
+using  Test, UUIDs, Dates, TOML
+import ..Pkg, LibGit2
+using  ..Utils
+
+@testset "Manifest.toml formats" begin
+    @testset "Default manifest format is v1" begin
+        isolate(loaded_depot=true) do
+            io = IOBuffer()
+            Pkg.activate(; io=io, temp=true)
+            output = String(take!(io))
+            @test occursin(r"Activating.*project at.*", output)
+            Pkg.add("Profile")
+            env_manifest = Pkg.Types.Context().env.manifest_file
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+        end
+    end
+
+    @testset "v1.0: activate, change, maintain manifest format" begin
+        env_dir = joinpath(@__DIR__, "manifest", "formats", "v1.0")
+        env_manifest = joinpath(env_dir, "Manifest.toml")
+        isfile(env_manifest) || error("Reference manifest is missing")
+        if Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+            error("Reference manifest file at $(env_manifest) is invalid")
+        end
+        isolate(loaded_depot=true) do
+            io = IOBuffer()
+            Pkg.activate(env_dir; io=io)
+            output = String(take!(io))
+            @test occursin(r"Activating.*project at.*`.*formats/v1.0`", output)
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+
+            Pkg.add("Profile")
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+
+            Pkg.rm("Profile")
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+        end
+    end
+
+    @testset "v2.0: activate, change, maintain manifest format" begin
+        env_dir = joinpath(@__DIR__, "manifest", "formats", "v2.0")
+        env_manifest = joinpath(env_dir, "Manifest.toml")
+        isfile(env_manifest) || error("Reference manifest is missing")
+        if Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+            error("Reference manifest file at $(env_manifest) is invalid")
+        end
+        isolate(loaded_depot=true) do
+            io = IOBuffer()
+            Pkg.activate(env_dir; io=io)
+            output = String(take!(io))
+            @test occursin(r"Activating.*project at.*`.*formats/v2.0`", output)
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+
+            Pkg.add("Profile")
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+
+            Pkg.rm("Profile")
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+        end
+    end
+end
+
+
+end # module

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -58,6 +58,20 @@ using  ..Utils
 
             Pkg.rm("Profile")
             @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+
+            m = Pkg.Types.read_manifest(env_manifest)
+            @test m.other["some_other_field"] = "other"
+            @test m.other["some_other_data"] = [1,2,3,4]
+            
+            mktemp() do (path, io)
+                Pkg.Types.write_manifest(io, m)
+                m2 = Pkg.Types.read_manifest(env_manifest)
+                @test m.deps == m2.deps
+                @test m.julia_version == m2.julia_version
+                @test m.manifest_format == m2.manifest_format
+                @test m.other == m2.other
+            end
+
         end
     end
 

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -60,10 +60,10 @@ using  ..Utils
             @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
 
             m = Pkg.Types.read_manifest(env_manifest)
-            @test m.other["some_other_field"] = "other"
-            @test m.other["some_other_data"] = [1,2,3,4]
-            
-            mktemp() do (path, io)
+            @test m.other["some_other_field"] == "other"
+            @test m.other["some_other_data"] == [1,2,3,4]
+
+            mktemp() do path, io
                 Pkg.Types.write_manifest(io, m)
                 m2 = Pkg.Types.read_manifest(env_manifest)
                 @test m.deps == m2.deps

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -60,6 +60,17 @@ using  ..Utils
             @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
         end
     end
+
+    @testset "v3.0: unknown format, warn" begin
+        # the reference file here is not actually v3.0. It just represents an unknown manifest format
+        env_dir = joinpath(@__DIR__, "manifest", "formats", "v3.0_unknown")
+        env_manifest = joinpath(env_dir, "Manifest.toml")
+        isfile(env_manifest) || error("Reference manifest is missing")
+        isolate(loaded_depot=true) do
+            io = IOBuffer()
+            @test_logs (:warn, "Unknown Manifest.toml format version detected. Unexpected behavior may occur") Pkg.activate(env_dir; io=io)
+        end
+    end
 end
 
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -2490,7 +2490,7 @@ tree_hash(root::AbstractString; kwargs...) = bytes2hex(@inferred Pkg.GitTools.tr
         chmod(joinpath(dir, "FooGit", "foo"), 0o644)
         write(joinpath(dir, "FooGit", ".git", "foo"), "foo")
         chmod(joinpath(dir, "FooGit", ".git", "foo"), 0o644)
-        @test tree_hash(joinpath(dir, "Foo")) == 
+        @test tree_hash(joinpath(dir, "Foo")) ==
               tree_hash(joinpath(dir, "FooGit")) ==
               "2f42e2c1c1afd4ef8c66a2aaba5d5e1baddcab33"
     end
@@ -2658,9 +2658,9 @@ end
     function get_manifest_block(name)
         manifest_path = joinpath(dirname(Base.active_project()), "Manifest.toml")
         @test isfile(manifest_path)
-        manifest = TOML.parsefile(manifest_path)
-        @test haskey(manifest, name)
-        return only(manifest[name])
+        deps = Base.get_deps(TOML.parsefile(manifest_path))
+        @test haskey(deps, name)
+        return only(deps[name])
     end
 
     isolate(loaded_depot=true) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ include("sandbox.jl")
 include("resolve.jl")
 include("misc.jl")
 include("force_latest_compatible_version.jl")
+include("manifests.jl")
 
 # clean up locally cached registry
 rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)

--- a/test/test_packages/BuildProjectFixedDeps/deps/build.jl
+++ b/test/test_packages/BuildProjectFixedDeps/deps/build.jl
@@ -3,7 +3,7 @@ build_artifact = joinpath(@__DIR__, "artifact")
 isfile(build_artifact) && rm(build_artifact)
 project = TOML.parsefile(Base.active_project())
 @assert get(project["deps"], "JSON", nothing) === nothing
-manifest = TOML.parsefile(joinpath(dirname(Base.active_project()), "Manifest.toml"))
+manifest = Base.get_deps(TOML.parsefile(joinpath(dirname(Base.active_project()), "Manifest.toml")))
 json = manifest["JSON"][1]
 @assert json["uuid"] == "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 @assert json["version"] == "0.19.0"


### PR DESCRIPTION
Initial discussion in #2557 

This is Part 1, which is intended to be backported to 1.6.2
- Teach Pkg new manifest format with `julia_version` and `manifest_format` metadata fields, and package deps nested under a `deps` field
- Still defaults to old format
- Maintains format of any existing Manifest.toml
- Warn if unknown `manifest_format` version is detected

Part 2: https://github.com/JuliaLang/Pkg.jl/pull/2580

- [x] Dependent on JuliaLang/julia#40765 - ~~GitHub actions CI has been limited to linux 64 and that PR's binary is used (ignore appveyor)~~
- [x] Needs explicit tests for old/new/unknown manifest formats
- [ ] Needs tests for invalid manifest formats