### PR TITLE
Precompilation: Fix recognizing when new versions of already loaded packages are already precompiled

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1000,7 +1000,7 @@ end
 
 function _is_stale(paths::Vector{String}, sourcepath::String)
     for path_to_try in paths
-        staledeps = Base.stale_cachefile(sourcepath, path_to_try)
+        staledeps = Base.stale_cachefile(sourcepath, path_to_try, ignore_loaded = true)
         staledeps === true ? continue : return false
     end
     return true


### PR DESCRIPTION
## Issue
A MWE should be easy for this issue that @kleinschmidt posted on slack
```
add Makie
   Resolving package versions...
    Updating `~/stuff/Project.toml`
  [ee78f7c6] + Makie v0.15.2
  No Changes to `~/stuff/Manifest.toml`
Precompiling project...
```
i.e. The specific Makie version was already in the Manifest where no changes were needed, however precompilation still did work.
I've also seen this in the wild.

## Fix
I believe this PR should be the fix, but I've not tested it yet

This disables the `Base.stale_cachefile` loaded module shortcut during stale cache checks
Depends on https://github.com/IanButterworth/julia/tree/ib/stale_cachefile_ignore_loaded

Basically `Base.stale_cachefile` was shortcutting the stale check if the package was loaded already because there used to be no reason to do anything else, so once users see those yellow check marks, they keep seeing them any time `Pkg.precompile` is called, until restarting the session.