### PR TITLE
Set headers in Pkg server requests from JULIA_PKG_SERVER_*

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -233,7 +233,7 @@ function get_metadata_headers(url::AbstractString)
     push!(headers, "Julia-CI-Variables" => join(ci_info, ';'))
     push!(headers, "Julia-Interactive" => string(isinteractive()))
     for (key, val) in ENV
-        m = match(r"^JULIA_PKG_HEADER_([A-Z0-9_]+)$"i, key)
+        m = match(r"^JULIA_PKG_SERVER_([A-Z0-9_]+)$"i, key)
         m === nothing && continue
         val = strip(val)
         isempty(val) && continue


### PR DESCRIPTION
Yet another alternative to #2767 and #2766.

This looks for environment variables with names that start with `JULIA_PKG_HEADER_` and uses the rest of the variable name and its value to populate HTTP headers sent along with requests to Pkg servers, prefixing each header with `Julia-`. For example, if the environment variable `JULIA_PKG_HEADER_REGISTRY_PREFERENCE` is set to `complete` then each Pkg server request will include the header

     Julia-Registry-Preference: complete

Details:

- header is not set if the value of the variable is all whitespace
- header name is determined by splitting on underscores and titlecasing each word, then joining words with dashes; `Julia-` is prefix
- if a header name is already set, it is not set again; this prevents using this mechanism to change standard header values and means that if multiple environment variables set the same header (e.g. multiple or  trailing underscores), then only the first one is sent
