### PR TITLE
ensure stdlibs do not take dependencies from the registry

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -410,10 +410,11 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
                 stdlib_name, stdlib_version = stdlibs_for_julia_version[uuid]
             end
 
-            # If we're requesting resolution of a package that is an unregistered stdlib (or one
-            # that tracks no version information) we must special-case it here.  This is further
-            # complicated by the fact that we can ask this question relative to a Julia version.
-            if is_unregistered_stdlib(uuid) || (uuid_is_stdlib && stdlib_version === nothing)
+            # If we're requesting resolution of a package that is an
+            # unregistered stdlib we must special-case it here.  This is further
+            # complicated by the fact that we can ask this question relative to
+            # a Julia version.
+            if is_unregistered_stdlib(uuid) || uuid_is_stdlib
                 path = Types.stdlib_path(stdlibs_for_julia_version[uuid][1])
                 proj_file = projectfile_path(path; strict=true)
                 @assert proj_file !== nothing

--- a/test/new.jl
+++ b/test/new.jl
@@ -2767,6 +2767,13 @@ end
         @test linalg_block["uuid"] == linalg_uuid
         @test !haskey(linalg_block, "version")
     end
+
+    isolate(loaded_depot=true) do
+        # Next, test that stdlibs do not get dependencies from the registry
+        Pkg.add("p7zip_jll")
+        p7zip_jll_uuid = UUID("3f19e933-33d8-53b3-aaab-bd5110c3b7a0")
+        @test !("Pkg" in keys(Pkg.dependencies()[p7zip_jll_uuid].dependencies))
+    end
 end
 
 end #module

--- a/test/new.jl
+++ b/test/new.jl
@@ -2770,6 +2770,10 @@ end
 
     isolate(loaded_depot=true) do
         # Next, test that stdlibs do not get dependencies from the registry
+        # NOTE: this test depends on the fact that in Julia v1.6+ we added
+        # "fake" JLLs that do not depend on Pkg while the "normal" p7zip_jll does.
+        # A future p7zip_jll in the registry may not depend on Pkg, so be sure
+        # to verify your assumptions when updating this test.
         Pkg.add("p7zip_jll")
         p7zip_jll_uuid = UUID("3f19e933-33d8-53b3-aaab-bd5110c3b7a0")
         @test !("Pkg" in keys(Pkg.dependencies()[p7zip_jll_uuid].dependencies))


### PR DESCRIPTION
Since stdlibs are versioned now, the presence of a version cannot be used to determine if one wants to treat an stdlib as a normal package.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/2698