### PR TITLE
Reread registry after updating it.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -248,7 +248,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
     # repo + unpinned -> name, uuid, repo.rev, repo.source, tree_hash
     # repo + pinned -> name, uuid, tree_hash
 
-    Registry.update(; io=ctx.io, force=false)
+    Operations.update_registries(ctx; force=false)
 
     project_deps_resolve!(ctx.env, pkgs)
     registry_resolve!(ctx.registries, pkgs)
@@ -315,8 +315,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
     Context!(ctx; kwargs...)
     if update_registry
         Registry.download_default_registries(ctx.io)
-        Registry.update(; io=ctx.io, force=true)
-        copy!(ctx.registries, Registry.reachable_registries())
+        Operations.update_registries(ctx; force=true)
     end
     Operations.prune_manifest(ctx.env)
     if isempty(pkgs)
@@ -1447,7 +1446,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
         if !(e isa PkgError) || update_registry == false
             rethrow(e)
         end
-        Registry.update(; io=ctx.io, force=false)
+        Operations.update_registries(ctx; force=false)
         Operations.check_registered(ctx.registries, pkgs)
     end
     new_git = UUID[]

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1051,6 +1051,12 @@ function update_package_add(ctx::Context, pkg::PackageSpec, entry::PackageEntry,
     return pkg
 end
 
+# Update registries AND read them back in.
+function update_registries(ctx::Context, registries...; kwargs...)
+     Registry.update(registries...; io=ctx.io, kwargs...)
+     copy!(ctx.registries, Registry.reachable_registries())
+end
+
 function is_all_registered(registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec})
     pkgs = filter(tracking_registered_version, pkgs)
     for pkg in pkgs

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -1,8 +1,7 @@
 module Registry
 
 import ..Pkg
-using ..Pkg: depots1, printpkgstyle, stdout_f, stderr_f, isdir_nothrow, pathrepr, pkg_server,
-             GitTools, OFFLINE_MODE, UPDATED_REGISTRY_THIS_SESSION
+using ..Pkg: depots1, printpkgstyle, stdout_f, stderr_f, isdir_nothrow, pathrepr, pkg_server, GitTools
 using ..Pkg.PlatformEngines: download_verify_unpack, download
 using UUIDs, LibGit2
 
@@ -320,10 +319,7 @@ Pkg.Registry.update(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
 """
 update(reg::Union{String,RegistrySpec}; kwargs...) = update([reg]; kwargs...)
 update(regs::Vector{String}; kwargs...) = update([RegistrySpec(name = name) for name in regs]; kwargs...)
-function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), force::Bool=true)
-    OFFLINE_MODE[] && return
-    !force && UPDATED_REGISTRY_THIS_SESSION[] && return
-
+function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f())
     isempty(regs) && (regs = reachable_registries(; depots=depots1()))
     errors = Tuple{String, String}[]
     registry_urls = nothing
@@ -402,7 +398,6 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
         end
         @error warn_str
     end
-    UPDATED_REGISTRY_THIS_SESSION[] = true
     return
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -579,7 +579,7 @@ function set_repo_source_from_registry!(ctx, pkg)
     registry_resolve!(ctx.registries, pkg)
     # Didn't find the package in the registry, but maybe it exists in the updated registry
     if !isresolved(pkg)
-        Registry.update(; io=ctx.io, force=false)
+        Pkg.Operations.update_registries(ctx; force=false)
         registry_resolve!(ctx.registries, pkg)
     end
     ensure_resolved(ctx.env.manifest, [pkg]; registry=true)


### PR DESCRIPTION
Fixes #2555.

When instantiate fails to find a package in the registry it calls `Registry.update()`, but all that does is to update the registry files on disk. This PR also reads the updated registry before proceeding.

Reviewing the other calls to `Registry.update()`, it seems like there may be a few more instances that expects the updated registry to be read in and possibly that should actually happen within `Registry.update()`.
