### PR TITLE
add the ability to add compat on "weak dependencies"

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -18,6 +18,27 @@ The format of the version specifier is described in detail below.
 !!! info
     Use the command `compat` to edit the compat entries in the Pkg REPL, or manually edit the project file.
 
+## Compatibility on "weak dependencies"
+
+!!! compat "Julia 1.9"
+    This feature requires Julia 1.9
+
+A weak dependency is a package that you do not depend on but still want to be able to add
+compatibility constraints on. This is for example useful when using Requires.jl to load
+dependencies "conditionally". This is done by adding the weak dependency under the `weakdeps` section
+and then adding a normal compat entry on it:
+
+```toml
+[weakdeps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[compat]
+Example = "0.5"
+```
+
+Possible use cases for this is when using Requires.jl and one wants to add a compat constrained
+on the "conditional dependency" that Requires.jl tends to be used for.
+
 ## Version specifier format
 
 Similar to other package managers, the Julia package manager respects [semantic versioning](https://semver.org/) (semver).

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -36,8 +36,9 @@ custom_isfile(in_memory_registry::Union{Dict, Nothing}, folder::AbstractString, 
     git_tree_sha1::Base.SHA1
     yanked::Bool
     @lazy uncompressed_compat::Union{Dict{UUID, VersionSpec}}
+    @lazy weak_uncompressed_compat::Union{Dict{UUID, VersionSpec}}
 end
-VersionInfo(git_tree_sha1::Base.SHA1, yanked::Bool) = VersionInfo(git_tree_sha1, yanked, uninit)
+VersionInfo(git_tree_sha1::Base.SHA1, yanked::Bool) = VersionInfo(git_tree_sha1, yanked, uninit, uninit)
 
 # This is the information that exists in e.g. General/A/ACME
 struct PkgInfo
@@ -53,6 +54,12 @@ struct PkgInfo
 
     # Deps.toml
     deps::Dict{VersionRange, Dict{String, UUID}}
+
+    # WeakCompat.toml
+    weak_compat::Dict{VersionRange, Dict{String, VersionSpec}}
+
+    # WeakDeps.toml
+    weak_deps::Dict{VersionRange, Dict{String, UUID}}
 end
 
 isyanked(pkg::PkgInfo, v::VersionNumber) = pkg.version_info[v].yanked
@@ -119,9 +126,41 @@ function initialize_uncompressed!(pkg::PkgInfo, versions = keys(pkg.version_info
     return pkg
 end
 
+function initialize_weak_uncompressed!(pkg::PkgInfo, versions = keys(pkg.version_info))
+    # Only valid to call this with existing versions of the package
+    # Remove all versions we have already uncompressed
+    versions = filter!(v -> !isinit(pkg.version_info[v], :weak_uncompressed_compat), collect(versions))
+
+    sort!(versions)
+
+    weak_uncompressed_compat = uncompress(pkg.weak_compat, versions)
+    weak_uncompressed_deps   = uncompress(pkg.weak_deps,   versions)
+
+    for v in versions
+        vinfo = pkg.version_info[v]
+        weak_compat = Dict{UUID, VersionSpec}()
+        weak_uncompressed_deps_v = weak_uncompressed_deps[v]
+        weak_uncompressed_compat_v = weak_uncompressed_compat[v]
+        for (pkg, uuid) in weak_uncompressed_deps_v
+            vspec = get(weak_uncompressed_compat_v, pkg, nothing)
+            weak_compat[uuid] = vspec === nothing ? VersionSpec() : vspec
+        end
+        @init! vinfo.weak_uncompressed_compat = weak_compat
+    end
+    return pkg
+end
+
 function compat_info(pkg::PkgInfo)
     initialize_uncompressed!(pkg)
     return Dict(v => info.uncompressed_compat for (v, info) in pkg.version_info)
+end
+
+function weak_compat_info(pkg::PkgInfo)
+    if isempty(pkg.weak_deps)
+        return nothing
+    end
+    initialize_weak_uncompressed!(pkg)
+    return Dict(v => info.weak_uncompressed_compat for (v, info) in pkg.version_info)
 end
 
 @lazy struct PkgEntry
@@ -150,13 +189,13 @@ function init_package_info!(pkg::PkgEntry)
     subdir = get(d_p, "subdir", nothing)::Union{Nothing, String}
 
     # Versions.toml
-    d_v = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Versions.toml")) ? 
+    d_v = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Versions.toml")) ?
         parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Versions.toml")) : Dict{String, Any}()
     version_info = Dict{VersionNumber, VersionInfo}(VersionNumber(k) =>
         VersionInfo(SHA1(v["git-tree-sha1"]::String), get(v, "yanked", false)::Bool) for (k, v) in d_v)
 
     # Compat.toml
-    compat_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Compat.toml")) ? 
+    compat_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Compat.toml")) ?
         parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Compat.toml")) : Dict{String, Any}()
     # The Compat.toml file might have string or vector values
     compat_data_toml = convert(Dict{String, Dict{String, Union{String, Vector{String}}}}, compat_data_toml)
@@ -181,7 +220,29 @@ function init_package_info!(pkg::PkgEntry)
     # All packages depend on julia
     deps[VersionRange()] = Dict("julia" => JULIA_UUID)
 
-    @init! pkg.info = PkgInfo(repo, subdir, version_info, compat, deps)
+    # WeakCompat.toml
+    weak_compat_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakCompat.toml")) ?
+    parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakCompat.toml")) : Dict{String, Any}()
+    weak_compat_data_toml = convert(Dict{String, Dict{String, Union{String, Vector{String}}}}, weak_compat_data_toml)
+    weak_compat = Dict{VersionRange, Dict{String, VersionSpec}}()
+    for (v, data) in weak_compat_data_toml
+        vr = VersionRange(v)
+        d = Dict{String, VersionSpec}(dep => VersionSpec(vr_dep) for (dep, vr_dep) in data)
+        weak_compat[vr] = d
+    end
+
+    # WeakDeps.toml
+    weak_deps_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakDeps.toml")) ?
+        parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakDeps.toml")) : Dict{String, Any}()
+    weak_deps_data_toml = convert(Dict{String, Dict{String, String}}, weak_deps_data_toml)
+    weak_deps = Dict{VersionRange, Dict{String, UUID}}()
+    for (v, data) in weak_deps_data_toml
+        vr = VersionRange(v)
+        d = Dict{String, UUID}(dep => UUID(uuid) for (dep, uuid) in data)
+        weak_deps[vr] = d
+    end
+
+    @init! pkg.info = PkgInfo(repo, subdir, version_info, compat, deps, weak_compat, weak_deps)
 
     return pkg.info
 end

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -236,13 +236,12 @@ mutable struct Graph
 
     function Graph(
             compat::Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}},
+            compat_weak::Dict{UUID,Dict{VersionNumber,Set{UUID}}},
             uuid_to_name::Dict{UUID,String},
             reqs::Requires,
             fixed::Dict{UUID,Fixed},
             verbose::Bool = false,
             julia_version::Union{VersionNumber,Nothing} = VERSION
-            ;
-            compat_weak::Dict{UUID,Dict{VersionNumber,Set{UUID}}} = Dict{UUID,Dict{VersionNumber,Set{UUID}}}(),
         )
 
         # Tell the resolver about julia itself
@@ -256,7 +255,6 @@ mutable struct Graph
 
         data = GraphData(compat, uuid_to_name, verbose)
         pkgs, np, spp, pdict, pvers, vdict, rlog = data.pkgs, data.np, data.spp, data.pdict, data.pvers, data.vdict, data.rlog
-
         extended_deps = let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
             [Vector{Dict{Int,BitVector}}(undef, spp[p0]-1) for p0 = 1:np]
         end
@@ -1441,7 +1439,7 @@ function prune_graph!(graph::Graph)
         return pvers0[vmsk0[1:(end-1)]]
     end
     new_pvers = [compute_pvers(new_p0) for new_p0 = 1:new_np]
-    
+
     # explicitly writing out the following loop since the generator equivalent caused type inference failure
     new_vdict = Vector{Dict{VersionNumber, Int}}(undef, length(new_pvers))
     for new_p0 in eachindex(new_vdict)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -239,6 +239,7 @@ Base.@kwdef mutable struct Project
     manifest::Union{String, Nothing} = nothing
     # Sections
     deps::Dict{String,UUID} = Dict{String,UUID}()
+    weakdeps::Dict{String,UUID} = Dict{String,UUID}()
     extras::Dict{String,UUID} = Dict{String,UUID}()
     targets::Dict{String,Vector{String}} = Dict{String,Vector{String}}()
     compat::Dict{String,Compat} = Dict{String,Compat}()
@@ -262,6 +263,7 @@ Base.@kwdef mutable struct PackageEntry
     repo::GitRepo = GitRepo()
     tree_hash::Union{Nothing,SHA1} = nothing
     deps::Dict{String,UUID} = Dict{String,UUID}()
+    weakdeps::Dict{String,UUID} = Dict{String,UUID}()
     uuid::Union{Nothing, UUID} = nothing
     other::Union{Dict,Nothing} = nothing
 end
@@ -272,9 +274,10 @@ Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
     t1.repo == t2.repo &&
     t1.tree_hash == t2.tree_hash &&
     t1.deps == t2.deps &&
+    t1.weakdeps == t2.weakdeps &&
     t1.uuid == t2.uuid
     # omits `other`
-Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps, x.uuid], init=h)  # omits `other`
+Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps, x.weakdeps, x.uuid], init=h)  # omits `other`
 
 Base.@kwdef mutable struct Manifest
     julia_version::Union{Nothing,VersionNumber} = nothing # only set to VERSION when resolving

