### PR TITLE
restore try catch for unpacking archive

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -511,7 +511,15 @@ function install_archive(
         url_success || continue
         dir = joinpath(tempdir(), randstring(12))
         push!(tmp_objects, dir) # for cleanup
-        unpack(path, dir; verbose=false)
+        # Might fail to extract an archive (https://github.com/JuliaPackaging/PkgServer.jl/issues/126)
+        try
+            unpack(path, dir; verbose=false)
+        catch e
+            e isa InterruptException && rethrow()
+            @warn "failed to extract archive downloaded from $(url)"
+            url_success = false
+        end
+        url_success || continue
         if top
             unpacked = dir
         else


### PR DESCRIPTION
Allows us to continue after a failed download from the PkgServer (e.g. from https://github.com/JuliaPackaging/PkgServer.jl/issues/126). Was removed in https://github.com/JuliaLang/Pkg.jl/commit/67ed9cb3541368e3f98867ed809de7c6db32f4cc#diff-6dfb4e40705b22a427451362ea83b4e3a763028e3dcaa3b9b1846aa1ec84370fL501