### PR TITLE
Asking to manually create deps/build.jl in the package directory in creating-packages.md

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -108,7 +108,8 @@ Hello aT157rHV
 ## Adding a build step to the package
 
 The build step is executed the first time a package is installed or when explicitly invoked with `build`.
-A package is built by executing the file `deps/build.jl`.
+A package is built by executing the file `deps/build.jl`, but please don't forget to manually create that 
+before runnning below command.
 
 ```julia-repl
 julia> print(read("deps/build.jl", String))


### PR DESCRIPTION
This is a little confusing when `generate HelloWorld`  did not create deps/ and test/ directory and their files.  See discourse post:  https://discourse.julialang.org/t/deps-and-test-folders-in-package/61003