### PR TITLE
Add missing Pkg.compat to docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,6 +40,7 @@ Pkg.instantiate
 Pkg.resolve
 Pkg.gc
 Pkg.status
+Pkg.compat
 Pkg.precompile
 Pkg.offline
 Pkg.setprotocol!


### PR DESCRIPTION
Adds `Pkg.compat` to the docs which was missed off in https://github.com/JuliaLang/Pkg.jl/pull/2702