### PR TITLE
Fix resolver's bug #2740

### DIFF
--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -425,7 +425,6 @@ function enforce_optimality!(sol::Vector{Int}, graph::Graph)
     bk_upperbound = similar(upperbound)
 
     # auxiliary sets to perform breadth-first search on the graph
-    seen = Set{Int}()
     staged = Set{Int}()
     staged_next = Set{Int}()
 
@@ -479,7 +478,6 @@ function enforce_optimality!(sol::Vector{Int}, graph::Graph)
             # if needed by another package
             try_uninstall || (lowerbound[p0] = new_s0) # note that we're in the move_up case
 
-            empty!(seen)
             empty!(staged)
             empty!(staged_next)
             push!(staged, p0)
@@ -487,12 +485,11 @@ function enforce_optimality!(sol::Vector{Int}, graph::Graph)
             while !isempty(staged)
                 for f0 in staged
                     for (j1,f1) in enumerate(gadj[f0])
-                        f1 == p0 && continue
-                        f1 ∈ seen && continue
                         s1 = sol[f1]
                         msk = gmsk[f0][j1]
-                        if try_uninstall
-                            bump_range = [s1] # when uninstalling, no further changes are allowed
+                        if f1 == p0 || try_uninstall
+                            # when uninstalling or looking at p0, no further changes are allowed
+                            bump_range = [s1]
                         else
                             lb1 = lowerbound[f1]
                             ub1 = upperbound[f1]
@@ -524,7 +521,6 @@ function enforce_optimality!(sol::Vector{Int}, graph::Graph)
                         end
                     end
                 end
-                union!(seen, staged)
                 staged, staged_next = staged_next, staged
                 empty!(staged_next)
             end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -396,11 +396,41 @@ end
     ]
     want_data = Dict("A"=>v"1", "B"=>v"2", "C"=>v"2", "D"=>v"2", "E"=>v"2")
     @test resolve_tst(deps_data, reqs_data, want_data)
+
+
+
+    VERBOSE && @info("SCHEME 11")
+    ## DEPENDENCY SCHEME 11: FOUR PACKAGES, WITH AN INCONSISTENCY
+    ## ref Pkg.jl issue #2740
+    deps_data = Any[
+        ["A", v"1", "C", "1"],
+        ["A", v"2", "C", "2"],
+        ["A", v"2", "D", "1"],
+        ["B", v"1", "D", "1"],
+        ["B", v"2", "D", "2"],
+        ["C", v"1", "D", "1"],
+        ["C", v"1", "B", "1"],
+        ["C", v"2", "D", "2"],
+        ["C", v"2", "B", "2"],
+        ["D", v"1"],
+        ["D", v"2"],
+    ]
+
+    @test sanity_tst(deps_data, [("A", v"2")])
+
+    # require A & B, any version (must use the highest non-inconsistent)
+    reqs_data = Any[
+        ["A", "*"],
+        ["B", "*"],
+    ]
+    want_data = Dict("A"=>v"1", "B"=>v"1", "C"=>v"1", "D"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
 end
 
 @testset "realistic" begin
     VERBOSE && @info("SCHEME REALISTIC")
-    ## DEPENDENCY SCHEME 11: A REALISTIC EXAMPLE
+    ## DEPENDENCY SCHEME 12: A REALISTIC EXAMPLE
     ## ref Julia issue #21485
 
     include("resolvedata1.jl")
@@ -408,7 +438,7 @@ end
     @test sanity_tst(ResolveData.deps_data, ResolveData.problematic_data)
     @test resolve_tst(ResolveData.deps_data, ResolveData.reqs_data, ResolveData.want_data)
 
-    ## DEPENDENCY SCHEME 12: A LARGER, MORE DIFFICULT REALISTIC EXAMPLE
+    ## DEPENDENCY SCHEME 13: A LARGER, MORE DIFFICULT REALISTIC EXAMPLE
     ## ref Pkg.jl issue #1949
 
     include("resolvedata2.jl")


### PR DESCRIPTION
According to my tests this fixes #2740.
It was an issue with an assumption made in the local optimizer, I managed to reduce the problem to an easy test case (which is now included in the tests).

For the record, the problem went like this: say we try to bump package A, say from v1 to v2. Package A depends on B and D. The bump to A requires to bump package B, while D must be left alone. In turn, however, the bump to B now requires bumping D too, which would make it incompatible with A. But the previous code did not check back on the dependency between A and D because it erroneously considered it to have been checked already. The new code keeps looking around the graph until no further changes are done (or an inconsistency is found, like in this example).