### PR TITLE
Switch release-1.8 CI to run on 1.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,7 @@ jobs:
           - ""
           - "pkg.julialang.org"
         julia-version:
-          # - '1.6'
-          - 'nightly'
+          - '1.8-nightly'
         exclude:
           - os: macOS-latest
             julia-arch: x86


### PR DESCRIPTION
Standard practice, but also to debug this issue https://buildkite.com/julialang/julia-release-1-dot-8/builds/65#dbe68b90-6238-4f40-af1e-f3e7a2b286b9/483-1349 from https://github.com/JuliaLang/julia/pull/44789
