### PR TITLE
Iterating over `RegexMatch` does not work in Julia 1.6

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -56,7 +56,7 @@ function get_server_dir(
     end
     isempty(Base.DEPOT_PATH) && return
     invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
-    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(only(m.captures)))))
+    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(m[1]))))
     return joinpath(depots1(), "servers", dir)
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -56,7 +56,7 @@ function get_server_dir(
     end
     isempty(Base.DEPOT_PATH) && return
     invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
-    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(only(m)))))
+    dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(only(m.captures)))))
     return joinpath(depots1(), "servers", dir)
 end
 


### PR DESCRIPTION
This is a follow-up to #3131.

We want to backport #3131 to Julia 1.6. However, iterating over `RegexMatch` does not work in Julia 1.6, so if `m` is a `RegexMatch`, we can't do `only(m)`. Instead, we have to do `only(m.captures)`.