### PR TITLE
Add project hash to manifest metadata and warn when manifest and project are out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Pkg v1.8 Release Notes
   i.e. `pkg> compat Fo<TAB>` autocompletes to `pkg> Foo 0.4,0.5` so that the existing entry can be edited.
 - Pkg now only tries to download packages from the package server in case the
   server tracks a registry that contains the package.
+- `Pkg.instantiate` will now warn when a Project.toml is out of sync with a Manifest.toml. It does this by storing a hash
+  of the project in the manifest when it is resolved, so that any change to the Project.toml without a re-resolve, such
+  as changing a compat bound or adding a dep, can be detected.
 
 Pkg v1.7 Release Notes
 ======================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Pkg v1.8 Release Notes
 - Pkg now only tries to download packages from the package server in case the
   server tracks a registry that contains the package.
 - `Pkg.instantiate` will now warn when a Project.toml is out of sync with a Manifest.toml. It does this by storing a hash
-  of the project in the manifest when it is resolved, so that any change to the Project.toml without a re-resolve, such
-  as changing a compat bound or adding a dep, can be detected.
+  of the project deps and compat entries (other fields are ignored) in the manifest when it is resolved, so that any change
+  to the Project.toml deps or compat entries without a re-resolve can be detected.
 
 Pkg v1.7 Release Notes
 ======================

--- a/src/API.jl
+++ b/src/API.jl
@@ -439,16 +439,17 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
     return
 end
 
-function is_manifest_current(ctx::Context = Context())
-    if haskey(ctx.env.manifest.other, "project_hash")
-        recorded_hash = ctx.env.manifest.other["project_hash"]
-        current_hash = Types.project_resolve_hash(ctx.env.project)
+function is_manifest_current(env::EnvCache)
+    if haskey(env.manifest.other, "project_hash")
+        recorded_hash = env.manifest.other["project_hash"]
+        current_hash = Types.project_resolve_hash(env.project)
         return recorded_hash == current_hash
     else
         # Manifest doesn't have a hash of the source Project recorded
         return nothing
     end
 end
+is_manifest_current(ctx::Context = Context()) = is_manifest_current(ctx.env)
 
 const UsageDict = Dict{String,DateTime}
 const UsageByDepotDict = Dict{String,UsageDict}
@@ -1505,9 +1506,10 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     end
     Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
 
-    if is_manifest_current(ctx) === false
-        @warn """The project hash recorded into the manifest when it was resolved does not match the hash of the current project.
-            A project dependency has been added/removed or compat entry has changed. The environment may need to be updated"""
+    if is_manifest_current(ctx.env) === false
+        @warn """The project and manifest may be out of sync. \
+        The project hash recorded into the manifest when it was resolved does not match the hash of the current project. \
+        A project dependency has been added/removed or compat entry has changed. The environment may need to be updated"""
     end
 
     Operations.prune_manifest(ctx.env)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1497,9 +1497,9 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
 
     if Operations.is_manifest_current(ctx.env) === false
-        @warn """The project and manifest may be out of sync.
-            A project dependency has been added/removed or compat entry has changed since the manifest was last resolved.
-            The environment may need to be updated. Try `Pkg.resolve()` or `Pkg.update()`."""
+        @warn """The project and manifest may be out of sync as either project dependencies have been \
+        added/removed or compat entries have changed since the manifest was last resolved.
+        Try `Pkg.resolve()` or consider `Pkg.update()` if necessary."""
     end
 
     Operations.prune_manifest(ctx.env)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1042,10 +1042,10 @@ precompile(pkg::String; kwargs...) = precompile(Context(), pkg; kwargs...)
 precompile(ctx::Context, pkg::String; kwargs...) = precompile(ctx, [pkg]; kwargs...)
 precompile(pkgs::Vector{String}=String[]; kwargs...) = precompile(Context(), pkgs; kwargs...)
 function precompile(ctx::Context, pkgs::Vector{String}=String[]; internal_call::Bool=false,
-                    strict::Bool=false, warn_loaded = true, kwargs...)
+                    strict::Bool=false, warn_loaded = true, already_instantiated = false, kwargs...)
     Context!(ctx; kwargs...)
     internal_call || resolve(ctx, silent_no_change = true)
