### PR TITLE
REPL: Fix labels in env selection

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -717,13 +717,17 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         API.add(string.(available_pkgs))
     elseif lower_resp in ["o"]
         editable_envs = filter(v -> v != "@stdlib", LOAD_PATH)
-        expanded_envs = Base.load_path_expand.(editable_envs)
-        envs = convert(Vector{String}, filter(x -> !isnothing(x), expanded_envs))
         option_list = String[]
         keybindings = Char[]
-        for i in 1:length(envs)
-            push!(option_list, "$(i): $(pathrepr(envs[i])) ($(editable_envs[i]))")
-            push!(keybindings, only("$i"))
+        for i in 1:length(editable_envs)
+            env = editable_envs[i]
+            expanded_env = Base.load_path_expand(env)
+
+            isnothing(expanded_env) && continue
+
+            n = length(option_list) + 1
+            push!(option_list, "$(n): $(pathrepr(expanded_env)) ($(env))")
+            push!(keybindings, only("$n"))
         end
         menu = TerminalMenus.RadioMenu(option_list, keybindings=keybindings, pagesize=length(option_list))
         print(ctx.io, "\e[1A\e[1G\e[0J") # go up one line, to the start, and clear it

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -719,7 +719,9 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         editable_envs = filter(v -> v != "@stdlib", LOAD_PATH)
         option_list = String[]
         keybindings = Char[]
-        for i in 1:length(editable_envs)
+        # We use digits 1-9 as keybindings in the env selection menu
+        # That's why we can display at most 9 items in the menu
+        for i in 1:min(length(editable_envs), 9)
             env = editable_envs[i]
             expanded_env = Base.load_path_expand(env)
 


### PR DESCRIPTION
Filtering of `expanded_envs` caused that `envs[i]` and `editable_envs[i]` did not correspond to the same environment.

Before:
```
julia> insert!(LOAD_PATH, 2, mktempdir())
4-element Vector{String}:
 "@"
 "/tmp/jl_DRt9jd"
 "@v#.#"
 "@stdlib"

julia> using PyPlot
 │ Package PyPlot not found, but a package named PyPlot is available from a registry. 
 │ Install package?
 │   (@v1.9) pkg> add PyPlot 
 └ Select environment:
 > 1: `/tmp/jl_DRt9jd` (@)
   2: `~/.julia/environments/v1.9/Project.toml` (/tmp/jl_DRt9jd)
```

With the PR:
```
julia> insert!(LOAD_PATH, 2, mktempdir())
4-element Vector{String}:
 "@"
 "/tmp/jl_x6zoyq"
 "@v#.#"
 "@stdlib"

julia> using PyPlot
 │ Package PyPlot not found, but a package named PyPlot is available from a registry. 
 │ Install package?
 │   (@v1.9) pkg> add PyPlot 
 └ Select environment:
 > 1: `/tmp/jl_x6zoyq` (/tmp/jl_x6zoyq)
   2: `~/.julia/environments/v1.9/Project.toml` (@v#.#)
```

Fixes #3031.

~~Regarding the implementation -- does `Base.load_path_expand` ever return `nothing` if given a non-`nothing` input? If not, then the code get get simpler. (I just followed the previous implementation.)~~

Also another side question: has it been discussed what should happen if there are >9 editable_envs? In that case, `only("$(n)")` fails.