### PR TITLE
Fix Project equality when compat entries are present

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -219,6 +219,7 @@ Base.@kwdef mutable struct Compat
     val::VersionSpec
     str::String
 end
+Base.:(==)(t1::Compat, t2::Compat) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Compat))
 
 Base.@kwdef mutable struct Project
     other::Dict{String,Any} = Dict{String,Any}()

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -219,7 +219,7 @@ Base.@kwdef mutable struct Compat
     val::VersionSpec
     str::String
 end
-Base.:(==)(t1::Compat, t2::Compat) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Compat))
+Base.:(==)(t1::Compat, t2::Compat) = t1.val == t2.val
 
 Base.@kwdef mutable struct Project
     other::Dict{String,Any} = Dict{String,Any}()

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -220,6 +220,7 @@ Base.@kwdef mutable struct Compat
     str::String
 end
 Base.:(==)(t1::Compat, t2::Compat) = t1.val == t2.val
+Base.hash(t::Compat, h::UInt) = hash(t.val, h)
 
 Base.@kwdef mutable struct Project
     other::Dict{String,Any} = Dict{String,Any}()

--- a/test/new.jl
+++ b/test/new.jl
@@ -2409,6 +2409,7 @@ end
             for property in propertynames(a)
                 @test getproperty(a, property) == getproperty(b, property)
             end
+            @test a == b
         end
         rm(dirname(temp); recursive = true, force = true)
     end

--- a/test/project/good/withcompat.toml
+++ b/test/project/good/withcompat.toml
@@ -1,0 +1,9 @@
+name = "FooBar"
+uuid = "3644d252-e973-11e8-2189-c5f41ab12867"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "0.1"


### PR DESCRIPTION
The compat field of a Project appears to breaking equality even when the projects are identical.

```julia
julia> Pkg.Types.Compat(Pkg.Types.VersionSpec("0.1"), "0.1") == Pkg.Types.Compat(Pkg.Types.VersionSpec("0.1"), "0.1")
false
```

This was observed in https://github.com/JuliaRegistries/General/pull/47659#issuecomment-961932857 where an unchanged Project was being re-written to disk, without any actual changes to the file even though [this check](https://github.com/JuliaLang/Pkg.jl/blob/6f8e36db88ed0c7727b5616b2baa58787cdc4e95/src/Types.jl#L1014) should prevent that 

I'm adding the tests first to prove the problem exists first.

Also, @staticfloat the pkgserver tests are failing with
```
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:66
```
