### PR TITLE
Standardize the CI workflow for checking and changing the UUID

### DIFF
--- a/.ci/change_uuid.jl
+++ b/.ci/change_uuid.jl
@@ -1,0 +1,5 @@
+using UUIDs
+
+project_filename = joinpath(dirname(@__DIR__), "Project.toml")
+
+write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"))

--- a/.ci/test_uuid_is_unchanged.jl
+++ b/.ci/test_uuid_is_unchanged.jl
@@ -1,7 +1,7 @@
 using Pkg
 using Test
 
-@testset "Pkg UUID" begin 
+@testset "Test that the UUID is unchanged" begin 
     project_filename = joinpath(dirname(@__DIR__), "Project.toml")
     project = Pkg.TOML.parsefile(project_filename)
     uuid = project["uuid"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,9 @@ jobs:
           # See https://github.com/actions/virtual-environments/issues/712
           echo "TMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
           echo "TEMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
-      - name: Run tests
-        run: |
-          julia test/pkg_uuid.jl
-          julia --project --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"54cfe95a-1eb2-52ea-b672-e2afdf69b78f\"\n"));'
-          julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+      - run: julia --color=yes .ci/test_uuid_is_unchanged.jl
+      - run: julia --color=yes .ci/change_uuid.jl
+      - run: julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
       - uses: julia-actions/julia-processcoverage@v1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ import Pkg
 
 using Test
 
-@testset "Ensure we're testing the correct Pkg" begin
+@testset "Test that we have imported the correct package" begin
     @test realpath(dirname(dirname(Base.pathof(Pkg)))) == realpath(dirname(@__DIR__))
 end
 


### PR DESCRIPTION
I want to standardize the CI workflow for checking and changing the UUID, so that it is exactly the same across all stdlibs that live in external repos.

That way, it is really easy for someone to set this up on a new external stdlib:
1. Copy two lines from the `.github/workflows/ci.yml` file in an existing external stdlib and paste those two lines into the `.github/workflows/ci.yml` file  in your new external stdlib
2. Copy two files from the `.ci/` directory in an existing external stdlib and paste those two lines into the `.github/workflows/ci.yml` file  in your new external stdlib
3. In the `.ci/test_uuid_is_unchanged.jl` file in your new external stdlib, change line 8 (`correct_uuid = "..."`) to contain the correct UUID for new external stdlib