### PR TITLE
Improve messaging in --all noops

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -280,6 +280,10 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, all_p
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, mode)
+        if isempty(pkgs)
+            Operations.show_update(ctx.env, ctx.registries; io=ctx.io)
+            return
+        end
     end
     require_not_empty(pkgs, :rm)
 
@@ -352,6 +356,10 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwar
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, PKGMODE_PROJECT)
+        if isempty(pkgs)
+            Operations.show_update(ctx.env, ctx.registries; io=ctx.io)
+            return
+        end
     end
     require_not_empty(pkgs, :pin)
 
@@ -383,6 +391,10 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwa
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, PKGMODE_PROJECT)
+        if isempty(pkgs)
+            Operations.show_update(ctx.env, ctx.registries; io=ctx.io)
+            return
+        end
     end
     require_not_empty(pkgs, :free)
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -280,12 +280,9 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, all_p
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, mode)
-        if isempty(pkgs)
-            Operations.show_update(ctx.env, ctx.registries; io=ctx.io)
-            return
-        end
+    else
+        require_not_empty(pkgs, :rm)
     end
-    require_not_empty(pkgs, :rm)
 
     for pkg in pkgs
         if pkg.name === nothing && pkg.uuid === nothing
@@ -356,12 +353,9 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwar
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, PKGMODE_PROJECT)
-        if isempty(pkgs)
-            Operations.show_update(ctx.env, ctx.registries; io=ctx.io)
-            return
-        end
+    else
+        require_not_empty(pkgs, :pin)
     end
-    require_not_empty(pkgs, :pin)
 
     for pkg in pkgs
         if pkg.name === nothing && pkg.uuid === nothing
@@ -391,12 +385,9 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwa
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, PKGMODE_PROJECT)
-        if isempty(pkgs)
-            Operations.show_update(ctx.env, ctx.registries; io=ctx.io)
-            return
-        end
+    else
+        require_not_empty(pkgs, :free)
     end
-    require_not_empty(pkgs, :free)
 
     for pkg in pkgs
         if pkg.name === nothing && pkg.uuid === nothing

--- a/test/new.jl
+++ b/test/new.jl
@@ -1868,6 +1868,11 @@ end
         end
         Pkg.rm(all_pkgs = true)
         @test !haskey(Pkg.dependencies(), exuuid)
+
+        # test that the noops don't error
+        Pkg.rm(all_pkgs = true)
+        Pkg.pin(all_pkgs = true)
+        Pkg.free(all_pkgs = true)
     end
     isolate() do
         Pkg.REPLMode.TEST_MODE[] = true


### PR DESCRIPTION
1.7
```
(@v1.7) pkg> st
      Status `~/.julia/environments/v1.7/Project.toml` (empty project)

(@v1.7) pkg> rm --all
ERROR: rm requires at least one package

(@v1.7) pkg> pin --all
ERROR: pin requires at least one package

(@v1.7) pkg> free --all
ERROR: free requires at least one package

```

This PR
```
(@v1.8) pkg> st
Status `~/.julia/environments/v1.8/Project.toml` (empty project)

(@v1.8) pkg> rm --all
  No Changes to `~/.julia/environments/v1.8/Project.toml`
  No Changes to `~/.julia/environments/v1.8/Manifest.toml`

(@v1.8) pkg> pin --all
  No Changes to `~/.julia/environments/v1.8/Project.toml`
  No Changes to `~/.julia/environments/v1.8/Manifest.toml`

(@v1.8) pkg> free --all
  No Changes to `~/.julia/environments/v1.8/Project.toml`
  No Changes to `~/.julia/environments/v1.8/Manifest.toml`
```