### PR TITLE
Before running the "test atomicity of write_env_usage" testset, make sure that the General registry has been installed

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -370,7 +370,7 @@ temp_pkg_dir() do project_path
         # to precompile Pkg given we're in a different depot
         run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg"`)
         # make sure the General registry is installed
-        run(pipeline(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; Pkg.Registry.add()"`; stdout=devnull, stderr=devnull))
+        Utils.show_output_if_command_errors(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; Pkg.Registry.add()"`)
         flag_start_dir = tempdir() # once n=Sys.CPU_THREADS files are in here, the processes can proceed to the concurrent test
         flag_end_file = tempname() # use creating this file as a way to stop the processes early if an error happens
         for i in 1:Sys.CPU_THREADS

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -368,6 +368,7 @@ temp_pkg_dir() do project_path
         iobs = IOBuffer[]
         Sys.CPU_THREADS == 1 && error("Cannot test for atomic usage log file interaction effectively with only Sys.CPU_THREADS=1")
         run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg"`) # to precompile Pkg given we're in a different depot
+        run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; Pkg.Registry.add()"`) # make sure the General registry is installed
         flag_start_dir = tempdir() # once n=Sys.CPU_THREADS files are in here, the processes can proceed to the concurrent test
         flag_end_file = tempname() # use creating this file as a way to stop the processes early if an error happens
         for i in 1:Sys.CPU_THREADS

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -367,8 +367,10 @@ temp_pkg_dir() do project_path
         tasks = Task[]
         iobs = IOBuffer[]
         Sys.CPU_THREADS == 1 && error("Cannot test for atomic usage log file interaction effectively with only Sys.CPU_THREADS=1")
-        run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg"`) # to precompile Pkg given we're in a different depot
-        run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; Pkg.Registry.add()"`) # make sure the General registry is installed
+        # to precompile Pkg given we're in a different depot
+        run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg"`)
+        # make sure the General registry is installed
+        run(pipeline(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; Pkg.Registry.add()"`; stdout=devnull, stderr=devnull))
         flag_start_dir = tempdir() # once n=Sys.CPU_THREADS files are in here, the processes can proceed to the concurrent test
         flag_end_file = tempname() # use creating this file as a way to stop the processes early if an error happens
         for i in 1:Sys.CPU_THREADS

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -298,4 +298,16 @@ function list_tarball_files(tarball_path::AbstractString)
     return names
 end
 
+function show_output_if_command_errors(cmd::Cmd)
+    out = IOBuffer()
+    proc = run(pipeline(cmd; stdout=out); wait = false)
+    wait(proc)
+    if !success(proc)
+        seekstart(out)
+        println(read(out, String))
+        Base.pipeline_error(proc)
+    end
+    return nothing
+end
+
 end


### PR DESCRIPTION
I'm hoping that this will fix the non-deterministic (but frequent) `Pkg` failures that I'm seeing in the `rr-net` job.