### PR TITLE
Precompilation: Adjustments for efficiency

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1264,7 +1264,13 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                         Base.release(parallel_limiter)
                     end
                 else
-                    !is_stale && (n_already_precomp += 1)
+                    if !is_stale
+                        n_already_precomp += 1
+                        try
+                            touch(path_to_try) # update timestamp of precompilation file
+                        catch # file might be read-only and then we fail to update timestamp, which is fine
+                        end
+                    end
                     suspended && !in(pkg, circular_deps) && push!(skipped_deps, pkg)
                 end
                 n_done += 1

--- a/src/API.jl
+++ b/src/API.jl
@@ -1024,7 +1024,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
         for (name, uuid) in ctx.env.project.deps if !Base.in_sysimage(Base.PkgId(uuid, name))
     ]
 
-    man = Pkg.Types.read_manifest(ctx.env.manifest_file)
+    man = ctx.env.manifest
     deps_pair_or_nothing = Iterators.map(man) do dep
         pkg = Base.PkgId(first(dep), last(dep).name)
         Base.in_sysimage(pkg) && return nothing


### PR DESCRIPTION
1. Use the EnvCache-ed manifest instead of re-reading the manifest file
2. If the cachefile isn't stale, update its mtime. This is already done in base. 
https://github.com/JuliaLang/julia/blob/0bd886297d2757adf75d346a7dbb438fd839f8e6/base/loading.jl#L753-L756
While I'm not sure why it was originally added, now that cachefiles are sorted by mtime during evaluation, there is the additional benefit of keeping the `mtime` of valid cache files up to date

More info: the cache file is `touch`-ed in base during code load to make the `mtime` of the cache more representative of last used time. So it does make sense to update it here too, I think.