### PR TITLE
safe_realpath: fix stack overflow

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,6 +58,7 @@ set_readonly(::Nothing) = nothing
 
 # try to call realpath on as much as possible
 function safe_realpath(path)
+    isempty(path) && return path
     if ispath(path)
         try
             return realpath(path)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -17,4 +17,12 @@ end
     hash(Pkg.Types.VersionSpec()) # hash isn't stable
     hash(Pkg.Types.PackageEntry()) # hash isn't stable because the internal `repo` field is a mutable struct
 end
+
+@testset "safe_realpath" begin
+    # issue #3085
+    for p in ("", "some-non-existing-path")
+        @test p == Pkg.safe_realpath(p)
+    end
+end
+
 end # module


### PR DESCRIPTION
This commit prevents stack overflow when `safe_realpath` is called with
a non-existing path that does not start with a `/`, such as

    "D:\ProjectA" (on a Windows machine without drive D:)
    ""
    "non-existing-path"

Resolves #3085