### PR TITLE
release-1.6: Revert "Make `write_env_usage` atomic (#2661)"

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -436,50 +436,15 @@ function write_env_usage(source_file::AbstractString, usage_filepath::AbstractSt
     # Ensure that log dir exists
     !ispath(logdir()) && mkpath(logdir())
 
+    # Generate entire entry as a string first
+    entry = sprint() do io
+        TOML.print(io, Dict(source_file => [Dict("time" => now())]))
+    end
+
+    # Append entry to log file in one chunk
     usage_file = joinpath(logdir(), usage_filepath)
-    timestamp = now()
-
-    ## Atomically write usage file
-    while true
-        # read existing usage file
-        usage = if isfile(usage_file)
-            TOML.parsefile(usage_file)
-        else
-            Dict{String, Any}()
-        end
-
-        # record new usage
-        usage[source_file] = [Dict("time" => timestamp)]
-
-        # keep only latest usage info
-        for k in keys(usage)
-            times = map(d -> Dates.DateTime(d["time"]), usage[k])
-            usage[k] = [Dict("time" => maximum(times))]
-        end
-
-        # Write to a temp file in the same directory as the destination
-        temp_usage_file = tempname(logdir())
-        open(temp_usage_file, "w") do io
-            TOML.print(io, usage, sorted=true)
-        end
-
-        # Move the temp file into place, replacing the original
-        mv(temp_usage_file, usage_file, force = true)
-
-        # Check that the new file has what we want in it
-        new_usage = if isfile(usage_file)
-            TOML.parsefile(usage_file)
-        else
-            Dict{String, Any}()
-        end
-        if haskey(new_usage, source_file)
-            for e in new_usage[source_file]
-                if Dates.DateTime(e["time"]) >= timestamp
-                    return
-                end
-            end
-        end
-        # If not, try again
+    open(usage_file, append=true) do io
+        write(io, entry)
     end
 end
 


### PR DESCRIPTION
This reverts commit 9f74abef301fabc7fbcf73afcf166b87a9e23703.

While this was supposed to increase the reliability of multiple Pkg instances running at the same time, it made the situation worse (https://github.com/JuliaLang/julia/pull/42253#issuecomment-920346866). Since the release is imminent, I will revert this and it can be improved on master.

cc @Sacha0 