### PR TITLE
Mention package server registries on Registries doc page

### DIFF
--- a/docs/src/registries.md
+++ b/docs/src/registries.md
@@ -44,6 +44,15 @@ Registry Status
 
 Registries are always added to the user depot, which is the first entry in `DEPOT_PATH` (cf. the [Glossary](@ref) section).
 
+!!! note "Registries from a package server"
+
+    It is possible for a package server to be advertising additional available package
+    registries. When Pkg runs with a clean Julia depot (e.g. after a fresh install), with
+    a custom package server configured with `JULIA_PKG_SERVER`, it will automatically
+    add all such available registries. If the depot already has some registries installed
+    (e.g. General), the additional ones can easily be installed with the no-argument
+    `registry add` command.
+
 ### Removing registries
 
 Registries can be removed with the `registry remove` (or `registry rm`) command.


### PR DESCRIPTION
I think it would be a good idea to advertise a bit more the fact that (1) a package server can advertise additional registries, and (2) how to then add them automatically.