### PR TITLE
CI: make the CI output quiet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - run: julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
-          JULIA_PKG_TEST_QUIET: "false" # "true" is the default. i.e. tests are quiet when this env var isn't set
+          JULIA_PKG_TEST_QUIET: "true" # "true" is the default. i.e. tests are quiet when this env var isn't set
       - uses: julia-actions/julia-processcoverage@v1
         env:
             JULIA_PKG_SERVER: ${{ matrix.pkg-server }}


### PR DESCRIPTION
This PR makes the CI output quiet.

If a user is trying to debug a PR, they can always change this value back to `"false"` on their PR branch, and then the PR CI will be verbose.