### PR TITLE
Add the no-argument `Pkg.Registry.add()` method, which automatically installs the default registries

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -40,6 +40,7 @@ Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/General.
 """
 add(reg::Union{String,RegistrySpec}; kwargs...) = add([reg]; kwargs...)
 add(regs::Vector{String}; kwargs...) = add(RegistrySpec[RegistrySpec(name = name) for name in regs]; kwargs...)
+add(; kwargs...) = add(RegistrySpec[]; kwargs...)
 function add(regs::Vector{RegistrySpec}; io::IO=stderr_f())
     if isempty(regs)
         download_default_registries(io, only_if_empty = false)


### PR DESCRIPTION
## Summary

This PR adds the no-argument `Pkg.Registry.add()` method, which automatically installs the default registries.

## Before this PR

"Functional" API:

```
$ JULIA_DEPOT_PATH=$(mktemp -d) ./julia -e 'import Pkg; Pkg.Registry.add()'
ERROR: MethodError: no method matching add()
Closest candidates are:
  add(::Union{String, Pkg.Registry.RegistrySpec}; kwargs...) at ~/Downloads/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:41
  add(::Vector{String}; kwargs...) at ~/Downloads/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:42
  add(::Vector{Pkg.Registry.RegistrySpec}; io) at ~/Downloads/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Registry/Registry.jl:43
Stacktrace:
 [1] top-level scope
   @ none:1
```

REPL mode:

```
$ JULIA_DEPOT_PATH=$(mktemp -d) ./julia -e 'import Pkg; Pkg.pkg"registry add"'
┌ Warning: The Pkg REPL mode is intended for interactive use only, and should not be used from scripts. It is recommended to use the functional API instead.
└ @ Pkg.REPLMode ~/Downloads/julia/usr/share/julia/stdlib/v1.8/Pkg/src/REPLMode/REPLMode.jl:378
  Installing known registries into `/var/folders/jy/7hh5zyw95cg2lh66lfpthqq80000gn/T/tmp.JA7VY9WL`
     Cloning registry from "https://github.com/JuliaRegistries/General.git"
       Added registry `General` to `/var/folders/jy/7hh5zyw95cg2lh66lfpthqq80000gn/T/tmp.JA7VY9WL/registries/General`
```

## After this PR

"Functional" API:

```
$ JULIA_DEPOT_PATH=$(mktemp -d) ./julia -e 'import Pkg; Pkg.Registry.add()'
  Installing known registries into `/var/folders/jy/7hh5zyw95cg2lh66lfpthqq80000gn/T/tmp.Ym1tAQm8`
     Cloning registry from "https://github.com/JuliaRegistries/General.git"
       Added registry `General` to `/var/folders/jy/7hh5zyw95cg2lh66lfpthqq80000gn/T/tmp.Ym1tAQm8/registries/General`
```

REPL mode:

```
$ JULIA_DEPOT_PATH=$(mktemp -d) ./julia -e 'import Pkg; Pkg.pkg"registry add"'
┌ Warning: The Pkg REPL mode is intended for interactive use only, and should not be used from scripts. It is recommended to use the functional API instead.
└ @ Pkg.REPLMode ~/Downloads/julia/usr/share/julia/stdlib/v1.8/Pkg/src/REPLMode/REPLMode.jl:378
  Installing known registries into `/var/folders/jy/7hh5zyw95cg2lh66lfpthqq80000gn/T/tmp.NJZU3SO9`
     Cloning registry from "https://github.com/JuliaRegistries/General.git"
       Added registry `General` to `/var/folders/jy/7hh5zyw95cg2lh66lfpthqq80000gn/T/tmp.NJZU3SO9/registries/General`
```