### PR TITLE
Disable the Codecov commit statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
-comment: false
+comment: false # Disable the comment that is posted on pull requests.
+coverage:
+  status:
+    patch: off # Disable the `codecov/patch` commit status.
+    project: off # Disable the `codecov/project` commit status.
 github_checks:
-    annotations: false
+    annotations: false # Disable the annotations in the "Files Changed" view of a pull request.


### PR DESCRIPTION
Personally, I find it distracting when I see a red ❌ (either on a pull request or on a commit on master), and then when I click on it, I see that all of the CI jobs actually passed, but the commit is red because either `codecov/patch` is red or `codecov/project` is red. I think we care mostly about whether or not the CI jobs are passing, not whether or not the code coverage has increased or decreased between commits.

Therefore, this pull request disables the Codecov commit statuses.