### PR TITLE
Add default registry if none available during pkg install prompt

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -655,6 +655,10 @@ const help = gen_help()
 
 function try_prompt_pkg_add(pkgs::Vector{Symbol})
     ctx = Context()
+    if isempty(ctx.registries)
+        Registry.download_default_registries(ctx.io)
+        ctx = Context()
+    end
     available_uuids = [Types.registered_uuids(ctx.registries, String(pkg)) for pkg in pkgs] # vector of vectors
     available_pkgs = pkgs[isempty.(available_uuids) .== false]
     isempty(available_pkgs) && return false


### PR DESCRIPTION
I think the current behavior could be a bit unfriendly to newcomers that read about how in 1.7 you just need to `using Foo` to install the package, because if that's the first think they try they won't have a registry installed

In a fresh depot:

## Master
```
julia> using CSV
ERROR: ArgumentError: Package CSV not found in current path.
- Run `import Pkg; Pkg.add("CSV")` to install the CSV package.
Stacktrace:
 [1] macro expansion
   @ ./loading.jl:1007 [inlined]
 [2] macro expansion
   @ ./lock.jl:221 [inlined]
 [3] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:988
```

## This PR
```
julia> using CSV
  Installing known registries into `/tmp/54234dsds`
 │ Package CSV not found, but a package named CSV is available from a registry. 
 │ Install package?
 │   (Pkg) pkg> add CSV 
 └ (y/n/o) [y]: 
```

