### PR TITLE
Pkg test suite: in the `TestArguments` test package, relax the assertion that `Base.JLOptions().depwarn` is `1`

### DIFF
--- a/test/test_packages/TestArguments/test/runtests.jl
+++ b/test/test_packages/TestArguments/test/runtests.jl
@@ -1,4 +1,4 @@
 @assert ARGS == ["a", "b"]
 @assert Base.JLOptions().quiet == 1 # --quiet
 @assert Base.JLOptions().check_bounds == 2 # overriden default when testing
-@assert Base.JLOptions().depwarn == 1 # Default to depwarn on
+@assert (Base.JLOptions().depwarn == 1) || (Base.JLOptions().depwarn == 2)


### PR DESCRIPTION
Fixes #2817