### PR TITLE
Make tests robust against Git's `init.defaultBranch` option being set, while still supporting Git 1.2.0+ and Git 2.0.0+

### DIFF
--- a/test/subdir.jl
+++ b/test/subdir.jl
@@ -127,8 +127,7 @@ end
 # Note: we cannot use `git init -b`, because that requires Git 2.28.0+, and we want to
 # support older versions of Git. Therefore, we instead use `git branch -f` and `git branch -D`,
 # which only require Git 1.2.0+ or Git 2.0.0+.
-function fix_default_branch(; dir::String)
-    new_branch_name = "master"
+function fix_default_branch(; dir::String, new_branch_name::String = "master")
     old_branch_name = _current_branch_name(; dir)
     git = gitcmd(dir)
     if old_branch_name != new_branch_name

--- a/test/subdir.jl
+++ b/test/subdir.jl
@@ -44,9 +44,10 @@ function setup_packages_repository(dir)
         """)
 
     git = gitcmd(dir)
-    run(pipeline(`$git init -b master -q`, stdout = stdout_f(), stderr = stderr_f()))
+    run(pipeline(`$git init -q`, stdout = stdout_f(), stderr = stderr_f()))
     run(pipeline(`$git add .`, stdout = stdout_f(), stderr = stderr_f()))
     run(pipeline(`$git commit -qm 'Create repository.'`, stdout = stdout_f(), stderr = stderr_f()))
+    fix_default_branch(; dir)
     package_tree_hash = readchomp(`$git rev-parse HEAD:julia`)
     dep_tree_hash = readchomp(`$git rev-parse HEAD:dependencies/Dep`)
     return package_tree_hash, dep_tree_hash
@@ -104,9 +105,46 @@ function setup_registry(dir, packages_dir_url, package_tree_hash, dep_tree_hash)
         """)
 
     git = gitcmd(dir)
-    run(pipeline(`$git init -b master -q`, stdout = stdout_f(), stderr = stderr_f()))
+    run(pipeline(`$git init -q`, stdout = stdout_f(), stderr = stderr_f()))
     run(pipeline(`$git add .`, stdout = stdout_f(), stderr = stderr_f()))
     run(pipeline(`$git commit -qm 'Create repository.'`, stdout = stdout_f(), stderr = stderr_f()))
+    fix_default_branch(; dir)
+end
+
+# Some of our tests assume that the default branch name is `master`.
+# However, if the user has `init.defaultBranch` set in their global Git config, `git init`
+# might create repositories with a default branch name that is not equal to `master`.
+#
+# Therefore, after we make the first commit to a new repository, we check and see what the
+# branch name is. If the branch name is `master`, we do nothing. If the branch name is not
+# `master`, then we run the following commands:
+# 1. `git branch -f master`
+# 2. `git checkout master`
+# 3. `git branch -D $(old_branch_name)`
+#
+# Note: this requires Git 1.2.0+ or Git 2.0.0+
+#
+# Note: we cannot use `git init -b`, because that requires Git 2.28.0+, and we want to
+# support older versions of Git. Therefore, we instead use `git branch -f` and `git branch -D`,
+# which only require Git 1.2.0+ or Git 2.0.0+.
+function fix_default_branch(; dir::String)
+    new_branch_name = "master"
+    old_branch_name = _current_branch_name(; dir)
+    git = gitcmd(dir)
+    if old_branch_name != new_branch_name
+        # Note: the `branch -f` flag is supported in Git 1.2.0+ and Git 2.0.0+
+        # Note: the `branch -D` flag is supported in Git 1.2.0+ and Git 2.0.0+
+        run(`$(git) branch -f $(new_branch_name)`)
+        run(`$(git) checkout $(new_branch_name)`)
+        run(`$(git) branch -D $(old_branch_name)`)
+    end
+    # A sanity check to make sure that the branch rename worked successfully.
+    @test _current_branch_name(; dir) == new_branch_name
+    return nothing
+end
+function _current_branch_name(; dir::String)
+    git = gitcmd(dir)
+    return strip(read(`$(git) rev-parse --abbrev-ref HEAD`, String))
 end
 
 @testset "subdir" begin


### PR DESCRIPTION
Follow-up to #2946
Replaces and closes #2948

## Description

After we make the first commit to a new repository, we check and see what the branch name is. If the branch name is `master`, we do nothing. If the branch name is not `master`, we run the following commands:

1. `git branch -f master`
2. `git checkout master`
3. `git branch -D $(old_branch_name)`

After running this command, the branch name is now `master`.

This supports Git 1.2.0+ and Git 2.0.0+. If someone really needs to support a version of Git older than 1.2.0, then we'll need to rewrite these tests to use the LibGit2 stdlib instead.

## Compatibility with Git 1.2.0+

#### Git 1.2.0: `branch -f`

https://github.com/git/git/blob/v1.2.0/Documentation/git-branch.txt#L28-L29

```
-f::
	Force a reset of <branchname> to <start-point> (or current head).
```

#### Git 1.2.0: `branch -D`

https://github.com/git/git/blob/v1.2.0/Documentation/git-branch.txt#L22-L26

```
-d::
	Delete a branch. The branch must be fully merged.

-D::
	Delete a branch irrespective of its index status.
```

## Compatibility with Git 2.0.0+

#### Git 2.0.0: `branch -f`

https://github.com/git/git/blob/v2.0.0/Documentation/git-branch.txt#L94-L97

```
-f::
--force::
	Reset <branchname> to <startpoint> if <branchname> exists
	already. Without `-f` 'git branch' refuses to change an existing branch.
```

#### Git 2.0.0: `branch -D`

https://github.com/git/git/blob/v2.0.0/Documentation/git-branch.txt#L77-L84

```
-d::
--delete::
	Delete a branch. The branch must be fully merged in its
	upstream branch, or in `HEAD` if no upstream was set with
	`--track` or `--set-upstream`.

-D::
	Delete a branch irrespective of its merged status.
```

https://github.com/git/git/blob/v2.0.0/Documentation/git-branch.txt#L64-L66

```
With a `-d` or `-D` option, `<branchname>` will be deleted.  You may
specify more than one branch for deletion.  If the branch currently
has a reflog then the reflog will also be deleted.
```