### PR TITLE
enforce not running with startup file when selecting dynamic artifacts and improve error message

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -626,9 +626,15 @@ function collect_artifacts(pkg_root::String; platform::AbstractPlatform=HostPlat
                 # Despite the fact that we inherit the project, since the in-memory manifest
                 # has not been updated yet, if we try to load any dependencies, it may fail.
                 # Therefore, this project inheritance is really only for Preferences, not dependencies.
-                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true)) $(triplet(platform))`)
+                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true)) --startup-file=no $(triplet(platform))`)
                 meta_toml = String(read(select_cmd))
-                push!(artifacts_tomls, (artifacts_toml, TOML.parse(meta_toml)))
+                res = TOML.tryparse(meta_toml)
+                if res isa TOML.ParserError
+                    errstr = sprint(showerror, res; context=stderr)
+                    pkgerror("failed to parse TOML output from running $(repr(selector_path)), got: \n$errstr")
+                else
+                    push!(artifacts_tomls, (artifacts_toml, TOML.parse(meta_toml)))
+                end
             else
                 # Otherwise, use the standard selector from `Artifacts`
                 artifacts = select_downloadable_artifacts(artifacts_toml; platform)


### PR DESCRIPTION
Even if a user runs with `--startup-file=1`, it can cause problems to run this with the startup file enabled since the process collects output from stdout. This causes for example https://github.com/JuliaLang/julia/issues/45583.

Also, in case the script outputs invalid TOML, it was hard to know what package caused this. Now it would write the error as:

```
ERROR: failed to parse TOML output from running "/home/kc//Pkg.jl/DynamicArtifact/.pkg/select_artifacts.jl", got: 
TOML Parser error:
none:1:6 error: expected equal sign after key
  Setup successful
       ^ 
```