### PR TITLE
remove extra license for PlatformEngines.jl, add some more names

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,32 +1,7 @@
 The Pkg.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2017-2021: Stefan Karpinski, and  contributors:
+> Copyright (c) 2017-2021: Stefan Karpinski, Kristoffer Carlsson, Fredrik Ekre, David Varela, Ian Butterworth, and contributors:
 > https://github.com/JuliaLang/Pkg.jl/graphs/contributors
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
->
-
-The file PlatformEngines.jl is under the following license:
-
-The BinaryProvider.jl package is licensed under the MIT "Expat" License:
-
-> Copyright (c) 2017: SimonDanisch.
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I looked through PlatformEngines.jl and there is basically nothing left from the original code there.

Also, since having your name in the LICENSE is apparently a cool thing, let's add some more. 