### PR TITLE
Point to help when command isn't recognized

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -283,8 +283,8 @@ end
 
 parse(input::String) =
     map(Base.Iterators.filter(!isempty, tokenize(input))) do words
-        statement, _ = core_parse(words)
-        statement.spec === nothing && pkgerror("Could not determine command. Type ? for help with available commands")
+        statement, input_word = core_parse(words)
+        statement.spec === nothing && pkgerror("`$input_word` is not a valid command. Type ? for help with available commands")
         statement.options = map(parse_option, statement.options)
         statement
     end

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -284,7 +284,7 @@ end
 parse(input::String) =
     map(Base.Iterators.filter(!isempty, tokenize(input))) do words
         statement, input_word = core_parse(words)
-        statement.spec === nothing && pkgerror("`$input_word` is not a valid command. Type ? for help with available commands")
+        statement.spec === nothing && pkgerror("`$input_word` is not a recognized command. Type ? for help with available commands")
         statement.options = map(parse_option, statement.options)
         statement
     end

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -633,6 +633,8 @@ function gen_help()
 **Welcome to the Pkg REPL-mode**. To return to the `julia>` prompt, either press
 backspace when the input line is empty or press Ctrl+C.
 
+Full documentation available at https://pkgdocs.julialang.org/
+
 **Synopsis**
 
     pkg> cmd [opts] [args]

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -284,7 +284,7 @@ end
 parse(input::String) =
     map(Base.Iterators.filter(!isempty, tokenize(input))) do words
         statement, _ = core_parse(words)
-        statement.spec === nothing && pkgerror("Could not determine command")
+        statement.spec === nothing && pkgerror("Could not determine command. Type ? for help with available commands")
         statement.options = map(parse_option, statement.options)
         statement
     end


### PR DESCRIPTION
Might help guide lost newcomers to the help docs.


```
(v1.8) pkg> version Foo
ERROR: Could not determine command. Type ? for help with available commands

```

For reference, this is what help shows

```
(v1.8) pkg> ?
  Welcome to the Pkg REPL-mode. To return to the julia> prompt, either press backspace when the input line
  is empty or press Ctrl+C.

  Synopsis

  pkg> cmd [opts] [args]

  Multiple commands can be given on the same line by interleaving a ; between the commands. Some commands
  have an alias, indicated below.

  Commands

  activate: set the primary environment the package manager manipulates

  add: add packages to project

  build: run the build script for packages

  compat: edit compat entries in the current Project

  develop, dev: clone the full package repo locally for development

  free: undoes a pin, develop, or stops tracking a repo

  gc: garbage collect packages not used for a significant time

  generate: generate files for a new project

  help, ?: show this message

  instantiate: downloads all the dependencies for the project

  pin: pins the version of packages

  precompile: precompile all the project dependencies

  redo: redo the latest change to the active project

  remove, rm: remove packages from project or manifest

  resolve: resolves to update the manifest from changes in dependencies of developed packages

  status, st: summarize contents of and changes to environment

  test: run tests for packages

  undo: undo the latest change to the active project

  update, up: update packages in manifest

  registry add: add package registries

  registry remove, rm: remove package registries

  registry status, st: information about installed registries

  registry update, up: update package registries
```