### PR TITLE
Fix reference to IOError on error path

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1039,7 +1039,7 @@ function _is_stale(paths::Vector{String}, sourcepath::String)
                 touch(path_to_try)
             catch ex
                 # file might be read-only and then we fail to update timestamp, which is fine
-                ex isa IOError || rethrow()
+                ex isa Base.IOError || rethrow()
             end
             return false
         end


### PR DESCRIPTION
@KristofferC noticed this error introduced in https://github.com/JuliaLang/Pkg.jl/pull/3213 in PkgEval 

https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/9dd9458_vs_d0156b5/SnoopCompile.primary.log
```
┌ Warning: The active manifest file has dependencies that were resolved with a different julia version (1.6.3-pre.1). Unexpected behavior may occur.
└ @ ~/.julia/packages/SnoopCompile/Q8zUg/test/testmodules/Stale/Manifest.toml:0
  Activating┌ Error: Pkg.precompile error
│   exception =
│    UndefVarError: `IOError` not defined
│    Stacktrace:
│     [1] _is_stale(paths::Vector{String}, sourcepath::String)
│       @ Pkg.API /opt/julia/share/julia/stdlib/v1.10/Pkg/src/API.jl:1042
...
│       @ Pkg.API ./task.jl:514
└ @ Pkg.API /opt/julia/share/julia/stdlib/v1.10/Pkg/src/API.jl:1198
 project at `/tmp/jl_cpuUxn`
```