### PR TITLE
Mention other contibutors in LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The Pkg.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2017-2021: Kristoffer Carlsson, Stefan Karpinski, and other contributors:
+> Copyright (c) 2017-2021: Stefan Karpinski, and  contributors:
 > https://github.com/JuliaLang/Pkg.jl/graphs/contributors
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 The Pkg.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2017: Stefan Karpinski.
+> Copyright (c) 2017-2021: Kristoffer Carlsson, Stefan Karpinski, and other contributors:
+> https://github.com/JuliaLang/Pkg.jl/graphs/contributors
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Other places in our stdlibs give a few contributors then a list.
It seemed odd that this mentioned only @StefanKarpinski .
Contrast [Statistics.jl](https://github.com/JuliaLang/Statistics.jl/blob/master/LICENSE.md)

> Copyright (c) 2012-2016: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, Dahua Lin, Simon Byrne, Andreas Noack, Douglas Bates, John Myles White, Simon Kornblith, and other contributors.

and

[Julia itself](https://github.com/JuliaLang/julia/blob/master/LICENSE.md):

> Copyright (c) 2009-2021: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors: https://github.com/JuliaLang/julia/contributors


Could go and list a whole bunch of names.
But  @KristofferC  and  @StefanKarpinski   are by a nontrivial margin the largest contributors, on all metrics.
After that it is a bit more mixed depending what metric.

Could also just say `Copyright Pkg.jl contributors` I guess?