### PR TITLE
Docs: add comment for what `.` in `activate .` means

### DIFF
--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -14,7 +14,7 @@ julia> mkdir("MyProject")
 julia> cd("MyProject")
 /Users/kristoffer/MyProject
 
-(v1.0) pkg> activate .
+(v1.0) pkg> activate . # "." means the current directory
 
 (MyProject) pkg> st
     Status `Project.toml`

--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -11,10 +11,10 @@ In order to create a new project, create a directory for it and then activate th
 ```julia-repl
 julia> mkdir("MyProject")
 
-julia> cd("MyProject")
+julia> cd("MyProject") # we can now use "." instead of a longer relative or full path
 /Users/kristoffer/MyProject
 
-(v1.0) pkg> activate . # "." means the current directory
+(v1.0) pkg> activate .
 
 (MyProject) pkg> st
     Status `Project.toml`

--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -11,9 +11,10 @@ In order to create a new project, create a directory for it and then activate th
 ```julia-repl
 julia> mkdir("MyProject")
 
-julia> cd("MyProject") # we can now use "." instead of a longer relative or full path
+julia> cd("MyProject")
 /Users/kristoffer/MyProject
 
+# we can now use "." instead of a longer relative or full path:
 (v1.0) pkg> activate .
 
 (MyProject) pkg> st


### PR DESCRIPTION
This came up recently on discourse. Though the dot is reasonably visible, it may be skimmed over or disregarded if there's no mention of why it is important.