### PR TITLE
[CI] Actually use the correct arch when downloading Julia, and update one of the tests to use Permutations v0.4.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
       - name: Fix TEMP on windows
         if: matrix.os == 'windows-latest'
         run: |

--- a/test/new.jl
+++ b/test/new.jl
@@ -286,6 +286,7 @@ end
     isolate(loaded_depot=true) do
         Pkg.add(name="Permutations", version="0.3.2")
         if Sys.WORD_SIZE == 32
+            # The Permutations.jl v0.3.2 tests are known to fail on 32-bit Julia
             @test_skip Pkg.test("Permutations")
         else
             Pkg.test("Permutations")

--- a/test/new.jl
+++ b/test/new.jl
@@ -284,7 +284,7 @@ end
 
 @testset "test: fallback when no project file exists" begin
     isolate(loaded_depot=true) do
-        Pkg.add(name="Permutations", version="0.4.9")
+        Pkg.add(name="Permutations", version="0.3.2")
         Pkg.test("Permutations")
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -285,7 +285,11 @@ end
 @testset "test: fallback when no project file exists" begin
     isolate(loaded_depot=true) do
         Pkg.add(name="Permutations", version="0.3.2")
-        Pkg.test("Permutations")
+        if Sys.WORD_SIZE == 32
+            @test_skip Pkg.test("Permutations")
+        else
+            Pkg.test("Permutations")
+        end 
     end
 end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -284,7 +284,7 @@ end
 
 @testset "test: fallback when no project file exists" begin
     isolate(loaded_depot=true) do
-        Pkg.add(name="Permutations", version="0.3.2")
+        Pkg.add(name="Permutations", version="0.4.9")
         Pkg.test("Permutations")
     end
 end


### PR DESCRIPTION
Currently, our "32-bit" CI jobs are not actually using 32-bit builds of Julia.