### PR TITLE
Missing package prompt: Switch default to `y`. Add text wrapping in prompt

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -680,7 +680,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             println(ctx.io, line)
         end
         printstyled(ctx.io, " └ "; color=:green)
-        Base.prompt(stdin, ctx.io, "(y/n)", default = "n")
+        Base.prompt(stdin, ctx.io, "(y/n)", default = "y")
     catch err
         if err isa InterruptException
             println(ctx.io)

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -7,7 +7,7 @@ using Markdown, UUIDs, Dates
 import REPL
 import REPL: LineEdit, REPLCompletions
 
-import ..casesensitive_isdir, ..OFFLINE_MODE
+import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap
 using ..Types, ..Operations, ..API, ..Registry, ..Resolve
 
 const TEST_MODE = Ref{Bool}(false)
@@ -662,15 +662,23 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         plural4 = length(available_pkgs) == 1 ? "" : "s"
         missing_pkg_list = length(pkgs) == 1 ? String(pkgs[1]) : "[$(join(pkgs, ", "))]"
         available_pkg_list = length(available_pkgs) == 1 ? String(available_pkgs[1]) : "[$(join(available_pkgs, ", "))]"
-        printstyled(ctx.io, " │ "; color=:green)
-        println(ctx.io, "Package$(plural1) $(missing_pkg_list) not found,",
-                            " but $(plural2) named $(available_pkg_list) $(plural3) available from a registry.")
+        msg1 = "Package$(plural1) $(missing_pkg_list) not found, but $(plural2) named $(available_pkg_list) $(plural3) available from a registry."
+        for line in linewrap(msg1, io = ctx.io, padding = length(" │ "))
+            printstyled(ctx.io, " │ "; color=:green)
+            println(ctx.io, line)
+        end
         printstyled(ctx.io, " │ "; color=:green)
         println(ctx.io, "Install package$(plural4)?")
-        printstyled(ctx.io, " │ "; color=:green)
-        print(ctx.io, "  ")
-        printstyled(ctx.io, REPLMode.promptf(); color=:blue)
-        println(ctx.io, "add ", join(available_pkgs, ' '))
+        msg2 = string("add ", join(available_pkgs, ' '))
+        for (i, line) in pairs(linewrap(msg2; io = ctx.io, padding = length(string(" |   ", REPLMode.promptf()))))
+            printstyled(ctx.io, " │   "; color=:green)
+            if i == 1
+                printstyled(ctx.io, REPLMode.promptf(); color=:blue)
+            else
+                print(ctx.io, " "^length(REPLMode.promptf()))
+            end
+            println(ctx.io, line)
+        end
         printstyled(ctx.io, " └ "; color=:green)
         Base.prompt(stdin, ctx.io, "(y/n)", default = "n")
     catch err

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,21 @@ function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=fa
     println(io, " ", text)
 end
 
+function linewrap(str::String; io = stdout, padding = 0, width = Base.displaysize(io)[2])
+    text_chunks = split(str, ' ')
+    lines = String[""]
+    for chunk in text_chunks
+        new_line_attempt = string(last(lines), chunk, " ")
+        if length(strip(new_line_attempt)) > width - padding
+            lines[end] = strip(last(lines))
+            push!(lines, string(chunk, " "))
+        else
+            lines[end] = new_line_attempt
+        end
+    end
+    return lines
+end
+
 const URL_regex = r"((file|git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?"x
 isurl(r::String) = occursin(URL_regex, r)
 


### PR DESCRIPTION
- Switches the default to `y`
- Add text wrapping to improve the formatting in narrow terminals

<img width="522" alt="Screen Shot 2021-05-11 at 3 54 42 PM" src="https://user-images.githubusercontent.com/1694067/117913184-e9b5ee00-b2ae-11eb-9e51-33b7d9a937dc.png">
<img width="323" alt="Screen Shot 2021-05-11 at 3 54 19 PM" src="https://user-images.githubusercontent.com/1694067/117913186-ea4e8480-b2ae-11eb-8a51-2557ff9f4868.png">

