### PR TITLE
Allow optional dependencies in the resolver (without changing VersionSet)

### DIFF
--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -19,15 +19,18 @@ const Requires = Dict{UUID,VersionSpec}
 struct Fixed
     version::VersionNumber
     requires::Requires
+    weak::Set{UUID}
 end
-Fixed(v::VersionNumber) = Fixed(v, Requires())
+Fixed(v::VersionNumber, requires::Requires = Requires()) = Fixed(v, requires, Set{UUID}())
 
-Base.:(==)(a::Fixed, b::Fixed) = a.version == b.version && a.requires == b.requires
-Base.hash(f::Fixed, h::UInt) = hash((f.version, f.requires), h + (0x68628b809fd417ca % UInt))
+Base.:(==)(a::Fixed, b::Fixed) = a.version == b.version && a.requires == b.requires && a.weak == b.weak
+Base.hash(f::Fixed, h::UInt) = hash((f.version, f.requires, f.weak), h + (0x68628b809fd417ca % UInt))
 
 Base.show(io::IO, f::Fixed) = isempty(f.requires) ?
     print(io, "Fixed(", repr(f.version), ")") :
-    print(io, "Fixed(", repr(f.version), ",", f.requires, ")")
+    isempty(f.weak) ?
+    print(io, "Fixed(", repr(f.version), ",", f.requires, ")") :
+    print(io, "Fixed(", repr(f.version), ",", f.requires, ", weak=", f.weak, ")")
 
 
 struct ResolverError <: Exception

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -377,7 +377,7 @@ function add_reqs!(graph::Graph, reqs::Requires)
     return graph
 end
 
-function _add_reqs!(graph::Graph, reqs::Requires, reason)
+function _add_reqs!(graph::Graph, reqs::Requires, reason; weak_reqs::Set{UUID} = Set{UUID}())
     gconstr = graph.gconstr
     spp = graph.spp
     req_inds = graph.req_inds
@@ -392,7 +392,8 @@ function _add_reqs!(graph::Graph, reqs::Requires, reason)
             rvn = pvers[rp0][rv0]
             rvn ∈ rvs || (new_constr[rv0] = false)
         end
-        new_constr[end] = false
+        weak = rp ∈ weak_reqs
+        new_constr[end] = weak
         old_constr = copy(gconstr[rp0])
         gconstr[rp0] .&= new_constr
         reason ≡ :explicit_requirement && push!(req_inds, rp0)
@@ -425,7 +426,7 @@ function _add_fixed!(graph::Graph, fixed::Dict{UUID,Fixed})
         gconstr[fp0] .&= new_constr
         push!(fix_inds, fp0)
         bkitem = log_event_fixed!(graph, fp, fx)
