### PR TITLE
[CI] Re-enable the "Check Historical Stdlib" CI check

### DIFF
--- a/.github/workflows/check_hsg.yml
+++ b/.github/workflows/check_hsg.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   check_hsg:
-    if: false # This line disables this CI check. TODO: delete this line.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
With the latest version of Downloads.jl that is now available on Julia nightly, I think the timeouts should be fixed.