### PR TITLE
Pkg requests: set Julia-Registry-Preference header based on JULIA_PKG_REGISTRY_PREFERENCE

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -232,8 +232,8 @@ function get_metadata_headers(url::AbstractString)
     end
     push!(headers, "Julia-CI-Variables" => join(ci_info, ';'))
     push!(headers, "Julia-Interactive" => string(isinteractive()))
-    registry_pref = get(ENV, "JULIA_PKG_REGISTRY_PREFERENCE", nothing)
-    if registry_pref !== nothing
+    registry_pref = get(ENV, "JULIA_PKG_REGISTRY_PREFERENCE", "")
+    if !isempty(strip(registry_pref))
         push!(headers, "Julia-Registry-Preference" => registry_pref)
     end
     return headers


### PR DESCRIPTION
Refs https://github.com/JuliaRegistries/General/issues/16777
Alternative to https://github.com/JuliaLang/Pkg.jl/pull/2766

This passes whatever value the environment variable `JULIA_PKG_REGISTRY_PREFERENCE` has through as a header. That's a bit unconstrained, but that means that if at some point a server supports other options here, we don't need to change the client.

@staticfloat is working on the pkg server side, which will ignore any value besides `complete` and `incomplete`, the former of which will cause `/registries` to redirect to `/registries.complete` and the latter of which will cause to redirect to `/registries.incomplete`, and those end-points will respectively respond with tree hashes for versions of the registry that are either already complete (pkg server has processed all the packages and artifacts) or incomplete (they haven't yet been processed). In the future, we could add more options without needing any client-side changes.

If this is used to talk to a server that doesn't understand this header, it will simply get ignored and the server will serve whatever registry versions is knows how to serve. If the variable isn't set at all, then the header doesn't get sent and the server chooses whatever registry version it prefers. That also means that we can change whether complete or incomplete is the default with purely server-side changes without modifying clients at all.