### PR TITLE
Warn if no registry is available during pkg install prompt

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -652,9 +652,20 @@ Some commands have an alias, indicated below.
 end
 
 const help = gen_help()
+const REG_WARNED = Ref{Bool}(false)
 
 function try_prompt_pkg_add(pkgs::Vector{Symbol})
     ctx = Context()
+    if isempty(ctx.registries)
+        if !REG_WARNED[]
+            printstyled(ctx.io, " │ "; color=:green)
+            printstyled(ctx.io, "Attempted to search for missing packages in Pkg registries but no registries are installed.\n")
+            printstyled(ctx.io, " └ "; color=:green)
+            printstyled(ctx.io, "Use Pkg mode to install a registry. Both `pkg> add` and `pkg> update` will install the default registries.\n\n")
+            REG_WARNED[] = true
+        end
+        return false
+    end
     available_uuids = [Types.registered_uuids(ctx.registries, String(pkg)) for pkg in pkgs] # vector of vectors
     available_pkgs = pkgs[isempty.(available_uuids) .== false]
     isempty(available_pkgs) && return false


### PR DESCRIPTION
Redo at #2862 

This instead warns once if no registries are installed.

If someone is operating in a mode where they intentionally have no registry installed (I assume quite rare?), they could hide this always with `import Pkg; Pkg.REG_WARNED[] = true`

```
julia> using CSV
 │ Attempted to search for missing packages in Pkg registries but no registries are installed.
 └ Use Pkg mode to install a registry. Both `pkg> add` and `pkg> update` will install the default registries.

ERROR: ArgumentError: Package CSV not found in current path.
- Run `import Pkg; Pkg.add("CSV")` to install the CSV package.
Stacktrace:
 [1] macro expansion
   @ ./loading.jl:1007 [inlined]
 [2] macro expansion
   @ ./lock.jl:221 [inlined]
 [3] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:988

julia> using CSV
ERROR: ArgumentError: Package CSV not found in current path.
- Run `import Pkg; Pkg.add("CSV")` to install the CSV package.
Stacktrace:
 [1] macro expansion
   @ ./loading.jl:1007 [inlined]
 [2] macro expansion
   @ ./lock.jl:221 [inlined]
 [3] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:988
```