### PR TITLE
generate: use joinpath instead of /

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -59,7 +59,7 @@ function project(io::IO, pkg::AbstractString, dir::AbstractString)
 end
 
 function entrypoint(io::IO, pkg::AbstractString, dir)
-    genfile(io, dir, "src/$pkg.jl") do file_io
+    genfile(io, joinpath(dir, "src"), "$pkg.jl") do file_io
         print(file_io,
            """
             module $pkg


### PR DESCRIPTION
A nit, but the mixed slashes here don't look so pretty:

```
(jl_Nd3gOk) pkg> generate MyPackage
  Generating  project MyPackage:
    MyPackage\Project.toml
    MyPackage\src/MyPackage.jl
```

I checked and the `genfile` function defined higher in the same file doesn't care whether this dir is in the second or third argument.
