### PR TITLE
fix missing passing along `allow_autoprecom` in an instance

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1438,7 +1438,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
             deps[pkg.name] = string(uuid)
         end
         Types.write_project(Dict("deps" => deps), ctx.env.project_file)
-        return instantiate(Context(); manifest=manifest, update_registry=update_registry, allow_autoprecomp=allow_autoprecomp, verbose=verbose, kwargs...)
+        return instantiate(Context(); manifest=manifest, update_registry=update_registry, allow_autoprecomp=allow_autoprecomp, verbose=verbose, platform=platform, kwargs...)
     end
     if (!isfile(ctx.env.manifest_file) && manifest === nothing) || manifest == false
         # given no manifest exists, only allow invoking a registry update if there are project deps


### PR DESCRIPTION
The current way of `instantiate` calling precompile and `precompile` calling instantiate is kind of brittle. This prevents two auto precompiles from running on a `Pkg.up