### PR TITLE
Only warn about a manifest being the old format once

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -284,8 +284,9 @@ function write_manifest(env::EnvCache)
 end
 function write_manifest(manifest::Manifest, manifest_file::AbstractString)
     if manifest.manifest_format.major == 1
-        @warn """The active manifest file at `$(manifest_file)` has an old format that is being maintained.
-            To update to the new format run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving.""" maxlog = 1 _id = Symbol(manifest_file)
+        @warn """The active manifest file has an old format that does not record the julia version. The dependencies
+            resolved in this manifest may be incompatible with the current julia version.
+            To update to the new format run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving.""" maxlog = 1 _id = Symbol(manifest_file) _file = manifest_file _line = 0 _module = nothing
     end
     return write_manifest(destructure(manifest), manifest_file)
 end
@@ -313,18 +314,18 @@ function check_warn_manifest_julia_version_compat(manifest::Manifest, manifest_f
     isempty(manifest.deps) && return
     if manifest.manifest_format < v"2"
         @warn """The active manifest file is an older format with no julia version entry. Dependencies may have \
-        been resolved with a different julia version.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+        been resolved with a different julia version.""" maxlog = 1 _id = Symbol(manifest_file) _file = manifest_file _line = 0 _module = nothing
         return
     end
     v = manifest.julia_version
     if v === nothing
         @warn """The active manifest file is missing a julia version entry. Dependencies may have \
-        been resolved with a different julia version.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+        been resolved with a different julia version.""" maxlog = 1 _id = Symbol(manifest_file) _file = manifest_file _line = 0 _module = nothing
         return
     end
     if v.major != VERSION.major && v.minor != VERSION.minor
         ver_str = something(manifest.julia_version, "pre-1.7")
         @warn """The active manifest file has dependencies that were resolved with a different julia \
-        version ($(manifest.julia_version)). Unexpected behavior may occur.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+        version ($(manifest.julia_version)). Unexpected behavior may occur.""" maxlog = 1 _id = Symbol(manifest_file) _file = manifest_file _line = 0 _module = nothing
     end
 end


### PR DESCRIPTION
This uses `maxlog = 1` and assigning all the manifest warnings the same `_id` to ensure the user only gets one warning per manifest file

Note that I'm setting the `_file` of the warning to the manifest file, so that the path at the bottom of the warning indicates the manifest path.
This is what the `@warn`'s in `check_warn_manifest_julia_version_compat` do already. Unfortunately setting `_line = 0` doesn't hide the line suffix.. that would be nice.


I'm activating my 1.6 env here because it's the old format.

Previously this would've warned twice

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0-DEV.123 (2021-07-02)
 _/ |\__'_|_|_|\__'_|  |  Commit 5584620db8 (2 days old master)
|__/                   |

julia> import Pkg

(Pkg) pkg> activate @v1.6
  Activating project at `~/.julia/environments/v1.6`

julia> using CSV
 │ Package CSV not found, but a package named CSV is available from a registry. 
 │ Install package?
 │   (@v1.6) pkg> add CSV 
 └ (y/n) [y]: 
    Updating registry at `~/.julia/registries/General`
    Updating git-repo `https://github.com/JuliaRegistries/General.git`
   Resolving package versions...
┌ Warning: The active manifest file has an old format that does not record the julia version. The dependencies
│ resolved in this manifest may be incompatible with the current julia version.
│ To update to the new format run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving.
└ @ ~/.julia/environments/v1.6/Manifest.toml:0
    Updating `~/.julia/environments/v1.6/Project.toml`
  [336ed68f] + CSV v0.8.5
    Updating `~/.julia/environments/v1.6/Manifest.toml`
  [336ed68f] + CSV v0.8.5
  [9a962f9c] + DataAPI v1.7.0
  [e2d170a0] + DataValueInterfaces v1.0.0
  [e2ba6199] ↑ ExprTools v0.1.3 ⇒ v0.1.4
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [2dfb63ee] + PooledArrays v1.2.1
  [91c51154] + SentinelArrays v1.3.3
  [3783bdb8] + TableTraits v1.0.1
  [bd369af6] + Tables v1.4.4
  [9fa8497b] + Future
  [8dfed614] + Test

julia> 


```
