### PR TITLE
tests: use parent testsets to summarize tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,19 +21,27 @@ Pkg.DEFAULT_IO[] = IOBuffer()
 
 include("utils.jl")
 
-include("new.jl")
-include("pkg.jl")
-include("repl.jl")
-include("api.jl")
-include("registry.jl")
-include("subdir.jl")
-include("artifacts.jl")
-include("binaryplatforms.jl")
-include("platformengines.jl")
-include("sandbox.jl")
-include("resolve.jl")
-include("misc.jl")
-include("force_latest_compatible_version.jl")
-include("manifests.jl")
+@testset "Pkg" verbose = true begin
+    @testset "$f" verbose = true for f in [
+        "new.jl",
+        "pkg.jl",
+        "repl.jl",
+        "pkg.jl",
+        "repl.jl",
+        "api.jl",
+        "registry.jl",
+        "subdir.jl",
+        "artifacts.jl",
+        "binaryplatforms.jl",
+        "platformengines.jl",
+        "sandbox.jl",
+        "resolve.jl",
+        "misc.jl",
+        "force_latest_compatible_version.jl",
+        "manifests.jl",
+        ]
+        include(f)
+    end
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,8 +21,8 @@ Pkg.DEFAULT_IO[] = IOBuffer()
 
 include("utils.jl")
 
-@testset "Pkg" verbose = true begin
-    @testset "$f" verbose = true for f in [
+@testset "Pkg" begin
+    @testset "$f" for f in [
         "new.jl",
         "pkg.jl",
         "repl.jl",


### PR DESCRIPTION
I think it's helpful to show the test summary at the end.

Pushing a verbose version first to show timing. I'll turn verbose off once that's run