### PR TITLE
Fix list formatting in PackageSpec documentation

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -469,7 +469,7 @@ This includes:
   * The `name` of the package.
   * The package's unique `uuid`.
   * A `version` (for example when adding a package). When upgrading, can also be an instance of
-   the enum [`UpgradeLevel`](@ref).
+    the enum [`UpgradeLevel`](@ref).
   * A `url` and an optional git `rev`ision. `rev` can be a branch name or a git commit SHA1.
   * A local `path`. This is equivalent to using the `url` argument but can be more descriptive.
   * A `subdir` which can be used when adding a package that is not in the root of a repository.


### PR DESCRIPTION
Fix of formatting error in [PackageSpec](https://pkgdocs.julialang.org/dev/api/#Pkg.PackageSpec) docstring breaking the list layout