### PR TITLE
CI: Re-enable testing on `i868-linux-gnu`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
         exclude:
           - os: macOS-latest
             julia-arch: x86
-          - os: ubuntu-latest # exclude because linux32 nightlies are stuck at commit 5b2a4b1e45 (2022-02-13 06:27 UTC)
-            julia-arch: x86
     steps:
       - name: Set git to use LF
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Replaces #3029