### PR TITLE
Automatically call `Pkg.gc()` after `up`, `pin`, `free` and `rm`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -148,6 +148,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status)
             foreach(pkg -> handle_package_input!(pkg), pkgs)
             ret = $f(ctx, pkgs; kwargs...)
             $(f in (:add, :up, :pin, :free, :build)) && Pkg._auto_precompile(ctx)
+            $(f in (:up, :pin, :free, :rm)) && Pkg._auto_gc(ctx)
             return ret
         end
         $f(ctx::Context; kwargs...) = $f(ctx, PackageSpec[]; kwargs...)
@@ -846,11 +847,9 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
         merge_orphanages!(new_orphanage, depot_orphaned_scratchspaces, spaces_to_delete, old_orphanage)
 
         # Write out the `new_orphanage` for this depot
-        if !isempty(new_orphanage) || isfile(orphanage_file)
-            mkpath(dirname(orphanage_file))
-            open(orphanage_file, "w") do io
-                TOML.print(io, new_orphanage, sorted=true)
-            end
+        mkpath(dirname(orphanage_file))
+        open(orphanage_file, "w") do io
+            TOML.print(io, new_orphanage, sorted=true)
         end
     end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -600,7 +600,7 @@ end
 ###########
 
 const DEPOT_ORPHANAGE_TIMESTAMPS = Dict{String,Float64}()
-_auto_gc_enabled = Ref{Bool}(true)
+const _auto_gc_enabled = Ref{Bool}(true)
 function _auto_gc(ctx::Types.Context; collect_delay::Period = Day(7))
     if !_auto_gc_enabled[]
         return

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -5,6 +5,7 @@ module Pkg
 import Random
 import REPL
 import TOML
+using Dates
 
 export @pkg_str
 export PackageSpec
@@ -593,6 +594,41 @@ function dir(pkg::String, paths::AbstractString...)
     path === nothing && return nothing
     return abspath(path, "..", "..", paths...)
 end
+
+###########
+# AUTO GC #
+###########
+
+const DEPOT_ORPHANAGE_TIMESTAMPS = Dict{String,Float64}()
+_auto_gc_enabled = Ref{Bool}(true)
+function _auto_gc(ctx::Types.Context; collect_delay::Period = Day(7))
+    if !_auto_gc_enabled[]
+        return
+    end
+
+    # If we don't know the last time this depot was GC'ed (because this is the
+    # first time we've looked this session), or it looks like we might want to
+    # collect; let's go ahead and hit the filesystem to find the mtime of the
+    # `orphaned.toml` file, which should tell us how long since the last time
+    # we GC'ed.
+    orphanage_path = joinpath(logdir(depots1()), "orphaned.toml")
+    delay_secs = Second(collect_delay).value
+    curr_time = time()
+    if curr_time - get(DEPOT_ORPHANAGE_TIMESTAMPS, depots1(), 0.0) >= delay_secs
+        DEPOT_ORPHANAGE_TIMESTAMPS[depots1()] = mtime(orphanage_path)
+    end
+
+    if curr_time - DEPOT_ORPHANAGE_TIMESTAMPS[depots1()] > delay_secs
+        @info("We haven't cleaned this depot up for a bit, running Pkg.gc()...")
+        try
+            Pkg.gc(ctx; collect_delay)
+            DEPOT_ORPHANAGE_TIMESTAMPS[depots1()] = curr_time
+        catch ex
+            @error("GC failed", exception=ex)
+        end
+    end
+end
+
 
 ##################
 # Precompilation #

--- a/test/new.jl
+++ b/test/new.jl
@@ -16,6 +16,8 @@ unicode_uuid = UUID("4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5")
 unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
 
+# Disable auto-gc for these tests
+Pkg._auto_gc_enabled[] = false
 
 #
 # # Depot Changes


### PR DESCRIPTION
We want to call `Pkg.gc()` every now and then, so let's automatically
call it after operations that can themselves result in orphaned package
versions (e.g. `rm` or `up`).  We wait the default GC collect interval,
using `mtime(orphanage_path)` as our marker of the last time we have
collected.  After each of the above operations, we query the current
time as compared to the last known GC time, hitting the filesystem only
when there is a possibility that we might need to GC.

Also, we now always write out an orphanage file (even if it's empty) to
ensure that the timestamp is always available.