### PR TITLE
sort REPL completions alphabetically

### DIFF
--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -200,7 +200,7 @@ function _completions(input, final, offset, index)
         return x
     else
         possible = filter(possible -> startswith(possible, partial), x)
-        return possible, offset:index, !isempty(possible)
+        return sort(possible), offset:index, !isempty(possible)
     end
 end
 


### PR DESCRIPTION
Currently, package completions are shown in 'random' order:

![Schermafbeelding 2021-06-07 om 13 28 56](https://user-images.githubusercontent.com/6933510/121009323-50d29f80-c794-11eb-833e-4ab05069bf4b.png)
