### PR TITLE
allow `--preserve` to be used in `up`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -320,6 +320,7 @@ end
 
 function up(ctx::Context, pkgs::Vector{PackageSpec};
             level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode=PKGMODE_PROJECT,
+            preserve::Union{Nothing,PreserveLevel}= isempty(pkgs) ? nothing : PRESERVE_ALL,
             update_registry::Bool=true,
             skip_writing_project::Bool=false,
             kwargs...)
@@ -338,7 +339,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx, ctx.env.manifest, pkgs)
     end
-    Operations.up(ctx, pkgs, level; skip_writing_project)
+    Operations.up(ctx, pkgs, level; skip_writing_project, preserve)
     return
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1241,13 +1241,9 @@ end
 
 function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
     if preserve == PRESERVE_ALL
-        pkgs = load_all_deps(env, pkgs)
-    elseif preserve == PRESERVE_DIRECT
-        pkgs = load_direct_deps(env, pkgs)
-    elseif preserve == PRESERVE_SEMVER
-        pkgs = load_direct_deps(env, pkgs; preserve=preserve)
-    elseif preserve == PRESERVE_NONE
-        pkgs = load_direct_deps(env, pkgs; preserve=preserve)
+        pkgs = load_all_deps(env, pkgs; preserve)
+    else
+        pkgs = load_direct_deps(env, pkgs; preserve)
     end
     check_registered(registries, pkgs)
 
@@ -1346,8 +1342,65 @@ function up_load_manifest_info!(pkg::PackageSpec, entry::PackageEntry)
     # `pkg.version` and `pkg.tree_hash` is set by `up_load_versions!`
 end
 
+
+function load_manifest_deps_up(env::EnvCache, pkgs::Vector{PackageSpec}=PackageSpec[];
+                            preserve::PreserveLevel=PRESERVE_ALL)
+    manifest = env.manifest
+    project = env.project
+    explicit_upgraded = Set(pkg.uuid for pkg in pkgs)
+
+    recursive_indirect_dependencies_of_explicitly_upgraded = Set{UUID}()
+    frontier = copy(explicit_upgraded)
+    new_frontier = Set{UUID}()
+    while !(isempty(frontier))
+        for uuid in frontier
+            entry = get(env.manifest, uuid, nothing)
+            entry === nothing && continue
+            uuid_deps = values(entry.deps)
+            for uuid_dep in uuid_deps
+                if !(uuid_dep in recursive_indirect_dependencies_of_explicitly_upgraded) #
+                    push!(recursive_indirect_dependencies_of_explicitly_upgraded, uuid_dep)
+                    push!(new_frontier, uuid_dep)
+                end
+            end
+        end
+        copy!(frontier, new_frontier)
+        empty!(new_frontier)
+    end
+
+    pkgs = copy(pkgs)
+    for (uuid, entry) in manifest
+        findfirst(pkg -> pkg.uuid == uuid, pkgs) === nothing || continue # do not duplicate packages
+        uuid in explicit_upgraded && continue # Allow explicit upgraded packages to upgrade.
+        if preserve == PRESERVE_NONE && uuid in recursive_indirect_dependencies_of_explicitly_upgraded
+            continue
+        elseif preserve == PRESERVE_DIRECT && uuid in recursive_indirect_dependencies_of_explicitly_upgraded && !(uuid in values(project.deps))
+            continue
+        end
+
+        # The rest of the packages get fixed
+        push!(pkgs, PackageSpec(
+            uuid      = uuid,
+            name      = entry.name,
+            path      = entry.path,
+            pinned    = entry.pinned,
+            repo      = entry.repo,
+            tree_hash = entry.tree_hash, # TODO should tree_hash be changed too?
+            version   = something(entry.version, VersionSpec())
+        ))
+    end
+    return pkgs
+end
+
+function targeted_resolve_up(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
+    pkgs = load_manifest_deps_up(env, pkgs; preserve=preserve)
+    check_registered(registries, pkgs)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version)
+    return pkgs, deps_map
+end
+
 function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
