### PR TITLE
Extend Pkg.offline to optionally handle offline registries. Use offline mode during precompile_script

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -33,6 +33,7 @@ devdir(depot = depots1()) = get(ENV, "JULIA_PKG_DEVDIR", joinpath(depot, "dev"))
 envdir(depot = depots1()) = joinpath(depot, "environments")
 const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 const OFFLINE_MODE = Ref(false)
+const OFFLINE_REGISTRY = Ref(false) # if the registry has offline-accessible source paths
 # For globally overriding in e.g. tests
 const DEFAULT_IO = Ref{Union{IO,Nothing}}(nothing)
 stderr_f() = something(DEFAULT_IO[], stderr)
@@ -484,7 +485,7 @@ Pkg.activate(; temp=true)
 const activate = API.activate
 
 """
-    Pkg.offline(b::Bool=true)
+    Pkg.offline(b::Bool=true; offline_registry::Bool=false)
 
 Enable (`b=true`) or disable (`b=false`) offline mode.
 
@@ -492,13 +493,24 @@ In offline mode Pkg tries to do as much as possible without connecting
 to internet. For example, when adding a package Pkg only considers
 versions that are already downloaded in version resolution.
 
+If the provided registries have offline-accessible paths `offline_registry`
+can be set to `true` to allow package installations.
+
 To work in offline mode across Julia sessions you can
 set the environment variable `JULIA_PKG_OFFLINE` to `"true"`.
+Similarly `JULIA_PKG_OFFLINE_REGISTRY` can be set.
 
 !!! compat "Julia 1.5"
     Pkg's offline mode requires Julia 1.5 or later.
+
+!!! compat "Julia 1.8"
+    The `offline_registry` mode requires Julia 1.8 or later.
 """
-offline(b::Bool=true) = (OFFLINE_MODE[] = b; nothing)
+function offline(b::Bool=true; offline_registry::Bool = false)
+    OFFLINE_MODE[] = b
+    OFFLINE_REGISTRY[] = offline_registry
+    nothing
+end
 
 """
     PackageSpec(name::String, [uuid::UUID, version::VersionNumber])
@@ -626,6 +638,7 @@ function __init__()
     end
     push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
     OFFLINE_MODE[] = get(ENV, "JULIA_PKG_OFFLINE", nothing) == "true"
+    OFFLINE_REGISTRY[] = get(ENV, "JULIA_PKG_OFFLINE_REGISTRY", nothing) == "true"
     return nothing
 end
 
@@ -776,6 +789,7 @@ const precompile_script = """
     import Pkg
     _pwd = pwd()
     tmp = Pkg._run_precompilation_script_setup()
+    Pkg.offline(true, offline_registry = true)
     $CTRL_C
     Pkg.add("TestPkg")
     Pkg.develop(Pkg.PackageSpec(path="TestPkg.jl"))
@@ -789,6 +803,7 @@ const precompile_script = """
     Pkg._run_precompilation_script_artifact()
     rm(tmp; recursive=true)
     cd(_pwd)
+    Pkg.offline(false, offline_registry = false)
     """
 
 end # module


### PR DESCRIPTION
- Extends `Pkg.offline()` with a `offline_registry` kwarg to set whether the registries have offline-accessible paths such that they can still be used to install packages in offline mode
- Uses this extended offline mode during `precompile_script` given the mock registry that is set up there uses local source paths. (Using the old `Pkg.offline(true)` wasn't enough as it disallowed using the registry to `Pkg.add` a package that wasn't already installed)

Instead of making this a build-specific hack, I thought there may be situations where users have locally linked registries that have local paths, that could be functional during _offline_ mode.

Fixes https://github.com/JuliaLang/julia/issues/43006

Previously lots of server requests were happening. None of these warnings happen now.

```
Generating REPL precompile statements... 25/36
#### inputting statement: ####
"Pkg.add(\"TestPkg\")"
####
julia> Pkg.add("TestPkg")
   Resolving package versions...
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:76
     Cloning [bddd00b5-e60b-4520-a64a-f93bb8a01829] TestPkg from /var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/TestPkg.jl
   Installed TestPkg ─ v0.1.0
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Project.toml`
  [bddd00b5] + TestPkg v0.1.0
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Manifest.toml`
  [bddd00b5] + TestPkg v0.1.0
  [ade2ca70] + Dates
  [de0858da] + Printf
  [4ec0a83e] + Unicode

Generating REPL precompile statements... 26/36
#### inputting statement: ####
"Pkg.develop(Pkg.PackageSpec(path=\"TestPkg.jl\"))"
####
julia> Pkg.develop(Pkg.PackageSpec(path="TestPkg.jl"))
   Resolving package versions...
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:76
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Project.toml`
  [bddd00b5] ~ TestPkg v0.1.0 ⇒ v0.1.0 `TestPkg.jl`
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Manifest.toml`
  [bddd00b5] ~ TestPkg v0.1.0 ⇒ v0.1.0 `TestPkg.jl`
  [ade2ca70] - Dates
  [de0858da] - Printf
  [4ec0a83e] - Unicode

Generating REPL precompile statements... 27/36
#### inputting statement: ####
"Pkg.add(Pkg.PackageSpec(path=\"TestPkg.jl/\"))"
####
julia> Pkg.add(Pkg.PackageSpec(path="TestPkg.jl/"))
     Cloning git-repo `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/TestPkg.jl`
    Updating git-repo `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/TestPkg.jl`
   Resolving package versions...
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:76
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Project.toml`
  [bddd00b5] ~ TestPkg v0.1.0 `TestPkg.jl` ⇒ v0.1.0 `TestPkg.jl#master`
    Updating `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Manifest.toml`
  [bddd00b5] ~ TestPkg v0.1.0 `TestPkg.jl` ⇒ v0.1.0 `TestPkg.jl#master`

Generating REPL precompile statements... 28/36
#### inputting statement: ####
"Pkg.REPLMode.try_prompt_pkg_add(Symbol[:notapackage])"
####
julia> Pkg.REPLMode.try_prompt_pkg_add(Symbol[:notapackage])
false

Generating REPL precompile statements... 29/36
#### inputting statement: ####
"Pkg.update()"
####
julia> Pkg.update()
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:76
    Updating registry at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/registries/Registry.toml`
    Updating git-repo `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/TestPkg.jl`
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:76
  No Changes to `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Project.toml`
  No Changes to `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_FmuO5s/Manifest.toml`
[ Info: We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 0 found
      Active scratchspaces: 0 found
     Deleted no artifacts, repos, packages or scratchspaces

Generating REPL precompile statements... 30/36
#### inputting statement: ####
"Pkg.precompile()"
####
julia> Pkg.precompile()
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:76
```