### PR TITLE
Add link to General’s FAQ

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -285,7 +285,7 @@ may fit your package better.
 
 ## Registering packages
 
-Once a package is ready it can be registered with the [General Registry](https://github.com/JuliaRegistries/General).
+Once a package is ready it can be registered with the [General Registry](https://github.com/JuliaRegistries/General#registering-a-package-in-general) (see also the [FAQ](https://github.com/JuliaRegistries/General#faq)).
 Currently packages are submitted via [`Registrator`](https://juliaregistrator.github.io/).
 In addition to `Registrator`, [`TagBot`](https://github.com/marketplace/actions/julia-tagbot) helps manage the process of tagging releases.
 


### PR DESCRIPTION
And adjust link to point to the readme. Hopefully this will make it more discoverable (without adding much verbosity here). Thanks to @jlchan for the suggestion on Slack.