### PR TITLE
Fix extended missing package add prompt

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -719,6 +719,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         editable_envs = filter(v -> v != "@stdlib", LOAD_PATH)
         option_list = String[]
         keybindings = Char[]
+        shown_envs = String[]
         # We use digits 1-9 as keybindings in the env selection menu
         # That's why we can display at most 9 items in the menu
         for i in 1:min(length(editable_envs), 9)
@@ -730,6 +731,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             n = length(option_list) + 1
             push!(option_list, "$(n): $(pathrepr(expanded_env)) ($(env))")
             push!(keybindings, only("$n"))
+            push!(shown_envs, expanded_env)
         end
         menu = TerminalMenus.RadioMenu(option_list, keybindings=keybindings, pagesize=length(option_list))
         print(ctx.io, "\e[1A\e[1G\e[0J") # go up one line, to the start, and clear it
@@ -744,7 +746,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             rethrow()
         end
         choice == -1 && return false
-        API.activate(envs[choice]) do
+        API.activate(shown_envs[choice]) do
             API.add(string.(available_pkgs))
         end
     elseif (lower_resp in ["n"])


### PR DESCRIPTION
https://github.com/JuliaLang/Pkg.jl/pull/3038 broke the extended `o` prompt options

```
julia> using ProfileView
 │ Package ProfileView not found, but a package named ProfileView is available from a registry. 
 │ Install package?
 │   (Pkg) pkg> add ProfileView 
 └ Select environment:
   1: `~/Documents/GitHub/Pkg.jl/Project.toml` (@)
 > 2: `~/.julia/environments/v1.9/Project.toml` (@v#.#)
ERROR: UndefVarError: envs not defined
Stacktrace:
  [1] try_prompt_pkg_add(pkgs::Vector{Symbol})
    @ Pkg.REPLMode /Applications/Julia-1.9.app/Contents/Resources/julia/share/julia/stdlib/v1.9/Pkg/src/REPLMode/REPLMode.jl:747
...
```

Obviously that means the prompt needs better tests (https://github.com/JuliaLang/Pkg.jl/issues/3083)

This PR just fixes the immediate issue