### PR TITLE
REPL: Status for comma-separated list of packages

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -167,7 +167,7 @@ Base.@kwdef mutable struct Statement
 end
 
 function lex(cmd::String)::Vector{QString}
-    replace_comma = (nothing!=match(r"^(add|rm|remove)+\s", cmd))
+    replace_comma = (nothing!=match(r"^(add|rm|remove|status)+\s", cmd))
     in_doublequote = false
     in_singlequote = false
     qstrings = QString[]

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -659,6 +659,9 @@ end
         git_init_and_commit(project_path)
         @test_logs () pkg"status --diff"
         @test_logs () pkg"status -d"
+
+        # comma-separated packages get parsed
+        pkg"status Example, Random"
     end
 end
 


### PR DESCRIPTION
This PR allows passing a comma-separated list of packages to `]status`.

Resolves #3049.

Also, I originally put the test [here](https://github.com/JuliaLang/Pkg.jl/blob/f81efda695d4c227fc81617c1400b1e067a36af1/test/repl.jl#L651) but then the error did not show up even when it should. Is that expected?