### PR TITLE
improve type stability of `Command(statement::Statement)`

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -365,7 +365,7 @@ function Command(statement::Statement)::Command
     # arguments
     arg_spec = statement.spec.argument_spec
     arguments = arg_spec.parser(statement.arguments, options)
-    if !(arg_spec.count.first <= length(arguments) <= arg_spec.count.second)
+    if !((arg_spec.count.first <= length(arguments) <= arg_spec.count.second)::Bool)
         pkgerror("Wrong number of arguments")
     end
     return Command(statement.spec, options, arguments)


### PR DESCRIPTION
I improved type stability to fix some invalidations. This is based on the following code:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("ArrayInterface")

julia> using SnoopCompileCore; invalidations = @snoopr(using ArrayInterface); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
...
inserting !(::Static.False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
```
The problem here is that `arguments` is only inferred as `Any`. I do not know whether we can assert something better (which may also fix the invalidations).

I suggest the labels `latency` and `backport-1.8`.