### PR TITLE
Some missed compat -> outdated replaces from #2284

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1875,7 +1875,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
         end
 
         latest_version = true
-        # Compat info
+        # Outdated info
         cinfo = nothing
         if outdated
             if diff == false && !is_stdlib(new.uuid)
@@ -1886,7 +1886,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
                 end
             end
         end
-        # if we are running with compat, only show packages that are upper bounded
+        # if we are running with outdated, only show packages that are upper bounded
         if outdated && latest_version
             continue
         end

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -365,7 +365,7 @@ includes the recursive dependencies of added packages given in the manifest.
 If there are any packages listed as arguments the output will be limited to those packages.
 The `--diff` option will, if the environment is in a git repository, limit
 the output to the difference as compared to the last git commit.
-The `--compat` option in addition show if some packages are not at their latest version
+The `--outdated` option in addition show if some packages are not at their latest version
 and what packages are holding them back.
 
 !!! compat "Julia 1.1"
@@ -375,7 +375,7 @@ and what packages are holding them back.
     The `--diff` option requires at least Julia 1.3. In earlier versions `--diff`
     is the default for environments in git repositories.
 
-!!! compat "Julia 1.8" 
+!!! compat "Julia 1.8"
     The `--outdated` option requires at least Julia 1.8.
 """,
 ],

--- a/test/new.jl
+++ b/test/new.jl
@@ -2162,7 +2162,7 @@ end
         Pkg.status("FooBar"; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
         @test occursin(r"No Matches in diff for `.+Manifest.toml`", readline(io))
     end
-    # Compat API
+    # Outdated API
     isolate(loaded_depot=true) do
         Pkg.Registry.add(Pkg.RegistrySpec[], io=devnull) # load reg before io capturing
         Pkg.add("Example"; io=devnull)


### PR DESCRIPTION
This is mainly just one docstring fix that was missed in the switch in #2284, 
but also some comment changes given that "compat" may be used to mean another thing in the status API shortly