### PR TITLE
Test suite: replace one use of `first(...)` with `only(...)`

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -2660,7 +2660,7 @@ end
         @test isfile(manifest_path)
         manifest = TOML.parsefile(manifest_path)
         @test haskey(manifest, name)
-        return first(manifest[name])
+        return only(manifest[name])
     end
 
     isolate(loaded_depot=true) do


### PR DESCRIPTION
In this particular test set, for a given package `name`, there should be exactly one corresponding manifest block.