### PR TITLE
`Pkg.build`: Don't build and precompile an uninstantiated environment twice

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1413,7 +1413,7 @@ end
 instantiate(; kwargs...) = instantiate(Context(); kwargs...)
 function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
                      update_registry::Bool=true, verbose::Bool=false,
-                     platform::AbstractPlatform=HostPlatform(), allow_autoprecomp::Bool=true, kwargs...)
+                     platform::AbstractPlatform=HostPlatform(), allow_build::Bool=true, allow_autoprecomp::Bool=true, kwargs...)
     Context!(ctx; kwargs...)
     if Registry.download_default_registries(ctx.io)
         copy!(ctx.registries, Registry.reachable_registries())
@@ -1501,7 +1501,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Install all artifacts
     Operations.download_artifacts(ctx.env; platform=platform, verbose=verbose)
     # Run build scripts
-    Operations.build_versions(ctx, union(new_apply, new_git); verbose=verbose)
+    allow_build && Operations.build_versions(ctx, union(new_apply, new_git); verbose=verbose)
 
     allow_autoprecomp && Pkg._auto_precompile(ctx)
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -822,7 +822,7 @@ end
 
 function build(ctx::Context, uuids::Set{UUID}, verbose::Bool)
     if any_package_not_installed(ctx.env.manifest) || !isfile(ctx.env.manifest_file)
-        Pkg.instantiate(ctx)
+        Pkg.instantiate(ctx, allow_build = false, allow_autoprecomp = false)
     end
     all_uuids = get_deps(ctx.env, uuids)
     build_versions(ctx, all_uuids; verbose)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/2624

# Before
```
(jl_SWIdMW) pkg> st
      Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_SWIdMW/Project.toml`
→ [f67ccb44] HDF5 v0.15.5
        Info packages marked with → not downloaded, use `instantiate` to download

(jl_SWIdMW) pkg> build
  Installing known registries into `/tmp/fdsfsd`
       Added registry `General` to `/tmp/fdsfsd/registries/General`
   Installed Lz4_jll ───── v1.9.3+0
   Installed Blosc_jll ─── v1.21.0+0
   Installed HDF5_jll ──── v1.12.0+1
   Installed Preferences ─ v1.2.2
   Installed Compat ────── v3.30.0
   Installed Requires ──── v1.1.3
   Installed JLLWrappers ─ v1.3.0
   Installed HDF5 ──────── v0.15.5
   Installed OpenSSL_jll ─ v1.1.10+0
   Installed Zstd_jll ──── v1.5.0+0
   Installed Blosc ─────── v0.7.0
  Downloaded artifact: HDF5
  Downloaded artifact: Blosc
  Downloaded artifact: Lz4
  Downloaded artifact: Zstd
  Downloaded artifact: OpenSSL
    Building HDF5 → `/tmp/fdsfsd/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/1d18a48a037b14052ca462ea9d05dee3ac607d23/build.log`
Precompiling project...
  14 dependencies successfully precompiled in 6 seconds
    Building HDF5 → `/tmp/fdsfsd/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/1d18a48a037b14052ca462ea9d05dee3ac607d23/build.log`
Precompiling project...
  1 dependency successfully precompiled in 2 seconds (13 already precompiled)
```

# This PR
```
(jl_SWIdMW) pkg> st
  Installing known registries into `/tmp/213fewf`
      Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_SWIdMW/Project.toml`
→ [f67ccb44] HDF5 v0.15.5
        Info packages marked with → not downloaded, use `instantiate` to download

(jl_SWIdMW) pkg> build
   Installed Preferences ─ v1.2.2
   Installed Blosc_jll ─── v1.21.0+0
   Installed Zstd_jll ──── v1.5.0+0
   Installed Lz4_jll ───── v1.9.3+0
   Installed OpenSSL_jll ─ v1.1.10+0
   Installed Requires ──── v1.1.3
   Installed HDF5 ──────── v0.15.5
   Installed JLLWrappers ─ v1.3.0
   Installed Compat ────── v3.30.0
   Installed HDF5_jll ──── v1.12.0+1
   Installed Blosc ─────── v0.7.0
  Downloaded artifact: Blosc
  Downloaded artifact: Zstd
  Downloaded artifact: OpenSSL
  Downloaded artifact: Lz4
  Downloaded artifact: HDF5
    Building HDF5 → `/tmp/213fewf/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/1d18a48a037b14052ca462ea9d05dee3ac607d23/build.log
Precompiling project...
  14 dependencies successfully precompiled in 6 seconds
```