### PR TITLE
Add environment variables for disabling auto-GC and/or disable the writing of environment usage

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -672,7 +672,7 @@ end
 const DEPOT_ORPHANAGE_TIMESTAMPS = Dict{String,Float64}()
 const _auto_gc_enabled = Ref{Bool}(true)
 function _auto_gc(ctx::Types.Context; collect_delay::Period = Day(7))
-    if !_auto_gc_enabled[]
+    if !(_auto_gc_enabled[] && Types.env_var_auto_gc() && Types.env_var_write_env_usage())
         return
     end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -470,7 +470,23 @@ function Context!(ctx::Context; kwargs...)
     return ctx
 end
 
+function env_var_auto_gc()
+    s = get(ENV, "JULIA_PKG_AUTO_GC", "true")
+    b = parse(Bool, s)::Bool
+    return b
+end
+
+function env_var_write_env_usage()
+    s = get(ENV, "JULIA_PKG_WRITE_ENV_USAGE", "true")
+    b = parse(Bool, s)::Bool
+    return b
+end
+
 function write_env_usage(source_file::AbstractString, usage_filepath::AbstractString)
+    if !env_var_write_env_usage()
+        return
+    end
+
     # Don't record ghost usage
     !isfile(source_file) && return
 


### PR DESCRIPTION
1. If you want to record environment usage, and you want to automatically run Pkg GC:
    - Do nothing. This is the default behavior.
2. If you want to record environment usage, but you do not want to automatically run Pkg GC:[^1]
    - `export JULIA_PKG_AUTO_GC="false"`
3. If you do not want to record environment usage, and you do not want to automatically run Pkg GC:
    - `export JULIA_PKG_WRITE_ENV_USAGE="false"`

Intentionally undocumented for now, so we can give it a try without having to commit to the API.

[^1]: For example, this use case would make sense if you do not want to automatically run Pkg GC, but you might still want to manually run `Pkg.gc()`.