### PR TITLE
disregard yanked versions when showing outdated packages

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1773,7 +1773,9 @@ function status_compat_info(pkg::PackageSpec, env::EnvCache, regs::Vector{Regist
         reg_pkg === nothing && continue
         info = Registry.registry_info(reg_pkg)
         reg_compat_info = Registry.compat_info(info)
-        max_version_reg = maximum(keys(reg_compat_info); init=v"0")
+        versions = keys(reg_compat_info)  
+        versions = filter(v -> !Registry.isyanked(info, v), versions)
+        max_version_reg = maximum(versions; init=v"0")
         max_version = max(max_version, max_version_reg)
         compat_spec = get_compat(env.project, pkg.name)
         versions_in_compat = filter(in(compat_spec), keys(reg_compat_info))


### PR DESCRIPTION
Fixes

```
(jl_uUTw8F) pkg> st --outdated -m
Status `/tmp/jl_uUTw8F/Manifest.toml`
⌃ [78c3b35d] Mocking v0.7.3 (<v0.7.4)
⌅ [88634af6] SaferIntegers v2.5.5 (<v3.0.3): FHIRClient

(jl_uUTw8F) pkg> add Mocking@0.7.4
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package Mocking [78c3b35d]:
 Mocking [78c3b35d] log:
 ├─possible versions are: 0.5.6-0.7.3 or uninstalled
 └─restricted to versions 0.7.4 by an explicit requirement — no versions left
``` 