### PR TITLE
[release-1.6] Add manifest julia_version difference warning

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1325,6 +1325,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Context!(ctx; kwargs...)
     if !isfile(ctx.env.project_file) && isfile(ctx.env.manifest_file)
         _manifest = Pkg.Types.read_manifest(ctx.env.manifest_file)
+        Types.check_warn_manifest_julia_version_compat(_manifest, ctx.env.manifest_file)
         deps = Dict{String,String}()
         for (uuid, pkg) in _manifest
             if pkg.name in keys(deps)
@@ -1345,6 +1346,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     if !isfile(ctx.env.manifest_file) && manifest == true
         pkgerror("expected manifest file at `$(ctx.env.manifest_file)` but it does not exist")
     end
+    Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
     Operations.prune_manifest(ctx)
     for (name, uuid) in ctx.env.project.deps
         get(ctx.env.manifest, uuid, nothing) === nothing || continue

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -326,8 +326,7 @@ function check_warn_manifest_julia_version_compat(manifest::Manifest, manifest_f
         "been resolved with a different julia version.") maxlog = 1 _file = manifest_file _line = 0 _module = nothing
         return
     end
-    if v.major != VERSION.major && v.minor != VERSION.minor
-        ver_str = something(manifest.julia_version, "pre-1.7")
+    if Base.thisminor(v) != Base.thisminor(VERSION)
         @warn string("The active manifest file has dependencies that were resolved with a different julia ",
         "version ($(manifest.julia_version)). Unexpected behavior may occur.") maxlog = 1 _file = manifest_file _line = 0 _module = nothing
     end

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -73,6 +73,14 @@ using  ..Utils
             end
 
         end
+
+        m = Pkg.Types.read_manifest(env_manifest)
+        msg = r"The active manifest file has dependencies that were resolved with a different julia version"
+        @test_logs (:warn, msg) Pkg.Types.check_warn_manifest_julia_version_compat(m, env_manifest)
+
+        m.julia_version = nothing
+        msg = r"The active manifest file is missing a julia version entry"
+        @test_logs (:warn, msg) Pkg.Types.check_warn_manifest_julia_version_compat(m, env_manifest)
     end
 
     @testset "v3.0: unknown format, warn" begin


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/Pkg.jl/issues/2665 I think it would be helpful for 1.6.2 to have something like this. Otherwise the user will get unactionable errors with no warning.

This is a 1.6-appropriate modification of the warning that was omitted in #2620 when backported in #2628