### PR TITLE
Don't warn about loaded modules during pre-test precomp, given new process will be used for tests

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1015,7 +1015,7 @@ function make_pkgspec(man, uuid)
 end
 
 precompile(; kwargs...) = precompile(Context(); kwargs...)
-function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false, kwargs...)
+function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false, warn_loaded = true, kwargs...)
     Context!(ctx; kwargs...)
     instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
@@ -1156,7 +1156,7 @@ function precompile(ctx::Context; internal_call::Bool=false, strict::Bool=false,
                         bar.max = n_total - n_already_precomp
                         final_loop || print(iostr, sprint(io -> show_progress(io, bar); context=io), "\n")
                         for dep in pkg_queue_show
-                            loaded = haskey(Base.loaded_modules, dep)
+                            loaded = warn_loaded && haskey(Base.loaded_modules, dep)
                             name = dep in direct_deps ? dep.name : string(color_string(dep.name, :light_black))
                             if dep in precomperr_deps
                                 print(iostr, color_string("  ? ", Base.warn_color()), name, "\n")

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1644,7 +1644,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         sandbox(ctx, pkg, source_path, testdir(source_path), test_project_override; force_latest_compatible_version, allow_earlier_backwards_compatible_versions, allow_reresolve) do
             test_fn !== nothing && test_fn()
             sandbox_ctx = Context(;io=ctx.io)
-            status(sandbox_ctx.env, sandbox_ctx.registries; mode=PKGMODE_COMBINED, io=sandbox_ctx.io)
+            status(sandbox_ctx.env, sandbox_ctx.registries; mode=PKGMODE_COMBINED, io=sandbox_ctx.io, ignore_indent = false)
             Pkg._auto_precompile(sandbox_ctx, warn_loaded = false)
             printpkgstyle(ctx.io, :Testing, "Running tests...")
             flush(stdout)
@@ -1907,7 +1907,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
 
     for pkg in package_statuses
         latest_version = pkg.compat_data === nothing
-        print(io, pkg.downloaded ? (all_packages_downloaded ? "" : " ") : not_installed_indicator)
+        print(io, pkg.downloaded ? " " : not_installed_indicator)
         printstyled(io, " [", string(pkg.uuid)[1:8], "] "; color = :light_black)
         diff ? print_diff(io, pkg.old, pkg.new) : print_single(io, pkg.new)
         if outdated && !diff && pkg.compat_data !== nothing

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1645,7 +1645,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
             test_fn !== nothing && test_fn()
             sandbox_ctx = Context(;io=ctx.io)
             status(sandbox_ctx.env, sandbox_ctx.registries; mode=PKGMODE_COMBINED, io=sandbox_ctx.io)
-            Pkg._auto_precompile(sandbox_ctx)
+            Pkg._auto_precompile(sandbox_ctx, warn_loaded = false)
             printpkgstyle(ctx.io, :Testing, "Running tests...")
             flush(stdout)
             cmd = gen_test_code(testfile(source_path); coverage=coverage, julia_args=julia_args, test_args=test_args)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -685,9 +685,9 @@ end
 # Precompilation #
 ##################
 
-function _auto_precompile(ctx::Types.Context)
+function _auto_precompile(ctx::Types.Context; warn_loaded = true)
     if Base.JLOptions().use_compiled_modules == 1 && tryparse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
-        Pkg.precompile(ctx; internal_call=true)
+        Pkg.precompile(ctx; internal_call=true, warn_loaded = warn_loaded)
     end
 end
 


### PR DESCRIPTION
Issue from @fredrikekre. When running `Pkg.test`, if the module being tested is loaded, but modified, the test process will warn with `1 dependency precompiled but a different version is currently loaded. Restart julia to access the new version` even though `test` is about to run the package in a new process and use the new version, which is a bit confusing.

```
$ cd $(mktemp -d) && pkg generate A && mkdir A/test && touch A/test/runtests.jl && julia --project=A -e 'using A; touch("A/src/A.jl"); using Pkg; Pkg.test("A")'
  Generating  project A:
    A/Project.toml
    A/src/A.jl
    Updating registry at `~/.julia/registries/General`
    Updating registry at `~/.julia/registries/Staging`
    Updating git-repo `https://github.com/fredrikekre/Staging.git`
  No Changes to `/private/var/folders/3c/t9m24k9j2h302_t_l0__gmpr0000gn/T/tmp.ILrhiARO/A/Project.toml`
  No Changes to `/private/var/folders/3c/t9m24k9j2h302_t_l0__gmpr0000gn/T/tmp.ILrhiARO/A/Manifest.toml`
     Testing A
      Status `/private/var/folders/3c/t9m24k9j2h302_t_l0__gmpr0000gn/T/jl_vmZdDW/Project.toml`
  [07d15813] A v0.1.0 `/private/var/folders/3c/t9m24k9j2h302_t_l0__gmpr0000gn/T/tmp.ILrhiARO/A`
      Status `/private/var/folders/3c/t9m24k9j2h302_t_l0__gmpr0000gn/T/jl_vmZdDW/Manifest.toml`
  [07d15813] A v0.1.0 `/private/var/folders/3c/t9m24k9j2h302_t_l0__gmpr0000gn/T/tmp.ILrhiARO/A`
Precompiling project...
  ✓ A
  1 dependency successfully precompiled in 3 seconds
  1 dependency precompiled but a different version is currently loaded. Restart julia to access the new version
     Testing Running tests...
     Testing A tests passed
```

This is happening because the precompilation during `Pkg.test` is happening in the current process, not the spawned child process.
I had thought it was in the child process because it's inside the `sandbox` do block, but that's obviously wrong.
https://github.com/JuliaLang/Pkg.jl/blob/b79518775a82c9eb3353b5dc2e9d855fe155b120/src/Operations.jl#L1644-L1653
I don't think it can be moved to the child process as `Pkg` isn't available via `import Pkg` in there, and  it might affect testing if a forceful `require` approach was used?

Also, I tidied some indenting:

Before
```
(@v1.8) pkg> test GitHub
     Testing GitHub
Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_pIPOWP/Project.toml`
 [bc5e4493] GitHub v5.7.0
 [cd3eb016] HTTP v0.9.14
 [682c06a0] JSON v0.21.2
 [739be429] MbedTLS v1.0.3
 [2133526b] SodiumSeal v0.1.1
 [2a0f44e3] Base64 `@stdlib/Base64`
 [ade2ca70] Dates `@stdlib/Dates`
 [6462fe0b] Sockets `@stdlib/Sockets`
 [8dfed614] Test `@stdlib/Test`
Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_pIPOWP/Manifest.toml`
 [bc5e4493] GitHub v5.7.0
 [cd3eb016] HTTP v0.9.14
 [83e8ac13] IniFile v0.5.0
 [692b3bcd] JLLWrappers v1.3.0
 [682c06a0] JSON v0.21.2
 [739be429] MbedTLS v1.0.3
 [69de0a69] Parsers v2.0.3
```

After
```
(@v1.8) pkg> test GitHub
     Testing GitHub
      Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_VRiinj/Project.toml`
  [bc5e4493] GitHub v5.7.0
  [cd3eb016] HTTP v0.9.14
  [682c06a0] JSON v0.21.2
  [739be429] MbedTLS v1.0.3
  [2133526b] SodiumSeal v0.1.1
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [6462fe0b] Sockets `@stdlib/Sockets`
  [8dfed614] Test `@stdlib/Test`
      Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_VRiinj/Manifest.toml`
  [bc5e4493] GitHub v5.7.0
  [cd3eb016] HTTP v0.9.14
  [83e8ac13] IniFile v0.5.0
  [692b3bcd] JLLWrappers v1.3.0
  [682c06a0] JSON v0.21.2
  [739be429] MbedTLS v1.0.3
  [69de0a69] Parsers v2.0.3
```