--- a/src/project.jl
+++ b/src/project.jl
@@ -2,7 +2,7 @@
 # UTILS #
 #########
 listed_deps(project::Project) =
-    append!(collect(keys(project.deps)), collect(keys(project.extras)))
+    append!(collect(keys(project.deps)), collect(keys(project.extras)), collect(keys(project.weakdeps)))
 
 ###########
 # READING #
@@ -73,21 +73,26 @@ end
 read_project_compat(raw, project::Project) =
     pkgerror("Expected `compat` section to be a key-value list")
 
-function validate(project::Project)
+function validate(project::Project; file=nothing)
     # deps
+    location_string = file === nothing ? "" : " at $(repr(file))."
     dep_uuids = collect(values(project.deps))
     if length(dep_uuids) != length(unique(dep_uuids))
-        pkgerror("Two different dependencies can not have the same uuid")
+        pkgerror("Two different dependencies can not have the same uuid" * location_string)
+    end
+    weak_dep_uuids = collect(values(project.weakdeps))
+    if length(weak_dep_uuids) != length(unique(weak_dep_uuids))
+        pkgerror("Two different weak dependencies can not have the same uuid" * location_string)
     end
     # extras
     extra_uuids = collect(values(project.extras))
     if length(extra_uuids) != length(unique(extra_uuids))
