### PR TITLE
Extend install prompt functionality

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -701,7 +701,8 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             API.activate(temp = true)
             API.add(string.(available_pkgs))
         elseif lower_resp in ["o"]
-            envs = filter(v -> v != "@stdlib", Base.LOAD_PATH)
+            expanded_envs = Base.load_path_expand.(filter(v -> v != "@stdlib", LOAD_PATH))
+            envs = convert(Vector{String}, filter(x -> !isnothing(x), expanded_envs))
             menu = TerminalMenus.RadioMenu(envs, pagesize=length(envs))
             rows_to_clear = called_from_help ? 5 : 1
             for _ in 1:rows_to_clear

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -705,11 +705,14 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         expanded_envs = Base.load_path_expand.(editable_envs)
         envs = convert(Vector{String}, filter(x -> !isnothing(x), expanded_envs))
         option_list = String[]
+        keybindings = Char[]
         for i in 1:length(envs)
-            push!(option_list, "$(pathrepr(envs[i])) ($(editable_envs[i]))")
+            push!(option_list, "$(i): $(pathrepr(envs[i])) ($(editable_envs[i]))")
+            push!(keybindings, only("$i"))
         end
-        push!(option_list, "Activate and install into new temporary environment")
-        menu = TerminalMenus.RadioMenu(option_list, pagesize=length(option_list))
+        push!(option_list, "t: Activate and install into new temporary environment")
+        push!(keybindings, 't')
+        menu = TerminalMenus.RadioMenu(option_list, keybindings=keybindings, pagesize=length(option_list))
         print(ctx.io, "\e[1A\e[1G\e[0J")
         printstyled(ctx.io, " └ "; color=:green)
         choice = try

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -6,6 +6,7 @@ using Markdown, UUIDs, Dates
 
 import REPL
 import REPL: LineEdit, REPLCompletions
+import REPL: TerminalMenus
 
 import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap
 using ..Types, ..Operations, ..API, ..Registry, ..Resolve
@@ -680,7 +681,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             println(ctx.io, line)
         end
         printstyled(ctx.io, " └ "; color=:green)
-        Base.prompt(stdin, ctx.io, "(y/n)", default = "y")
+        Base.prompt(stdin, ctx.io, "(y/n/o/t or ? for details)", default = "y")
     catch err
         if err isa InterruptException # if ^C is entered
             println(ctx.io)
@@ -692,15 +693,72 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         println(ctx.io)
         return false
     end
-    if lowercase(resp) in ["y", "yes"]
-        API.add(string.(available_pkgs))
+    function handle_resp(resp, called_from_help)
+        lower_resp = lowercase(resp)
+        if lower_resp in ["y", "yes"]
+            API.add(string.(available_pkgs))
+        elseif lower_resp in ["t", "temp"]
+            API.activate(temp = true)
+            API.add(string.(available_pkgs))
+        elseif lower_resp in ["o"]
+            envs = filter(v -> v != "@stdlib", Base.LOAD_PATH)
+            menu = TerminalMenus.RadioMenu(envs, pagesize=length(envs))
+            rows_to_clear = called_from_help ? 5 : 1
+            for _ in 1:rows_to_clear
+                print(ctx.io, "\e[1A\e[1G\e[0J")
+            end
+            printstyled(ctx.io, " └ "; color=:green)
+            choice = try
+                TerminalMenus.request("Select an environment from the load path", menu)
+            catch err
+                if err isa InterruptException # if ^C is entered
+                    println(ctx.io)
+                    return false
+                end
+                rethrow()
+            end
+            choice == -1 && return false
+            API.activate(envs[choice]) do
+                API.add(string.(available_pkgs))
+            end
+        elseif !called_from_help && (lower_resp in ["?"])
+            options = ["y: Add package to the current environment",
+                "n: Don't add the package",
+                "o: Select an environment from the load path to add the package to",
+                "t: Activate a new temporary environment and add the package"]
+            menu = TerminalMenus.RadioMenu(options, pagesize=4)
+            print(ctx.io, "\e[1A\e[1G\e[0J")
+            printstyled(ctx.io, " └ "; color=:green)
+            choice = try
+                TerminalMenus.request("Select an option", menu)
+            catch err
+                if err isa InterruptException # if ^C is entered
+                    println(ctx.io)
+                    return false
+                end
+                rethrow()
+            end
+            choice == -1 && return false
+            return ["y", "n", "o", "t"][choice]
+        elseif (lower_resp in ["n"])
+            return false
+        else
+            println(ctx.io, "Selection not recognized")
+            return false
+        end
         if length(available_pkgs) < length(pkgs)
             return false # declare that some pkgs couldn't be installed
         else
             return true
         end
     end
-    return false
+
+    ret = handle_resp(resp, false)
+    if ret isa Bool
+        return ret
+    else
+        return handle_resp(ret, true)
+    end
 end
 
 end #module

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -8,7 +8,7 @@ import REPL
 import REPL: LineEdit, REPLCompletions
 import REPL: TerminalMenus
 
-import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap
+import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap, ..pathrepr
 using ..Types, ..Operations, ..API, ..Registry, ..Resolve
 
 const TEST_MODE = Ref{Bool}(false)
@@ -706,7 +706,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         envs = convert(Vector{String}, filter(x -> !isnothing(x), expanded_envs))
         option_list = String[]
         for i in 1:length(envs)
-            push!(option_list, "`$(envs[i])` ($(editable_envs[i]))")
+            push!(option_list, "$(pathrepr(envs[i])) ($(editable_envs[i]))")
         end
         push!(option_list, "Activate and install into new temporary environment")
         menu = TerminalMenus.RadioMenu(option_list, pagesize=length(option_list))


### PR DESCRIPTION
Adds two options and a help mode, while intending to not take up more room or overload with information.

<img width="615" alt="Screen Shot 2021-07-11 at 10 59 06 PM" src="https://user-images.githubusercontent.com/1694067/125224470-b3d7ba80-e29b-11eb-8841-cf4a973197ff.png">
<img width="631" alt="Screen Shot 2021-07-11 at 10 59 16 PM" src="https://user-images.githubusercontent.com/1694067/125224473-b63a1480-e29b-11eb-83a3-ce0c3e33460f.png">
<img width="613" alt="Screen Shot 2021-07-11 at 10 59 36 PM" src="https://user-images.githubusercontent.com/1694067/125224477-b76b4180-e29b-11eb-9d6b-825b62647ce8.png">

@StefanKarpinski @oxinabox would you mind giving this a go? The experience is a little hard to capture fully in screenshots.

Also, is there a better way to show the `LOAD_PATH` and a function to do the conversion? 
i.e. instead of `["@", "@v#.#"]` show `["/path/to/MyProject", "@v1.8"]`

Note that I dropped `@stdlib` from the options