### PR TITLE
Make `f(ctx` methods part of API

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -461,6 +461,15 @@ end
         end
         @test haskey(Pkg.project().dependencies, "Example")
     end
+    # Basic add with context by version. Issue #2938
+    isolate(loaded_depot=true) do
+        Pkg.add(Pkg.Types.Context(), [Pkg.PackageSpec(;name="Example", version="0.5.3")])
+        Pkg.dependencies(exuuid) do ex
+            @test ex.is_tracking_registry
+            @test ex.version == v"0.5.3"
+        end
+        @test haskey(Pkg.project().dependencies, "Example")
+    end
     # Basic Add by VersionRange
     #= TODO
     isolate(loaded_depot=true) do


### PR DESCRIPTION
As @KristofferC pointed out in https://github.com/JuliaLang/Pkg.jl/issues/2938#issuecomment-1012105819 the `add(ctx..` etc entry points are considered internals.

BinaryBuilder needs to set `add(Context(; julia_version), ...`) for the julia version resolver stuff.

So it seems best to make that format formally part of the API, and pass them through the necessary processing steps.

This also distinguishes the API entry points from internals.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/2938

Todo:
- [ ] Add tests for all the added API entrypoints

cc. @giordano 
