### PR TITLE
Tweak compatability documentation

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -61,7 +61,7 @@ remains backward compatible with 0.2.0.  See also [The `version` field](@ref).
 
 ### Caret specifiers
 
-A caret specifier allows upgrade that would be compatible according to semver.
+Carets allow upgrade that would be compatible according to semver, and are the default behaviour if no specifier is used.
 An updated dependency is considered compatible if the new version does not modify the left-most non zero digit in the version specifier.
 
 Some examples are shown below.
@@ -100,11 +100,12 @@ For all versions with a major version of 0 the tilde and caret specifiers are eq
 
 ### Equality specifier
 
-Equality can be used to specify an exact version:
+Equality can be used to specify exact versions:
 
 ```toml
 [compat]
-PkgA = "= 1.2.3"  # [1.2.3, 1.2.3]
+PkgA = "=1.2.3"           # [1.2.3, 1.2.3]
+PkgA = "=0.10.1, =0.10.3" # 0.10.1 or 0.10.3
 ```
 
 ### Inequality specifiers

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -61,7 +61,7 @@ remains backward compatible with 0.2.0.  See also [The `version` field](@ref).
 
 ### Caret specifiers
 
-Carets allow upgrade that would be compatible according to semver, and are the default behaviour if no specifier is used.
+A caret (`^`) specifier allows upgrade that would be compatible according to semver. This is the default behavior if no specifier is used.
 An updated dependency is considered compatible if the new version does not modify the left-most non zero digit in the version specifier.
 
 Some examples are shown below.


### PR DESCRIPTION
This PR expands on two minor points that had contributed to my confusion about how compat worked for patch versions.

- The caret section doesn't specify that caret is the default. It is listed a few paragraphs above - but it is easy to miss the connection when you are reading the caret docs specifically.
- According to PackageCompatUI equality can specify multiple distinct specific versions. The docs only had examples for specifying one version, which made it appear to not be possible to specify multiple versions explicitly, as other specifiers all have multiple examples.