### PR TITLE
fix not warning about old manifest during Pkg.test

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1398,9 +1398,9 @@ function sandbox_preserve(env::EnvCache, target::PackageSpec, test_project::Stri
     if env.pkg !== nothing
         env.manifest[env.pkg.uuid] = PackageEntry(;name=env.pkg.name, path=dirname(env.project_file),
                                                   deps=env.project.deps)
-        # if the source manifest is an old format, upgrade the manifest_format so
-        # that warnings aren't thrown for the temp sandbox manifest
     end
+    # if the source manifest is an old format, upgrade the manifest_format so
+    # that warnings aren't thrown for the temp sandbox manifest
     if env.manifest.manifest_format < v"2.0"
         env.manifest.manifest_format = v"2.0"
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1400,9 +1400,9 @@ function sandbox_preserve(env::EnvCache, target::PackageSpec, test_project::Stri
                                                   deps=env.project.deps)
         # if the source manifest is an old format, upgrade the manifest_format so
         # that warnings aren't thrown for the temp sandbox manifest
-        if env.manifest.manifest_format < v"2.0"
-            env.manifest.manifest_format = v"2.0"
-        end
+    end
+    if env.manifest.manifest_format < v"2.0"
+        env.manifest.manifest_format = v"2.0"
     end
     # preserve important nodes
     keep = [target.uuid]


### PR DESCRIPTION
https://github.com/JuliaLang/Pkg.jl/pull/2617 was supposed to fix this but I just tried `Pkg.test` a random package and the warning still showed up. In my opinion, this manifest upgrade should happen unconditionally, and not just when testing the active project.