### PR TITLE
Remove precompile resolve

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1502,9 +1502,8 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
 
     if Operations.is_manifest_current(ctx.env) === false
-        @warn """The project and manifest may be out of sync as either project dependencies have been \
-        added/removed or compat entries have changed since the manifest was last resolved.
-        Try `Pkg.resolve()` or consider `Pkg.update()` if necessary."""
+        @warn """The project dependencies or compat requirements have changed since the manifest was last resolved.
+        It is recommended to `Pkg.resolve()` or consider `Pkg.update()` if necessary."""
     end
 
     Operations.prune_manifest(ctx.env)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1038,7 +1038,6 @@ precompile(pkgs::Vector{String}=String[]; kwargs...) = precompile(Context(), pkg
 function precompile(ctx::Context, pkgs::Vector{String}=String[]; internal_call::Bool=false,
                     strict::Bool=false, warn_loaded = true, already_instantiated = false, kwargs...)
     Context!(ctx; kwargs...)
-    internal_call || resolve(ctx, silent_no_change = true)
     already_instantiated || instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -321,7 +321,6 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
             level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode=PKGMODE_PROJECT,
             update_registry::Bool=true,
             skip_writing_project::Bool=false,
-            silent_no_change::Bool=false,
             kwargs...)
     Context!(ctx; kwargs...)
     if update_registry
@@ -338,7 +337,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx.env.manifest, pkgs)
     end
-    Operations.up(ctx, pkgs, level; skip_writing_project, silent_no_change)
+    Operations.up(ctx, pkgs, level; skip_writing_project)
     return
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2006,9 +2006,8 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
         print_status(env, old_env, registries, header, filter_uuids, filter_names; diff, ignore_indent, io, outdated, silent_no_change)
     end
     if is_manifest_current(env) === false
-        printpkgstyle(io, :Warning, """The project and manifest may be out of sync as either project dependencies have been \
-        added/removed or compat entries have changed since the manifest was last resolved. \
-        Try `Pkg.resolve()` or consider `Pkg.update()` if necessary.""", ignore_indent; color=Base.warn_color())
+        printpkgstyle(io, :Warning, """The project dependencies or compat requirements have changed since the manifest was last resolved. \
+        It is recommended to `Pkg.resolve()` or consider `Pkg.update()` if necessary.""", ignore_indent; color=Base.warn_color())
     end
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1280,7 +1280,7 @@ function up_load_manifest_info!(pkg::PackageSpec, entry::PackageEntry)
 end
 
 function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
-            skip_writing_project::Bool=false, silent_no_change::Bool=false)
+            skip_writing_project::Bool=false)
     new_git = Set{UUID}()
     # TODO check all pkg.version == VersionSpec()
     # set version constraints according to `level`
@@ -1299,7 +1299,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     new_apply = download_source(ctx)
     download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)
     write_env(ctx.env; skip_writing_project) # write env before building
-    show_update(ctx.env, ctx.registries; io=ctx.io, silent_no_change)
+    show_update(ctx.env, ctx.registries; io=ctx.io)
     build_versions(ctx, union(new_apply, new_git))
 end
 
@@ -1859,7 +1859,7 @@ struct PackageStatusData
 end
 
 function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registries::Vector{Registry.RegistryInstance}, header::Symbol,
-                      uuids::Vector, names::Vector; manifest=true, diff=false, ignore_indent::Bool, outdated::Bool, io::IO, silent_no_change::Bool)
+                      uuids::Vector, names::Vector; manifest=true, diff=false, ignore_indent::Bool, outdated::Bool, io::IO)
     not_installed_indicator = sprint((io, args) -> printstyled(io, args...; color=:red), "→", context=io)
     not_latest_version_indicator = sprint((io, args) -> printstyled(io, args...; color=:yellow), "↓", context=io)
     filter = !isempty(uuids) || !isempty(names)
@@ -1873,7 +1873,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
     end
     xs = !diff ? xs : eltype(xs)[(id, old, new) for (id, old, new) in xs if old != new]
     if isempty(xs)
-        silent_no_change || printpkgstyle(io, Symbol("No Changes"), "to $(pathrepr(manifest ? env.manifest_file : env.project_file))", ignore_indent)
+        printpkgstyle(io, Symbol("No Changes"), "to $(pathrepr(manifest ? env.manifest_file : env.project_file))", ignore_indent)
         return nothing
     end
     xs = !filter ? xs : eltype(xs)[(id, old, new) for (id, old, new) in xs if (id in uuids || something(new, old).name in names)]
@@ -1963,17 +1963,17 @@ function git_head_env(env, project_dir)
     end
 end
 
-function show_update(env::EnvCache, registries::Vector{Registry.RegistryInstance}; io::IO, silent_no_change::Bool = false)
+function show_update(env::EnvCache, registries::Vector{Registry.RegistryInstance}; io::IO)
     old_env = EnvCache()
     old_env.project = env.original_project
     old_env.manifest = env.original_manifest
