### PR TITLE
release1.7: Revert "Enable installation of versioned historical stdlibs (#2614)"

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -22,7 +22,7 @@ using SHA
 
 export UUID, SHA1, VersionRange, VersionSpec,
     PackageSpec, PackageEntry, EnvCache, Context, GitRepo, Context!, Manifest, Project, err_rep,
-    PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlib_version, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
+    PkgError, pkgerror, has_name, has_uuid, is_stdlib, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml, find_registered!,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved,
     registered_name,
     manifest_info,
@@ -405,9 +405,8 @@ is_stdlib(uuid::UUID) = uuid in keys(stdlibs())
 
 # Find the entry in `STDLIBS_BY_VERSION`
 # that corresponds to the requested version, and use that.
-# If we can't find one, defaults to `UNREGISTERED_STDLIBS`
 function get_last_stdlibs(julia_version::VersionNumber)
-    last_stdlibs = UNREGISTERED_STDLIBS
+    last_stdlibs = Dict{UUID,String}()
     for (version, stdlibs) in STDLIBS_BY_VERSION
         if VersionNumber(julia_version.major, julia_version.minor, julia_version.patch) < version
             break
@@ -416,10 +415,6 @@ function get_last_stdlibs(julia_version::VersionNumber)
     end
     return last_stdlibs
 end
-# If `julia_version` is set to `nothing`, that means (essentially) treat all registered
-# stdlibs as normal packages so that we get the latest versions of everything, ignoring
-# julia compat.  So we set the list of stdlibs to that of only the unregistered stdlibs.
-get_last_stdlibs(::Nothing) = UNREGISTERED_STDLIBS
 
 # Allow asking if something is an stdlib for a particular version of Julia
 function is_stdlib(uuid::UUID, julia_version::Union{VersionNumber, Nothing})
@@ -428,22 +423,21 @@ function is_stdlib(uuid::UUID, julia_version::Union{VersionNumber, Nothing})
         return is_stdlib(uuid)
     end
 
+    # If this UUID is known to be unregistered, always return `true`
+    if haskey(UNREGISTERED_STDLIBS, uuid)
+        return true
+    end
+
+    # Otherwise, if the `julia_version` is `nothing`, all registered stdlibs
+    # will be treated like normal packages.
+    if julia_version === nothing
+        return false
+    end
+
     last_stdlibs = get_last_stdlibs(julia_version)
     # Note that if the user asks for something like `julia_version = 0.7.0`, we'll
     # fall through with an empty `last_stdlibs`, which will always return `false`.
     return uuid in keys(last_stdlibs)
-end
-
-# Return the version of a stdlib with respect to a particular Julia version, or
-# `nothing` if that stdlib is not versioned.  We only store version numbers for
-# stdlibs that are external and thus could be installed from their repositories,
-# e.g. things like `GMP_jll`, `Tar`, etc...
-function stdlib_version(uuid::UUID, julia_version::Union{VersionNumber,Nothing})
-    last_stdlibs = get_last_stdlibs(julia_version)
-    if !(uuid in keys(last_stdlibs))
-        return nothing
-    end
-    return last_stdlibs[uuid][2]
 end
 
 is_unregistered_stdlib(uuid::UUID) = haskey(UNREGISTERED_STDLIBS, uuid)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2668,6 +2668,16 @@ end
     end
 
     isolate(loaded_depot=true) do
+        # Test that adding `NetworkOptions` results in a `Manifest.toml` with no version
+        # which means that it was treated as a standard library
+        Pkg.add("NetworkOptions")
+        block = get_manifest_block("NetworkOptions")
+        @test haskey(block, "uuid")
+        @test block["uuid"] == networkoptions_uuid
+        @test !haskey(block, "version")
+    end
+
+    isolate(loaded_depot=true) do
         # Next, test that if we ask for `v1.5` it DOES have a version, and that GMP_jll installs v6.1.X
         Pkg.add(["NetworkOptions", "GMP_jll"]; julia_version=v"1.5")
         no_block = get_manifest_block("NetworkOptions")
@@ -2688,7 +2698,7 @@ end
         artifacts_toml = joinpath(gmp_jll_dir, "Artifacts.toml")
         @test isfile(artifacts_toml)
         meta = artifact_meta("GMP", artifacts_toml)
-        @test meta !== nothing
+        @test meta != nothing
 
         gmp_artifact_path = artifact_path(Base.SHA1(meta["git-tree-sha1"]))
         @test isdir(gmp_artifact_path)
@@ -2700,22 +2710,8 @@ end
         end
     end
 
-    # Next, test that if we ask for `v1.6`, GMP_jll gets `v6.2.0`, and for `v1.7`, it gets `v6.2.1`
-    function do_gmp_test(julia_version, gmp_version)
-        isolate(loaded_depot=true) do
-            Pkg.add("GMP_jll"; julia_version)
-            gmp_block = get_manifest_block("GMP_jll")
-            @test haskey(gmp_block, "uuid")
-            @test gmp_block["uuid"] == gmp_jll_uuid
-            @test haskey(gmp_block, "version")
-            @test startswith(gmp_block["version"], string(gmp_version))
-        end
-    end
-    do_gmp_test(v"1.6", v"6.2.0")
-    do_gmp_test(v"1.7", v"6.2.1")
-
     isolate(loaded_depot=true) do
-        # Next, test that if we ask for `nothing`, NetworkOptions has a `version` but `LinearAlgebra` does not.
+        # Next, test that if we ask for `nothing`, NetworkOptions has a `version` but `LinearAlgebra` does.
         Pkg.add(["LinearAlgebra", "NetworkOptions"]; julia_version=nothing)
         no_block = get_manifest_block("NetworkOptions")
         @test haskey(no_block, "uuid")

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -435,6 +435,8 @@ end
             return versions[idx]
         end
 
+        #=
+        # DISABLED FOR NOW BECAUSE THE JLL INTO STDLIBS BROKE IT
         # First, we're going to resolve for specific versions of Julia, ensuring we get the right dep versions:
         Pkg.Registry.download_default_registries(Pkg.stdout_f())
         ctx = Pkg.Types.Context(;julia_version=v"1.5")
@@ -467,6 +469,7 @@ end
         mpfr = find_by_name(versions, "MPFR_jll")
         @test mpfr !== nothing
         @test mpfr.version.major == 4 && mpfr.version.minor == 0
+        =#
     end
 end
 


### PR DESCRIPTION
This reverts commit e9b6ffb5bf67a6bb0a590f8ed8ddb72cc83d8f2e.

Adding `version` fields to all stdlibs is too scary to add this late in the release process (ref https://github.com/JuliaLang/julia/issues/41266). I will revert this on 1.7 and then we could potentially add it back if it could be done in a way that does not change the manifest.