### PR TITLE
Drop build info from julia version stored in manifest

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -295,17 +295,21 @@ dropbuild(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch, isempty(v
 # looks at uuid, version, repo/path,
 # sets version to a VersionNumber
 # adds any other packages which may be in the dependency graph
-# all versioned packges should have a `tree_hash`
+# all versioned packages should have a `tree_hash`
 function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
     # compatibility
     if julia_version !== nothing
-        env.manifest.julia_version = julia_version
+        try
+            error()
+        catch err
+            @error "julia_version branch hit" exception=(err, catch_backtrace())
+        end
+        # only set the manifest julia_version if ctx.julia_version is not nothing
+        env.manifest.julia_version = dropbuild(VERSION)
         v = intersect(julia_version, get_compat(env.project, "julia"))
         if isempty(v)
             @warn "julia version requirement for project not satisfied" _module=nothing _file=nothing
         end
-    else
-        env.manifest.julia_version = dropbuild(VERSION)
     end
     names = Dict{UUID, String}(uuid => name for (uuid, (name, version)) in stdlibs())
     # recursive search for packages which are tracking a path

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -287,6 +287,9 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
     return fixed
 end
 
+# drops build detail in version but keeps the main prerelease context
+# i.e. dropbuild(v"2.0.1-rc1.21321") == v"2.0.1-rc1"
+dropbuild(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch, isempty(v.prerelease) ? () : (v.prerelease[1],))
 
 # Resolve a set of versions given package version specs
 # looks at uuid, version, repo/path,
@@ -302,7 +305,7 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
             @warn "julia version requirement for project not satisfied" _module=nothing _file=nothing
         end
     else
-        env.manifest.julia_version = VERSION
+        env.manifest.julia_version = dropbuild(VERSION)
     end
     names = Dict{UUID, String}(uuid => name for (uuid, (name, version)) in stdlibs())
     # recursive search for packages which are tracking a path

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -299,11 +299,6 @@ dropbuild(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch, isempty(v
 function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
     # compatibility
     if julia_version !== nothing
-        try
-            error()
-        catch err
-            @error "julia_version branch hit" exception=(err, catch_backtrace())
-        end
         # only set the manifest julia_version if ctx.julia_version is not nothing
         env.manifest.julia_version = dropbuild(VERSION)
         v = intersect(julia_version, get_compat(env.project, "julia"))

--- a/test/manifest/formats/v2.0/Manifest.toml
+++ b/test/manifest/formats/v2.0/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.0-DEV.1199"
+julia_version = "1.7.0-DEV"
 manifest_format = "2.0"
 some_other_field = "other"
 some_other_data = [1,2,3,4]

--- a/test/manifest/formats/v3.0_unknown/Manifest.toml
+++ b/test/manifest/formats/v3.0_unknown/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.0-DEV.1199"
+julia_version = "1.7.0-DEV"
 manifest_format = "3.0" # NOT ACTUALLY v3.0 format. Just here to test a warning!
 
 [[deps.Logging]]


### PR DESCRIPTION
Having the full build info was proving too noisy for checked-in manifests on master