### PR TITLE
Precompile: Fix touch on cache files to make sure latest is used first during load

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1033,7 +1033,16 @@ end
 function _is_stale(paths::Vector{String}, sourcepath::String)
     for path_to_try in paths
         staledeps = Base.stale_cachefile(sourcepath, path_to_try, ignore_loaded = true)
-        staledeps === true ? continue : return false
+        if staledeps !== true
+            try
+                # update timestamp of precompilation file so that it is the first to be tried by code loading
+                touch(path_to_try)
+            catch ex
+                # file might be read-only and then we fail to update timestamp, which is fine
+                ex isa IOError || rethrow()
+            end
+            return false
+        end
     end
     return true
 end
@@ -1344,13 +1353,7 @@ function precompile(ctx::Context, pkgs::Vector{String}=String[]; internal_call::
                         Base.release(parallel_limiter)
                     end
                 else
-                    if !is_stale
-                        n_already_precomp += 1
-                        try
-                            touch(path_to_try) # update timestamp of precompilation file
-                        catch # file might be read-only and then we fail to update timestamp, which is fine
-                        end
-                    end
+                    is_stale || (n_already_precomp += 1)
                     suspended && push!(skipped_deps, pkg)
                 end
                 n_done += 1


### PR DESCRIPTION
As noted https://github.com/JuliaLang/Pkg.jl/pull/2569#issuecomment-1251814774 this touch was silently broken, meaning that the identified cache files weren't promoted to the front of the queue during load time. This may speed up load times.

Thanks @thchr !