### PR TITLE
Enable installation of versioned historical stdlibs

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -131,8 +131,8 @@ function update_manifest!(env::EnvCache, pkgs::Vector{PackageSpec}, deps_map, ju
         entry = PackageEntry(;name = pkg.name, version = pkg.version, pinned = pkg.pinned,
                              tree_hash = pkg.tree_hash, path = pkg.path, repo = pkg.repo, uuid=pkg.uuid)
         if is_stdlib(pkg.uuid, julia_version)
-            # do not set version for stdlibs
-            entry.version = nothing
+            # Only set stdlib versions for versioned (external) stdlibs
+            entry.version = stdlib_version(pkg.uuid, julia_version)
         end
         if Types.is_project(env, pkg)
             entry.deps = env.project.deps
@@ -381,6 +381,7 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
         union!(uuids, fixed_uuids)
     end
 
+    stdlibs_for_julia_version = Types.get_last_stdlibs(julia_version)
     seen = Set{UUID}()
 
     # pkg -> version -> (dependency => compat):
@@ -396,13 +397,21 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
         for uuid in unseen
             push!(seen, uuid)
             uuid in keys(fixed) && continue
-            all_compat_u   = get_or_make!(all_compat,   uuid)
+            all_compat_u = get_or_make!(all_compat,   uuid)
 
-            # If we're requesting resolution of a package that is an stdlib and is not registered,
-            # we must special-case it here.  This is further complicated by the fact that we can
-            # ask this question relative to a particular Julia version.
-            if is_unregistered_stdlib(uuid) || is_stdlib(uuid, julia_version)
-                path = Types.stdlib_path(stdlibs()[uuid])
+            uuid_is_stdlib = false
+            stdlib_name = ""
+            stdlib_version = nothing
+            if haskey(stdlibs_for_julia_version, uuid)
+                uuid_is_stdlib = true
+                stdlib_name, stdlib_version = stdlibs_for_julia_version[uuid]
+            end
+
+            # If we're requesting resolution of a package that is an unregistered stdlib (or one
+            # that tracks no version information) we must special-case it here.  This is further
+            # complicated by the fact that we can ask this question relative to a Julia version.
+            if is_unregistered_stdlib(uuid) || (uuid_is_stdlib && stdlib_version === nothing)
+                path = Types.stdlib_path(stdlibs_for_julia_version[uuid][1])
                 proj_file = projectfile_path(path; strict=true)
                 @assert proj_file !== nothing
                 proj = read_package(proj_file)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -22,7 +22,7 @@ using SHA
 
 export UUID, SHA1, VersionRange, VersionSpec,
     PackageSpec, PackageEntry, EnvCache, Context, GitRepo, Context!, Manifest, Project, err_rep,
-    PkgError, pkgerror, has_name, has_uuid, is_stdlib, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
+    PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlib_version, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved,
     registered_name,
     manifest_info,
@@ -411,8 +411,9 @@ is_stdlib(uuid::UUID) = uuid in keys(stdlibs())
 
 # Find the entry in `STDLIBS_BY_VERSION`
 # that corresponds to the requested version, and use that.
+# If we can't find one, defaults to `UNREGISTERED_STDLIBS`
 function get_last_stdlibs(julia_version::VersionNumber)
-    last_stdlibs = Dict{UUID,String}()
+    last_stdlibs = UNREGISTERED_STDLIBS
     for (version, stdlibs) in STDLIBS_BY_VERSION
         if VersionNumber(julia_version.major, julia_version.minor, julia_version.patch) < version
             break
@@ -421,6 +422,10 @@ function get_last_stdlibs(julia_version::VersionNumber)
     end
     return last_stdlibs
 end
+# If `julia_version` is set to `nothing`, that means (essentially) treat all registered
+# stdlibs as normal packages so that we get the latest versions of everything, ignoring
+# julia compat.  So we set the list of stdlibs to that of only the unregistered stdlibs.
+get_last_stdlibs(::Nothing) = UNREGISTERED_STDLIBS
 
 # Allow asking if something is an stdlib for a particular version of Julia
 function is_stdlib(uuid::UUID, julia_version::Union{VersionNumber, Nothing})
@@ -429,21 +434,22 @@ function is_stdlib(uuid::UUID, julia_version::Union{VersionNumber, Nothing})
         return is_stdlib(uuid)
     end
 
-    # If this UUID is known to be unregistered, always return `true`
-    if haskey(UNREGISTERED_STDLIBS, uuid)
-        return true
-    end
-
-    # Otherwise, if the `julia_version` is `nothing`, all registered stdlibs
-    # will be treated like normal packages.
-    if julia_version === nothing
-        return false
-    end
-
     last_stdlibs = get_last_stdlibs(julia_version)
     # Note that if the user asks for something like `julia_version = 0.7.0`, we'll
     # fall through with an empty `last_stdlibs`, which will always return `false`.
     return uuid in keys(last_stdlibs)
+end
+
+# Return the version of a stdlib with respect to a particular Julia version, or
+# `nothing` if that stdlib is not versioned.  We only store version numbers for
+# stdlibs that are external and thus could be installed from their repositories,
+# e.g. things like `GMP_jll`, `Tar`, etc...
+function stdlib_version(uuid::UUID, julia_version::Union{VersionNumber,Nothing})
+    last_stdlibs = get_last_stdlibs(julia_version)
+    if !(uuid in keys(last_stdlibs))
+        return nothing
+    end
+    return last_stdlibs[uuid][2]
 end
 
 is_unregistered_stdlib(uuid::UUID) = haskey(UNREGISTERED_STDLIBS, uuid)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2668,16 +2668,6 @@ end
     end
 
     isolate(loaded_depot=true) do
-        # Test that adding `NetworkOptions` results in a `Manifest.toml` with no version
-        # which means that it was treated as a standard library
-        Pkg.add("NetworkOptions")
-        block = get_manifest_block("NetworkOptions")
-        @test haskey(block, "uuid")
-        @test block["uuid"] == networkoptions_uuid
-        @test !haskey(block, "version")
-    end
-
-    isolate(loaded_depot=true) do
         # Next, test that if we ask for `v1.5` it DOES have a version, and that GMP_jll installs v6.1.X
         Pkg.add(["NetworkOptions", "GMP_jll"]; julia_version=v"1.5")
         no_block = get_manifest_block("NetworkOptions")
@@ -2698,7 +2688,7 @@ end
         artifacts_toml = joinpath(gmp_jll_dir, "Artifacts.toml")
         @test isfile(artifacts_toml)
         meta = artifact_meta("GMP", artifacts_toml)
-        @test meta != nothing
+        @test meta !== nothing
 
         gmp_artifact_path = artifact_path(Base.SHA1(meta["git-tree-sha1"]))
         @test isdir(gmp_artifact_path)
@@ -2710,8 +2700,22 @@ end
         end
     end
 
+    # Next, test that if we ask for `v1.6`, GMP_jll gets `v6.2.0`, and for `v1.7`, it gets `v6.2.1`
+    function do_gmp_test(julia_version, gmp_version)
+        isolate(loaded_depot=true) do
+            Pkg.add("GMP_jll"; julia_version)
+            gmp_block = get_manifest_block("GMP_jll")
+            @test haskey(gmp_block, "uuid")
+            @test gmp_block["uuid"] == gmp_jll_uuid
+            @test haskey(gmp_block, "version")
+            @test startswith(gmp_block["version"], string(gmp_version))
+        end
+    end
+    do_gmp_test(v"1.6", v"6.2.0")
+    do_gmp_test(v"1.7", v"6.2.1")
+
     isolate(loaded_depot=true) do
-        # Next, test that if we ask for `nothing`, NetworkOptions has a `version` but `LinearAlgebra` does.
+        # Next, test that if we ask for `nothing`, NetworkOptions has a `version` but `LinearAlgebra` does not.
         Pkg.add(["LinearAlgebra", "NetworkOptions"]; julia_version=nothing)
         no_block = get_manifest_block("NetworkOptions")
         @test haskey(no_block, "uuid")

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -435,7 +435,6 @@ end
             return versions[idx]
         end
 
-        # DISABLED FOR NOW BECAUSE THE JLL INTO STDLIBS BROKE IT
         # First, we're going to resolve for specific versions of Julia, ensuring we get the right dep versions:
         Pkg.Registry.download_default_registries(Pkg.stdout_f())
         ctx = Pkg.Types.Context(;julia_version=v"1.5")

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -435,7 +435,6 @@ end
             return versions[idx]
         end
 
-        #=
         # DISABLED FOR NOW BECAUSE THE JLL INTO STDLIBS BROKE IT
         # First, we're going to resolve for specific versions of Julia, ensuring we get the right dep versions:
         Pkg.Registry.download_default_registries(Pkg.stdout_f())
@@ -469,7 +468,6 @@ end
         mpfr = find_by_name(versions, "MPFR_jll")
         @test mpfr !== nothing
         @test mpfr.version.major == 4 && mpfr.version.minor == 0
-        =#
     end
 end
 


### PR DESCRIPTION
Fixes #2479

When installing stdlibs, if we are requesting a versioned stdlib, record
its version in the manifest and download/install it.  This allows for
tools such as BinaryBuilder to download the correct JLL for e.g.
`GMP_jll` when targeting Julia v1.6, for example.

This does slightly change manifest writing; `Manifest.toml` files now
record the version of versioned stdlibs (such as `Pkg`, `Tar`, all JLL
stdlibs, `NetworkOptions`, etc...) however this has no impact on code
loading (as they still do not contain `git-tree-sha1` entries).