### PR TITLE
add ranked suggestions to `add` error

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -261,7 +261,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
     project_deps_resolve!(ctx.env, pkgs)
     registry_resolve!(ctx.registries, pkgs)
     stdlib_resolve!(pkgs)
-    ensure_resolved(ctx.env.manifest, pkgs, registry=true)
+    ensure_resolved(ctx, ctx.env.manifest, pkgs, registry=true)
 
     for pkg in pkgs
         if Types.collides_with_project(ctx.env, pkg)
@@ -298,7 +298,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode=PKGMODE_PROJECT, all_p
 
     mode == PKGMODE_PROJECT && project_deps_resolve!(ctx.env, pkgs)
     mode == PKGMODE_MANIFEST && manifest_resolve!(ctx.env.manifest, pkgs)
-    ensure_resolved(ctx.env.manifest, pkgs)
+    ensure_resolved(ctx, ctx.env.manifest, pkgs)
 
     Operations.rm(ctx, pkgs; mode)
     return
@@ -336,7 +336,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         mode == PKGMODE_MANIFEST && manifest_resolve!(ctx.env.manifest, pkgs)
         project_deps_resolve!(ctx.env, pkgs)
         manifest_resolve!(ctx.env.manifest, pkgs)
-        ensure_resolved(ctx.env.manifest, pkgs)
+        ensure_resolved(ctx, ctx.env.manifest, pkgs)
     end
     Operations.up(ctx, pkgs, level; skip_writing_project)
     return
@@ -375,7 +375,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwar
     end
 
     project_deps_resolve!(ctx.env, pkgs)
-    ensure_resolved(ctx.env.manifest, pkgs)
+    ensure_resolved(ctx, ctx.env.manifest, pkgs)
     Operations.pin(ctx, pkgs)
     return
 end
@@ -401,7 +401,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwa
     end
 
     manifest_resolve!(ctx.env.manifest, pkgs)
-    ensure_resolved(ctx.env.manifest, pkgs)
+    ensure_resolved(ctx, ctx.env.manifest, pkgs)
 
     Operations.free(ctx, pkgs; err_if_free = !all_pkgs)
     return
@@ -426,7 +426,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         project_resolve!(ctx.env, pkgs)
         project_deps_resolve!(ctx.env, pkgs)
         manifest_resolve!(ctx.env.manifest, pkgs)
-        ensure_resolved(ctx.env.manifest, pkgs)
+        ensure_resolved(ctx, ctx.env.manifest, pkgs)
     end
     Operations.test(
         ctx,
@@ -1020,7 +1020,7 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}; verbose=false, kwargs...
     end
     project_resolve!(ctx.env, pkgs)
     manifest_resolve!(ctx.env.manifest, pkgs)
-    ensure_resolved(ctx.env.manifest, pkgs)
+    ensure_resolved(ctx, ctx.env.manifest, pkgs)
     Operations.build(ctx, Set{UUID}(pkg.uuid for pkg in pkgs), verbose)
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -627,7 +627,7 @@ function set_repo_source_from_registry!(ctx, pkg)
         Pkg.Operations.update_registries(ctx; force=false)
         registry_resolve!(ctx.registries, pkg)
     end
-    ensure_resolved(ctx.env.manifest, [pkg]; registry=true)
+    ensure_resolved(ctx, ctx.env.manifest, [pkg]; registry=true)
     # We might have been given a name / uuid combo that does not have an entry in the registry
     for reg in ctx.registries
         regpkg = get(reg, pkg.uuid, nothing)
@@ -885,7 +885,7 @@ function stdlib_resolve!(pkgs::AbstractVector{PackageSpec})
 end
 
 # Ensure that all packages are fully resolved
