### PR TITLE
Allow local default registry (by `path`)

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -512,6 +512,27 @@ julia> ENV["JULIA_PKG_SERVER"] = ""
 ""
 ```
 
+A local registry path can be used by setting the `JULIA_PKG_DEFAULT_REGISTRY_PATH` environment variables, it is
+best used in combination with `JULIA_PKG_SERVER` and `JULIA_PKG_DEFAULT_REGISTRY_URL`:
+
+```julia
+# use a .git repo instead of data from the default pkg server
+julia> ENV["JULIA_PKG_SERVER"] = "";
+
+# do not use default url https://github.com/JuliaRegistries/General [1]
+julia> ENV["JULIA_PKG_DEFAULT_REGISTRY_URL"] = "";
+
+# given path is a local clone of [1]
+julia> ENV["JULIA_PKG_DEFAULT_REGISTRY_PATH"] = "file:///home/user/General";
+
+# clones the `General` registry from local path
+(v1.0) pkg> status
+  Installing known registries into `~/.julia`
+     Cloning registry from "file:///home/user/General"
+       Added registry `General` to `~/.julia/registries/General`
+[...]
+```
+
 For clarification, some sources are not provided by Pkg server
 
 * packages/registries fetched via `git`

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -6,8 +6,7 @@ using Artifacts
 import Artifacts: artifact_names, ARTIFACTS_DIR_OVERRIDE, ARTIFACT_OVERRIDES, artifact_paths,
                   artifacts_dirs, pack_platform!, unpack_platform, load_artifacts_toml,
                   query_override, with_artifacts_directory, load_overrides
-import ..get_bool_env
-import ..set_readonly
+import ..Pkg
 import ..GitTools
 import ..TOML
 using ..MiniProgressBars
@@ -59,7 +58,7 @@ function create_artifact(f::Function)
             # Move this generated directory to its final destination, set it to read-only
             mv(temp_dir, new_path)
             chmod(new_path, filemode(dirname(new_path)))
-            set_readonly(new_path)
+            Pkg.set_readonly(new_path)
         end
 
         # Give the people what they want
@@ -363,7 +362,7 @@ function download_artifact(
             # Since tree hash calculation is still broken on some systems, e.g. Pkg.jl#1860,
             # and Pkg.jl#2317 so we allow setting JULIA_PKG_IGNORE_HASHES=1 to ignore the
             # error and move the artifact to the expected location and return true
-            ignore_hash = get_bool_env("JULIA_PKG_IGNORE_HASHES")
+            ignore_hash = Pkg.get_bool_env("JULIA_PKG_IGNORE_HASHES")
             if ignore_hash
                 msg *= "\n\$JULIA_PKG_IGNORE_HASHES is set to 1: ignoring error and moving artifact to the expected location"
                 @error(msg)

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -4,13 +4,13 @@ module GitTools
 
 using ..Pkg
 using ..MiniProgressBars
-import ..get_bool_env, ..can_fancyprint, ..printpkgstyle, ..stdout_f
+import ..can_fancyprint, ..printpkgstyle
 using SHA
 import Base: SHA1
 import LibGit2
 using Printf
 
-use_cli_git() = get_bool_env("JULIA_PKG_USE_CLI_GIT")
+use_cli_git() = Pkg.get_bool_env("JULIA_PKG_USE_CLI_GIT")
 
 function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     progress = unsafe_load(progress)
@@ -25,7 +25,7 @@ function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
         bar.max = progress.total_objects
         bar.current = progress.received_objects
     end
-    show_progress(stdout_f(), bar)
+    show_progress(Pkg.stdout_f(), bar)
     return Cint(0)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,8 +91,10 @@ function casesensitive_isdir(dir::String)
     isdir_nothrow(dir) && lastdir in readdir(joinpath(dir, ".."))
 end
 
+str2bool(var::String) = var in ("t", "true", "y", "yes", "1")
+
 get_bool_env(name::String; default::String="false") =
-    lowercase(get(ENV, name, default)) in ("t", "true", "y", "yes", "1")
+    str2bool(lowercase(get(ENV, name, default)))
 
 ## ordering of UUIDs ##
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947

--- a/test/new.jl
+++ b/test/new.jl
@@ -2795,12 +2795,13 @@ end
         mktempdir() do tmp
             ENV["JULIA_DEPOT_PATH"] = "tmp"
             Base.init_depot_path()
-            Pkg.Registry.DEFAULT_REGISTRIES[1].url = Utils.REGISTRY_DIR
-            Pkg.Registry.DEFAULT_REGISTRIES[1].path = nothing
-            cp(joinpath(@__DIR__, "test_packages", "BasicSandbox"), joinpath(tmp, "BasicSandbox"))
-            git_init_and_commit(joinpath(tmp, "BasicSandbox"))
-            cd(tmp) do
-                Pkg.add(path="BasicSandbox")
+            withenv("JULIA_PKG_DEFAULT_REGISTRY_URL" => Utils.REGISTRY_DIR,
+                    "JULIA_PKG_DEFAULT_REGISTRY_PATH" => nothing) do
+                cp(joinpath(@__DIR__, "test_packages", "BasicSandbox"), joinpath(tmp, "BasicSandbox"))
+                git_init_and_commit(joinpath(tmp, "BasicSandbox"))
+                cd(tmp) do
+                    Pkg.add(path="BasicSandbox")
+                end
             end
         end
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -49,9 +49,6 @@ function isolate(fn::Function; loaded_depot=false, linked_reg=true)
     old_home_project = Base.HOME_PROJECT[]
     old_active_project = Base.ACTIVE_PROJECT[]
     old_working_directory = pwd()
-    old_general_registry_url = Pkg.Registry.DEFAULT_REGISTRIES[1].url
-    old_general_registry_path = Pkg.Registry.DEFAULT_REGISTRIES[1].path
-    old_general_registry_linked = Pkg.Registry.DEFAULT_REGISTRIES[1].linked
     try
         # Clone/download the registry only once
         if !isdir(REGISTRY_DIR)
@@ -63,13 +60,13 @@ function isolate(fn::Function; loaded_depot=false, linked_reg=true)
         Base.HOME_PROJECT[] = nothing
         Base.ACTIVE_PROJECT[] = nothing
         Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
-        Pkg.Registry.DEFAULT_REGISTRIES[1].url = nothing
-        Pkg.Registry.DEFAULT_REGISTRIES[1].path = REGISTRY_DIR
-        Pkg.Registry.DEFAULT_REGISTRIES[1].linked = linked_reg
         Pkg.REPLMode.TEST_MODE[] = false
         withenv("JULIA_PROJECT" => nothing,
                 "JULIA_LOAD_PATH" => nothing,
-                "JULIA_PKG_DEVDIR" => nothing) do
+                "JULIA_PKG_DEVDIR" => nothing,
+                "JULIA_PKG_DEFAULT_REGISTRY_URL" => "",
+                "JULIA_PKG_DEFAULT_REGISTRY_PATH" => REGISTRY_DIR,
+                "JULIA_PKG_DEFAULT_REGISTRY_LINKED" => linked_reg) do
             target_depot = nothing
             try
                 target_depot = mktempdir()
@@ -96,9 +93,6 @@ function isolate(fn::Function; loaded_depot=false, linked_reg=true)
         Base.ACTIVE_PROJECT[] = old_active_project
         cd(old_working_directory)
         Pkg.REPLMode.TEST_MODE[] = false # reset unconditionally
-        Pkg.Registry.DEFAULT_REGISTRIES[1].path = old_general_registry_path
-        Pkg.Registry.DEFAULT_REGISTRIES[1].url = old_general_registry_url
-        Pkg.Registry.DEFAULT_REGISTRIES[1].linked = old_general_registry_linked
     end
 end
 
@@ -121,9 +115,6 @@ function temp_pkg_dir(fn::Function;rm=true, linked_reg=true)
     old_depot_path = copy(DEPOT_PATH)
     old_home_project = Base.HOME_PROJECT[]
     old_active_project = Base.ACTIVE_PROJECT[]
-    old_general_registry_url = Pkg.Registry.DEFAULT_REGISTRIES[1].url
-    old_general_registry_path = Pkg.Registry.DEFAULT_REGISTRIES[1].path
-    old_general_registry_linked = Pkg.Registry.DEFAULT_REGISTRIES[1].linked
     try
         # Clone/download the registry only once
         if !isdir(REGISTRY_DIR)
@@ -134,12 +125,12 @@ function temp_pkg_dir(fn::Function;rm=true, linked_reg=true)
         empty!(DEPOT_PATH)
         Base.HOME_PROJECT[] = nothing
         Base.ACTIVE_PROJECT[] = nothing
-        Pkg.Registry.DEFAULT_REGISTRIES[1].url = nothing
-        Pkg.Registry.DEFAULT_REGISTRIES[1].path = REGISTRY_DIR
-        Pkg.Registry.DEFAULT_REGISTRIES[1].linked = linked_reg
         withenv("JULIA_PROJECT" => nothing,
                 "JULIA_LOAD_PATH" => nothing,
-                "JULIA_PKG_DEVDIR" => nothing) do
+                "JULIA_PKG_DEVDIR" => nothing,
+                "JULIA_PKG_DEFAULT_REGISTRY_URL" => "",
+                "JULIA_PKG_DEFAULT_REGISTRY_PATH" => REGISTRY_DIR,
+                "JULIA_PKG_DEFAULT_REGISTRY_LINKED" => linked_reg) do
             env_dir = mktempdir()
             depot_dir = mktempdir()
             try
@@ -163,9 +154,6 @@ function temp_pkg_dir(fn::Function;rm=true, linked_reg=true)
         append!(DEPOT_PATH, old_depot_path)
         Base.HOME_PROJECT[] = old_home_project
         Base.ACTIVE_PROJECT[] = old_active_project
-        Pkg.Registry.DEFAULT_REGISTRIES[1].path = old_general_registry_path
-        Pkg.Registry.DEFAULT_REGISTRIES[1].url = old_general_registry_url
-        Pkg.Registry.DEFAULT_REGISTRIES[1].linked = old_general_registry_linked
     end
 end
 


### PR DESCRIPTION
This PR allows to use a local registry (from `file://` protocol) instead of cloning from `https`, and is useful for setting up multiple julia for multiple users where the bandwidth is limited and a local clone of https://github.com/JuliaRegistries/General is available.

The implementation adds `JULIA_PKG_DEFAULT_REGISTRY_PATH`, `JULIA_PKG_DEFAULT_REGISTRY_URL` and `JULIA_PKG_DEFAULT_REGISTRY_LINKED` environment variables, in order to dynamically parametrize the default registries from environment, instead of hard-coding the url.

As a side effect, this PR simplifies the tests by extending the `withenv` constructs for setting up different default registries.

The docs have been enhanced to document the usage of the added environment variables.

All tests are passing locally on nightly.
