### PR TITLE
Consistently parse all boolean environment variables

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -6,6 +6,7 @@ using Artifacts
 import Artifacts: artifact_names, ARTIFACTS_DIR_OVERRIDE, ARTIFACT_OVERRIDES, artifact_paths,
                   artifacts_dirs, pack_platform!, unpack_platform, load_artifacts_toml,
                   query_override, with_artifacts_directory, load_overrides
+import ..bool_env
 import ..set_readonly
 import ..GitTools
 import ..TOML
@@ -357,7 +358,7 @@ function download_artifact(
             # Since tree hash calculation is still broken on some systems, e.g. Pkg.jl#1860,
             # and Pkg.jl#2317 so we allow setting JULIA_PKG_IGNORE_HASHES=1 to ignore the
             # error and move the artifact to the expected location and return true
-            ignore_hash = get(ENV, "JULIA_PKG_IGNORE_HASHES", nothing) == "1"
+            ignore_hash = bool_env("JULIA_PKG_IGNORE_HASHES")
             if ignore_hash
                 msg *= "\n\$JULIA_PKG_IGNORE_HASHES is set to 1: ignoring error and moving artifact to the expected location"
             end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -6,7 +6,7 @@ using Artifacts
 import Artifacts: artifact_names, ARTIFACTS_DIR_OVERRIDE, ARTIFACT_OVERRIDES, artifact_paths,
                   artifacts_dirs, pack_platform!, unpack_platform, load_artifacts_toml,
                   query_override, with_artifacts_directory, load_overrides
-import ..bool_env
+import ..get_bool_env
 import ..set_readonly
 import ..GitTools
 import ..TOML
@@ -358,7 +358,7 @@ function download_artifact(
             # Since tree hash calculation is still broken on some systems, e.g. Pkg.jl#1860,
             # and Pkg.jl#2317 so we allow setting JULIA_PKG_IGNORE_HASHES=1 to ignore the
             # error and move the artifact to the expected location and return true
-            ignore_hash = bool_env("JULIA_PKG_IGNORE_HASHES")
+            ignore_hash = get_bool_env("JULIA_PKG_IGNORE_HASHES")
             if ignore_hash
                 msg *= "\n\$JULIA_PKG_IGNORE_HASHES is set to 1: ignoring error and moving artifact to the expected location"
             end

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -4,13 +4,13 @@ module GitTools
 
 using ..Pkg
 using ..MiniProgressBars
-import ..can_fancyprint, ..printpkgstyle
+import ..bool_env, ..can_fancyprint, ..printpkgstyle
 using SHA
 import Base: SHA1
 import LibGit2
 using Printf
 
-use_cli_git() = get(ENV, "JULIA_PKG_USE_CLI_GIT", "") == "true"
+use_cli_git() = bool_env("JULIA_PKG_USE_CLI_GIT")
 
 function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     progress = unsafe_load(progress)

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -4,13 +4,13 @@ module GitTools
 
 using ..Pkg
 using ..MiniProgressBars
-import ..bool_env, ..can_fancyprint, ..printpkgstyle
+import ..get_bool_env, ..can_fancyprint, ..printpkgstyle
 using SHA
 import Base: SHA1
 import LibGit2
 using Printf
 
-use_cli_git() = bool_env("JULIA_PKG_USE_CLI_GIT")
+use_cli_git() = get_bool_env("JULIA_PKG_USE_CLI_GIT")
 
 function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     progress = unsafe_load(progress)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -636,7 +636,7 @@ function __init__()
         end
     end
     push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
-    OFFLINE_MODE[] = bool_env("JULIA_PKG_OFFLINE")
+    OFFLINE_MODE[] = get_bool_env("JULIA_PKG_OFFLINE")
     return nothing
 end
 
@@ -705,7 +705,7 @@ end
 ##################
 
 function _auto_precompile(ctx::Types.Context; warn_loaded = true, already_instantiated = false)
-    if Base.JLOptions().use_compiled_modules == 1 && bool_env("JULIA_PKG_PRECOMPILE_AUTO"; default="true")
+    if Base.JLOptions().use_compiled_modules == 1 && get_bool_env("JULIA_PKG_PRECOMPILE_AUTO"; default="true")
         Pkg.precompile(ctx; internal_call=true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
     end
 end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -636,7 +636,7 @@ function __init__()
         end
     end
     push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
-    OFFLINE_MODE[] = get(ENV, "JULIA_PKG_OFFLINE", nothing) == "true"
+    OFFLINE_MODE[] = bool_env("JULIA_PKG_OFFLINE")
     return nothing
 end
 
@@ -705,7 +705,7 @@ end
 ##################
 
 function _auto_precompile(ctx::Types.Context; warn_loaded = true, already_instantiated = false)
-    if Base.JLOptions().use_compiled_modules == 1 && tryparse(Int, get(ENV, "JULIA_PKG_PRECOMPILE_AUTO", "1")) == 1
+    if Base.JLOptions().use_compiled_modules == 1 && bool_env("JULIA_PKG_PRECOMPILE_AUTO"; default="true")
         Pkg.precompile(ctx; internal_call=true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
     end
 end

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -2,7 +2,7 @@ module Registry
 
 import ..Pkg
 using ..Pkg: depots1, printpkgstyle, stderr_f, isdir_nothrow, pathrepr, pkg_server,
-             GitTools
+             GitTools, bool_env
 using ..Pkg.PlatformEngines: download_verify_unpack, download, download_verify, exe7z
 using UUIDs, LibGit2, TOML
 
@@ -141,7 +141,7 @@ function registry_use_pkg_server()
 end
 
 registry_read_from_tarball() =
-    registry_use_pkg_server() && !(get(ENV, "JULIA_PKG_UNPACK_REGISTRY", "") == "true")
+    registry_use_pkg_server() && !bool_env("JULIA_PKG_UNPACK_REGISTRY")
 
 function check_registry_state(reg)
     reg_currently_uses_pkg_server = reg.tree_info !== nothing

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -2,7 +2,7 @@ module Registry
 
 import ..Pkg
 using ..Pkg: depots1, printpkgstyle, stderr_f, isdir_nothrow, pathrepr, pkg_server,
-             GitTools, bool_env
+             GitTools, get_bool_env
 using ..Pkg.PlatformEngines: download_verify_unpack, download, download_verify, exe7z
 using UUIDs, LibGit2, TOML
 
@@ -141,7 +141,7 @@ function registry_use_pkg_server()
 end
 
 registry_read_from_tarball() =
-    registry_use_pkg_server() && !bool_env("JULIA_PKG_UNPACK_REGISTRY")
+    registry_use_pkg_server() && !get_bool_env("JULIA_PKG_UNPACK_REGISTRY")
 
 function check_registry_state(reg)
     reg_currently_uses_pkg_server = reg.tree_info !== nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,7 +90,7 @@ function casesensitive_isdir(dir::String)
     isdir_nothrow(dir) && lastdir in readdir(joinpath(dir, ".."))
 end
 
-bool_env(name::String; default::String="false") =
+get_bool_env(name::String; default::String="false") =
     lowercase(get(ENV, name, default)) in ("t", "true", "y", "yes", "1")
 
 ## ordering of UUIDs ##

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,6 +90,9 @@ function casesensitive_isdir(dir::String)
     isdir_nothrow(dir) && lastdir in readdir(joinpath(dir, ".."))
 end
 
+bool_env(name::String; default::String="false") =
+    lowercase(get(ENV, name, default)) in ("t", "true", "y", "yes", "1")
+
 ## ordering of UUIDs ##
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value


### PR DESCRIPTION
Note: this is basically only checking the truthy values, so values like `"truw"` would silently be parsed as a falsy value, but as far as I can tell that's what's happening at the moment anyways, so I don't think there is any practical change.

Address https://github.com/JuliaLang/Pkg.jl/issues/2705#issuecomment-978147571.