-    instantiate(ctx; allow_autoprecomp=false, kwargs...)
+    already_instantiated || instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
 
     # Windows sometimes hits a ReadOnlyMemoryError, so we halve the default number of tasks. Issue #2323
@@ -1520,7 +1520,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     end
     # check if all source code and artifacts are downloaded to exit early
     if Operations.is_instantiated(ctx.env)
-        allow_autoprecomp && Pkg._auto_precompile(ctx)
+        allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
         return
     end
 
@@ -1577,7 +1577,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Run build scripts
     allow_build && Operations.build_versions(ctx, union(new_apply, new_git); verbose=verbose)
 
-    allow_autoprecomp && Pkg._auto_precompile(ctx)
+    allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
 end
 
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -1497,9 +1497,9 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
 
     if Operations.is_manifest_current(ctx.env) === false
-        @warn """The project and manifest may be out of sync. \
-        The project hash recorded into the manifest when it was resolved does not match the hash of the current project. \
-        A project dependency has been added/removed or compat entry has changed. The environment may need to be updated"""
+        @warn """The project and manifest may be out of sync.
+            A project dependency has been added/removed or compat entry has changed since the manifest was last resolved.
+            The environment may need to be updated. Try `Pkg.resolve()` or `Pkg.update()`."""
     end
 
     Operations.prune_manifest(ctx.env)

--- a/src/API.jl
+++ b/src/API.jl
@@ -439,17 +439,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
     return
 end
 
-function is_manifest_current(env::EnvCache)
-    if haskey(env.manifest.other, "project_hash")
-        recorded_hash = env.manifest.other["project_hash"]
-        current_hash = Types.project_resolve_hash(env.project)
-        return recorded_hash == current_hash
-    else
-        # Manifest doesn't have a hash of the source Project recorded
-        return nothing
-    end
-end
-is_manifest_current(ctx::Context = Context()) = is_manifest_current(ctx.env)
+is_manifest_current(ctx::Context = Context()) = Operations.is_manifest_current(ctx.env)
 
 const UsageDict = Dict{String,DateTime}
 const UsageByDepotDict = Dict{String,UsageDict}
@@ -1506,7 +1496,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     end
     Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
 
