### PR TITLE
backport invalidation fixes to 1.8

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -565,8 +565,10 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
             # Write out the TOML file for this depot
             usage_path = joinpath(logdir(depot), fname)
             if !(isempty(usage)::Bool) || isfile(usage_path)
-                open(usage_path, "w") do io
-                    TOML.print(io, usage, sorted=true)
+                let usage=usage
+                    open(usage_path, "w") do io
+                        TOML.print(io, usage, sorted=true)
+                    end
                 end
             end
         end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -132,7 +132,7 @@ end
 
 function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
     julia_version = haskey(raw, "julia_version") ? VersionNumber(raw["julia_version"]) : nothing
-    manifest_format = VersionNumber(raw["manifest_format"])
+    manifest_format = VersionNumber(raw["manifest_format"]::String)
     if !in(manifest_format.major, 1:2)
         if f_or_io isa IO
             @warn "Unknown Manifest.toml format version detected in streamed manifest. Unexpected behavior may occur" manifest_format


### PR DESCRIPTION
I backported two PRs with invalidation fixes (merged into `master`) to `release-1.8`. They fix a few hundred invalidations when loading Static.jl, ArrayInterface.jl or anything using that (basically everything from JuliaSIMD with LoopVectorization.jl, SciML with OrdinaryDiffEq.jl etc.).