### PR TITLE
Check `PackageSpec` has a valid `name` before trying to use it as a key in `unresolved_uuids` dict in `ensure_unresolved` function and throw more informative error

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -930,6 +930,7 @@ function ensure_resolved(ctx::Context, manifest::Manifest,
     unresolved_uuids = Dict{String,Vector{UUID}}()
     for pkg in pkgs
         has_uuid(pkg) && continue
+        !has_name(pkg) && !has_uuid(pkg) && pkgerror("Package $pkg has neither name nor uuid")
         uuids = [uuid for (uuid, entry) in manifest if entry.name == pkg.name]
         sort!(uuids, by=uuid -> uuid.value)
         unresolved_uuids[pkg.name] = uuids

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -921,4 +921,12 @@ end
     end
 end
 
+@testset "Issue #3069" begin
+    p = PackageSpec(; path="test_packages/Example")
+    @test_throws Pkg.Types.PkgError("Package PackageSpec(
+          path = test_packages/Example
+          version = *
+        ) has neither name nor uuid") ensure_resolved(Pkg.Types.Context(), Pkg.Types.Manifest(), [p])
+end
+
 end # module


### PR DESCRIPTION
Fixes #3069