### PR TITLE
Cancel pkg install prompt when ^D is entered - Add a missing newline

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -682,13 +682,17 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         printstyled(ctx.io, " └ "; color=:green)
         Base.prompt(stdin, ctx.io, "(y/n)", default = "y")
     catch err
-        if err isa InterruptException
+        if err isa InterruptException # if ^C is entered
             println(ctx.io)
             return false
         end
         rethrow()
     end
-    if !isnothing(resp) && lowercase(resp) in ["y", "yes"]
+    if isnothing(resp) # if ^D is entered
+        println(ctx.io)
+        return false
+    end
+    if lowercase(resp) in ["y", "yes"]
         API.add(string.(available_pkgs))
         if length(available_pkgs) < length(pkgs)
             return false # declare that some pkgs couldn't be installed


### PR DESCRIPTION
I made the mistake of not trying #2631 before opening it. 
Just needed a newline otherwise the error printed on the same line as the prompt.

This PR
```
julia> using Flux
 │ Package Flux not found, but a package named Flux is available from a registry. 
 │ Install package?
 │   (Pkg) pkg> add Flux 
 └ (y/n) [y]: ^D
ERROR: ArgumentError: Package Flux not found in current path:
- Run `import Pkg; Pkg.add("Flux")` to install the Flux package.

Stacktrace:
 [1] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:967

```