### PR TITLE
Cache pkg_server_registry_info

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -682,7 +682,8 @@ function download_source(ctx::Context; readonly=true)
     max_name = maximum(widths; init=0)
 
     # Check what registries the current pkg server tracks
-    server_registry_info = Registry.pkg_server_registry_info()
+    # Use cached registry info if available as it will have been updated during a Pkg.update
+    server_registry_info = Registry.pkg_server_registry_info(use_cached = true)
 
     @sync begin
         jobs = Channel{eltype(pkgs_to_install)}(ctx.num_concurrent_downloads)


### PR DESCRIPTION
`Registry.pkg_server_registry_info()` gets spammed by `Operations.download_source` even if it's a no-op during CI tests, and each time it takes ~0.2 seconds (on my local connection)

This change lets a cache be used, unless the registry is being actively updated by `Pkg.update`

Timing of the non-cached version
```
julia> for i in 1:15
       @time i Pkg.Registry.pkg_server_registry_info()
       end
1 ->  0.407793 seconds (1.76 k allocations: 99.586 KiB)
2 ->  0.210918 seconds (1.64 k allocations: 97.094 KiB)
3 ->  0.228319 seconds (1.64 k allocations: 97.094 KiB)
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:76
4 ->  3.183332 seconds (1.83 k allocations: 109.609 KiB)
5 ->  0.148870 seconds (1.63 k allocations: 96.922 KiB)
6 ->  0.213015 seconds (1.64 k allocations: 97.141 KiB)
7 ->  0.210455 seconds (1.63 k allocations: 97.047 KiB)
8 ->  0.192349 seconds (1.63 k allocations: 96.922 KiB)
9 ->  0.345246 seconds (1.64 k allocations: 97.141 KiB)
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:76
10 ->  0.138192 seconds (1.79 k allocations: 108.562 KiB)
11 ->  0.164107 seconds (1.63 k allocations: 96.922 KiB)
12 ->  0.129385 seconds (1.63 k allocations: 96.922 KiB)
13 ->  0.129309 seconds (1.63 k allocations: 96.922 KiB)
14 ->  0.179831 seconds (1.63 k allocations: 96.922 KiB)
15 ->  0.156235 seconds (1.63 k allocations: 96.922 KiB)
```

And here's a snippet of this change with some `@info`s thrown in for whether the new cache is used or not

```
     Testing Running tests...
Test Summary:                                  | Pass  Total
Test that we have imported the correct package |    1      1
┌ Info: Pkg Server metadata:
│ HTTP/2 301 
│ server: Varnish
│ retry-after: 0
│ location: https://us-east.pkg.julialang.org/
│ x-geo-continent: NA
│ x-geo-country: US
│ x-geo-region: MA
│ accept-ranges: bytes
│ date: Sun, 07 Nov 2021 02:59:52 GMT
│ via: 1.1 varnish
│ x-served-by: cache-bos4658-BOS
│ x-cache: HIT
│ x-cache-hits: 0
│ x-timer: S1636253993.564160,VS0,VE0
│ content-length: 0
│ 
│ HTTP/2 200 
│ server: nginx/1.21.3
│ date: Sun, 07 Nov 2021 02:59:52 GMT
│ content-type: text/html
│ content-length: 402
│ accept-ranges: bytes
│ x-lb-strategy: pkgservers_roundrobin
└ 
[ Info: pkg_server_registry_info downloaded
[ Info: Downloading General registry from https://pkg.julialang.org/registry/23338594-aafe-5451-b93e-139f81909106/6d6285b496bb930c1370807be8b784105fd103ed
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info downloaded
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Test Summary: | Pass  Total
Depot setup   |   30     30
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Test Summary:  | Pass  Total
test: printing |    5      5
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Hello World! 2591640919196918694
┌ Warning: The active manifest file is an older format with no julia version entry. Dependencies may have been resolved with a different julia version.
└ @ /private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_oQeGH2/TransferSubgraph/Manifest.toml:0
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Hello World![ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Test Summary:    | Pass  Total
test: sandboxing |   12     12
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
hello
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Test Summary:                 | Pass  Total
test: 'targets' based testing |   11     11
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Test Summary: | Pass  Total
Permutation   |   37     37
Test Summary:        | Pass  Total
CoxeterDecomposition |    9      9
Test Summary:                              |
test: fallback when no project file exists | No tests
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
┌ Warning: using test/REQUIRE files is deprecated and current support is lacking in some areas
└ @ Pkg.Operations ~/Documents/GitHub/Pkg.jl/src/Operations.jl:1566
[ Info: pkg_server_registry_info cache used
Test Summary: | Pass  Total
Articles      |    7      7
Test Summary: | Pass  Total
Int → Eng     |   34     34
Test Summary: | Pass  Total
Int ← Eng     |  175    175
Test Summary: | Pass  Total
Pluralize     |  113    113
Test Summary: | Pass  Total
Singularize   |   73     73
Test Summary: | Pass  Total
List          |   14     14
Test Summary: | Pass  Total
Text          |    7      7
Test Summary: | Pass  Total
Quantities    |   10     10
Test Summary:             |
using a test/REQUIRE file | No tests
Test Summary:  | Pass  Total
activate: repl |   15     15
Test Summary: | Pass  Total
activate      |    8      8
[ Info: pkg_server_registry_info downloaded
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
Test Summary:       | Pass  Total
add: input checking |   14     14
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
Test Summary:                      | Pass  Total
add: changes to the active project |   25     25
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
┌ Warning: The active manifest file at `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_bTfvXh/CompatOutOfSync/Manifest.toml` has an old format that is being maintained.
│ To update to the new format run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving.
└ @ Pkg.Types ~/Documents/GitHub/Pkg.jl/src/manifest.jl:287
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:77
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info downloaded
[ Info: pkg_server_registry_info cache used
[ Info: pkg_server_registry_info cache used
Test Summary:              | Pass  Total
add: package state changes |   52     52
```