### PR TITLE
Improve error handling when registry downloads fail

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -383,7 +383,6 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                                     Pkg.Types.pkgerror("could not download $url \nException: $(sprint(showerror, err))")
                                 end
                                 tree_info_file = joinpath(tmp, ".tree_info.toml")
-                                hash = pkg_server_url_hash(url)
                                 write(tree_info_file, "git-tree-sha1 = " * repr(string(new_hash)))
                                 mv(tmp, reg.path, force=true)
                             end

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -172,7 +172,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             try
                 download_verify(url, nothing, tmp)
             catch err
-                Pkg.Types.pkgerror("could not download $url")
+                Pkg.Types.pkgerror("could not download $url \nException: $(sprint(showerror, err))")
             end
             if reg.name === nothing
                 # Need to look up the registry name here
@@ -202,7 +202,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
                     try
                         download_verify_unpack(url, nothing, tmp, ignore_existence = true, io = io)
                     catch err
-                        Pkg.Types.pkgerror("could not download $url")
+                        Pkg.Types.pkgerror("could not download $url \nException: $(sprint(showerror, err))")
                     end
                     tree_info_file = joinpath(tmp, ".tree_info.toml")
                     hash = pkg_server_url_hash(url)

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -362,7 +362,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                             try
                                 download_verify(url, nothing, tmp)
                             catch err
-                                @error "could not download $url" exception=err
+                                Pkg.Types.pkgerror("could not download $url \nException: $(sprint(showerror, err))")
                             end
                             # If we have an uncompressed Pkg server registry, remove it and get the compressed version
                             if isdir(reg.path)
@@ -380,7 +380,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                                 try
                                     download_verify_unpack(url, nothing, tmp, ignore_existence = true, io=io)
                                 catch err
-                                    @error "could not download $url" exception=err
+                                    Pkg.Types.pkgerror("could not download $url \nException: $(sprint(showerror, err))")
                                 end
                                 tree_info_file = joinpath(tmp, ".tree_info.toml")
                                 hash = pkg_server_url_hash(url)

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -362,7 +362,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                             try
                                 download_verify(url, nothing, tmp)
                             catch err
-                                push!(errors, (reg.path, "registry failed to download from $url: $(sprint(showerror, err))"))
+                                push!(errors, (reg.path, "failed to download from $(url). Exception: $(sprint(showerror, err))"))
                                 @goto done
                             end
                             # If we have an uncompressed Pkg server registry, remove it and get the compressed version
@@ -382,7 +382,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                                 try
                                     download_verify_unpack(url, nothing, tmp, ignore_existence = true, io=io)
                                 catch err
-                                    push!(errors, (reg.path, "registry failed to download and unpack from $url: $(sprint(showerror, err))"))
+                                    push!(errors, (reg.path, "failed to download and unpack from $(url). Exception: $(sprint(showerror, err))"))
                                     @goto done
                                 end
                                 tree_info_file = joinpath(tmp, ".tree_info.toml")


### PR DESCRIPTION
Fixes `@error`'s being used where proceeding isn't possible, and instead throws formatted pkgerrors

Currently:
```
(jl_iVmdM3) pkg> up
    Updating registry at `~/.julia/registries/General.toml`
┌ Error: could not download https://pkg.julialang.org/registry/23338594-aafe-5451-b93e-139f81909106/476c29fc17d4642f0e27bfc8addbd5fed45b9b31
│   exception = HTTP/1.1 502 Bad Gateway while requesting https://pkg.julialang.org/registry/23338594-aafe-5451-b93e-139f81909106/476c29fc17d4642f0e27bfc8addbd5fed45b9b31
└ @ Pkg.Registry /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:365
ERROR: IOError: open("/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_jOfglp", 0, 0): no such file or directory (ENOENT)
Stacktrace:
  [1] uv_error
    @ ./libuv.jl:97 [inlined]
  [2] open(path::String, flags::UInt16, mode::Int64)
    @ Base.Filesystem ./filesystem.jl:107
  [3] open
    @ ./filesystem.jl:99 [inlined]
  [4] sendfile(src::String, dst::String)
    @ Base.Filesystem ./file.jl:991
  [5] cp(src::String, dst::String; force::Bool, follow_symlinks::Bool)
    @ Base.Filesystem ./file.jl:383
  [6] rename(src::String, dst::String; force::Bool)
    @ Base.Filesystem ./file.jl:980
  [7] rename
    @ ./file.jl:977 [inlined]
  [8] #mv#15
    @ ./file.jl:425 [inlined]
  [9] update(regs::Vector{Pkg.Registry.RegistrySpec}; io::Base.TTY, force::Bool)
    @ Pkg.Registry /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:372
 [10] update_registries(ctx::Pkg.Types.Context; force::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1098
 [11] add(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}; preserve::Pkg.Types.PreserveLevel, platform::Base.BinaryPlatforms.Platform, kwargs::Base.Pairs{Symbol, Base.TTY, Tuple{Symbol}, NamedTuple{(:io,), Tuple{Base.TTY}}})
    @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:258
 [12] add(pkgs::Vector{Pkg.Types.PackageSpec}; io::Base.TTY, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:155
 [13] add(pkgs::Vector{Pkg.Types.PackageSpec})
    @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:145
 [14] do_cmd!(command::Pkg.REPLMode.Command, repl::REPL.LineEditREPL)
    @ Pkg.REPLMode /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/REPLMode/REPLMode.jl:408
 [15] do_cmd(repl::REPL.LineEditREPL, input::String; do_rethrow::Bool)
    @ Pkg.REPLMode /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/REPLMode/REPLMode.jl:386
 [16] do_cmd
    @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/REPLMode/REPLMode.jl:377 [inlined]
 [17] (::Pkg.REPLMode.var"#24#27"{REPL.LineEditREPL, REPL.LineEdit.Prompt})(s::REPL.LineEdit.MIState, buf::IOBuffer, ok::Bool)
    @ Pkg.REPLMode /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/REPLMode/REPLMode.jl:550
 [18] #invokelatest#2
    @ ./essentials.jl:734 [inlined]
 [19] invokelatest
    @ ./essentials.jl:732 [inlined]
 [20] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/LineEdit.jl:2509
 [21] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/REPL.jl:1245
 [22] (::REPL.var"#49#54"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ./task.jl:423
```