### PR TITLE
Inform user about Julia versions that support new manifest in warning msg.

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -285,7 +285,7 @@ end
 function write_manifest(manifest::Manifest, manifest_file::AbstractString)
     if manifest.manifest_format.major == 1
         @warn """The active manifest file at `$(manifest_file)` has an old format that is being maintained.
-            To update to the new format run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving.
+            To update to the new format, which is supported by Julia versions ≥ 1.6.2, run `Pkg.upgrade_manifest()` which will upgrade the format without re-resolving.
             To then record the julia version re-resolve with `Pkg.resolve()` and if there are resolve conflicts consider `Pkg.update()`.""" maxlog = 1 _id = Symbol(manifest_file)
     end
     return write_manifest(destructure(manifest), manifest_file)


### PR DESCRIPTION
(trivial change, see [discussion](https://discourse.julialang.org/t/julia-version-lower-bound-for-new-manifest-format/76152/))