### PR TITLE
Set `__precompile__(false)` in the `ArtifactOverrideLoading` test package

### DIFF
--- a/test/test_packages/ArtifactOverrideLoading/src/ArtifactOverrideLoading.jl
+++ b/test/test_packages/ArtifactOverrideLoading/src/ArtifactOverrideLoading.jl
@@ -1,3 +1,4 @@
+__precompile__(false)
 module ArtifactOverrideLoading
 using Pkg.Artifacts
 export arty_path, barty_path


### PR DESCRIPTION
This pull request fixes the following two warnings:

```
┌ Warning: Module Pkg with build ID 159589902205 is missing from the cache.
│ This may mean Pkg [54cfe95a-1eb2-52ea-b672-e2afdf69b78f] does not support precompilation but is imported by a module that does.
└ @ Base loading.jl:1160
┌ Warning: Module Pkg with build ID 159589902205 is missing from the cache.
│ This may mean Pkg [54cfe95a-1eb2-52ea-b672-e2afdf69b78f] does not support precompilation but is imported by a module that does.
└ @ Base loading.jl:1160
```

Ref https://github.com/JuliaLang/Pkg.jl/pull/2919#issuecomment-1005366034

---

### TODO

- [x] Set `JULIA_PKG_TEST_QUIET` back to `false`