-        pkgerror("Two different `extra` dependencies can not have the same uuid")
+        pkgerror("Two different `extra` dependencies can not have the same uuid" * location_string)
     end
-    dep_names = keys(project.deps)
     # TODO decide what to do in when `add`ing a dep that is already in `extras`
     #   also, reintroduce test files for this
     #=
+    dep_names = keys(project.deps)
     for (name, uuid) in project.extras
         name in dep_names && pkgerror("name `$name` is listed in both `deps` and `extras`")
         uuid in dep_uuids && pkgerror("uuid `$uuid` is listed in both `deps` and `extras`")
@@ -100,18 +105,18 @@ function validate(project::Project)
             pkgerror("A dependency was named twice in target `$target`")
         end
         dep in listed || pkgerror("""
-            Dependency `$dep` in target `$target` not listed in `deps` or `extras` section.
-            """)
+            Dependency `$dep` in target `$target` not listed in `deps`, `weakdeps` or `extras` section
+            """ * location_string)
     end
     # compat
     for (name, version) in project.compat
         name == "julia" && continue
         name in listed ||
-            pkgerror("Compat `$name` not listed in `deps` or `extras` section.")
+            pkgerror("Compat `$name` not listed in `deps`, `weakdeps` or `extras` section" * location_string)
     end
 end
 
-function Project(raw::Dict)
+function Project(raw::Dict; file=nothing)
     project = Project()
     project.other    = raw
     project.name     = get(raw, "name", nothing)::Union{String, Nothing}
@@ -119,10 +124,11 @@ function Project(raw::Dict)
     project.uuid     = read_project_uuid(get(raw, "uuid", nothing))
     project.version  = read_project_version(get(raw, "version", nothing))
     project.deps     = read_project_deps(get(raw, "deps", nothing), "deps")
+    project.weakdeps = read_project_deps(get(raw, "weakdeps", nothing), "weakdeps")
     project.extras   = read_project_deps(get(raw, "extras", nothing), "extras")
     project.compat   = read_project_compat(get(raw, "compat", nothing), project)
     project.targets  = read_project_targets(get(raw, "targets", nothing), project)
-    validate(project)
+    validate(project; file)
     return project
 end
 
@@ -139,7 +145,7 @@ function read_project(f_or_io::Union{String, IO})
         end
         rethrow()
     end
-    return Project(raw)
+    return Project(raw; file= f_or_io isa IO ? nothing : f_or_io)
 end
 
 
@@ -168,6 +174,7 @@ function destructure(project::Project)::Dict
     entry!("version",  project.version)
     entry!("manifest", project.manifest)
     entry!("deps",     project.deps)
+    entry!("weakdeps", project.weakdeps)
     entry!("extras",   project.extras)
     entry!("compat",   Dict(name => x.str for (name, x) in project.compat))
     entry!("targets",  project.targets)

--- a/test/new.jl
+++ b/test/new.jl
@@ -3039,4 +3039,12 @@ if :version in fieldnames(Base.PkgOrigin)
 end
 end
 
+@testset "weak deps" begin
+    isolate(loaded_depot=true) do
+        Pkg.activate(; temp=true)
+        Pkg.develop(path=joinpath(@__DIR__, "test_packages/", "HasWeakDeps"))
+        @test_throws Pkg.Resolve.ResolverError Pkg.add(; name = "OffsetArrays", version = "0.9.0")
+    end
+end
+
 end #module

--- a/test/resolve_utils.jl
+++ b/test/resolve_utils.jl
@@ -81,7 +81,7 @@ function graph_from_data(deps_data)
             end
         end
     end
-    return Graph(all_compat, uuid_to_name, Requires(), fixed, VERBOSE; compat_weak=all_compat_w)
+    return Graph(all_compat, all_compat_w, uuid_to_name, Requires(), fixed, VERBOSE)
 end
 function reqs_from_data(reqs_data, graph::Graph)
     reqs = Dict{UUID,VersionSpec}()

--- a/test/test_packages/HasWeakDeps/Project.toml
+++ b/test/test_packages/HasWeakDeps/Project.toml
@@ -1,0 +1,19 @@
+name = "HasWeakDeps"
+uuid = "4d3288b3-3afc-4bb6-85f3-489fffe514c8"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[weakdeps]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+
+[compat]
+Example = "0.5"
+OffsetArrays = "1.12"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["OffsetArrays", "Test"]

--- a/test/test_packages/HasWeakDeps/src/HasWeakDeps.jl
+++ b/test/test_packages/HasWeakDeps/src/HasWeakDeps.jl
@@ -1,0 +1,5 @@
+module HasWeakDeps
+
+using Example
+
+end # module


### PR DESCRIPTION
This is the part of the Pkg changes of the weak deps / glue code saga that is independent of the actual mechanism of how the conditional dependency gets loaded. This is useful on its own, for example with Requires.jl.

To properly test this we need to either make our own registry that has a weak dependency, or add some packages to the General registry.

It would also be good to start working on Registrator support for this feature (cc @GunnarFarneback).