### PR TITLE
Allow users to set the max number of precompile tasks by setting `JULIA_MAX_NUM_PRECOMPILE_TASKS="<=n"`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1079,9 +1079,22 @@ function precompile(ctx::Context, pkgs::Vector{String}=String[]; internal_call::
     # Windows sometimes hits a ReadOnlyMemoryError, so we halve the default number of tasks. Issue #2323
     # TODO: Investigate why this happens in windows and restore the full task limit
     default_num_tasks = Sys.iswindows() ? div(Sys.CPU_THREADS::Int, 2) + 1 : Sys.CPU_THREADS::Int + 1
-    default_num_tasks = min(default_num_tasks, 16) # limit for better stability on shared resource systems
+    num_task_env = get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", nothing)
+    if num_task_env === nothing
+        # limit for better stability on shared resource systems
+        num_tasks = min(default_num_tasks, 16)::Int
+    else
+        m = match(r"^<=(\d*?)$", num_task_env)
+        if m === nothing
+            # JULIA_NUM_PRECOMPILE_TASKS="n"
+            num_tasks = parse(Int, num_task_env)::Int
+        else
+            # JULIA_NUM_PRECOMPILE_TASKS="<=n"
+            max_num_tasks = parse(Int, m[1])::Int
+            num_tasks = min(default_num_tasks, max_num_tasks)::Int
+        end
+    end
 
-    num_tasks = parse(Int, get(ENV, "JULIA_NUM_PRECOMPILE_TASKS", string(default_num_tasks)))
     parallel_limiter = Base.Semaphore(num_tasks)
     io = ctx.io
     fancyprint = can_fancyprint(io)


### PR DESCRIPTION
I have a hetereogeneous collection of machines. Across all of these machines, I want to enforce a limit of no more than `10` precompile tasks. However, some machines are small and only have e.g. four CPU threads; on those machines, instead of using `10` precompile tasks, I want to be using `5` tasks, which is what Pkg would decide to use if I didn't set any environment variables.

Unfortunately, with the existing `JULIA_NUM_PRECOMPILE_TASKS` environment variable, if I set `JULIA_NUM_PRECOMPILE_TASKS="10"`, then Pkg will use `10` precompile tasks even on the small machines.

Therefore, this PR adds the ability to set e.g. `JULIA_NUM_PRECOMPILE_TASKS="<=10"`.