-    status(env, registries; header=:Updating, mode=PKGMODE_COMBINED, env_diff=old_env, ignore_indent=false, io=io, silent_no_change)
+    status(env, registries; header=:Updating, mode=PKGMODE_COMBINED, env_diff=old_env, ignore_indent=false, io=io)
     return nothing
 end
 
 function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}=PackageSpec[];
                 header=nothing, mode::PackageMode=PKGMODE_PROJECT, git_diff::Bool=false, env_diff=nothing, ignore_indent=true,
-                io::IO, outdated::Bool=false, silent_no_change::Bool=false)
+                io::IO, outdated::Bool=false)
     io == Base.devnull && return
     # if a package, print header
     if header === nothing && env.pkg !== nothing
@@ -2000,10 +2000,10 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
     diff = old_env !== nothing
     header = something(header, diff ? :Diff : :Status)
     if mode == PKGMODE_PROJECT || mode == PKGMODE_COMBINED
-        print_status(env, old_env, registries, header, filter_uuids, filter_names; manifest=false, diff, ignore_indent, io, outdated, silent_no_change)
+        print_status(env, old_env, registries, header, filter_uuids, filter_names; manifest=false, diff, ignore_indent, io, outdated)
     end
     if mode == PKGMODE_MANIFEST || mode == PKGMODE_COMBINED
-        print_status(env, old_env, registries, header, filter_uuids, filter_names; diff, ignore_indent, io, outdated, silent_no_change)
+        print_status(env, old_env, registries, header, filter_uuids, filter_names; diff, ignore_indent, io, outdated)
     end
     if is_manifest_current(env) === false
         printpkgstyle(io, :Warning, """The project dependencies or compat requirements have changed since the manifest was last resolved. \

--- a/test/api.jl
+++ b/test/api.jl
@@ -219,6 +219,7 @@ end
 
         ## Tests when circularity goes through the active project
         Pkg.activate("CircularDep1")
+        Pkg.resolve() # necessary because resolving in `Pkg.precompile` has been removed
         @test_logs (:warn, r"Circular dependency detected") Pkg.precompile()
         Pkg.activate(".")
         Pkg.activate("CircularDep2")

--- a/test/api.jl
+++ b/test/api.jl
@@ -223,6 +223,7 @@ end
         @test_logs (:warn, r"Circular dependency detected") Pkg.precompile()
         Pkg.activate(".")
         Pkg.activate("CircularDep2")
+        Pkg.resolve() # necessary because resolving in `Pkg.precompile` has been removed
         @test_logs (:warn, r"Circular dependency detected") Pkg.precompile()
         Pkg.activate(".")
         Pkg.activate("CircularDep3")

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -175,23 +175,24 @@ end
                 Pkg.compat("Example", "0.4")
                 @test Pkg.is_manifest_current() === false
                 Pkg.status(io = iob)
-                @test occursin("The project and manifest may be out of sync", String(take!(iob)))
-                @test_logs (:warn, r"The project and manifest may be out of sync") Pkg.instantiate()
+                sync_msg_str = r"The project dependencies or compat requirements have changed since the manifest was last resolved."
+                @test occursin(sync_msg_str, String(take!(iob)))
+                @test_logs (:warn, sync_msg_str) Pkg.instantiate()
 
                 Pkg.update()
                 @test Pkg.is_manifest_current() === true
                 Pkg.status(io = iob)
-                @test !occursin("The project and manifest may be out of sync", String(take!(iob)))
+                @test !occursin(sync_msg_str, String(take!(iob)))
 
                 Pkg.compat("Example", "0.5")
                 Pkg.status(io = iob)
-                @test occursin("The project and manifest may be out of sync", String(take!(iob)))
-                @test_logs (:warn, r"The project and manifest may be out of sync") Pkg.instantiate()
+                @test occursin(sync_msg_str, String(take!(iob)))
+                @test_logs (:warn, sync_msg_str) Pkg.instantiate()
 
                 Pkg.rm("Example")
                 @test Pkg.is_manifest_current() === true
                 Pkg.status(io = iob)
-                @test !occursin("The project and manifest may be out of sync", String(take!(iob)))
+                @test !occursin(sync_msg_str, String(take!(iob)))
             end
         end
     end


### PR DESCRIPTION
A resolve was previously added to direct calls of `Pkg.precompile` to try to prevent the unexpected behavior users saw when the manifest was out of sync with the project.

The manifest out of sync warning introduced in https://github.com/JuliaLang/Pkg.jl/pull/2815 actually serves as a warning if the manifest isn't resolved/in-sync with the project, so this resolve can be removed.

Closes #2904 

But removing the resolve does expose the risk of not detecting circular deps fully, as demonstrated by two resolves needing to be added to the circular dep tests. 