### PR TITLE
Allow watchers for the active project

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -58,6 +58,20 @@ const TOML_LOCK = ReentrantLock()
 parse_toml(toml_file::AbstractString) =
     Base.invokelatest(deepcopy_toml, Base.parsed_toml(toml_file, TOML_CACHE, TOML_LOCK))::Dict{String, Any}
 
+## Watchers for when the active project changes (e.g., Revise)
+# Each should be a thunk, i.e., `f()`. To determine the current active project,
+# the thunk can query `Base.active_project()`.
+const active_project_watcher_thunks = []
+function notify_active_project_watchers()
+    for f in active_project_watcher_thunks
+        try
+            Base.invokelatest(f)
+        catch
+        end
+    end
+    return nothing
+end
+
 #################
 # Pkg Error #
 #################

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -302,7 +302,10 @@ function write_manifest(io::IO, raw_manifest::Dict)
 end
 function write_manifest(raw_manifest::Dict, manifest_file::AbstractString)
     str = sprint(write_manifest, raw_manifest)
-    write(manifest_file, str)
+    ispreexisting = isfile(manifest_file)
+    ret = write(manifest_file, str)
+    !ispreexisting && notify_active_project_watchers()
+    return ret
 end
 
 ############

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -7,3 +7,12 @@ using Pkg
     f() = Pkg.Types.UNREGISTERED_STDLIBS
     @inferred f()
 end
+
+@testset "watchers" begin
+    val = Ref(false)
+    push!(Pkg.Types.active_project_watcher_thunks, () -> val[] = true)
+    push!(Pkg.Types.active_project_watcher_thunks, () -> error("broken"))
+    Pkg.Types.notify_active_project_watchers()
+    @test val[]
+    for _ = 1:2 pop!(Pkg.Types.active_project_watcher_thunks) end  # clean up
+end


### PR DESCRIPTION
This allows packages (with Revise as the intended target) to register
themselves as watchers for when the active project changes.
This will make it possible to effectively switch which manifest files
are analyzed for changes to the running source.