### PR TITLE
respect versions in sysimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Pkg v1.9 Release Notes
+=======================
+
+- Pkg will now respect the version of packages put into the sysimage using e.g. PackageCompiler. For example,
+  if version 1.3.2 of package A is in the sysimage, Pkg will always install that version when adding the package,
+  or when the packge is installed as a dependency to some other package.
+
 Pkg v1.8 Release Notes
 ======================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Pkg v1.9 Release Notes
 
 - Pkg will now respect the version of packages put into the sysimage using e.g. PackageCompiler. For example,
   if version 1.3.2 of package A is in the sysimage, Pkg will always install that version when adding the package,
-  or when the packge is installed as a dependency to some other package.
+  or when the packge is installed as a dependency to some other package. This can be disabled by calling `Pkg.respect_sysimage_versions(false)`.
 
 Pkg v1.8 Release Notes
 ======================

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,6 +43,7 @@ Pkg.status
 Pkg.compat
 Pkg.precompile
 Pkg.offline
+Pkg.respect_sysimage_versions
 Pkg.setprotocol!
 Pkg.dependencies
 Pkg.project

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -458,12 +458,14 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
                         end
 
                         # Skip package version that are not the same as external packages in sysimage
-                        pkgid = Base.PkgId(uuid, pkg.name)
-                        if PKGORIGIN_HAVE_VERSION && RESPECT_SYSIMAGE_VERSIONS[] && Base.in_sysimage(pkgid)
-                            pkgorigin = get(Base.pkgorigins, pkgid, nothing)
-                            if pkgorigin !== nothing && pkgorigin.version !== nothing
-                                if v !== pkgorigin.version
-                                    continue
+                        if PKGORIGIN_HAVE_VERSION && RESPECT_SYSIMAGE_VERSIONS[] && julia_version == VERSION
+                            pkgid = Base.PkgId(uuid, pkg.name)
+                            if Base.in_sysimage(pkgid)
+                                pkgorigin = get(Base.pkgorigins, pkgid, nothing)
+                                if pkgorigin !== nothing && pkgorigin.version !== nothing
+                                    if v != pkgorigin.version
+                                        continue
+                                    end
                                 end
                             end
                         end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -33,6 +33,7 @@ devdir(depot = depots1()) = get(ENV, "JULIA_PKG_DEVDIR", joinpath(depot, "dev"))
 envdir(depot = depots1()) = joinpath(depot, "environments")
 const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 const OFFLINE_MODE = Ref(false)
+const RESPECT_SYSIMAGE_VERSIONS = Ref(true)
 # For globally overriding in e.g. tests
 const DEFAULT_IO = Ref{Union{IO,Nothing}}(nothing)
 stderr_f() = something(DEFAULT_IO[], stderr)
@@ -512,6 +513,19 @@ set the environment variable `JULIA_PKG_OFFLINE` to `"true"`.
     Pkg's offline mode requires Julia 1.5 or later.
 """
 offline(b::Bool=true) = (OFFLINE_MODE[] = b; nothing)
+
+"""
+    Pkg.respect_sysimage_versions(b::Bool=true)
+
+Enable (`b=true`) or disable (`b=false`) respecting versions that are in the
+sysimage (enabled by default).
+
+If this option is enabled, Pkg will only install packages that have been put into the sysimage
+(e.g. via PackageCompiler) at the version of the package in the sysimage.
+Also, trying to add a package at a URL or `develop` a package that is in the sysimage
+will error.
+"""
+respect_sysimage_versions(b::Bool=true) = (RESPECT_SYSIMAGE_VERSIONS[] = b; nothing)
 
 """
     PackageSpec(name::String, [uuid::UUID, version::VersionNumber])

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -624,7 +624,13 @@ function init_log!(data::GraphData)
         else
             vspec = range_compressed_versionspec(versions)
             vers = logstr(id, vspec)
+            uuid = data.pkgs[p0]
+            name = data.uuid_to_name[uuid]
+            pkgid = Base.PkgId(uuid, name)
             msg = "possible versions are: $vers or uninstalled"
+            if Base.in_sysimage(pkgid)
+                msg *= " (package in sysimage!)"
+            end
         end
         first_entry = get!(rlog.pool, p) do
             ResolveLogEntry(rlog.journal, p, "$(logstr(id)) log:")

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -12,7 +12,7 @@ using REPL.TerminalMenus
 
 using TOML
 import ..Pkg, ..Registry
