### PR TITLE
Docs: document `Registry.add()` from #2898

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -28,6 +28,8 @@ url::Union{String,Nothing}=nothing, path::Union{String,Nothing}=nothing, linked:
 
 Add new package registries.
 
+The no-argument `Pkg.Registry.add()` will install the default registries.
+
 !!! compat "Julia 1.1"
     Pkg's registry handling requires at least Julia 1.1.
 


### PR DESCRIPTION
This is documenting #2898, which would make it the first-and-only public API to install the default registries. Yay!

Feel free to edit the PR to change the wording, I mostly wanted to get the ball rolling.