### PR TITLE
Ensure `@stdlib` is on `LOAD_PATH` for `.pkg/` hooks

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -626,7 +626,8 @@ function collect_artifacts(pkg_root::String; platform::AbstractPlatform=HostPlat
                 # Despite the fact that we inherit the project, since the in-memory manifest
                 # has not been updated yet, if we try to load any dependencies, it may fail.
                 # Therefore, this project inheritance is really only for Preferences, not dependencies.
-                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true)) --startup-file=no $(triplet(platform))`)
+                # We only guarantee access to the `stdlib`, which is why we set `add_stdlib` here.
+                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true, add_stdlib=true)) --startup-file=no $(triplet(platform))`)
                 meta_toml = String(read(select_cmd))
                 res = TOML.tryparse(meta_toml)
                 if res isa TOML.ParserError
@@ -922,9 +923,12 @@ function dependency_order_uuids(env::EnvCache, uuids::Vector{UUID})::Dict{UUID,I
     return order
 end
 
-function gen_build_code(build_file::String; inherit_project::Bool = false)
+function gen_build_code(build_file::String; inherit_project::Bool = false, add_stdlib::Bool = false)
     code = """
         $(Base.load_path_setup_code(false))
+        if $(add_stdlib)
+            push!(Base.LOAD_PATH, "@stdlib")
+        end
         cd($(repr(dirname(build_file))))
         include($(repr(build_file)))
         """


### PR DESCRIPTION
We need to be able to load the standard libraries such as `TOML`,
`Artifacts`, etc... when running our `.pkg` hooks such as
`.pkg/select_artifacts.jl`.  While these are usually available, they are
not available during tests, so let's ensure that `@stdlib` is always on
the load path.

To trigger the issue, use the following code on Julia v1.8 or later, as
only Julia v1.8+ is compatible with an `LLVM_jll` new enough to use the
`.pkg` hooks.

```
import Pkg

mktempdir() do dir
    cd(dir)
    Pkg.activate(dir)
    Pkg.generate("SomePkg")
    mkdir("SomePkg/test")
    touch("SomePkg/test/runtests.jl")
    Pkg.activate("SomePkg/test") do
        Pkg.add("LLVM_jll")
    end
    Pkg.activate("SomePkg") do
        Pkg.test()
    end
end
```