-    if is_manifest_current(ctx.env) === false
+    if Operations.is_manifest_current(ctx.env) === false
         @warn """The project and manifest may be out of sync. \
         The project hash recorded into the manifest when it was resolved does not match the hash of the current project. \
         A project dependency has been added/removed or compat entry has changed. The environment may need to be updated"""

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -142,6 +142,7 @@ function update_manifest!(env::EnvCache, pkgs::Vector{PackageSpec}, deps_map, ju
         env.manifest[pkg.uuid] = entry
     end
     prune_manifest(env)
+    record_project_hash(env)
 end
 
 
@@ -801,6 +802,9 @@ function prune_manifest(manifest::Manifest, keep::Vector{UUID})
     return manifest
 end
 
+function record_project_hash(env::EnvCache)
+    env.manifest.other["project_hash"] = Types.project_resolve_hash(env.project)
+end
 
 #########
 # Build #
@@ -1058,6 +1062,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
     end
     # only keep reachable manifest entires
     prune_manifest(ctx.env)
+    record_project_hash(ctx.env)
     # update project & manifest
     write_env(ctx.env)
     show_update(ctx.env, ctx.registries; io=ctx.io)
@@ -1432,6 +1437,7 @@ function sandbox_preserve(env::EnvCache, target::PackageSpec, test_project::Stri
     # preserve important nodes
     keep = [target.uuid]
     append!(keep, collect(values(read_project(test_project).deps)))
+    record_project_hash(env)
     # prune and return
     return prune_manifest(env.manifest, keep)
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2001,8 +2001,8 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
     end
     if is_manifest_current(env) === false
         printpkgstyle(io, :Warning, """The project and manifest may be out of sync. \
-        The project hash recorded into the manifest when it was resolved does not match the hash of the current project. \
-        A project dependency has been added/removed or compat entry has changed. The environment may need to be updated""", ignore_indent; color=Base.warn_color())
+        A project dependency has been added/removed or compat entry has changed since the manifest was last resolved. \
+        The environment may need to be updated. Try `Pkg.resolve()` or `Pkg.update()`.""", ignore_indent; color=Base.warn_color())
     end
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2000,9 +2000,9 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
         print_status(env, old_env, registries, header, filter_uuids, filter_names; diff, ignore_indent, io, outdated, silent_no_change)
     end
     if is_manifest_current(env) === false
-        printpkgstyle(io, :Warning, """The project and manifest may be out of sync. \
-        A project dependency has been added/removed or compat entry has changed since the manifest was last resolved. \
-        The environment may need to be updated. Try `Pkg.resolve()` or `Pkg.update()`.""", ignore_indent; color=Base.warn_color())
+        printpkgstyle(io, :Warning, """The project and manifest may be out of sync as either project dependencies have been \
+        added/removed or compat entries have changed since the manifest was last resolved. \
+        Try `Pkg.resolve()` or consider `Pkg.update()` if necessary.""", ignore_indent; color=Base.warn_color())
     end
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -14,7 +14,7 @@ import ..Artifacts: ensure_artifact_installed, artifact_names, extract_all_hashe
                     artifact_exists, select_downloadable_artifacts
 using Base.BinaryPlatforms
 import ...Pkg
-import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE, UPDATED_REGISTRY_THIS_SESSION
+import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE, UPDATED_REGISTRY_THIS_SESSION, is_manifest_current
 
 #########
 # Utils #
@@ -1998,6 +1998,11 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
     end
     if mode == PKGMODE_MANIFEST || mode == PKGMODE_COMBINED
         print_status(env, old_env, registries, header, filter_uuids, filter_names; diff, ignore_indent, io, outdated, silent_no_change)
+    end
+    if is_manifest_current(env) === false
+        printpkgstyle(io, :Warning, """The project and manifest may be out of sync. \
+        The project hash recorded into the manifest when it was resolved does not match the hash of the current project. \
+        A project dependency has been added/removed or compat entry has changed. The environment may need to be updated""", ignore_indent; color=Base.warn_color())
     end
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -14,7 +14,7 @@ import ..Artifacts: ensure_artifact_installed, artifact_names, extract_all_hashe
                     artifact_exists, select_downloadable_artifacts
 using Base.BinaryPlatforms
 import ...Pkg
-import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE, UPDATED_REGISTRY_THIS_SESSION, is_manifest_current
+import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE, UPDATED_REGISTRY_THIS_SESSION
 
 #########
 # Utils #
@@ -2003,6 +2003,17 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
         printpkgstyle(io, :Warning, """The project and manifest may be out of sync. \
         The project hash recorded into the manifest when it was resolved does not match the hash of the current project. \
         A project dependency has been added/removed or compat entry has changed. The environment may need to be updated""", ignore_indent; color=Base.warn_color())
+    end
+end
+
+function is_manifest_current(env::EnvCache)
+    if haskey(env.manifest.other, "project_hash")
+        recorded_hash = env.manifest.other["project_hash"]
+        current_hash = Types.project_resolve_hash(env.project)
+        return recorded_hash == current_hash
+    else
+        # Manifest doesn't have a hash of the source Project recorded
+        return nothing
     end
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -702,9 +702,9 @@ end
 # Precompilation #
 ##################
 
-function _auto_precompile(ctx::Types.Context; warn_loaded = true)
+function _auto_precompile(ctx::Types.Context; warn_loaded = true, already_instantiated = false)
     if Base.JLOptions().use_compiled_modules == 1 && tryparse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
-        Pkg.precompile(ctx; internal_call=true, warn_loaded = warn_loaded)
+        Pkg.precompile(ctx; internal_call=true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
     end
 end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -612,6 +612,16 @@ Upgrades the format of the manifest file from v1.0 to v2.0 without re-resolving.
 """
 const upgrade_manifest = API.upgrade_manifest
 
+"""
+    is_manifest_current(ctx::Context = Context())
+
+Returns whether the active manifest was resolved from the active project state.
+For instance, if the project had compat entries changed, but the manifest wasn't re-resolved, this would return false.
+
+If the manifest doesn't have the project hash recorded, `nothing` is returned.
+"""
+const is_manifest_current = API.is_manifest_current
+
 function __init__()
     if isdefined(Base, :active_repl)
         REPLMode.repl_init(Base.active_repl)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -219,6 +219,7 @@ Base.@kwdef mutable struct Compat
     val::VersionSpec
     str::String
 end
+Base.hash(t::Compat, h::UInt) = foldr(hash, [t.val, t.str], init=h)
 
 Base.@kwdef mutable struct Project
     other::Dict{String,Any} = Dict{String,Any}()
@@ -235,6 +236,9 @@ Base.@kwdef mutable struct Project
 end
 Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Project))
 Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
