### PR TITLE
only attempt to use Pkg server for package downloads if the server tracks a registry containing that package

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -20,9 +20,9 @@ const REGISTRY_DIR = joinpath(REGISTRY_DEPOT, "registries", "General")
 const GENERAL_UUID = UUID("23338594-aafe-5451-b93e-139f81909106")
 
 function init_reg()
-    url, _ = Pkg.Registry.pkg_server_registry_url(GENERAL_UUID, nothing)
     mkpath(REGISTRY_DIR)
     if Pkg.Registry.registry_use_pkg_server()
+        url = Pkg.Registry.pkg_server_registry_urls()[GENERAL_UUID]
         @info "Downloading General registry from $url"
         Pkg.PlatformEngines.download_verify_unpack(url, nothing, REGISTRY_DIR, ignore_existence = true, io = stderr)
         tree_info_file = joinpath(REGISTRY_DIR, ".tree_info.toml")


### PR DESCRIPTION
Prevents "leaking" private UUIDs and git tree SHAs to the package server.

This should also be done for artifacts but can be done in a follow up PR.