### PR TITLE
New manifest: Set `julia_version` during resolve only, and warn if instantiating a manifest that was resolved in a different or unknown julia version

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1415,6 +1415,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     end
     if !isfile(ctx.env.project_file) && isfile(ctx.env.manifest_file)
         _manifest = Pkg.Types.read_manifest(ctx.env.manifest_file)
+        Types.check_warn_manifest_julia_version_compat(_manifest, ctx.env.manifest_file)
         deps = Dict{String,String}()
         for (uuid, pkg) in _manifest
             if pkg.name in keys(deps)
@@ -1433,6 +1434,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     if !isfile(ctx.env.manifest_file) && manifest == true
         pkgerror("expected manifest file at `$(ctx.env.manifest_file)` but it does not exist")
     end
+    Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
     Operations.prune_manifest(ctx.env)
     for (name, uuid) in ctx.env.project.deps
         get(ctx.env.manifest, uuid, nothing) === nothing || continue

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -288,10 +288,13 @@ end
 function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
     # compatibility
     if julia_version !== nothing
+        env.manifest.julia_version = julia_version
         v = intersect(julia_version, get_compat(env.project, "julia"))
         if isempty(v)
             @warn "julia version requirement for project not satisfied" _module=nothing _file=nothing
         end
+    else
+        env.manifest.julia_version = VERSION
     end
     names = Dict{UUID, String}(uuid => stdlib for (uuid, stdlib) in stdlibs())
     # recursive search for packages which are tracking a path

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -261,7 +261,7 @@ Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
 Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps, x.uuid], init=h)  # omits `other`
 
 Base.@kwdef mutable struct Manifest
-    julia_version::Union{Nothing,VersionNumber} = Base.VERSION
+    julia_version::Union{Nothing,VersionNumber} = nothing # only set to VERSION when resolving
     manifest_format::VersionNumber = v"2.0.0"
     deps::Dict{UUID,PackageEntry} = Dict{UUID,PackageEntry}()
     other::Dict{String,Any} = Dict{String,Any}()

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -160,7 +160,7 @@ function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
                 deps = read_deps(get(info::Dict, "deps", nothing))
             catch
                 # TODO: Should probably not unconditionally log something
-                @error "Could not parse entry for `$name`"
+                @error "Could not parse entry for `$name`" f_or_io
                 rethrow()
             end
             entry.other = info::Union{Dict,Nothing}

--- a/test/new.jl
+++ b/test/new.jl
@@ -895,7 +895,7 @@ end
                               ) Pkg.pkg"add some/really/random/Dir"
         # warn if not explicit about adding directory
         mkdir("Example")
-        @test_logs (:info, r"Use `./Example` to add or develop the local directory at `.*`.") Pkg.pkg"add Example"
+        @test_logs (:info, r"Use `./Example` to add or develop the local directory at `.*`.") match_mode=:any Pkg.pkg"add Example"
     end end
 end
 
@@ -1967,7 +1967,7 @@ end
     # other
     isolate(loaded_depot=true) do
         @test_deprecated Pkg.status(Pkg.PKGMODE_MANIFEST)
-        @test_logs (:warn, r"diff option only available") Pkg.status(diff=true)
+        @test_logs (:warn, r"diff option only available") match_mode=:any Pkg.status(diff=true)
     end
     # State changes
     isolate(loaded_depot=true) do

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -255,8 +255,8 @@ temp_pkg_dir() do project_path
         @test Base.ACTIVE_PROJECT[] === nothing
         # expansion of ~
         if !Sys.iswindows()
-            pkg"activate ~/Foo"
-            @test Base.active_project() == joinpath(homedir(), "Foo", "Project.toml")
+            pkg"activate ~/Foo_lzTkPF6N"
+            @test Base.active_project() == joinpath(homedir(), "Foo_lzTkPF6N", "Project.toml")
         end
     end
 end


### PR DESCRIPTION
The intention is to use the new manifest format `julia_version` to guide the user when the manifest is (potentially) incompatible with the julia version.

- The `julia_version` field in the manifest is now only set during resolve
- Adds a `@warn` (maxlog = 1 per manifest path) when loading the manifest (any action that uses `Context()` plus a direct instantiate of a manifest)

For old format manifests:
```
┌ Warning: The active manifest file is an older format with no julia version entry. Dependencies may have been resolved with a different julia version.
└ @ ~/Documents/GitHub/Pkg.jl/test/manifest/formats/v1.0/Manifest.toml:0
```
For new format manifests with the `julia_version` field:
```
┌ Warning: The active manifest file has dependencies that were resolved with a different julia version (1.7.0-DEV.1199). Unexpected behavior may occur.
└ @ ~/Documents/GitHub/Pkg.jl/test/manifest/formats/v2.0/Manifest.toml:0
```

Questions:
When should the warning also be shown? After activate?

What if julia is started up via `--project`. Should there be a warning in the julia repl?

On master/non-released versions the full version check could create a lot of noise. Should the version check just be for `major.minor`? Edit: Implemented