### PR TITLE
fix docstring of Pkg.status

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -383,7 +383,7 @@ from packages that are tracking a path.
 const resolve = API.resolve
 
 """
-    Pkg.status([pkgs...]; mode::PackageMode=PKGMODE_PROJECT, diff::Bool=false, io::IO=stdout)
+    Pkg.status([pkgs...]; mode::PackageMode=PKGMODE_PROJECT, diff::Bool=false, io::IO=stderr)
 
 Print out the status of the project/manifest.
 If `mode` is `PKGMODE_PROJECT`, print out status only about the packages


### PR DESCRIPTION
The default output seems to be `stderr`.

```
~ $ julia -e 'using Pkg; Pkg.status()' 2>/dev/null
~ $ julia -e 'using Pkg; Pkg.status()' 1>/dev/null
      Status `~/.julia/environments/v1.6/Project.toml`
  [69666777] Arrow v1.5.0
  [a80a1652] BenchmarkHistograms v0.2.0
  [6e4b80f9] BenchmarkTools v1.0.0
  [336ed68f] CSV v0.8.5
...
```