### PR TITLE
Improve error message for already dev'ed package that doesn't have a Project.toml

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -783,7 +783,7 @@ end
 function resolve_projectfile!(env::EnvCache, pkg, project_path)
     project_file = projectfile_path(project_path; strict=true)
     project_file === nothing && pkgerror(string("could not find project file in package at `",
-                                                pkg.repo.source !== nothing ? pkg.repo.source : (pkg.path)), "` maybe `subdir` needs to be specified")
+                    something(pkg.repo.source, pkg.path, project_path), "` maybe `subdir` needs to be specified"))
     project_data = read_package(project_file)
     if pkg.uuid === nothing || pkg.uuid == project_data.uuid
         pkg.uuid = project_data.uuid


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/1956

```
(@v1.8) pkg> dev LightGraphs
ERROR: could not find project file in package at `/Users/ian/.julia/dev/LightGraphs` maybe `subdir` needs to be specified
```

cc. @Keno