### PR TITLE
If `Base.DEPOT_PATH` is empty, `Pkg.PlatformEngines.get_server_dir` should return `nothing` (instead of erroring)

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -54,6 +54,7 @@ function get_server_dir(
         @warn "malformed Pkg server value" server
         return
     end
+    isempty(Base.DEPOT_PATH) && return
     joinpath(depots1(), "servers", String(m.captures[1]))
 end
 


### PR DESCRIPTION
Fixes #2807