### PR TITLE
New Manifest.toml format: Pt 2. Default to new format, warn if old format is being maintained

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1670,4 +1670,17 @@ function handle_package_input!(pkg::PackageSpec)
     pkg.uuid = pkg.uuid isa String ? UUID(pkg.uuid) : pkg.uuid
 end
 
+function upgrade_manifest(ctx::Context = Context())
+    before_format = ctx.env.manifest.manifest_format
+    if before_format == v"2.0"
+        pkgerror("Format of manifest file at `$(ctx.env.manifest_file)` already up to date: manifest_format == $(before_format)")
+    elseif before_format != v"1.0"
+        pkgerror("Format of manifest file at `$(ctx.env.manifest_file)` version is unrecogized: manifest_format == $(before_format)")
+    end
+    ctx.env.manifest.manifest_format = v"2.0"
+    Types.write_manifest(ctx.env)
+    printpkgstyle(ctx.io, :Updated, "Format of manifest file at `$(ctx.env.manifest_file)` updated from v$(before_format.major).$(before_format.minor) to v2.0")
+    return nothing
+end
+
 end # module

--- a/src/API.jl
+++ b/src/API.jl
@@ -1678,6 +1678,7 @@ function upgrade_manifest(ctx::Context = Context())
         pkgerror("Format of manifest file at `$(ctx.env.manifest_file)` version is unrecogized: manifest_format == $(before_format)")
     end
     ctx.env.manifest.manifest_format = v"2.0"
+    ctx.env.manifest.julia_version = VERSION
     Types.write_manifest(ctx.env)
     printpkgstyle(ctx.io, :Updated, "Format of manifest file at `$(ctx.env.manifest_file)` updated from v$(before_format.major).$(before_format.minor) to v2.0")
     return nothing

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -561,7 +561,6 @@ const RegistrySpec = Registry.RegistrySpec
 
 """
     upgrade_manifest()
-    upgrade_manifest(ctx::Context)
 
 Upgrades the format of the manifest file from v1.0 to v2.0 without re-resolving.
 """

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -559,6 +559,13 @@ Below is a comparison between the REPL mode and the functional API::
 """
 const RegistrySpec = Registry.RegistrySpec
 
+"""
+    upgrade_manifest()
+    upgrade_manifest(ctx::Context)
+
+Upgrades the format of the manifest file from v1.0 to v2.0 without re-resolving.
+"""
+const upgrade_manifest = API.upgrade_manifest
 
 function __init__()
     if isdefined(Base, :active_repl)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -262,7 +262,7 @@ Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.
 
 Base.@kwdef mutable struct Manifest
     julia_version::Union{Nothing,VersionNumber} = Base.VERSION
-    manifest_format::VersionNumber = v"1.0.0" # default to older flat format
+    manifest_format::VersionNumber = v"2.0.0"
     deps::Dict{UUID,PackageEntry} = Dict{UUID,PackageEntry}()
     other::Dict{String,Any} = Dict{String,Any}()
 end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -281,6 +281,12 @@ function write_manifest(env::EnvCache)
     write_manifest(env.manifest, env.manifest_file)
 end
 function write_manifest(manifest::Manifest, manifest_file::AbstractString)
+    if manifest.manifest_format.major == 1
+        @warn """The active manifest file has an old format that is being maintained.
+            To update to the new format:
+                1. Delete the manifest file at `$(manifest_file)`
+                2. Run `import Pkg; Pkg.resolve()`""" maxlog = 1
+    end
     return write_manifest(destructure(manifest), manifest_file)
 end
 function write_manifest(io::IO, manifest::Manifest)

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -282,10 +282,8 @@ function write_manifest(env::EnvCache)
 end
 function write_manifest(manifest::Manifest, manifest_file::AbstractString)
     if manifest.manifest_format.major == 1
-        @warn """The active manifest file has an old format that is being maintained.
-            To update to the new format:
-                1. Delete the manifest file at `$(manifest_file)`
-                2. Run `import Pkg; Pkg.resolve()`""" maxlog = 1
+        @warn """The active manifest file at `$(manifest_file)` has an old format that is being maintained.
+            To update to the new format run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving""" maxlog = 1
     end
     return write_manifest(destructure(manifest), manifest_file)
 end

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -5,7 +5,7 @@ import ..Pkg, LibGit2
 using  ..Utils
 
 @testset "Manifest.toml formats" begin
-    @testset "Default manifest format is v1" begin
+    @testset "Default manifest format is v2" begin
         isolate(loaded_depot=true) do
             io = IOBuffer()
             Pkg.activate(; io=io, temp=true)
@@ -13,7 +13,8 @@ using  ..Utils
             @test occursin(r"Activating.*project at.*", output)
             Pkg.add("Profile")
             env_manifest = Pkg.Types.Context().env.manifest_file
-            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+            @test Pkg.Types.Context().env.manifest.manifest_format == v"2.0.0"
         end
     end
 


### PR DESCRIPTION
New Manifest.toml format: Pt 2. (For 1.7 only, not to be backported to 1.6.2)
- Defaults to the new manifest format
- Warns the user (once) if an old format manifest is being maintained

Continuation after part 1 (https://github.com/JuliaLang/Pkg.jl/pull/2561)

Fixes #1458 
Fixes #2508 
Closes #2557 