### PR TITLE
deprecate Pkg.activate do-block syntax from public API

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1671,15 +1671,9 @@ function activate(path::AbstractString; shared::Bool=false, temp::Bool=false, io
     add_snapshot_to_undo()
     return nothing
 end
-function activate(f::Function, new_project::AbstractString)
-    old = Base.ACTIVE_PROJECT[]
-    Base.ACTIVE_PROJECT[] = new_project
-    try
-        f()
-    finally
-        Base.ACTIVE_PROJECT[] = old
-    end
-end
+
+@deprecate activate(f::Function, new_project::AbstractString) Operations.activate(f::Function, new_project::AbstractString)
+
 
 function compat(ctx::Context; io = nothing)
     io = something(io, ctx.io)
@@ -1899,7 +1893,7 @@ end
 function upgrade_manifest(man_path::String)
     dir = mktempdir()
     cp(man_path, joinpath(dir, "Manifest.toml"))
-    Pkg.activate(dir) do
+    Pkg.Operations.activate(dir) do
         Pkg.upgrade_manifest()
     end
     mv(joinpath(dir, "Manifest.toml"), man_path, force = true)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1003,6 +1003,17 @@ end
 ##############
 # Operations #
 ##############
+
+function activate(f::Function, new_project::AbstractString)
+    old = Base.ACTIVE_PROJECT[]
+    Base.ACTIVE_PROJECT[] = new_project
+    try
+        f()
+    finally
+        Base.ACTIVE_PROJECT[] = old
+    end
+end
+
 function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
     drop = UUID[]
     # find manifest-mode drops

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -735,7 +735,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             rethrow()
         end
         choice == -1 && return false
-        API.activate(envs[choice]) do
+        Operations.activate(envs[choice]) do
             API.add(string.(available_pkgs))
         end
     elseif (lower_resp in ["n"])

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -465,7 +465,7 @@ end
         Pkg.activate(ap_path)
         @test !isdir(artifact_path(engaged_hash))
         @test !isdir(artifact_path(disengaged_hash))
-    
+
         # Instantiate with the environment variable set, but with an explicit
         # tag set in the platform object, which overrides.
         withenv("FLOOBLECRANK" => "disengaged") do
@@ -633,7 +633,7 @@ end
 
         # Verify that the name-based override worked; extract paths from module that
         # loads overridden package artifacts.
-        Pkg.activate(depot_container) do
+        Pkg.Operations.activate(depot_container) do
             copy_test_package(depot_container, "ArtifactOverrideLoading")
             add_this_pkg()
             Pkg.develop(Pkg.Types.PackageSpec(
@@ -682,7 +682,7 @@ end
 
         # Verify that the name-based override worked; extract paths from module that
         # loads overridden package artifacts.
-        Pkg.activate(depot_container) do
+        Pkg.Operations.activate(depot_container) do
             (arty_path, barty_path) = Core.eval(Module(:__anon__), quote
                 using ArtifactOverrideLoading
                 arty_path, barty_path


### PR DESCRIPTION
This is what was decided in https://github.com/JuliaLang/Pkg.jl/pull/2639
cc. @st-- @fredrikekre 

```
% ../julia/julia --project --depwarn=yes
...
julia> import Pkg
[ Info: Precompiling Pkg [44cfe95a-1eb2-52ea-b672-e2afdf69b79f]

julia> Pkg.activate("/tmp/123") do
       Pkg.status()
       end
┌ Warning: `activate(f::Function, new_project::AbstractString)` is deprecated, use `Operations.activate(f::Function, new_project::AbstractString)` instead.
│   caller = top-level scope at REPL[2]:1
└ @ Core REPL[2]:1
Status `/private/tmp/123/Project.toml` (empty project)
```

But does it achieve the right message? It's not saying "don't use this", just "use this other function".
Perhaps `@deprecate` needs a `warn_against = true` mode that says something like:

```
┌ Warning: `activate(f::Function, new_project::AbstractString)` is deprecated, this functionality should not be used but  `Operations.activate(f::Function, new_project::AbstractString)` does exist as a replacement.
│   caller = top-level scope at REPL[2]:1
└ @ Core REPL[2]:1
```