### PR TITLE
Correct compat annotation for extended platform selection

### DIFF
--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -230,8 +230,8 @@ This is deduced automatically by the `artifacts""` string macro, however if you 
 
 ## Extending Platform Selection
 
-!!! compat "Julia 1.6"
-    Pkg's extended platform selection requires at least Julia 1.6, and is considered experimental.
+!!! compat "Julia 1.7"
+    Pkg's extended platform selection requires at least Julia 1.7, and is considered experimental.
 
 New in Julia 1.6, `Platform` objects can have extended attributes applied to them, allowing artifacts to be tagged with things such as CUDA driver version compatibility, microarchitectural compatibility, julia version compatibility and more!
 Note that this feature is considered experimental and may change in the future.


### PR DESCRIPTION
#2024 didn't make it in time for 1.6 and wasn't backported, so adjust the compat
docs to account for that.
