### PR TITLE
[CI] For now, disable the "Check Historical Stdlib Generator" CI check

### DIFF
--- a/.github/workflows/check_hsg.yml
+++ b/.github/workflows/check_hsg.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   check_hsg:
+    if: false # This line disables this CI check. TODO: delete this line.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
This job keeps timing out. It's not particularly helpful to have a CI job that always times out.

We can re-enable this job once we fix the timeouts.