### PR TITLE
Offer to install default registries if none available during missing pkg install prompt

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -656,13 +656,11 @@ const help = gen_help()
 
 function try_prompt_pkg_add(pkgs::Vector{Symbol})
     ctx = Context()
-    # any user that doesn't have registries and doesn't want this prompt can `empty!(Pkg.Registry.DEFAULT_REGISTRIES)`
-    if isempty(ctx.registries) && !isempty(DEFAULT_REGISTRIES)
+    if isempty(ctx.registries)
         printstyled(ctx.io, " │ "; color=:green)
-        printstyled(ctx.io, "Attempted to search for missing packages in Pkg registries but no registries are installed.\n")
+        printstyled(ctx.io, "Attempted to find missing packages in package registries but no registries are installed.\n")
         printstyled(ctx.io, " └ "; color=:green)
-        plural = length(DEFAULT_REGISTRIES) == 1 ? "y" : "ies"
-        resp = Base.prompt(stdin, ctx.io, "Install the default registr$(plural)? (y/n)", default = "y")
+        resp = Base.prompt(stdin, ctx.io, "Install default registries? (y/n)", default = "y")
         if lowercase(strip(resp)) == "y"
             Registry.download_default_registries(ctx.io)
             ctx = Context()

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -652,20 +652,9 @@ Some commands have an alias, indicated below.
 end
 
 const help = gen_help()
-const REG_WARNED = Ref{Bool}(false)
 
 function try_prompt_pkg_add(pkgs::Vector{Symbol})
     ctx = Context()
-    if isempty(ctx.registries)
-        if !REG_WARNED[]
-            printstyled(ctx.io, " │ "; color=:green)
-            printstyled(ctx.io, "Attempted to search for missing packages in Pkg registries but no registries are installed.\n")
-            printstyled(ctx.io, " └ "; color=:green)
-            printstyled(ctx.io, "Use Pkg mode to install a registry. Both `pkg> add` and `pkg> update` will install the default registries.\n\n")
-            REG_WARNED[] = true
-        end
-        return false
-    end
     available_uuids = [Types.registered_uuids(ctx.registries, String(pkg)) for pkg in pkgs] # vector of vectors
     available_pkgs = pkgs[isempty.(available_uuids) .== false]
     isempty(available_pkgs) && return false


### PR DESCRIPTION
This seems to be the most popular solution to https://github.com/JuliaLang/Pkg.jl/issues/2873

I will drop the revert commit once https://github.com/JuliaLang/Pkg.jl/pull/2882 is merged

```
julia> using CSV
 │ Attempted to search for missing packages in Pkg registries but no registries are installed.
 └ Install the default registry? (y/n) [y]: 
  Installing known registries into `/tmp/92738`
 │ Package CSV not found, but a package named CSV is available from a registry. 
 │ Install package?
 │   (Pkg) pkg> add CSV 
 └ (y/n/o) [y]: 
```
```
julia> using CSV
 │ Attempted to search for missing packages in Pkg registries but no registries are installed.
 └ Install the default registry? (y/n) [y]: n
ERROR: ArgumentError: Package CSV not found in current path.
- Run `import Pkg; Pkg.add("CSV")` to install the CSV package.
Stacktrace:
 [1] macro expansion
   @ ./loading.jl:1007 [inlined]
 [2] macro expansion
   @ ./lock.jl:221 [inlined]
 [3] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:988
```

~~If someone wanted to explicitly have no registries and not install the default ones, then they can `import Pkg; empty!(Pkg.Registry.DEFAULT_REGISTRIES)`~~


Apologies that getting here involved two reverted PRs. I was keen to get this into 1.7.0 but it was discovered too late, and discussion about what the best approach would be has been ongoing.