### PR TITLE
fixes for JET's `mode=:typo` report

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -590,7 +590,7 @@ ensure_artifact_installed(name::AbstractString, artifacts_toml::AbstractString; 
 ensure_artifact_installed(name::AbstractString, meta::Dict, artifacts_toml::AbstractString; kwargs...) =
     ensure_artifact_installed(string(name)::String, meta, string(artifacts_toml)::String; kwargs...)
 ensure_all_artifacts_installed(artifacts_toml::AbstractString; kwargs...) =
-    ensure_all_artifacts_installed(string(name)::String; kwargs...)
+    ensure_all_artifacts_installed(string(artifacts_toml)::String; kwargs...)
 extract_all_hashes(artifacts_toml::AbstractString; kwargs...) =
     extract_all_hashes(string(artifacts_toml)::String; kwargs...)
 

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -82,8 +82,7 @@ function uncompress(compressed::Dict{VersionRange, Dict{String, T}}, vsorted::Ve
             uv = uncompressed[v]
             for (key, value) in data
                 if haskey(uv, key)
-                    # Change to an error?
-                    error("Overlapping ranges for $(key) in $(repr(path)) for version $v.")
+                    error("Overlapping ranges for $(key) in manifest for version $v.")
                 else
                     uv[key] = value
                 end

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -82,7 +82,7 @@ function uncompress(compressed::Dict{VersionRange, Dict{String, T}}, vsorted::Ve
             uv = uncompressed[v]
             for (key, value) in data
                 if haskey(uv, key)
-                    error("Overlapping ranges for $(key) in manifest for version $v.")
+                    error("Overlapping ranges for $(key) for version $v in registry.")
                 else
                     uv[key] = value
                 end


### PR DESCRIPTION
Similar to #3207, but just running with `report_package(Pkg; target_defined_modules=true, mode=:typo)`.

After this (and with #3207), there's just 2 `:typo`-issues remaining (one is https://github.com/JuliaLang/Pkg.jl/pull/2569#issuecomment-1251931205 and the other I don't understand):
 ```jl
 ═════ 2 possible errors found ═════
┌ @ /home/tchr/dev/julia-pkgs/Pkg.jl/src/Operations.jl:2099 Pkg.Operations.is_tracking_repo(new)
│┌ @ /home/tchr/dev/julia-pkgs/Pkg.jl/src/Operations.jl:230 pkg.repo
││┌ @ Base.jl:37 Base.getfield(x, f)
│││ type Pkg.Types.EnvCache has no field repo
││└──────────────
┌ @ /home/tchr/dev/julia-pkgs/Pkg.jl/src/API.jl:1350 Pkg.API.touch(Pkg.API.path_to_try)
│ variable Pkg.API.path_to_try is not defined
└────────────────────────────────────────────────────
```

This also manually updates `ext/LazilyInitializedFields.jl` to its upstream version in order to get https://github.com/KristofferC/LazilyInitializedFields.jl/pull/23.