### PR TITLE
Modify the `PlatformEngines.get_server_dir` function to convert `domain:port` to `domain_port`

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -56,7 +56,7 @@ function get_server_dir(
     end
     isempty(Base.DEPOT_PATH) && return
     invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
-    dir = replace(String(only(m)), (c => '_' for c in invalid_filename_chars)...);
+    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(only(m)))))
     return joinpath(depots1(), "servers", dir)
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -55,9 +55,8 @@ function get_server_dir(
         return
     end
     isempty(Base.DEPOT_PATH) && return
-    m_1 = only(m)::AbstractString
     invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
-    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(m_1)))
+    dir = replace(String(only(m)), (c => '_' for c in invalid_filename_chars)...);
     return joinpath(depots1(), "servers", dir)
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -49,13 +49,19 @@ function get_server_dir(
 )
     server === nothing && return
     url == server || startswith(url, "$server/") || return
-    m = match(r"^\w+://([^\\/]+)(?:$|/)", server)
+    m = match(r"^\w+://(?:[^\\/@]+@)?([^\\/:]+)(:(\d*?))?(?:$|/|:)", server)
     if m === nothing
         @warn "malformed Pkg server value" server
         return
     end
     isempty(Base.DEPOT_PATH) && return
-    joinpath(depots1(), "servers", String(m.captures[1]))
+    m_1 = m[1]::AbstractString
+    if m[2] === nothing
+        return joinpath(Pkg.depots1(), "servers", m_1)
+    else
+        m_3 = m[3]::AbstractString
+        return joinpath(Pkg.depots1(), "servers", m_1 * "_" * m_3)
+    end
 end
 
 const AUTH_ERROR_HANDLERS = Pair{Union{String, Regex},Any}[]

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -49,19 +49,16 @@ function get_server_dir(
 )
     server === nothing && return
     url == server || startswith(url, "$server/") || return
-    m = match(r"^\w+://(?:[^\\/@]+@)?([^\\/:]+)(:(\d*?))?(?:$|/|:)", server)
+    m = match(r"^\w+://([^\\/]+)(?:$|/)", server)
     if m === nothing
         @warn "malformed Pkg server value" server
         return
     end
     isempty(Base.DEPOT_PATH) && return
-    m_1 = m[1]::AbstractString
-    if m[2] === nothing
-        return joinpath(Pkg.depots1(), "servers", m_1)
-    else
-        m_3 = m[3]::AbstractString
-        return joinpath(Pkg.depots1(), "servers", m_1 * "_" * m_3)
-    end
+    m_1 = only(m)::AbstractString
+    invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
+    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(m_1)))
+    return joinpath(Pkg.depots1(), "servers", dir)
 end
 
 const AUTH_ERROR_HANDLERS = Pair{Union{String, Regex},Any}[]

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -58,7 +58,7 @@ function get_server_dir(
     m_1 = only(m)::AbstractString
     invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
     dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(m_1)))
-    return joinpath(Pkg.depots1(), "servers", dir)
+    return joinpath(depots1(), "servers", dir)
 end
 
 const AUTH_ERROR_HANDLERS = Pair{Union{String, Regex},Any}[]

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -209,7 +209,12 @@ end
         if observed != expected
             @error "Test failure" url server expected_directory observed expected
         end
+
         @test observed == expected
+
+        # Test for Windows drive letter shenanigans
+        @test startswith(observed, Pkg.depots1())
+        @test startswith(observed, joinpath(Pkg.depots1(), "servers"))
     end
 
     @testset "get_server_dir" begin

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -197,21 +197,42 @@ end
 
     ENV["JULIA_PKG_SERVER"] = ""
 
-    test_server_dir(url, server, ::Nothing) =
-        @test PlatformEngines.get_server_dir(url, server) == nothing
-    test_server_dir(url, server, domain) =
-        @test PlatformEngines.get_server_dir(url, server) ==
-            joinpath(Pkg.depots1(), "servers", domain)
+    function test_server_dir(url, server, ::Nothing)
+        observed = PlatformEngines.get_server_dir(url, server)
+        expected = nothing
+        @test observed === expected
+    end
+    function test_server_dir(url, server, expected_directory::AbstractString)
+        observed = PlatformEngines.get_server_dir(url, server)
+        expected = joinpath(Pkg.depots1(), "servers", expected_directory)
+        @debug "" url server expected_directory observed expected
+        if observed != expected
+            @error "Test failure" url server expected_directory observed expected
+        end
+        @test observed == expected
+    end
 
     @testset "get_server_dir" begin
         test_server_dir("https://foo.bar/baz/a", nothing, nothing)
         test_server_dir("https://foo.bar/baz/a", "https://bar", nothing)
         test_server_dir("https://foo.bar/baz/a", "foo.bar", nothing)
         test_server_dir("https://foo.bar/bazx", "https://foo.bar/baz", nothing)
-        test_server_dir("https://foo.bar/baz/a", "https://foo.bar", "foo.bar")
-        test_server_dir("https://foo.bar/baz", "https://foo.bar/baz", "foo.bar")
-        test_server_dir("https://foo.bar/baz/a", "https://foo.bar/baz", "foo.bar")
-        test_server_dir("https://foo.bar/baz/a", "https://foo.bar/baz", "foo.bar")
+
+        for host in ["localhost", "foo", "foo.bar", "foo.bar.baz"]
+            for protocol in ["http", "https"]
+                for port in [("", ""), (":1234", "_1234")]
+                    port_original, port_transformed = port
+
+                    for server_suffix in ["", "/hello", "/hello/world"]
+                        server = "$(protocol)://$(host)$(port_original)$(server_suffix)"
+                        for url_suffix in ["/", "/foo", "/foo/bar", "/foo/bar/baz"]
+                            url = "$(server)$(url_suffix)"
+                            test_server_dir(url, server, "$(host)$(port_transformed)")
+                        end
+                    end
+                end
+            end
+        end
     end
 
     called = 0


### PR DESCRIPTION
Fixes #3130 