### PR TITLE
Only show the Codecov commit statuses on pull requests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,11 @@
-comment: false
+comment: false # Disable the comment that is posted on pull requests.
+coverage:
+  status:
+    patch: off
+      default:
+        only_pulls: true # Only show the `codecov/patch` commit status on pull requests.
+    project: off
+      default:
+        only_pulls: true # Only show the `codecov/project` commit status on pull requests.
 github_checks:
-    annotations: false
+    annotations: false # Disable the annotations in the "Files Changed" view of a pull request.

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,10 @@
 comment: false # Disable the comment that is posted on pull requests.
 coverage:
   status:
-    patch: off
+    patch:
       default:
         only_pulls: true # Only show the `codecov/patch` commit status on pull requests.
-    project: off
+    project:
       default:
         only_pulls: true # Only show the `codecov/project` commit status on pull requests.
 github_checks:


### PR DESCRIPTION
Replaces #2887

With this pull request, Codecov commit statuses will continue to be shown on pull requests. However, they will not be shown on master.