### PR TITLE
Warn if non-latest version is installed after explicit `up`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1300,6 +1300,13 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)
     write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io, silent_no_change)
+    for pkg in pkgs
+        latest_available = get_latest_compatible_version(ctx, pkg.uuid, Pkg.Types.VersionSpec())
+        currently_installed = manifest_info(ctx.env.manifest, pkg.uuid).version
+        if latest_available > currently_installed
+            @warn """$(pkg.name) (at $(currently_installed)) could not be updated to the latest version ($(latest_available). Run `Pkg.add(name="$(pkg.name)", version=$(latest_available))` to learn why."""
+        end
+    end
     build_versions(ctx, union(new_apply, new_git))
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1292,6 +1292,8 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     for pkg in pkgs
         up_load_manifest_info!(pkg, manifest_info(ctx.env.manifest, pkg.uuid))
     end
+    
+    oringal_pkgs = pkgs
     pkgs = load_direct_deps(ctx.env, pkgs; preserve = (level == UPLEVEL_FIXED ? PRESERVE_NONE : PRESERVE_DIRECT))
     check_registered(ctx.registries, pkgs)
     deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version)
@@ -1300,11 +1302,11 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)
     write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io, silent_no_change)
-    for pkg in pkgs
+    for pkg in oringal_pkgs
         latest_available = get_latest_compatible_version(ctx, pkg.uuid, Pkg.Types.VersionSpec())
         currently_installed = manifest_info(ctx.env.manifest, pkg.uuid).version
         if latest_available > currently_installed
-            @warn """$(pkg.name) (at $(currently_installed)) could not be updated to the latest version ($(latest_available). Run `Pkg.add(name="$(pkg.name)", version=$(latest_available))` to learn why."""
+            @warn """$(pkg.name) (at $(currently_installed)) could not be updated to the latest version ($(latest_available)). Run `Pkg.add(name="$(pkg.name)", version=$(repr(latest_available)))` to learn why."""
         end
     end
     build_versions(ctx, union(new_apply, new_git))


### PR DESCRIPTION
This is just a draft PR to get the ball rolling to fix #1655. This only warns that a more recent version is available, it does not say why (I don't know how to implement that: #2583).

# Demo
```julia
(Pkg) pkg> activate --temp
  Activating new project at `/var/folders/v_/fhpj9jn151d4p9c2fdw2gv780000gn/T/jl_9ciGWf`

(jl_9ciGWf) pkg> add Pluto@0.16.4 Configurations

# This installs Configurations@0.16 because of a bound by this old version of Pluto. 0.17 is available.

(jl_9ciGWf) pkg> up Configurations

    Updating registry at `~/.julia/registries/General.toml`
  No Changes to `/private/var/folders/v_/fhpj9jn151d4p9c2fdw2gv780000gn/T/jl_WblATC/Project.toml`
  No Changes to `/private/var/folders/v_/fhpj9jn151d4p9c2fdw2gv780000gn/T/jl_WblATC/Manifest.toml`

┌ Warning: Configurations (at 0.16.6) could not be updated to the latest version (0.17.0). Run `Pkg.add(name="Configurations", version=v"0.17.0")` to learn why.
└ @ Pkg.Operations ~/Documents/PkgClone.jl/src/Operations.jl:1309
```
