### PR TITLE
CI: automatically cancel old PR builds when a new commit is pushed to the PR branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ on:
 defaults:
   run:
     shell: bash
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This will result in more efficient usage of our CI resources.