### PR TITLE
fix API invalidations from Static.jl

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -508,7 +508,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
         let usage=usage
             reduce_usage!(joinpath(logdir(depot), "manifest_usage.toml")) do filename, info
                 # For Manifest usage, store only the last DateTime for each filename found
-                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"]))
+                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"])::DateTime)
             end
         end
         manifest_usage_by_depot[depot] = usage
@@ -517,7 +517,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
         let usage=usage
             reduce_usage!(joinpath(logdir(depot), "artifact_usage.toml")) do filename, info
                 # For Artifact usage, store only the last DateTime for each filename found
-                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"]))
+                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"])::DateTime)
             end
         end
         artifact_usage_by_depot[depot] = usage
@@ -528,7 +528,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
         let usage=usage
             reduce_usage!(joinpath(logdir(depot), "scratch_usage.toml")) do filename, info
                 # For Artifact usage, store only the last DateTime for each filename found
-                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"]))
+                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"])::DateTime)
                 if !haskey(parents, filename)
                     parents[filename] = Set{String}()
                 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -565,7 +565,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
 
             # Write out the TOML file for this depot
             usage_path = joinpath(logdir(depot), fname)
-            if !isempty(usage) || isfile(usage_path)
+            if !(isempty(usage)::Bool) || isfile(usage_path)
                 open(usage_path, "w") do io
                     TOML.print(io, usage, sorted=true)
                 end


### PR DESCRIPTION
This should hopefully fix some invalidations coming from Static.jl.

<details>

<summary>
Here is the code:

</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.8) pkg> activate --temp

(jl_PDrBpd) pkg> add Static
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_PDrBpd/Project.toml`
  [aedffcd0] + Static v0.7.6
    Updating `/tmp/jl_PDrBpd/Manifest.toml`
  [615f187c] + IfElse v0.1.1
  [aedffcd0] + Static v0.7.6

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Static

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
7-element Vector{SnoopCompile.MethodInvalidations}:
...
inserting ifelse(::False, x, y) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:88 invalidated:
...
                 7: signature Tuple{typeof(ifelse), Any, DateTime, Any} triggered MethodInstance for max(::DateTime, ::Any) (31 children)

julia> ftrees = filtermod(Pkg.API, trees)
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
   mt_backedges: 1: signature Tuple{typeof(!), Any} triggered MethodInstance for (::Pkg.API.var"#write_condensed_toml#182")(::Pkg.API.var"#153#184"{Set{String}}, ::Dict{String, Dict{String, DateTime}}, ::String) (0 children)
                 2: signature Tuple{typeof(!), Any} triggered MethodInstance for (::Pkg.API.var"#write_condensed_toml#182")(::Pkg.API.var"#156#187"{Set{String}}, ::Dict{String, Dict{String, DateTime}}, ::String) (0 children)
                 3: signature Tuple{typeof(!), Any} triggered MethodInstance for (::Pkg.API.var"#write_condensed_toml#182")(::Pkg.API.var"#159#190"{Dict{String, Dict{String, Set{String}}}, Set{String}, Set{String}}, ::Dict{String, Dict{String, DateTime}}, ::String) (0 children)
```

</details>

