### PR TITLE
Use levsort for `add` suggestions

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -913,12 +913,18 @@ function ensure_resolved(ctx::Context, manifest::Manifest,
                     join(io, what, ", ", " or ")
                     print(io, ")")
                     all_names = available_names(ctx; manifest, include_registries = registry)
-                    all_names_ranked, any_score_gt_zero = fuzzysort(name, all_names)
-                    if any_score_gt_zero
+                    closest_names_ranked = REPL.levsort(name, all_names)
+                    if !isempty(closest_names_ranked)
                         println(io)
                         prefix = "   Suggestions:"
                         printstyled(io, prefix, color = Base.info_color())
-                        REPL.printmatches(io, name, all_names_ranked; cols = REPL._displaysize(ctx.io)[2] - length(prefix))
+                        printed_length = length(prefix)
+                        disp_width = displaysize(ctx.io)[2]
+                        for name in closest_names_ranked
+                            printed_length += length(name) + 1
+                            printed_length > disp_width && break # exit if next print will exceed terminal width
+                            print(io, " ", name)
+                        end
                     end
                 else
                     join(io, uuids, ", ", " or ")
@@ -934,12 +940,6 @@ function ensure_resolved(ctx::Context, manifest::Manifest,
         end
     end
     pkgerror(msg)
-end
-
-# copied from REPL to efficiently expose if any score is >0
-function fuzzysort(search::String, candidates::Vector{String})
-    scores = map(cand -> (REPL.fuzzyscore(search, cand), -Float64(REPL.levenshtein(search, cand))), candidates)
-    candidates[sortperm(scores)] |> reverse, any(s -> s[1] > 0, scores)
 end
 
 function available_names(ctx::Context = Context(); manifest::Manifest = ctx.env.manifest, include_registries::Bool = true)


### PR DESCRIPTION
As @ericphanson [pointed out](https://github.com/JuliaLang/Pkg.jl/pull/2985#discussion_r810556268), levsort seems to work better

<img width="988" alt="Screen Shot 2022-02-20 at 6 57 34 PM" src="https://user-images.githubusercontent.com/1694067/154870331-4cb1aa4d-dbeb-4c9d-8d3a-ad35bb383c2e.png">

However, some of these are quite distant, especially for short names.

@ericphanson any idea of a better threshold to use here?