### PR TITLE
improve inferrability of `prune_graph!`

### DIFF
--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -1439,7 +1439,13 @@ function prune_graph!(graph::Graph)
         return pvers0[vmsk0[1:(end-1)]]
     end
     new_pvers = [compute_pvers(new_p0) for new_p0 = 1:new_np]
-    new_vdict = [Dict(vn => v0 for (v0,vn) in enumerate(new_pvers[new_p0])) for new_p0 = 1:new_np]
+    new_vdict = Vector{Dict{VersionNumber, Int}}(undef, length(new_pvers))
+    for new_p0 in eachindex(new_vdict)
+        new_vdict[new_p0] = Dict(vn => v0 for (v0,vn) in enumerate(new_pvers[new_p0]))
+    end
+    # The code above is essentially equivalent to
+    # new_vdict = [Dict(vn => v0 for (v0,vn) in enumerate(new_pvers[new_p0])) for new_p0 = 1:new_np]
+    # but leads to improved type stability and reduced invalidations.
 
     # The new constraints are all going to be `true`, except possibly
     # for the "uninstalled" state, which we copy over from the old

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -1439,13 +1439,12 @@ function prune_graph!(graph::Graph)
         return pvers0[vmsk0[1:(end-1)]]
     end
     new_pvers = [compute_pvers(new_p0) for new_p0 = 1:new_np]
+    
+    # explicitly writing out the following loop since the generator equivalent caused type inference failure
     new_vdict = Vector{Dict{VersionNumber, Int}}(undef, length(new_pvers))
     for new_p0 in eachindex(new_vdict)
         new_vdict[new_p0] = Dict(vn => v0 for (v0,vn) in enumerate(new_pvers[new_p0]))
     end
-    # The code above is essentially equivalent to
-    # new_vdict = [Dict(vn => v0 for (v0,vn) in enumerate(new_pvers[new_p0])) for new_p0 = 1:new_np]
-    # but leads to improved type stability and reduced invalidations.
 
     # The new constraints are all going to be `true`, except possibly
     # for the "uninstalled" state, which we copy over from the old


### PR DESCRIPTION
I improved type stability to fix some invalidations. This is based on the following code:

```julia
julia> import Pkg; Pkg.activate(temp=true); Pkg.add("HDF5")

julia> using SnoopCompileCore; invalidations = @snoopr(using HDF5); using SnoopCompile

julia> length(uinvalidated(invalidations))
168

julia> trees = invalidation_trees(invalidations)
...
 inserting convert(::Type{I}, ::Type{F}) where {I<:Integer, F<:HDF5.Filters.Filter} in HDF5.Filters at ~/.julia/packages/HDF5/T4H0V/src/filters/filters.jl:428 invalidated:
...
   backedges: 1: superseding convert(::Type{Union{}}, x) in Base at essentials.jl:213 with MethodInstance for convert(::Core.TypeofBottom, ::Any) (164 children)
   # quite a lot goes back to prune_graph!

```

I suggest the labels `latency` and `backport-1.8`. With a recent build of Pkg based on the `release-1.8` branch and this commit, I get
```julia
julia> length(uinvalidated(invalidations))
44
```