### PR TITLE
Add sleeps when overwriting the TOML files

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -234,6 +234,7 @@ end
         @test_throws ErrorException bind_artifact!(artifacts_toml, "foo_txt", hash2)
         @test artifact_hash("foo_txt", artifacts_toml) == hash
         bind_artifact!(artifacts_toml, "foo_txt", hash2; force=true)
+        sleep(1)
         @test artifact_hash("foo_txt", artifacts_toml) == hash2
 
         # Test that we can un-bind
@@ -254,6 +255,7 @@ end
         @test artifact_hash("foo_txt", artifacts_toml; platform=Platform("x86_64", "macos")) == nothing
         @test_throws ErrorException bind_artifact!(artifacts_toml, "foo_txt", hash2; download_info=download_info, platform=linux64)
         bind_artifact!(artifacts_toml, "foo_txt", hash2; download_info=download_info, platform=linux64, force=true)
+        sleep(1)
         bind_artifact!(artifacts_toml, "foo_txt", hash; download_info=download_info, platform=win32)
         @test artifact_hash("foo_txt", artifacts_toml; platform=linux64) == hash2
         @test artifact_hash("foo_txt", artifacts_toml; platform=win32) == hash


### PR DESCRIPTION
Checking the hash of a file that was just written to might lead to wrong results, this test has a data race that leads to weird results, adding a sleep will probably help it. It seems it was "broke" it https://github.com/JuliaLang/julia/pull/46944/files. 
@vtjnash 
Should hopefully fix https://github.com/JuliaLang/Pkg.jl/issues/3212