### PR TITLE
WIP: allow dev in offline mode

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -662,6 +662,8 @@ function download_source(ctx::Context; readonly=true)
         push!(pkgs_to_install, (;pkg, urls, path))
     end
 
+    OFFLINE_MODE[] && return Set{UUID}(entry.pkg.uuid for entry in pkgs_to_install)
+
     ########################################
     # Install from archives asynchronously #
     ########################################


### PR DESCRIPTION
A recent storm and internet outage helped me discover that `Pkg.offline` is still limited in its coverage. This PR is essentially a conversation-starter (I haven't even tested whether this works). To discover holes in the coverage and guard against future regressions, it seems that the best way to do this would be to have a fairly extensive set of tests that run in internet-disconnected mode. Is there a reasonable way to do this? Pulling out the ethernet and shutting down the laptop wifi do not seem very CI-friendly :-). This is not an area of expertise for me.