### PR TITLE
Don't count deletion failures in `gc` space savings

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -887,6 +887,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
             Base.rm(path; recursive=true, force=true)
         catch e
             @warn("Failed to delete $path", exception=e)
+            return 0
         end
         if verbose
             printpkgstyle(ctx.io, :Deleted, pathrepr(path) * " (" *


### PR DESCRIPTION
If we failed to delete this tree, don't include its size in our space savings.

Closes https://github.com/JuliaLang/Pkg.jl/issues/1872