### PR TITLE
fix invalidations from Static.jl

### DIFF
--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -132,8 +132,8 @@ end
 
 function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
     julia_version = haskey(raw, "julia_version") ? VersionNumber(raw["julia_version"]) : nothing
-    manifest_format = VersionNumber(raw["manifest_format"])
-    if !(in(manifest_format.major, 1:2)::Bool)
+    manifest_format = VersionNumber(raw["manifest_format"]::String)
+    if !in(manifest_format.major, 1:2)
         if f_or_io isa IO
             @warn "Unknown Manifest.toml format version detected in streamed manifest. Unexpected behavior may occur" manifest_format
         else

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -133,7 +133,7 @@ end
 function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
     julia_version = haskey(raw, "julia_version") ? VersionNumber(raw["julia_version"]) : nothing
     manifest_format = VersionNumber(raw["manifest_format"])
-    if !in(manifest_format.major, 1:2)
+    if !(in(manifest_format.major, 1:2)::Bool)
         if f_or_io isa IO
             @warn "Unknown Manifest.toml format version detected in streamed manifest. Unexpected behavior may occur" manifest_format
         else


### PR DESCRIPTION
This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 77: signature Tuple{typeof(!), Any} triggered MethodInstance for Pkg.Types.Manifest(::Dict{String, Any}, ::String) (97 children)
...
```

I suggest the labels `latency` and `backport-1.8`.