### PR TITLE
CI: set a max timeout of 60 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ defaults:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +63,7 @@ jobs:
           file: lcov.info
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1.0.0
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
The default GitHub Actions timeout is 6 hours, which I think is too long.

This PR sets the timeout to 60 minutes, but we could even consider decreasing it further to e.g. 40 minutes or 30 minutes.