### PR TITLE
Precompile: Improve handling of packages that are missing modules

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1250,8 +1250,8 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                         end
                         loaded && (n_loaded += 1)
                     catch err
-                        if err isa ErrorException
-                            failed_deps[pkg] = (strict || is_direct_dep) ? String(take!(iob)) : ""
+                        if err isa ErrorException || (err isa ArgumentError && startswith(err.msg, "Invalid header in cache file"))
+                            failed_deps[pkg] = (strict || is_direct_dep) ? string(sprint(showerror, err), "\n", String(take!(iob))) : ""
                             !fancyprint && lock(print_lock) do
                                 println(io, string(color_string("  ✗ ", Base.error_color()), name))
                             end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1100,6 +1100,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
 
     function handle_interrupt(err)
         notify(interrupted_or_done)
+        sleep(0.2) # yield for a period to let the print loop cease first
         if err isa InterruptException
             lock(print_lock) do
                 println(io, " Interrupted: Exiting precompilation...")


### PR DESCRIPTION
The error in https://github.com/JuliaLang/Pkg.jl/issues/2560 is unhelpful because 
1) a more insightful message from stderr is suppressed 
2) the error aborts the entire precomp process 

This PR fixes both of those

```
(test) pkg> precompile
    Updating registry at `~/.julia/registries/General`
    Updating git-repo `https://github.com/JuliaRegistries/General.git`
  No Changes to `~/test/Project.toml`
  No Changes to `~/test/Manifest.toml`
Precompiling project...
  ✗ test
  0 dependencies successfully precompiled in 2 seconds

ERROR: The following 1 direct dependency failed to precompile:

test [08419116-8e91-4029-9e54-f56135b4ba74]

ArgumentError: Invalid header in cache file /Users/ian/.julia/compiled/v1.7/test/jl_stYIsR.
WARNING: --output requested, but no modules defined during run

(test) pkg> 
```



Fixes https://github.com/JuliaLang/Pkg.jl/issues/2560