-            skip_writing_project::Bool=false)
+            skip_writing_project::Bool=false, preserve::Union{Nothing,PreserveLevel}=nothing)
     new_git = Set{UUID}()
     # TODO check all pkg.version == VersionSpec()
     # set version constraints according to `level`
@@ -1359,9 +1412,13 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     for pkg in pkgs
         up_load_manifest_info!(pkg, manifest_info(ctx.env.manifest, pkg.uuid))
     end
-    pkgs = load_direct_deps(ctx.env, pkgs; preserve = (level == UPLEVEL_FIXED ? PRESERVE_NONE : PRESERVE_DIRECT))
-    check_registered(ctx.registries, pkgs)
-    deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version)
+    if preserve !== nothing
+        pkgs, deps_map = targeted_resolve_up(ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
+    else
+        pkgs = load_direct_deps(ctx.env, pkgs; preserve = (level == UPLEVEL_FIXED ? PRESERVE_NONE : PRESERVE_DIRECT))
+        check_registered(ctx.registries, pkgs)
+        deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version)
+    end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
     download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -196,12 +196,17 @@ through the dependency graph starting from the dependencies.
 const why = API.why
 
 """
-    Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT)
+    Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT, preserve::PreserveLevel)
     Pkg.update(pkg::Union{String, Vector{String}})
     Pkg.update(pkg::Union{PackageSpec, Vector{PackageSpec}})
 
-Update a package `pkg`. If no posistional argument is given, update all packages in the manifest if `mode` is `PKGMODE_MANIFEST` and packages in both manifest and project if `mode` is `PKGMODE_PROJECT`.
+If no posistional argument is given, update all packages in the manifest if `mode` is `PKGMODE_MANIFEST` and packages in both manifest and project if `mode` is `PKGMODE_PROJECT`.
 If no positional argument is given, `level` can be used to control by how much packages are allowed to be upgraded (major, minor, patch, fixed).
+
+If packages are given as positional arguments, the `preserve` argument can be used to control what other packages are allowed to update:
+- `PRESERVE_ALL` (default): Only allow `pkg` to update.
+- `PRESERVE_DIRECT`: Only allow `pkg` and indirect dependencies that are not a direct dependency in the project to update.
+- `PRESERVE_NONE`: Allow `pkg` and all its indirect dependencies to update.
 
 After any package updates the project will be precompiled. See more at [Project Precompilation](@ref).
 

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -311,6 +311,7 @@ PSA[:name => "update",
         PSA[:name => "minor", :api => :level => UPLEVEL_MINOR],
         PSA[:name => "patch", :api => :level => UPLEVEL_PATCH],
         PSA[:name => "fixed", :api => :level => UPLEVEL_FIXED],
+        PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
     :completions => complete_installed_packages,
     :description => "update packages in manifest",
@@ -319,6 +320,7 @@ PSA[:name => "update",
     [up|update] [-m|--manifest] [opts] pkg[=uuid] [@version] ...
 
     opts: --major | --minor | --patch | --fixed
+          --preserve=<all/direct/none>
 
 Update `pkg` within the constraints of the indicated version
 specifications. These specifications are of the form `@1`, `@1.2` or `@1.2.3`, allowing


### PR DESCRIPTION
This PR is intended to implement https://github.com/JuliaLang/Pkg.jl/issues/2344#issuecomment-942226805.

Here is an example of usage:

Setup:

```
(Pkg) pkg> activate --temp
  Activating new project at `/tmp/jl_BxVsSw`

(jl_pV0GRk) pkg> add Plots@1.24 StructArrays@0.6.4 PlotThemes@2.0.0
   Resolving package versions...
    Updating `/tmp/jl_pV0GRk/Project.toml`
⌃ [ccf2f8ad] + PlotThemes v2.0.0
⌃ [91a5bcdd] + Plots v1.24.3
⌃ [09ab397b] + StructArrays v0.6.4
...

(jl_pV0GRk) pkg> rm PlotThemes
    Updating `/tmp/jl_pV0GRk/Project.toml`
  [ccf2f8ad] - PlotThemes v2.0.0
  No Changes to `/tmp/jl_pV0GRk/Manifest.toml`
...
```

We now have two outdated packages in the Project:

```
(jl_pV0GRk) pkg> st --outdated
Status `/tmp/jl_pV0GRk/Project.toml`
⌃ [91a5bcdd] Plots v1.24.3 (<v1.25.11)
⌃ [09ab397b] StructArrays v0.6.4 (<v0.6.5)
```

And some outdated in the Manifest (note especially PlotThemes).

```
(jl_pV0GRk) pkg> st -m --outdated
Status `/tmp/jl_pV0GRk/Manifest.toml`
⌅ [28b8d3ca] GR v0.62.1 (<v0.64.0): Plots
⌅ [77ba4419] NaNMath v0.3.7 (<v1.0.0): Plots, RecipesPipeline
⌃ [ccf2f8ad] PlotThemes v2.0.0 (<v2.0.1)
⌃ [91a5bcdd] Plots v1.24.3 (<v1.25.11)
⌅ [01d81517] RecipesPipeline v0.4.1 (<v0.5.0): Plots
⌃ [09ab397b] StructArrays v0.6.4 (<v0.6.5)
```

First, `up Plots` should only allow `Plots` to upgrade and nothing else:

```
(jl_pV0GRk) pkg> up Plots
    Updating registry at `~/.julia/registries/General.toml`
    Updating `/tmp/jl_pV0GRk/Project.toml`
⌃ [91a5bcdd] ↑ Plots v1.24.3 ⇒ v1.25.3
    Updating `/tmp/jl_pV0GRk/Manifest.toml`
⌃ [91a5bcdd] ↑ Plots v1.24.3 ⇒ v1.25.3
  [41fe7b60] + Unzip v0.1.2
        Info Packages marked with ⌃ have new versions available
```

Ok, go back to the old Plots version:

```
(jl_pV0GRk) pkg> add Plots@1.24
   Resolving package versions...
    Updating `/tmp/jl_pV0GRk/Project.toml`
⌃ [91a5bcdd] ↓ Plots v1.25.3 ⇒ v1.24.3
....
```

Second, `up --preserve=direct Plots` should allow Plots and indirect dependencies not in the project to upgrade:

```
(jl_pV0GRk) pkg> up --preserve=direct Plots
    Updating registry at `~/.julia/registries/General.toml`
    Updating `/tmp/jl_pV0GRk/Project.toml`
  [91a5bcdd] ↑ Plots v1.24.3 ⇒ v1.25.11
    Updating `/tmp/jl_pV0GRk/Manifest.toml`
  [28b8d3ca] ↑ GR v0.62.1 ⇒ v0.64.0
  [ccf2f8ad] ↑ PlotThemes v2.0.0 ⇒ v2.0.1
  [91a5bcdd] ↑ Plots v1.24.3 ⇒ v1.25.11
  [01d81517] ↑ RecipesPipeline v0.4.1 ⇒ v0.5.0
  [05181044] + RelocatableFolders v0.1.3
  [41fe7b60] + Unzip v0.1.2
```

Importantly, StructArrays which is in the project is not updated. 

Thirdly, `--preserve=none` should allow even StructArrays to update:

```
(jl_pV0GRk) pkg> up --preserve=none Plots
    Updating registry at `~/.julia/registries/General.toml`
    Updating `/tmp/jl_pV0GRk/Project.toml`
  [09ab397b] ↑ StructArrays v0.6.4 ⇒ v0.6.5
    Updating `/tmp/jl_pV0GRk/Manifest.toml`
  [09ab397b] ↑ StructArrays v0.6.4 ⇒ v0.6.5
``` 

TODO:
- Tests
- Better docs
