### PR TITLE
Add example of deving local file path

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -182,6 +182,10 @@ When tracking a path, the package manager will never modify the files at that pa
 If `dev` is used on a local path, that path to that package is recorded and used when loading that package.
 The path will be recorded relative to the project file, unless it is given as an absolute path.
 
+```julia-repl
+(v1.0) pkg> dev /Users/logankilpatrick/Desktop/Example
+```
+
 To stop tracking a path and use the registered version again, use `free`:
 
 ```julia-repl

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -183,7 +183,7 @@ If `dev` is used on a local path, that path to that package is recorded and used
 The path will be recorded relative to the project file, unless it is given as an absolute path.
 
 ```julia-repl
-(v1.0) pkg> dev /Users/logankilpatrick/Desktop/Example
+(v1.0) pkg> dev /Users/kristoffer/Desktop/Example
 ```
 
 To stop tracking a path and use the registered version again, use `free`:


### PR DESCRIPTION
There is currently no example for deving a local package via its file path. This simple example adds one. We can switch this to show Kristoffer's file path if we want as well.