### PR TITLE
Use explicit module name in trailing comment

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -66,7 +66,7 @@ function entrypoint(io::IO, pkg::AbstractString, dir)
 
             greet() = print("Hello World!")
 
-            end # module
+            end # module $pkg
             """
         )
     end


### PR DESCRIPTION
Change the trailing comment produced by `generate` to use the explicit module name.
This might be helpful to avoid confusion when scanning the file,
e.g. if there are submodules.