### PR TITLE
Fix manifest version check bug

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -323,8 +323,7 @@ function check_warn_manifest_julia_version_compat(manifest::Manifest, manifest_f
         been resolved with a different julia version.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
         return
     end
-    if v.major != VERSION.major && v.minor != VERSION.minor
-        ver_str = something(manifest.julia_version, "pre-1.7")
+    if Base.thisminor(v) != Base.thisminor(VERSION)
         @warn """The active manifest file has dependencies that were resolved with a different julia \
         version ($(manifest.julia_version)). Unexpected behavior may occur.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
     end

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -87,6 +87,16 @@ end
                 @test m.other == m2.other
             end
         end
+        reference_manifest_isolated_test("v2.0") do env_dir, env_manifest
+            m = Pkg.Types.read_manifest(env_manifest)
+            m.julia_version = v"1.5.0"
+            msg = r"The active manifest file has dependencies that were resolved with a different julia version"
+            @test_logs (:warn, msg) Pkg.Types.check_warn_manifest_julia_version_compat(m, env_manifest)
+
+            m.julia_version = nothing
+            msg = r"The active manifest file is missing a julia version entry"
+            @test_logs (:warn, msg) Pkg.Types.check_warn_manifest_julia_version_compat(m, env_manifest)
+        end
     end
 
     @testset "v3.0: unknown format, warn" begin


### PR DESCRIPTION
I realized in https://github.com/JuliaLang/Pkg.jl/pull/2666 that there's a bug preventing the manifest julia version mismatch log from showing.

#2666 takes care of the 1.6 backport