### PR TITLE
Remove superfluous field url from RegistryInstance.

### DIFF
--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -210,7 +210,6 @@ struct RegistryInstance
     path::String
     name::String
     uuid::UUID
-    url::Union{String, Nothing}
     repo::Union{String, Nothing}
     description::Union{String, Nothing}
     pkgs::Dict{UUID, PkgEntry}
@@ -282,7 +281,6 @@ function RegistryInstance(path::AbstractString)
         path,
         d["name"]::String,
         UUID(d["uuid"]::String),
-        get(d, "url", nothing)::Union{String, Nothing},
         get(d, "repo", nothing)::Union{String, Nothing},
         get(d, "description", nothing)::Union{String, Nothing},
         pkgs,


### PR DESCRIPTION
`RegistryInstance` has a field `url` that is filled in from the corresponding entry in `Registry.toml` if it exists. However, it is unclear what purpose this is supposed to have and it doesn't exist in General, nor in any other registry I've seen.

This PR just removes it. The `repo` field remains, which does exist in General and other registries.
