### PR TITLE
Pkg test suite: do not try to write to or modify the directory containing the Pkg source code

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,11 +21,6 @@ Pkg.DEFAULT_IO[] = IOBuffer()
 
 include("utils.jl")
 
-# Clean slate. Make sure to not start with an outdated registry
-rm(joinpath(@__DIR__, "registries"); force = true, recursive = true)
-rm(Utils.LOADED_DEPOT; force = true, recursive = true)
-rm(Utils.REGISTRY_DEPOT; force = true, recursive = true)
-
 include("new.jl")
 include("pkg.jl")
 include("repl.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -12,6 +12,8 @@ export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
        git_init_package, add_this_pkg, TEST_SIG, TEST_PKG, isolate, LOADED_DEPOT,
        list_tarball_files
 
+const CACHE_DIRECTORY = mktempdir(; cleanup = true)
+
 const LOADED_DEPOT = joinpath(@__DIR__, "loaded_depot")
 
 const REGISTRY_DEPOT = joinpath(@__DIR__, "registry_depot")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -14,9 +14,9 @@ export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
 
 const CACHE_DIRECTORY = mktempdir(; cleanup = true)
 
-const LOADED_DEPOT = joinpath(@__DIR__, "loaded_depot")
+const LOADED_DEPOT = joinpath(CACHE_DIRECTORY, "loaded_depot")
 
-const REGISTRY_DEPOT = joinpath(@__DIR__, "registry_depot")
+const REGISTRY_DEPOT = joinpath(CACHE_DIRECTORY, "registry_depot")
 const REGISTRY_DIR = joinpath(REGISTRY_DEPOT, "registries", "General")
 
 const GENERAL_UUID = UUID("23338594-aafe-5451-b93e-139f81909106")


### PR DESCRIPTION
In certain situations (e.g. when we download the Julia binaries at the beginning of the Buildkite `tester_*` jobs), the `stdlib/Pkg` directory may be read-only. So instead of trying to write to the `stdlib/Pkg/test` directory, let's just use a temp directory instead.