### PR TITLE
Temporarily exclude linux32 from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
         exclude:
           - os: macOS-latest
             julia-arch: x86
+          - os: ubuntu-latest # exclude because linux32 nightlies are stuck at commit 5b2a4b1e45 (2022-02-13 06:27 UTC)
+            julia-arch: x86
     steps:
       - name: Set git to use LF
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
linux32 nightlies are stuck at `commit 5b2a4b1e45 (2022-02-13 06:27 UTC)` and as far as I know, will likely be for a while yet.

This blocks merging PRs that need changes in the base repo like https://github.com/JuliaLang/Pkg.jl/pull/2793 and https://github.com/JuliaLang/Pkg.jl/pull/3021 

So I'm proposing excluding linux32 from CI until nightlies recover

We have Pkg tests run on Base now for linux32, I believe.. so regressions will be picked up after updating the Pkg commit in base

cc. @staticfloat @DilumAluthge 