### PR TITLE
Resolve after setting compat via Pkg.compat

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1773,6 +1773,8 @@ function compat(ctx::Context; io = nothing)
     end
     new_entry = strip(resp)
     compat(ctx, dep, string(new_entry))
+    printpkgstyle(io, :Resolve, "checking for complance with the new compat rules")
+    resolve(ctx)
     return
 end
 function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io = nothing, kwargs...)
@@ -1788,6 +1790,8 @@ function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io
         else
             printpkgstyle(io, :Compat, "entry set:\n  $(pkg) = $(repr(compat_str))")
         end
+        printpkgstyle(io, :Resolve, "checking for compliance with the new compat rules")
+        resolve(ctx)
         return
     else
         pkgerror("No package named $pkg in current Project")

--- a/src/API.jl
+++ b/src/API.jl
@@ -20,6 +20,7 @@ using Base.BinaryPlatforms
 import ..stderr_f, ..stdout_f
 using ..Artifacts: artifact_paths
 using ..MiniProgressBars
+import ..Resolve: ResolverError
 
 include("generate.jl")
 
@@ -1773,8 +1774,16 @@ function compat(ctx::Context; io = nothing)
     end
     new_entry = strip(resp)
     compat(ctx, dep, string(new_entry))
-    printpkgstyle(io, :Resolve, "checking for complance with the new compat rules")
-    resolve(ctx)
+    printpkgstyle(io, :Resolve, "checking for complance with the new compat rules...")
+    try
+        resolve(ctx)
+    catch e
+        if e isa ResolverError
+            printpkgstyle(io, :Error, e.msg, color = Base.warn_color())
+        else
+            rethrow()
+        end
+    end
     return
 end
 function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io = nothing, kwargs...)
@@ -1790,8 +1799,16 @@ function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io
         else
             printpkgstyle(io, :Compat, "entry set:\n  $(pkg) = $(repr(compat_str))")
         end
-        printpkgstyle(io, :Resolve, "checking for compliance with the new compat rules")
-        resolve(ctx)
+        printpkgstyle(io, :Resolve, "checking for compliance with the new compat rules...")
+        try
+            resolve(ctx)
+        catch e
+            if e isa ResolverError
+                printpkgstyle(io, :Error, e.msg, color = Base.warn_color())
+            else
+                rethrow()
+            end
+        end
         return
     else
         pkgerror("No package named $pkg in current Project")

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -389,13 +389,15 @@ PSA[:name => "compat",
     :api => API.compat,
     :arg_count => 0 => 2,
     :completions => complete_installed_packages_and_compat,
-    :description => "edit compat entries in the current Project",
+    :description => "edit compat entries in the current Project and re-resolve",
     :help => md"""
     compat [pkg] [compat_string]
 
 Edit project [compat] entries directly, or via an interactive menu by not specifying any arguments.
 When directly editing use tab to complete the package name and any existing compat entry.
 Specifying a package with a blank compat entry will remove the entry.
+After changing compat entries a `resolve` will be attempted to check whether the current
+environment is compliant with the new compat rules.
 """,
 ],
 PSA[:name => "gc",


### PR DESCRIPTION
With the new `pkg> compat` entry method, and the project/manifest sync checking (#2815) I think it makes sense to automatically resolve after changing the compat entry via that interface

For instance
```
(@v1.8) pkg> st
Status `~/.julia/environments/v1.8/Project.toml`
  [336ed68f] CSV v0.8.0

(@v1.8) pkg> compat CSV 0.9
      Compat entry set:
  CSV = "0.9"
     Resolve checking for compliance with the new compat rules...
       Error empty intersection between CSV@0.8.0 and project compatibility 0.9

(@v1.8) pkg> up
...

(@v1.8) pkg> compat CSV 0.9
      Compat entry set:
  CSV = "0.9"
     Resolve checking for compliance with the new compat rules...
  No Changes to `~/.julia/environments/v1.8/Project.toml`
  No Changes to `~/.julia/environments/v1.8/Manifest.toml`
```