### PR TITLE
add offline mode to API docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -41,6 +41,7 @@ Pkg.resolve
 Pkg.gc
 Pkg.status
 Pkg.precompile
+Pkg.offline
 Pkg.setprotocol!
 Pkg.dependencies
 Pkg.project


### PR DESCRIPTION
If a feature is not in the docs, does it even exist?