### PR TITLE
hopefully fix invalidations in API from AbstractFFTs

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -566,8 +566,10 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
             # Write out the TOML file for this depot
             usage_path = joinpath(logdir(depot), fname)
             if !isempty(usage) || isfile(usage_path)
-                open(usage_path, "w") do io
-                    TOML.print(io, usage, sorted=true)
+                let usage=usage
+                    open(usage_path, "w") do io
+                        TOML.print(io, usage, sorted=true)
+                    end
                 end
             end
         end


### PR DESCRIPTION
This required a bit of hunting an I'm not completely sure whether it fixes the problem, so please help me understand this better.

I ran SnoopCompile and found
```
inserting extrema(f::AbstractFFTs.Frequencies) in AbstractFFTs at ~/.julia/packages/AbstractFFTs/Wg2Yf/src/definitions.jl:456 invalidated:
   backedges: 1: superseding extrema(a::AbstractArray; dims, kw...) in Base at reducedim.jl:994 with MethodInstance for extrema(::AbstractVector) (30 children)
   9 mt_cache
```

Running
```julia

...
Choose a call for analysis (q to quit):
     extrema(::AbstractVector)
       #sort!#8(::Base.Sort.Algorithm, ::typeof(isless), ::typeof(identity), ::Nothing, ::Base.Order.ForwardOrder
         (::Base.var"#sort!##kw")(::NamedTuple{(:by,), Tuple{typeof(identity)}}, ::typeof(sort!), ::AbstractVecto
           #_print#10(::Int64, ::Bool, ::Bool, ::typeof(identity), ::typeof(TOML.Internals.Printer._print), ::Not
             (::TOML.Internals.Printer.var"#_print##kw")(::NamedTuple{(:sorted, :by), Tuple{Bool, typeof(identity
               (::TOML.Internals.Printer.var"#_print##kw")(::NamedTuple{(:sorted, :by), Tuple{Bool, typeof(identi
                 #print#15(::Bool, ::typeof(identity), ::typeof(TOML.Internals.Printer.print), ::IOStream, ::Abst
                   (::TOML.Internals.Printer.var"#print##kw")(::NamedTuple{(:sorted,), Tuple{Bool}}, ::typeof(TOM
 >                   (::Pkg.API.var"#152#183")(::IOStream)
...
Body::Core.Const(nothing)
    @ /cache/build/default-amdci4-3/julialang/julia-release-1-dot-8/usr/share/julia/stdlib/v1.8/Pkg/src/API.jl:569 within `#152`
1 ─ %1  = (:sorted,)::Core.Const((:sorted,))
│   %2  = Core.apply_type(Core.NamedTuple, %1)::Core.Const(NamedTuple{(:sorted,)})
│   %3  = Core.tuple(true)::Core.Const((true,))
│   %4  = (%2)(%3)::Core.Const((sorted = true,))
│   %5  = Base.getproperty(Pkg.API.TOML, :print)::Core.Const(TOML.Internals.Printer.print)
│   %6  = Core.kwfunc(%5)::Core.Const(TOML.Internals.Printer.var"#print##kw"())
│   %7  = Base.getproperty(Pkg.API.TOML, :print)::Core.Const(TOML.Internals.Printer.print)
│   %8  = Core.getfield(#self#, :usage)::Core.Box
```
The `Core.Box` suggests the [common problem with closures](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured), so I added a `let` block. Is this okay?