### PR TITLE
Use precompile context to find package location

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1241,8 +1241,13 @@ function precompile(ctx::Context, pkgs::Vector{String}=String[]; internal_call::
     Base.LOADING_CACHE[] = Base.LoadingCache()
     for (pkg, deps) in depsmap # precompilation loop
         paths = Base.find_all_in_cache_path(pkg)
-        sourcepath = Base.locate_package(pkg)
-        if sourcepath === nothing
+        pkgpath = Base.manifest_uuid_path(ctx.env.project_file, pkg)
+        if pkgpath !== nothing
+            sourcepath = Base.entry_path(pkgpath, pkg.name)
+        else
+            sourcepath = Base.locate_package(pkg)
+        end
+        if sourcepath === nothing || !isfile(sourcepath)
             failed_deps[pkg] = "Error: Missing source file for $(pkg)"
             notify(was_processed[pkg])
             continue

--- a/test/api.jl
+++ b/test/api.jl
@@ -263,4 +263,19 @@ end
     end
 end
 
+@testset "operate via contexts" begin
+    isolate() do
+        mktempdir() do dir
+            cd(dir) do
+                Pkg.generate("MyProj")
+            end
+            ctx = Pkg.Types.Context(env=Pkg.Types.EnvCache(joinpath(dir, "MyProj", "Project.toml")))
+            Pkg.add(ctx, [PackageSpec("Example")])
+            Pkg.precompile(ctx)
+        end
+    end
+end
+
+
+
 end # module APITests


### PR DESCRIPTION
Precompile currently calls `Base.locate_package`, which which looks in the current environment, rather than the environment specified via the context. This changes the logic to look up the path via the context environment, and fall back on `Base.locate_package` if this was not successful.