### PR TITLE
Enable switching to the previous environment

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -12,7 +12,7 @@ using Serialization
 
 import ..depots, ..depots1, ..logdir, ..devdir, ..printpkgstyle
 import ..Operations, ..GitTools, ..Pkg, ..Registry
-import ..can_fancyprint, ..pathrepr, ..isurl
+import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH
 using ..Types, ..TOML
 using ..Types: VersionTypes
 using Base.BinaryPlatforms
@@ -1527,9 +1527,11 @@ function status(ctx::Context, pkgs::Vector{PackageSpec}; diff::Bool=false, mode=
 end
 
 
-function activate(;temp=false, shared=false, io::IO=stderr_f())
+function activate(;temp=false, shared=false, prev=false, io::IO=stderr_f())
     shared && pkgerror("Must give a name for a shared environment")
     temp && return activate(mktempdir(); io=io)
+    prev && return activate(PREV_ENV_PATH[]; io=io)
+    PREV_ENV_PATH[] = Base.active_project()
     Base.ACTIVE_PROJECT[] = nothing
     p = Base.active_project()
     p === nothing || printpkgstyle(io, :Activating, "project at $(pathrepr(dirname(p)))")
@@ -1585,6 +1587,7 @@ function activate(path::AbstractString; shared::Bool=false, temp::Bool=false, io
             fullpath = joinpath(Pkg.envdir(Pkg.depots1()), path)
         end
     end
+    PREV_ENV_PATH[] = Base.active_project()
     Base.ACTIVE_PROJECT[] = Base.load_path_expand(fullpath)
     p = Base.active_project()
     if p !== nothing

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -37,6 +37,7 @@ const OFFLINE_MODE = Ref(false)
 const DEFAULT_IO = Ref{Union{IO,Nothing}}(nothing)
 stderr_f() = something(DEFAULT_IO[], stderr)
 stdout_f() = something(DEFAULT_IO[], stdout)
+const PREV_ENV_PATH = Ref{String}("")
 
 can_fancyprint(io::IO) = (io isa Base.TTY) && (get(ENV, "CI", nothing) != "true")
 
@@ -393,7 +394,7 @@ any packages listed as arguments, the output will be limited to those packages.
 Setting `diff=true` will, if the environment is in a git repository, limit
 the output to the difference as compared to the last git commit.
 
-See [`Pkg.project`](@ref) and [`Pkg.dependencies`](@ref) to get the project/manifest 
+See [`Pkg.project`](@ref) and [`Pkg.dependencies`](@ref) to get the project/manifest
 status as a Julia object instead of printing it.
 
 !!! compat "Julia 1.1"
@@ -583,6 +584,7 @@ function __init__()
     end
     push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
     OFFLINE_MODE[] = get(ENV, "JULIA_PKG_OFFLINE", nothing) == "true"
+    PREV_ENV_PATH[] = get_last_used_env_from_usage()
     return nothing
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -584,11 +584,6 @@ function __init__()
     end
     push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
     OFFLINE_MODE[] = get(ENV, "JULIA_PKG_OFFLINE", nothing) == "true"
-    try
-        PREV_ENV_PATH[] = get_last_used_env_from_usage()
-    catch
-        # Silently suppress errors in case the manifest usage file cannot be parsed, given this is init
-    end
     return nothing
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -584,7 +584,11 @@ function __init__()
     end
     push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
     OFFLINE_MODE[] = get(ENV, "JULIA_PKG_OFFLINE", nothing) == "true"
-    PREV_ENV_PATH[] = get_last_used_env_from_usage()
+    try
+        PREV_ENV_PATH[] = get_last_used_env_from_usage()
+    catch
+        # Silently suppress errors in case the manifest usage file cannot be parsed, given this is init
+    end
     return nothing
 end
 

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -195,7 +195,10 @@ function parse_activate(args::Vector{QString}, options)
             return [x.raw]
         end
         x = x.raw
-        if first(x) == '@'
+        if x == "-"
+            options[:prev] = true
+            return []
+        elseif first(x) == '@'
             options[:shared] = true
             return [x[2:end]]
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,18 +99,13 @@ function get_last_used_env_from_usage()
     usage_file = joinpath(logdir(depots1()), "manifest_usage.toml")
     last_used = ""
     last_used_time = typemin(Dates.DateTime)
-    try
-        for (filename, infos) in Types.parse_toml(usage_file), info in infos
-            if haskey(info, "time")
-                if info["time"] > last_used_time
-                    last_used_time = info["time"]
-                    last_used = filename
-                end
+    for (filename, infos) in Types.parse_toml(usage_file), info in infos
+        if haskey(info, "time")
+            if info["time"] > last_used_time
+                last_used_time = info["time"]
+                last_used = filename
             end
         end
-    catch
-        # Given this is run on __init__, silently error if the manifest usage file cannot be parsed
-        return ""
     end
     last_env = dirname(last_used)
     if isdir(last_env)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,23 +94,3 @@ end
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value
 end
-
-function get_last_used_env_from_usage()
-    usage_file = joinpath(logdir(depots1()), "manifest_usage.toml")
-    last_used = ""
-    last_used_time = typemin(Dates.DateTime)
-    for (filename, infos) in Types.parse_toml(usage_file), info in infos
-        if haskey(info, "time")
-            if info["time"] > last_used_time
-                last_used_time = info["time"]
-                last_used = filename
-            end
-        end
-    end
-    last_env = dirname(last_used)
-    if isdir(last_env)
-        return last_env
-    else
-        return ""
-    end
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,3 +94,28 @@ end
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value
 end
+
+function get_last_used_env_from_usage()
+    usage_file = joinpath(logdir(depots1()), "manifest_usage.toml")
+    last_used = ""
+    last_used_time = typemin(Dates.DateTime)
+    try
+        for (filename, infos) in Types.parse_toml(usage_file), info in infos
+            if haskey(info, "time")
+                if info["time"] > last_used_time
+                    last_used_time = info["time"]
+                    last_used = filename
+                end
+            end
+        end
+    catch
+        # Given this is run on __init__, silently error if the manifest usage file cannot be parsed
+        return ""
+    end
+    last_env = dirname(last_used)
+    if isdir(last_env)
+        return last_env
+    else
+        return ""
+    end
+end

--- a/test/new.jl
+++ b/test/new.jl
@@ -325,6 +325,10 @@ end
         api, opts = first(Pkg.pkg"activate --temp")
         @test api == Pkg.activate
         @test opts == Dict(:temp => true)
+        # - activating the previous project
+        api, opts = first(Pkg.pkg"activate -")
+        @test api == Pkg.activate
+        @test opts == Dict(:prev => true)
     end
 end
 
@@ -337,6 +341,23 @@ end
         Pkg.activate(; io=io, temp=true)
         output = String(take!(io))
         @test occursin(r"Activating new project at `.*`", output)
+        prev_env = Base.active_project()
+
+        # - activating the previous project
+        Pkg.activate(; temp=true)
+        @test prev_env != Base.active_project()
+        Pkg.activate(; prev=true)
+        @test prev_env == Base.active_project()
+
+        Pkg.activate(; temp=true)
+        @test prev_env != Base.active_project()
+        Pkg.activate(; prev=true)
+        @test prev_env == Base.active_project()
+
+        Pkg.activate("")
+        @test prev_env != Base.active_project()
+        Pkg.activate(; prev=true)
+        @test prev_env == Base.active_project()
     end
 end
 


### PR DESCRIPTION
Adds `pkg> activate -` and `Pkg.activate(prev=true)` to switch to the previously active environment. Matches `cd -` and `git checkout -` behavior.

There was a suggestion to instead do this with a blank `pkg> activate` but for me at least that's muscle memory for getting to the `@x.x` env.

```julia
(Pkg) pkg> activate --temp
  Activating new project at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_d8KZ5n`

(jl_d8KZ5n) pkg> activate -
  Activating project at `~/Documents/GitHub/Pkg.jl`

(Pkg) pkg> activate -
  Activating new project at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_d8KZ5n`

(jl_d8KZ5n) pkg> activate
  Activating project at `~/.julia/environments/v1.8`

(@v1.8) pkg> activate -
  Activating new project at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_d8KZ5n`

(jl_d8KZ5n) pkg> activate -
  Activating project at `~/.julia/environments/v1.8`

(@v1.8) pkg> activate .
  Activating project at `~/Documents/GitHub/Pkg.jl`

(Pkg) pkg> activate -
  Activating project at `~/.julia/environments/v1.8`

(@v1.8) pkg> activate -
  Activating project at `~/Documents/GitHub/Pkg.jl`

(Pkg) pkg>
```

Note that the previously used environment is looked up from the manifest usage file on startup, which is quick for my 6KB usage file. 
And this should be quick generally given the usage file is now minimized with https://github.com/JuliaLang/Pkg.jl/pull/2661
```julia
julia> @btime Pkg.get_last_used_env_from_usage()
  85.058 μs (910 allocations: 55.55 KiB)
"/Users/ian/Documents/GitHub/Pkg.jl"
```

Will add tests if this goes forward