### PR TITLE
Ensure that test preferences are properly stacked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /tmp
+/test/tmp
 *.jl.mem
 *.jl.cov
 *.jl.*.cov

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -992,12 +992,12 @@ function build_versions(ctx::Context, uuids::Set{UUID}; verbose=false)
         local build_project_override, build_project_preferences
         if isfile(projectfile_path(builddir(source_path)))
             build_project_override = nothing
-            with_load_path([builddir(source_path)]) do
+            with_load_path([builddir(source_path), Base.LOAD_PATH...]) do
                 build_project_preferences = Base.get_preferences()
             end
         else
             build_project_override = gen_target_project(ctx, pkg, source_path, "build")
-            with_load_path([projectfile_path(source_path)]) do
+            with_load_path([projectfile_path(source_path), Base.LOAD_PATH...]) do
                 build_project_preferences = Base.get_preferences()
             end
         end
@@ -1725,12 +1725,12 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
         local test_project_preferences, test_project_override
         if isfile(projectfile_path(testdir(source_path)))
             test_project_override = nothing
-            with_load_path(testdir(source_path)) do
+            with_load_path([testdir(source_path), Base.LOAD_PATH...]) do
                 test_project_preferences = Base.get_preferences()
             end
         else
             test_project_override = gen_target_project(ctx, pkg, source_path, "test")
-            with_load_path(projectfile_path(source_path)) do
+            with_load_path([projectfile_path(source_path), Base.LOAD_PATH...]) do
                 test_project_preferences = Base.get_preferences()
             end
         end


### PR DESCRIPTION
When calling `Pkg.test("Foo")`, some information from the calling
environment is incorporated into the tests of `Foo`; for example, if the
calling environment places restrictions on the package versions of
`Bar`, a dependency of `Foo`, those restrictions will be honored when
resolving the dependencies of the test environment for `Foo`.
Similarly, we should honor preferences set within the calling
environment.  The easiest way to do this is to layer the test
environment onto the end of the current `LOAD_PATH` instead of wholesale
replacing it, as we were doing when copying preferences over for the
test environment.

With this change it is now viable to test alternate configurations of a
package without dev'ing it out and modifying it directly.  If a package
`Foo` uses preference to alter its behavior, previously you would need
to `dev` it out and insert an override into its `LocalPreferneces.toml`
(or `test/LocalPreferences.toml`, if it had a separate test project) in
order for the preference to be read during test time.  Now, one can
simply set the preference in an environment that has `Foo` added, then
run `Pkg.test("Foo")`, and as long as the package itself doesn't define
the preference within its own testing environment, it will pick up the
default from the environment.

We allow the package to override values coming in from the environment,
as there may be rather sensitive preferences that it is best to not
allow easy overriding from.  For these cases, there is of course still
the `dev`-and-edit method available for tests.