### PR TITLE
Minor compat edit mode error show fix

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1813,7 +1813,7 @@ function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io
             resolve(ctx)
         catch e
             if e isa ResolverError
-                printpkgstyle(io, :Error, e.msg, color = Base.warn_color())
+                printpkgstyle(io, :Error, string(e.msg), color = Base.warn_color())
             else
                 rethrow()
             end


### PR DESCRIPTION
This was hitting the following, when trying to show the resolver error
```
(@v1.8) pkg> compat ProfileView
      Compat entry removed for ProfileView
     Resolve checking for compliance with the new compat rules...
ERROR: MethodError: no method matching printpkgstyle(::Base.TTY, ::Symbol, ::SubString{String}; color=:yellow)
Closest candidates are:
  printpkgstyle(::IO, ::Symbol, ::String) at ~/Documents/GitHub/Pkg.jl/src/utils.jl:2 got unsupported keyword argument "color"
  printpkgstyle(::IO, ::Symbol, ::String, ::Bool; color) at ~/Documents/GitHub/Pkg.jl/src/utils.jl:2
Stacktrace:
  [1] compat(ctx::Pkg.Types.Context, pkg::String, compat_str::Nothing; io::Nothing, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Pkg.API ~/Documents/GitHub/Pkg.jl/src/API.jl:1816
...
```