### PR TITLE
Fix basedocs

### DIFF
--- a/docs/src/basedocs.md
+++ b/docs/src/basedocs.md
@@ -19,7 +19,8 @@ import Markdown
 file = joinpath(Sys.STDLIB, "Pkg", "docs", "src", "getting-started.md")
 str = read(file, String)
 str = replace(str, r"^#.*$"m => "")
-str = replace(str, "[API Reference](@ref)" =>
-          "[API Reference](https://pkgdocs.julialang.org/v1/api/)")
+str = replace(str, "[API Reference](@ref)" => "[API Reference](https://pkgdocs.julialang.org/v1/api/)")
+str = replace(str, "(@ref Working-with-Environments)" => "(https://pkgdocs.julialang.org/v1/environments/)")
+str = replace(str, "(@ref Managing-Packages)" => "(https://pkgdocs.julialang.org/v1/managing-packages/)")
 Markdown.parse(str)
 ```

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -381,7 +381,7 @@ if `D` is required by other packages that you are trying to use.
     For instance, a common pitfall is having more than a few packages in your default (i.e. `(@1.8)`) environment,
     and using that as an environment for all tasks you're using julia for. It's better to create a dedicated project
     for the task you're working on, and keep the dependencies there minimal. To read more see
-    [Working with Environments](@ref)
+    [Working with Environments](@ref Working-with-Environments)
 
 The error message has a lot of crucial information.
 It may be easiest to interpret piecewise:


### PR DESCRIPTION
The linking in the base docs broke because getting-started linked out to pages not included in base docs
```
┌ Error: reference for 'Managing-Packages' could not be found in src/stdlib/Pkg.md.
└ @ Documenter.CrossReferences /usr/home/julia/buildbot/w1_builder/package_freebsd64/build/doc/deps/packages/Documenter/yf96B/src/Utilities/Utilities.jl:32
┌ Error: reference for 'Working-with-Environments' could not be found in src/stdlib/Pkg.md.
└ @ Documenter.CrossReferences /usr/home/julia/buildbot/w1_builder/package_freebsd64/build/doc/deps/packages/Documenter/yf96B/src/Utilities/Utilities.jl:32
```