### PR TITLE
Cleanup before exit after tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,4 +69,6 @@ Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger())
     end
 end
 
+Base.Filesystem.temp_cleanup_purge(force=true)
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,6 @@ Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger())
     end
 end
 
-Base.Filesystem.temp_cleanup_purge(force=true)
+@showtime Base.Filesystem.temp_cleanup_purge(force=true)
 
 end # module


### PR DESCRIPTION
Sometimes the cleanup takes too long and Base CI thinks it's hanging and kills the process.