### PR TITLE
remove artifact docstrings from manual that does not exist

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -74,14 +74,10 @@ Pkg.Registry.status
 Pkg.Artifacts.create_artifact
 Pkg.Artifacts.remove_artifact
 Pkg.Artifacts.verify_artifact
-Pkg.Artifacts.artifact_meta
-Pkg.Artifacts.artifact_hash
 Pkg.Artifacts.bind_artifact!
 Pkg.Artifacts.unbind_artifact!
 Pkg.Artifacts.download_artifact
-Pkg.Artifacts.find_artifacts_toml
 Pkg.Artifacts.ensure_artifact_installed
 Pkg.Artifacts.ensure_all_artifacts_installed
-Pkg.Artifacts.@artifact_str
 Pkg.Artifacts.archive_artifact
 ```


### PR DESCRIPTION
See https://pkgdocs.julialang.org/dev/api/#Artifacts-Reference

![bild](https://user-images.githubusercontent.com/1282691/128849328-574cff25-8950-43b6-9699-b26316cada11.png)
