### PR TITLE
Make new manifest equality and hash ignore metadata

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -266,8 +266,8 @@ Base.@kwdef mutable struct Manifest
     deps::Dict{UUID,PackageEntry} = Dict{UUID,PackageEntry}()
     other::Dict{String,Any} = Dict{String,Any}()
 end
-Base.:(==)(t1::Manifest, t2::Manifest) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Manifest))
-Base.hash(m::Manifest, h::UInt) = foldr(hash, [getfield(m, x) for x in fieldnames(Manifest)], init=h)
+Base.:(==)(t1::Manifest, t2::Manifest) = t1.deps == t2.deps
+Base.hash(m::Manifest, h::UInt) = hash(m.deps, h)
 Base.getindex(m::Manifest, i_or_key) = getindex(m.deps, i_or_key)
 Base.get(m::Manifest, key, default) = get(m.deps, key, default)
 Base.setindex!(m::Manifest, i_or_key, value) = setindex!(m.deps, i_or_key, value)


### PR DESCRIPTION
My theory is that this is causing the undo errors in https://github.com/JuliaLang/Pkg.jl/pull/2628

But I don't know why those tests don't fail on master.