### PR TITLE
Improve precompilation for Pkg

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -774,6 +774,7 @@ const precompile_script = """
     Pkg.add(Pkg.PackageSpec(path="TestPkg.jl/"))
     Pkg.REPLMode.try_prompt_pkg_add(Symbol[:notapackage])
     Pkg.update()
+    Pkg.precompile()
     ] add Te\t\t$CTRL_C
     ] st
     $CTRL_C


### PR DESCRIPTION
First call:

Before PR:

```
julia> @time Pkg.Registry.RegistryInstance("/Users/kristoffercarlsson/.julia/registries/General.toml")
  0.556092 seconds (1.47 M allocations: 94.536 MiB, 6.15% gc time, 4.97% compilation time)
```

After PR:

```
julia> @time Pkg.Registry.RegistryInstance("/Users/kristoffercarlsson/.julia/registries/General.toml")
  0.341857 seconds (1.18 M allocations: 78.710 MiB, 6.37% gc time, 0.06% compilation time)
```