### PR TITLE
Allow optional dependencies in the resolver

### DIFF
--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -581,7 +581,7 @@ Finds a minimal collection of ranges as a `VersionSpec`, that permits everything
 `subset`, but does not permit anything else from the `pool`.
 """
 function range_compressed_versionspec(pool, subset=pool)
-    length(subset)==1 && return VersionSpec(only(subset))
+    length(subset) == 1 && return VersionSpec(only(subset))
     # PREM-OPT: we keep re-sorting these, probably not required.
     sort!(pool)
     sort!(subset)
@@ -597,10 +597,10 @@ function range_compressed_versionspec(pool, subset=pool)
             push!(contiguous_subsets, VersionRange(range_start, range_end))
             range_start = s  # start a new range
             while (s != pool[pool_ii])  # advance til time to start
-                pool_ii+=1
+                pool_ii += 1
             end
         end
-        pool_ii+=1
+        pool_ii += 1
     end
     push!(contiguous_subsets, VersionRange(range_start, last(subset)))
 
@@ -1467,8 +1467,8 @@ function prune_graph!(graph::Graph)
         new_j0 > length(new_gadj[new_p0]) || continue
         push!(new_gadj[new_p0], new_p1)
         push!(new_gadj[new_p1], new_p0)
-        new_j0 = length(new_gadj[new_p0])
-        new_j1 = length(new_gadj[new_p1])
+        @assert new_j0 == length(new_gadj[new_p0])
+        @assert new_j1 == length(new_gadj[new_p1])
 
         new_adjdict[new_p1][new_p0] = new_j0
         new_adjdict[new_p0][new_p1] = new_j1

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -167,7 +167,6 @@ end
     deps_data = Any[
         ["A", v"1", "B", "2-*"],
         ["A", v"1", "C", "2-*"],
-        # ["A", v"1", "julia", "10"],
         ["A", v"2", "B", "1"],
         ["A", v"2", "C", "1"],
         ["B", v"1", "C", "2-*"],
@@ -426,11 +425,124 @@ end
     want_data = Dict("A"=>v"1", "B"=>v"1", "C"=>v"1", "D"=>v"1")
     @test resolve_tst(deps_data, reqs_data, want_data)
 
+
+    VERBOSE && @info("SCHEME 12")
+    ## DEPENDENCY SCHEME 12: TWO PACKAGES, DAG, WEAK DEPENDENCY
+    deps_data = Any[
+        ["A", v"1", "B", "1-*", :weak],
+        ["A", v"2", "B", "2-*", :weak],
+        ["B", v"1"],
+        ["B", v"2"]
+    ]
+
+    @test sanity_tst(deps_data)
+    @test sanity_tst(deps_data, pkgs=["A", "B"])
+    @test sanity_tst(deps_data, pkgs=["B"])
+    @test sanity_tst(deps_data, pkgs=["A"])
+
+    # require just B
+    reqs_data = Any[
+        ["B", "*"]
+    ]
+
+    want_data = Dict("B"=>v"2")
+    resolve_tst(deps_data, reqs_data, want_data)
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require just A
+    reqs_data = Any[
+        ["A", "*"]
+    ]
+    want_data = Dict("A"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require A and B
+    reqs_data = Any[
+        ["A", "*"],
+        ["B", "*"]
+    ]
+    want_data = Dict("A"=>v"2", "B"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require A and B, invompatible versions
+    reqs_data = Any[
+        ["A", "2-*"],
+        ["B", "1"]
+    ]
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data, want_data)
+
+
+    VERBOSE && @info("SCHEME 13")
+    ## DEPENDENCY SCHEME 13: LIKE 9 (SIX PACKAGES, DAG), WITH SOME WEAK DEPENDENCIES
+    deps_data = Any[
+        ["A", v"1"],
+        ["A", v"2"],
+        ["A", v"3"],
+        ["B", v"1", "A", "1"],
+        ["B", v"2", "A", "*"],
+        ["C", v"1", "A", "2", :weak],
+        ["C", v"2", "A", "2-*"],
+        ["D", v"1", "B", "1-*"],
+        ["D", v"2", "B", "2-*", :weak],
+        ["E", v"1", "D", "*"],
+        ["F", v"1", "A", "1-2"],
+        ["F", v"1", "E", "*"],
+        ["F", v"2", "C", "2-*"],
+        ["F", v"2", "E", "*"],
+    ]
+
+    @test sanity_tst(deps_data)
+
+    # require just F
+    reqs_data = Any[
+        ["F", "*"]
+    ]
+    want_data = Dict("A"=>v"3", "C"=>v"2",
+                    "D"=>v"2", "E"=>v"1", "F"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require just F, lower version
+    reqs_data = Any[
+        ["F", "1"]
+    ]
+    want_data = Dict("A"=>v"2", "D"=>v"2",
+                    "E"=>v"1", "F"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require F and B; force lower B version -> must bring down F, A, and D versions too
+    reqs_data = Any[
+        ["F", "*"],
+        ["B", "1"]
+    ]
+    want_data = Dict("A"=>v"1", "B"=>v"1", "D"=>v"1",
+                    "E"=>v"1", "F"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require F and D; force lower D version -> must not bring down F version, and bring in B
+    reqs_data = Any[
+        ["F", "*"],
+        ["D", "1"]
+    ]
+    want_data = Dict("A"=>v"3", "B"=>v"2", "C"=>v"2",
+                    "D"=>v"1", "E"=>v"1", "F"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require F and C; force lower C version -> must bring down F and A versions
+    reqs_data = Any[
+        ["F", "*"],
+        ["C", "1"]
+    ]
+    want_data = Dict("A"=>v"2", "C"=>v"1",
+                    "D"=>v"2", "E"=>v"1", "F"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+
+
 end
 
 @testset "realistic" begin
     VERBOSE && @info("SCHEME REALISTIC")
-    ## DEPENDENCY SCHEME 12: A REALISTIC EXAMPLE
+    ## DEPENDENCY SCHEME 14: A REALISTIC EXAMPLE
     ## ref Julia issue #21485
 
     include("resolvedata1.jl")
@@ -438,7 +550,7 @@ end
     @test sanity_tst(ResolveData.deps_data, ResolveData.problematic_data)
     @test resolve_tst(ResolveData.deps_data, ResolveData.reqs_data, ResolveData.want_data)
 
-    ## DEPENDENCY SCHEME 13: A LARGER, MORE DIFFICULT REALISTIC EXAMPLE
+    ## DEPENDENCY SCHEME 15: A LARGER, MORE DIFFICULT REALISTIC EXAMPLE
     ## ref Pkg.jl issue #1949
 
     include("resolvedata2.jl")
@@ -449,7 +561,7 @@ end
 
 @testset "nasty" begin
     VERBOSE && @info("SCHEME NASTY")
-    ## DEPENDENCY SCHEME 13: A NASTY CASE
+    ## DEPENDENCY SCHEME 16: A NASTY CASE
 
     include("NastyGenerator.jl")
     deps_data, reqs_data, want_data, problematic_data = NastyGenerator.generate_nasty(5, 20, q=20, d=4, sat = true)

--- a/test/resolve_utils.jl
+++ b/test/resolve_utils.jl
@@ -33,7 +33,7 @@ wantuuids(want_data) = Dict{UUID,VersionNumber}(pkguuid(p) => v for (p,v) in wan
 Generate a package dependency graph from the entries in the array `deps_data`, where each entry
 is an array of the form `["PkgName", v"x.y.z", "DependencyA", v"Ax.Ay.Az", ...]`.
 This states that the package "PkgName" with version `v"x.y.z"` depends on "DependencyA" with the
-specified compatibility information.
+specified compatibility information. The last entry of the array can optionally be `:weak`.
 """
 function graph_from_data(deps_data)
     uuid_to_name = Dict{UUID,String}()