-import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_dir, stdlib_path, isurl, stderr_f
+import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_dir, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS
 import Base.BinaryPlatforms: Platform
 using ..Pkg.Versions
 
@@ -526,6 +526,18 @@ function devpath(env::EnvCache, name::AbstractString, shared::Bool)
     return joinpath(dev_dir, name)
 end
 
+function error_if_in_sysimage(pkg::PackageSpec)
+    RESPECT_SYSIMAGE_VERSIONS[] || return false
+    if pkg.uuid === nothing
+        @error "Expected package to have a set UUID, please file a bug report"
+        return false
+    end
+    pkgid = Base.PkgId(pkg.uuid, pkg.name)
+    if Base.in_sysimage(pkgid)
+        pkgerror("tried to develop or add a package by URL that is already in the sysimage")
+    end
+end
+
 function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
     # First, check if we can compute the path easily (which requires a given local path or name)
     is_local_path = pkg.repo.source !== nothing && !isurl(pkg.repo.source)
@@ -544,6 +556,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
         end
         if isdir(dev_path)
             resolve_projectfile!(ctx.env, pkg, dev_path)
+            error_if_in_sysimage(pkg)
             if is_local_path
                 pkg.path = isabspath(dev_path) ? dev_path : relative_project_path(ctx.env.project_file, dev_path)
             else
@@ -605,6 +618,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
     if !has_uuid(pkg)
         resolve_projectfile!(ctx.env, pkg, dev_path)
     end
+    error_if_in_sysimage(pkg)
     pkg.path = shared ? dev_path : relative_project_path(ctx.env.project_file, dev_path)
     if pkg.repo.subdir !== nothing
         pkg.path = joinpath(pkg.path, pkg.repo.subdir)
@@ -735,13 +749,15 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
 
             # If we already resolved a uuid, we can bail early if this package is already installed at the current tree_hash
             if has_uuid(pkg)
+                error_if_in_sysimage(pkg)
                 version_path = Pkg.Operations.source_path(ctx.env.project_file, pkg, ctx.julia_version)
                 isdir(version_path) && return false
             end
 
             temp_path = mktempdir()
             GitTools.checkout_tree_to_path(repo, tree_hash_object, temp_path)
-            package = resolve_projectfile!(ctx.env, pkg, temp_path)
+            resolve_projectfile!(ctx.env, pkg, temp_path)
+            error_if_in_sysimage(pkg)
 
             # Now that we are fully resolved (name, UUID, tree_hash, repo.source, repo.rev), we can finally
             # check to see if the package exists at its canonical path.


### PR DESCRIPTION
I created a sysimage with an outdated Plots versions, loaded Julia with that sysimage and created a temp repo and added Plots:

```
(Pkg) pkg> activate --temp
  Activating new project at `/var/folders/26/gw1dqz6n5zsbkp72mktkhz3c0000gn/T/jl_hr2NH5`

(jl_hr2NH5) pkg> add Plots
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/private/var/folders/26/gw1dqz6n5zsbkp72mktkhz3c0000gn/T/jl_hr2NH5/Project.toml`
⌃ [91a5bcdd] + Plots v1.24.3
    Updating `/private/var/folders/26/gw1dqz6n5zsbkp72mktkhz3c0000gn/T/jl_hr2NH5/Manifest.toml`
  [79e6a3ab] + Adapt v3.3.3
  [d360d2e6] + ChainRulesCore v1.12.2

(jl_hr2NH5) pkg> st --outdated -m
Status `/private/var/folders/26/gw1dqz6n5zsbkp72mktkhz3c0000gn/T/jl_hr2NH5/Manifest.toml`
⌅ [28b8d3ca] GR v0.62.1 (<v0.64.0): Plots
⌅ [77ba4419] NaNMath v0.3.7 (<v1.0.0): Plots, RecipesPipeline
⌃ [91a5bcdd] Plots v1.24.3 (<v1.25.11)
⌅ [01d81517] RecipesPipeline v0.4.1 (<v0.5.1): Plots

(jl_hr2NH5) pkg> up
  No Changes to `/private/var/folders/26/gw1dqz6n5zsbkp72mktkhz3c0000gn/T/jl_hr2NH5/Project.toml`
  No Changes to `/private/var/folders/26/gw1dqz6n5zsbkp72mktkhz3c0000gn/T/jl_hr2NH5/Manifest.toml`
```

Requires https://github.com/JuliaLang/julia/pull/44318