+
+# only hash the deps and compat fields as they are the only fields that affect a resolve
+project_resolve_hash(t::Project, h::UInt = UInt(0)) = string(foldr(hash, [t.deps, t.compat], init=h))
 
 
 Base.@kwdef mutable struct PackageEntry

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -237,10 +237,10 @@ Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2,
 Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
 
 # only hash the deps and compat fields as they are the only fields that affect a resolve
-function project_resolve_hash(t::Project, h::UInt = UInt(0))
+function project_resolve_hash(t::Project)
     iob = IOBuffer()
-    foreach(((name, uuid),) -> println(io, name, "=", uuid), sort!(collect(t.deps); by=first))
-    foreach(((name, compat),) -> println(name, "=", compat.val), sort!(collect(t.compat); by=first))
+    foreach(((name, uuid),) -> println(iob, name, "=", uuid), sort!(collect(t.deps); by=first))
+    foreach(((name, compat),) -> println(iob, name, "=", compat.val), sort!(collect(t.compat); by=first))
     return bytes2hex(sha1(seekstart(iob)))
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -219,7 +219,6 @@ Base.@kwdef mutable struct Compat
     val::VersionSpec
     str::String
 end
-Base.hash(t::Compat, h::UInt) = foldr(hash, [t.val, t.str], init=h)
 
 Base.@kwdef mutable struct Project
     other::Dict{String,Any} = Dict{String,Any}()
@@ -240,8 +239,8 @@ Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames
 # only hash the deps and compat fields as they are the only fields that affect a resolve
 function project_resolve_hash(t::Project, h::UInt = UInt(0))
     iob = IOBuffer()
-    println(iob, t.deps)
-    println(iob, t.compat)
+    foreach(((name, uuid),) -> println(io, name, "=", uuid), sort!(collect(t.deps); by=first))
+    foreach(((name, compat),) -> println(name, "=", compat.val), sort!(collect(t.compat); by=first))
     return bytes2hex(sha1(seekstart(iob)))
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -238,8 +238,12 @@ Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2,
 Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init=h)
 
 # only hash the deps and compat fields as they are the only fields that affect a resolve
-project_resolve_hash(t::Project, h::UInt = UInt(0)) = string(foldr(hash, [t.deps, t.compat], init=h))
-
+function project_resolve_hash(t::Project, h::UInt = UInt(0))
+    iob = IOBuffer()
+    println(iob, t.deps)
+    println(iob, t.compat)
+    return bytes2hex(sha1(seekstart(iob)))
+end
 
 Base.@kwdef mutable struct PackageEntry
     name::Union{String,Nothing} = nothing

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -148,6 +148,36 @@ end
                 end
             end
         end
+        @testset "project_hash for identifying out of sync manifest" begin
+            isolate(loaded_depot=true) do
+                iob = IOBuffer()
+
+                Pkg.activate(; temp=true)
+                Pkg.add("Example")
+                @test Pkg.is_manifest_current() === true
+
+                Pkg.compat("Example", "0.4")
+                @test Pkg.is_manifest_current() === false
+                Pkg.status(io = iob)
+                @test occursin("The project and manifest may be out of sync", String(take!(iob)))
+                @test_logs (:warn, r"The project and manifest may be out of sync") Pkg.instantiate()
+
+                Pkg.update()
+                @test Pkg.is_manifest_current() === true
+                Pkg.status(io = iob)
+                @test !occursin("The project and manifest may be out of sync", String(take!(iob)))
+
+                Pkg.compat("Example", "0.5")
+                Pkg.status(io = iob)
+                @test occursin("The project and manifest may be out of sync", String(take!(iob)))
+                @test_logs (:warn, r"The project and manifest may be out of sync") Pkg.instantiate()
+
+                Pkg.rm("Example")
+                @test Pkg.is_manifest_current() === true
+                Pkg.status(io = iob)
+                @test !occursin("The project and manifest may be out of sync", String(take!(iob)))
+            end
+        end
     end
 end
 


