### PR TITLE
Test suite: skip the "ensure registry is installed" step if `Pkg.Registry.reachable_registries()` is not empty

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -370,7 +370,7 @@ temp_pkg_dir() do project_path
         # to precompile Pkg given we're in a different depot
         run(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg"`)
         # make sure the General registry is installed
-        Utils.show_output_if_command_errors(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; Pkg.Registry.add()"`)
+        Utils.show_output_if_command_errors(`$(Base.julia_cmd()) --project="$(pkgdir(Pkg))" -e "import Pkg; isempty(Pkg.Registry.reachable_registries()) && Pkg.Registry.add()"`)
         flag_start_dir = tempdir() # once n=Sys.CPU_THREADS files are in here, the processes can proceed to the concurrent test
         flag_end_file = tempname() # use creating this file as a way to stop the processes early if an error happens
         for i in 1:Sys.CPU_THREADS


### PR DESCRIPTION
If the user has opted out of the Pkg server, then `Pkg.Registry.add()` will always do a Git clone of the General registry, even if the depot already contains the General registry. In the CI for this repo, in the macOS CI job that uses Julia nightly and does not use the Pkg server, we are seeing frequent Git clone errors during this line, which perhaps is due to bad network connectivity on GitHub's macOS machines. However, because this line is inside a `temp_pkg_dir`, it is likely that the depot has already been initialized with the General registry, and thus this line is unnecessary. To be safe, instead of deleting the line entirely, we modify it so that the Git clone is only performed if no registries are found in the depot.