### PR TITLE
Allow control of --bounds-check in Pkg.test

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -403,7 +403,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwa
 end
 
 function test(ctx::Context, pkgs::Vector{PackageSpec};
-              coverage=false, test_fn=nothing,
+              coverage=false, check_bounds=true, test_fn=nothing,
               julia_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
               test_args::Union{Cmd, AbstractVector{<:AbstractString}}=``,
               force_latest_compatible_version::Bool=false,
@@ -427,6 +427,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         ctx,
         pkgs;
         coverage,
+        check_bounds,
         test_fn,
         julia_args,
         test_args,

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1358,6 +1358,7 @@ end
 
 function gen_test_code(testfile::String;
         coverage=false,
+        check_bounds=true,
         julia_args::Cmd=``,
         test_args::Cmd=``)
     code = """
@@ -1371,7 +1372,7 @@ function gen_test_code(testfile::String;
         --code-coverage=$(coverage ? "user" : "none")
         --color=$(Base.have_color === nothing ? "auto" : Base.have_color ? "yes" : "no")
         --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
-        --check-bounds=yes
+        $(check_bounds === nothing ? `` : """--check-bounds=$(check_bounds ? "yes" : "no")""")
         --depwarn=$(Base.JLOptions().depwarn == 2 ? "error" : "yes")
         --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
         --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
@@ -1574,7 +1575,7 @@ end
 testdir(source_path::String) = joinpath(source_path, "test")
 testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 function test(ctx::Context, pkgs::Vector{PackageSpec};
-              coverage=false, julia_args::Cmd=``, test_args::Cmd=``,
+              coverage=false, check_bounds=true, julia_args::Cmd=``, test_args::Cmd=``,
               test_fn=nothing,
               force_latest_compatible_version::Bool=false,
               allow_earlier_backwards_compatible_versions::Bool=true,
@@ -1627,7 +1628,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
             Pkg._auto_precompile(sandbox_ctx)
             printpkgstyle(ctx.io, :Testing, "Running tests...")
             flush(stdout)
-            cmd = gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args)
+            cmd = gen_test_code(testfile(source_path); coverage, check_bounds, julia_args, test_args)
             p = run(ignorestatus(cmd))
             if success(p)
                 printpkgstyle(ctx.io, :Testing, pkg.name * " tests passed ")

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -190,6 +190,7 @@ const update = API.up
 
 **Keyword arguments:**
   - `coverage::Bool=false`: enable or disable generation of coverage statistics.
+  - `check_bounds::Union{Bool, Nothing}=true`: force bounds checking to be on or off, or the julia default auto via `nothing`
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
 
@@ -393,7 +394,7 @@ any packages listed as arguments, the output will be limited to those packages.
 Setting `diff=true` will, if the environment is in a git repository, limit
 the output to the difference as compared to the last git commit.
 
-See [`Pkg.project`](@ref) and [`Pkg.dependencies`](@ref) to get the project/manifest 
+See [`Pkg.project`](@ref) and [`Pkg.dependencies`](@ref) to get the project/manifest
 status as a Julia object instead of printing it.
 
 !!! compat "Julia 1.1"


### PR DESCRIPTION
Forcing bounds checking to be on can severely slow down some test code, so it would be useful to be able to allow bounds checking to be the julia default automatic that observes in-code declarations (set here via `check_bounds = nothing` which omits the `--check-bounds` option entirely).

There may be some use cases where forcing it off entirely may be desired too (`check_bounds = false`), so all three are supported