### PR TITLE
Detect uncompressible registry tarballs during update. Add path to error

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -369,7 +369,7 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                                     @goto done_tarball_read
                                 end
                                 try
-                                    uncompress_registry(tmp) # check that it is uncompressable before moving into place
+                                    uncompress_registry(tmp; store = false) # check that it is uncompressable before moving into place
                                 catch err
                                     push!(errors, (reg.path, "downloaded registry from $(url) cannot be uncompressed. Exception: $(sprint(showerror, err))"))
                                     @goto done_tarball_read

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -368,6 +368,12 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                                     push!(errors, (reg.path, "failed to download from $(url). Exception: $(sprint(showerror, err))"))
                                     @goto done_tarball_read
                                 end
+                                try
+                                    uncompress_registry(tmp) # check that it is uncompressable before moving into place
+                                catch err
+                                    push!(errors, (reg.path, "downloaded registry from $(url) cannot be uncompressed. Exception: $(sprint(showerror, err))"))
+                                    @goto done_tarball_read
+                                end
                                 # If we have an uncompressed Pkg server registry, remove it and get the compressed version
                                 if isdir(reg.path)
                                     Base.rm(reg.path; recursive=true, force=true)

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -188,7 +188,7 @@ function init_package_info!(pkg::PkgEntry)
 end
 
 
-function uncompress_registry(tar_gz::AbstractString)
+function uncompress_registry(tar_gz::AbstractString; store::Bool = true)
     if !isfile(tar_gz)
         error("$(repr(tar_gz)): No such file")
     end
@@ -200,7 +200,10 @@ function uncompress_registry(tar_gz::AbstractString)
             Tar.read_tarball(x->true, tar; buf=buf) do hdr, _
                 if hdr.type == :file
                     Tar.read_data(tar, io; size=hdr.size, buf=buf)
-                    data[hdr.path] = String(take!(io))
+                    d = String(take!(io))
+                    if store
+                        data[hdr.path] = d
+                    end
                 end
             end
         end


### PR DESCRIPTION
Tries to help https://github.com/JuliaLang/Pkg.jl/issues/2997

I wanted to add some guidance like "Try a `pkg> registry rm/add`" but `registry rm` tries to load the `RegistryInstance` so hits the same error.

Saying simply `rm regpath` also doesn't help because you also need to delete the toml, so the instruction gets a bit long.

Alternatively, could the file hash of the tarball be stored in the registry toml, and it checked in `verify_compressed_registry_toml`