-function ensure_resolved(manifest::Manifest,
+function ensure_resolved(ctx::Context, manifest::Manifest,
         pkgs::AbstractVector{PackageSpec};
         registry::Bool=false,)::Nothing
     unresolved_uuids = Dict{String,Vector{UUID}}()
@@ -901,7 +901,6 @@ function ensure_resolved(manifest::Manifest,
         push!(unresolved_names, pkg.uuid)
     end
     isempty(unresolved_uuids) && isempty(unresolved_names) && return
-    ctx = Context()
     msg = sprint(context = ctx.io) do io
         if !isempty(unresolved_uuids)
             print(io, "The following package names could not be resolved:")

--- a/test/new.jl
+++ b/test/new.jl
@@ -407,6 +407,19 @@ end
         @test_throws PkgError(
             "version specification invalid when tracking a repository: `0.5.0` specified for package `Example`"
             ) Pkg.add(name="Example", rev="master", version="0.5.0")
+        # Adding with a slight typo gives suggestions
+        try Pkg.add("Examplle")
+            @assert false # to fail if add doesn't error
+        catch err
+            @test err isa PkgError
+            @test match(r"ERROR: The following package names could not be resolved:", err.msg) !== nothing
+            @test match(r"* Examplle (not found in project, manifest or registry)", err.msg) !== nothing
+            @test match(r"Suggestions:", err.msg) !== nothing
+            @test match(r"Example", err.msg) !== nothing
+        end
+        @test_throws PkgError(
+            "name, UUID, URL, or filesystem path specification required when calling `add`"
+            ) Pkg.add(Pkg.PackageSpec())
         # Adding an unregistered package
         @test_throws PkgError Pkg.add("ThisIsHopefullyRandom012856014925701382")
         # Wrong UUID

--- a/test/new.jl
+++ b/test/new.jl
@@ -410,7 +410,7 @@ end
         # Adding with a slight typo gives suggestions
         try
             Pkg.add("Examplle")
-            @assert false # to fail if add doesn't error
+            @test false # to fail if add doesn't error
          catch err
             @test err isa PkgError
             @test occursin("The following package names could not be resolved:", err.msg)
@@ -442,7 +442,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         close(LibGit2.init(tempdir))
         try Pkg.add(path=tempdir)
-            @assert false
+            @test false # to fail if add doesn't error
         catch err
             @test err isa PkgError
             @test match(r"^invalid git HEAD", err.msg) !== nothing

--- a/test/new.jl
+++ b/test/new.jl
@@ -408,14 +408,15 @@ end
             "version specification invalid when tracking a repository: `0.5.0` specified for package `Example`"
             ) Pkg.add(name="Example", rev="master", version="0.5.0")
         # Adding with a slight typo gives suggestions
-        try Pkg.add("Examplle")
+        try
+            Pkg.add("Examplle")
             @assert false # to fail if add doesn't error
-        catch err
+         catch err
             @test err isa PkgError
-            @test match(r"ERROR: The following package names could not be resolved:", err.msg) !== nothing
-            @test match(r"* Examplle (not found in project, manifest or registry)", err.msg) !== nothing
-            @test match(r"Suggestions:", err.msg) !== nothing
-            @test match(r"Example", err.msg) !== nothing
+            @test occursin("The following package names could not be resolved:", err.msg)
+            @test occursin("Examplle (not found in project, manifest or registry)", err.msg)
+            @test occursin("Suggestions:", err.msg)
+            # @test occursin("Example", err.msg) # can't test this as each char in "Example" is individually colorized
         end
         @test_throws PkgError(
             "name, UUID, URL, or filesystem path specification required when calling `add`"


### PR DESCRIPTION
When a package isn't found by name this adds a number of ranked matches (depending on the result scores and terminal width), via the same fuzzyscore search that `REPL` does for help mode.

<img width="654" alt="Screen Shot 2022-02-13 at 3 51 00 PM" src="https://user-images.githubusercontent.com/1694067/153774533-3328df81-57ed-4072-917b-1617aec03460.png">

If there are no match scores above zero, no suggestions are shown.
It seems like the search could be improved in REPL because it's unfortunate that the diffeq spelling mistake isn't found.
Also the `fuzzysort` method tweak could be upstreamed.

It adds a bit of slowness, but I think that's ok for this kind of user feedback (this is with 3 registries including General)

master
```
julia> @time try Pkg.add("Image"); catch  end
  0.009007 seconds (23.61 k allocations: 2.039 MiB)

julia> @time try Pkg.add("Image"); catch  end
  0.008462 seconds (23.62 k allocations: 2.040 MiB)
```

this PR
```
julia> @time try Pkg.add("Image"); catch end
  0.027184 seconds (101.59 k allocations: 13.357 MiB)

julia> @time try Pkg.add("Image"); catch end
  0.044085 seconds (101.59 k allocations: 13.357 MiB, 22.40% gc time)

julia> @time try Pkg.add("Image"); catch end
  0.026322 seconds (101.59 k allocations: 13.356 MiB)
```


Closes https://github.com/JuliaLang/Pkg.jl/issues/2911