### PR TITLE
return early if no packages to install

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -673,6 +673,8 @@ function download_source(ctx::Context; readonly=true)
         push!(pkgs_to_install, (;pkg, urls, path))
     end
 
+    length(pkgs_to_install) == 0 && return Set{UUID}()
+
     ########################################
     # Install from archives asynchronously #
     ########################################


### PR DESCRIPTION
Should fix the same problem as https://github.com/JuliaLang/Pkg.jl/pull/2827 tried to address so perhaps the cache can be removed now? It should be ok to ask the PkgServer for this given that we are going to go and download a full package anyway? @IanButterworth?