@@ -52,7 +52,8 @@ function graph_from_data(deps_data)
         end
         isempty(r) && continue
         rp = r[1]
-        rvs = VersionSpec(r[2:end]...)
+        weak = length(r) > 1 && r[end] == :weak
+        rvs = VersionSpec(r[2:(end-weak)]...; weak)
         deps[p][vn][rp] = rvs
     end
     for (p,preq) in deps


### PR DESCRIPTION
This closes #3125.
A couple of things:
1. The first commit adds a `weak` attribute to `VersionSpec`, like in the idea by @IanButterworth. Indeed, in the resolver code, that is definitely the most straightforward way to do it. It required a couple of design decisions though. This is what I did, which could be debatable:
    * When intersecting a weak and a non-weak `VersionSpec`, the result is non-weak
    * It is not allowed to take a union of a weak and non-weak `VersionSpec` (the resolver code does not use `union` and I wasn't sure what, if any, would be a possible use case)
    * In printing, weak dependencies ranges show up with a `ʷ` character appended. This is maybe ugly, but in this way the information is preserved when showing log traces etc. An alternative proposal: let the ranges show as normal, letting them be less informative, but add a `; weak=true` string when using `show`.
  Opinions or further proposals welcome.
2. I have revised all the code and I don't think that any other part of the code should need to be changed, but I performed only limited testing (see the two new schemes in `"test/resolve.jl"), mainly for lack of time but also because it's not exactly easy to come up with interesting artificial scenarios. Hopefully, someone can try this out on more realistic cases, and even add to the test files.