### PR TITLE
Missing package install prompt: Strip any rogue spaces from user input

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -692,6 +692,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         println(ctx.io)
         return false
     end
+    resp = strip(resp)
     if lowercase(resp) in ["y", "yes"]
         API.add(string.(available_pkgs))
         if length(available_pkgs) < length(pkgs)


### PR DESCRIPTION
Handles if the user adds a space after "y " which would be treated currently as "n"

I kept this separate from #2669 in case that doesn't get resolved before 1.7 goes out