### PR TITLE
Delete the `Pkg.Versions.:≳` function

### DIFF
--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -38,9 +38,6 @@ function ≲(b::VersionBound, v::VersionNumber)
     return (v.major, v.minor, v.patch) >= (b[1], b[2], b[3])
 end
 
-≳(v::VersionNumber, b::VersionBound) = v ≲ b
-≳(b::VersionBound, v::VersionNumber) = b ≲ v
-
 function isless_ll(a::VersionBound, b::VersionBound)
     m, n = a.n, b.n
     for i = 1:min(m, n)


### PR DESCRIPTION
If I understand correctly, the current definitions of `Pkg.Versions.:≳` are incorrect, right?

Right now, `≳` is defined as such:
- `v ≳ b` if and only if `v ≲ b`
- `b ≳ v` if and only if `b ≲ v`

This PR instead defines `≳` as such:
- `v ≳ b` if and only if `b ≲ v`
- `b ≳ v` if and only if `v ≲ b`