### PR DESCRIPTION
One of the reasons I was a fan of adding extensible metadata to the manifest was to be able to save a hash of the project state in the manifest, to make it easy to identify when the manifest and project are out of sync. i.e. a project dep entry has been manually added/removed in the toml file, or a compat entry added/changed/removed

Note that the project hash used here only hashes the deps and compat fields of the project, the rest shouldn't affect a resolve, so should be free to change.

One thing this would allow is CI to easily check whether checked-in manifests are valid, as it's easy to forget to update them.
Currently Pkg.instantiate doesn't check compat bounds and just does what the manifest says. This adds a warning.

Todo:

- [x] Add tests

```
julia> import Pkg
[ Info: Precompiling Pkg [44cfe95a-1eb2-52ea-b672-e2afdf69b79f]

(Pkg) pkg> activate --temp
  Activating new project at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW`

(jl_2QJmtW) pkg> add CSV
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW/Project.toml`
  [336ed68f] + CSV v0.9.10
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW/Manifest.toml`
  [336ed68f] + CSV v0.9.10
...

(jl_2QJmtW) pkg> compat CSV 0.8
      Compat entry set:
  CSV = "0.8"

(jl_2QJmtW) pkg> instantiate
┌ Warning: The project hash recorded into the manifest when it was resolved does not match the hash of the current project.
│ A project dependency has been added/removed or compat entry has changed. The environment may need to be updated
└ @ Pkg.API ~/Documents/GitHub/Pkg.jl/src/API.jl:1509

(jl_2QJmtW) pkg> up
    Updating registry at `~/.julia/registries/General.toml`
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW/Project.toml`
  [336ed68f] ↓ CSV v0.9.10 ⇒ v0.8.5
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW/Manifest.toml`
  [336ed68f] ↓ CSV v0.9.10 ⇒ v0.8.5
  [944b1d66] - CodecZlib v0.7.0
  [48062228] - FilePathsBase v0.9.13
  [842dd82b] - InlineStrings v1.0.1
  [69de0a69] ↓ Parsers v2.1.1 ⇒ v1.1.2
  [3bb67fe8] - TranscodingStreams v0.9.6
  [ea10d353] - WeakRefStrings v1.4.1
  [cf7118a7] - UUIDs
  [83775a58] - Zlib_jll v1.2.12+1

(jl_2QJmtW) pkg> instantiate

(jl_2QJmtW) pkg> compat CSV 0.9
      Compat entry set:
  CSV = "0.9"

(jl_2QJmtW) pkg> instantiate
┌ Warning: The project hash recorded into the manifest when it was resolved does not match the hash of the current project.
│ A project dependency has been added/removed or compat entry has changed. The environment may need to be updated
└ @ Pkg.API ~/Documents/GitHub/Pkg.jl/src/API.jl:1509

(jl_2QJmtW) pkg> rm CSV
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW/Project.toml`
  [336ed68f] - CSV v0.8.5
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_2QJmtW/Manifest.toml`
  [336ed68f] - CSV v0.8.5
...

(jl_2QJmtW) pkg> instantiate

julia> Pkg.is_manifest_current()
true

(jl_2QJmtW) pkg> add CSV
...

(jl_2QJmtW) pkg> compat CSV 0.8
      Compat entry set:
  CSV = "0.8"

julia> Pkg.is_manifest_current()
false

(jl_2QJmtW) pkg> instantiate
┌ Warning: The project hash recorded into the manifest when it was resolved does not match the hash of the current project.
│ A project dependency has been added/removed or compat entry has changed. The environment may need to be updated
└ @ Pkg.API ~/Documents/GitHub/Pkg.jl/src/API.jl:1509

```
