### PR TITLE
Add a CI job that checks if the list of historical stdlibs needs to be updated

### DIFF
--- a/.ci/check_hsg.jl
+++ b/.ci/check_hsg.jl
@@ -1,0 +1,49 @@
+function check_hsg()
+    assert_clean_working_directory()
+    run_hsg()
+    assert_clean_working_directory()
+    return nothing
+end
+
+function assert_clean_working_directory()
+    if !isempty(strip(read(`git status --short`, String)))
+        msg = "The working directory is dirty"
+        @error msg
+
+        println("Output of `git status`:")
+        println(strip(read(`git status`, String)))
+
+        run(`git add -A`)
+
+        println("Output of `git diff HEAD`:")
+        println(strip(read(`git diff HEAD`, String)))
+
+        run(`git reset`)
+
+        throw(ErrorException(msg))
+    else
+        @info "The working directory is clean"
+        return nothing
+    end
+end
+
+function run_hsg()
+    env2 = copy(ENV)
+    delete!(env2, "JULIA_DEPOT_PATH")
+    delete!(env2, "JULIA_LOAD_PATH")
+    delete!(env2, "JULIA_PROJECT")
+    env2["JULIA_DEPOT_PATH"] = mktempdir(; cleanup = true)
+    julia_binary = Base.julia_cmd().exec[1]
+    hsg_directory = joinpath("ext", "HistoricaStdlibGenerator")
+    hsg_generate_file = joinpath(hsg_directory, "generate_historical_stdlibs.jl")
+
+    cmd_1 = `$(julia_binary) --project=$(hsg_directory) -e 'import Pkg; Pkg.instantiate()'`
+    cmd_2 = `$(julia_binary) --project=$(hsg_directory) $(hsg_generate_file)`
+
+    run(setenv(cmd_1, env2))
+    run(setenv(cmd_2, env2))
+
+    return nothing
+end
+
+check_hsg()

--- a/.github/workflows/check_hsg.yml
+++ b/.github/workflows/check_hsg.yml
@@ -1,0 +1,24 @@
+name: Check Historical Stdlib Generator
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  check_hsg:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: julia-actions/setup-julia@latest
+        with:
+          # version: '1'
+          version: 'nightly'
+      - run: julia --color=yes .ci/check_hsg.jl


### PR DESCRIPTION
This pull request add a new CI job that does the following steps:

1. Checks that the working directory is clean.
2. Instantiates the project at `ext/HistoricaStdlibGenerator`.
3. Runs the `ext/HistoricaStdlibGenerator/generate_historical_stdlibs.jl` script.
4. Checks that the working directory is still clean. If the working directory is dirty, we do the following:
    - Print the output of `git status`.
    - Print the output of `git diff HEAD`.
    - Throw an exception, thus causing the CI job to fail.