-        _add_reqs!(graph, fx.requires, (fp, bkitem))
+        _add_reqs!(graph, fx.requires, (fp, bkitem); weak_reqs=fx.weak)
     end
     return graph
 end

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -585,7 +585,7 @@ Finds a minimal collection of ranges as a `VersionSpec`, that permits everything
 `subset`, but does not permit anything else from the `pool`.
 """
 function range_compressed_versionspec(pool, subset=pool)
-    length(subset)==1 && return VersionSpec(only(subset))
+    length(subset) == 1 && return VersionSpec(only(subset))
     # PREM-OPT: we keep re-sorting these, probably not required.
     sort!(pool)
     sort!(subset)
@@ -601,10 +601,10 @@ function range_compressed_versionspec(pool, subset=pool)
             push!(contiguous_subsets, VersionRange(range_start, range_end))
             range_start = s  # start a new range
             while (s != pool[pool_ii])  # advance til time to start
-                pool_ii+=1
+                pool_ii += 1
             end
         end
-        pool_ii+=1
+        pool_ii += 1
     end
     push!(contiguous_subsets, VersionRange(range_start, last(subset)))
 
@@ -1471,8 +1471,8 @@ function prune_graph!(graph::Graph)
         new_j0 > length(new_gadj[new_p0]) || continue
         push!(new_gadj[new_p0], new_p1)
         push!(new_gadj[new_p1], new_p0)
-        new_j0 = length(new_gadj[new_p0])
-        new_j1 = length(new_gadj[new_p1])
+        @assert new_j0 == length(new_gadj[new_p0])
+        @assert new_j1 == length(new_gadj[new_p1])
 
         new_adjdict[new_p1][new_p0] = new_j0
         new_adjdict[new_p0][new_p1] = new_j1

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -167,7 +167,6 @@ end
     deps_data = Any[
         ["A", v"1", "B", "2-*"],
         ["A", v"1", "C", "2-*"],
-        # ["A", v"1", "julia", "10"],
         ["A", v"2", "B", "1"],
         ["A", v"2", "C", "1"],
         ["B", v"1", "C", "2-*"],
@@ -426,11 +425,122 @@ end
     want_data = Dict("A"=>v"1", "B"=>v"1", "C"=>v"1", "D"=>v"1")
     @test resolve_tst(deps_data, reqs_data, want_data)
 
+
+    VERBOSE && @info("SCHEME 12")
+    ## DEPENDENCY SCHEME 12: TWO PACKAGES, DAG, WEAK DEPENDENCY
+    deps_data = Any[
+        ["A", v"1", "B", "1-*", :weak],
+        ["A", v"2", "B", "2-*", :weak],
+        ["B", v"1"],
+        ["B", v"2"]
+    ]
+
+    @test sanity_tst(deps_data)
+    @test sanity_tst(deps_data, pkgs=["A", "B"])
+    @test sanity_tst(deps_data, pkgs=["B"])
+    @test sanity_tst(deps_data, pkgs=["A"])
+
+    # require just B
+    reqs_data = Any[
+        ["B", "*"]
+    ]
+    want_data = Dict("B"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require just A
+    reqs_data = Any[
+        ["A", "*"]
+    ]
+    want_data = Dict("A"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require A and B
+    reqs_data = Any[
+        ["A", "*"],
+        ["B", "*"]
+    ]
+    want_data = Dict("A"=>v"2", "B"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require A and B, invompatible versions
+    reqs_data = Any[
+        ["A", "2-*"],
+        ["B", "1"]
+    ]
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data, want_data)
+
+
+    VERBOSE && @info("SCHEME 13")
+    ## DEPENDENCY SCHEME 13: LIKE 9 (SIX PACKAGES, DAG), WITH SOME WEAK DEPENDENCIES
+    deps_data = Any[
+        ["A", v"1"],
+        ["A", v"2"],
+        ["A", v"3"],
+        ["B", v"1", "A", "1"],
+        ["B", v"2", "A", "*"],
+        ["C", v"1", "A", "2", :weak],
+        ["C", v"2", "A", "2-*"],
+        ["D", v"1", "B", "1-*"],
+        ["D", v"2", "B", "2-*", :weak],
+        ["E", v"1", "D", "*"],
+        ["F", v"1", "A", "1-2"],
+        ["F", v"1", "E", "*"],
+        ["F", v"2", "C", "2-*"],
+        ["F", v"2", "E", "*"],
+    ]
+
+    @test sanity_tst(deps_data)
+
+    # require just F
+    reqs_data = Any[
+        ["F", "*"]
+    ]
+    want_data = Dict("A"=>v"3", "C"=>v"2",
+                    "D"=>v"2", "E"=>v"1", "F"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require just F, lower version
+    reqs_data = Any[
+        ["F", "1"]
+    ]
+    want_data = Dict("A"=>v"2", "D"=>v"2",
+                    "E"=>v"1", "F"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require F and B; force lower B version -> must bring down F, A, and D versions too
+    reqs_data = Any[
+        ["F", "*"],
+        ["B", "1"]
+    ]
+    want_data = Dict("A"=>v"1", "B"=>v"1", "D"=>v"1",
+                    "E"=>v"1", "F"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require F and D; force lower D version -> must not bring down F version, and bring in B
+    reqs_data = Any[
+        ["F", "*"],
+        ["D", "1"]
+    ]
+    want_data = Dict("A"=>v"3", "B"=>v"2", "C"=>v"2",
+                    "D"=>v"1", "E"=>v"1", "F"=>v"2")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+    # require F and C; force lower C version -> must bring down F and A versions
+    reqs_data = Any[
+        ["F", "*"],
+        ["C", "1"]
+    ]
+    want_data = Dict("A"=>v"2", "C"=>v"1",
+                    "D"=>v"2", "E"=>v"1", "F"=>v"1")
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+
+
 end
 
 @testset "realistic" begin
     VERBOSE && @info("SCHEME REALISTIC")
-    ## DEPENDENCY SCHEME 12: A REALISTIC EXAMPLE
+    ## DEPENDENCY SCHEME 14: A REALISTIC EXAMPLE
     ## ref Julia issue #21485
 
     include("resolvedata1.jl")
@@ -438,7 +548,7 @@ end
     @test sanity_tst(ResolveData.deps_data, ResolveData.problematic_data)
     @test resolve_tst(ResolveData.deps_data, ResolveData.reqs_data, ResolveData.want_data)
 
-    ## DEPENDENCY SCHEME 13: A LARGER, MORE DIFFICULT REALISTIC EXAMPLE
+    ## DEPENDENCY SCHEME 15: A LARGER, MORE DIFFICULT REALISTIC EXAMPLE
     ## ref Pkg.jl issue #1949
 
     include("resolvedata2.jl")
@@ -449,7 +559,7 @@ end
 
 @testset "nasty" begin
     VERBOSE && @info("SCHEME NASTY")
-    ## DEPENDENCY SCHEME 13: A NASTY CASE
+    ## DEPENDENCY SCHEME 16: A NASTY CASE
 
     include("NastyGenerator.jl")
     deps_data, reqs_data, want_data, problematic_data = NastyGenerator.generate_nasty(5, 20, q=20, d=4, sat = true)


### PR DESCRIPTION
This closes #3125 and it's an alternative implementation to #3204.
It does not change `VersionSet` so it does not have any of the associated difficulties there. 
It adds a keyword argument to the `GraphType` constructor instead ([here](https://github.com/carlobaldassi/Pkg3.jl/blob/56f5fdc9419b3a9ddc10cac5f73dc6da05d55734/src/Resolve/graphtype.jl#L245)). The type is `Dict{UUID,Dict{VersionNumber,Set{UUID}}}`.
@KristofferC this is what was discussed [here](https://github.com/JuliaLang/Pkg.jl/pull/3204#issuecomment-1251017819).
The building of the structure is a little cumbersome, an example can be seen [here](https://github.com/carlobaldassi/Pkg3.jl/blob/56f5fdc9419b3a9ddc10cac5f73dc6da05d55734/test/resolve_utils.jl#L76-L79).

This still needs testing, just as much as #3204 did.





