### PR TITLE
Fix isolate reg symlink override in test, avoid unnecessary and buggy local git clone

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -204,6 +204,11 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
                     registry = Registry.RegistryInstance(regpath)
                     printpkgstyle(io, :Symlinked, "registry `$(Base.contractuser(registry.name))` to `$(Base.contractuser(regpath))`")
                     return
+                elseif reg.url !== nothing && reg.linked == true
+                    pkgerror("""
+                    A symlinked registry was requested but `path` was not set and `url` was set to `$url`.
+                    Set only `path` and `linked = true` to use registry symlinking.
+                    """)
                 elseif url !== nothing && registry_use_pkg_server()
                     # download from Pkg server
                     try

--- a/test/new.jl
+++ b/test/new.jl
@@ -2839,14 +2839,15 @@ end
 @testset "relative depot path" begin
     isolate(loaded_depot=false) do
         mktempdir() do tmp
-            ENV["JULIA_DEPOT_PATH"] = "tmp"
-            Base.init_depot_path()
-            Pkg.Registry.DEFAULT_REGISTRIES[1].url = Utils.REGISTRY_DIR
-            Pkg.Registry.DEFAULT_REGISTRIES[1].path = nothing
-            cp(joinpath(@__DIR__, "test_packages", "BasicSandbox"), joinpath(tmp, "BasicSandbox"))
-            git_init_and_commit(joinpath(tmp, "BasicSandbox"))
-            cd(tmp) do
-                Pkg.add(path="BasicSandbox")
+            withenv("JULIA_DEPOT_PATH" => "tmp") do
+                Base.init_depot_path()
+                Pkg.Registry.DEFAULT_REGISTRIES[1].path = Utils.REGISTRY_DIR # set path because symlink reg uses path
+                Pkg.Registry.DEFAULT_REGISTRIES[1].url = nothing
+                cp(joinpath(@__DIR__, "test_packages", "BasicSandbox"), joinpath(tmp, "BasicSandbox"))
+                git_init_and_commit(joinpath(tmp, "BasicSandbox"))
+                cd(tmp) do
+                    Pkg.add(path="BasicSandbox")
+                end
             end
         end
     end
@@ -2876,7 +2877,7 @@ using Pkg.Types: is_stdlib
     @test is_stdlib(pkg_uuid, nothing)
 
     empty!(Pkg.Types.STDLIBS_BY_VERSION)
-    
+
     # Test that we can probe for stdlibs for the current version with no STDLIBS_BY_VERSION,
     # but that we throw a PkgError if we ask for a particular julia version.
     @test is_stdlib(networkoptions_uuid)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2841,8 +2841,6 @@ end
         mktempdir() do tmp
             withenv("JULIA_DEPOT_PATH" => "tmp") do
                 Base.init_depot_path()
-                Pkg.Registry.DEFAULT_REGISTRIES[1].path = Utils.REGISTRY_DIR # set path because symlink reg uses path
-                Pkg.Registry.DEFAULT_REGISTRIES[1].url = nothing
                 cp(joinpath(@__DIR__, "test_packages", "BasicSandbox"), joinpath(tmp, "BasicSandbox"))
                 git_init_and_commit(joinpath(tmp, "BasicSandbox"))
                 cd(tmp) do


### PR DESCRIPTION
The use of setting the `reg.url` rather than `reg.path` was forcing a git clone of a local repo, rather than the reg symlink that `isolate` does by default (kwarg `linked_reg`)

Should fix the latter issue in #3238 

Also fixes a leaky env var


https://buildkite.com/julialang/julia-master/builds/17451#01840d41-5812-480a-af01-b67b5fce2501/477-979

```
Error During Test at /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2839
  | Got exception outside of a @test
  | git repository not found at `/private/var/tmp/agent-tempdirs/default-macmini-aarch64-2.0/tmp/jl_TlE4la/registry_depot/registries/General`
  | Stacktrace:
  | [1] pkgerror(msg::String)
  | @ Pkg.Types /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Types.jl:68
  | [2] clone(io::IOStream, url::String, source_path::String; header::String, credentials::Nothing, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ Pkg.GitTools /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/GitTools.jl:124
  | [3] clone
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/GitTools.jl:88 [inlined]
  | [4] (::Pkg.Registry.var"#40#43"{Pkg.Registry.RegistrySpec, Nothing, IOStream, String})(tmp::String)
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:226
  | [5] mktempdir(fn::Pkg.Registry.var"#40#43"{Pkg.Registry.RegistrySpec, Nothing, IOStream, String}, parent::String; prefix::String)
  | @ Base.Filesystem ./file.jl:760
  | [6] mktempdir(fn::Function, parent::String)
  | @ Base.Filesystem ./file.jl:756
  | [7] mktempdir
  | @ ./file.jl:756 [inlined]
  | [8] (::Pkg.Registry.var"#38#41"{IOStream, Vector{Pkg.Registry.RegistrySpec}, String})()
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:196
  | [9] mkpidlock(f::Pkg.Registry.var"#38#41"{IOStream, Vector{Pkg.Registry.RegistrySpec}, String}, at::String, pid::Int32; kwopts::Base.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:stale_age,), Tuple{Int64}}})
  | @ FileWatching.Pidfile /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:82
  | [10] mkpidlock
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:79 [inlined]
  | [11] #mkpidlock#6
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:77 [inlined]
  | [12] mkpidlock
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:77 [inlined]
  | [13] download_registries(io::IOStream, regs::Vector{Pkg.Registry.RegistrySpec}, depot::String)
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:165
  | [14] download_default_registries(io::IOStream; only_if_empty::Bool, depot::String)
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:108
  | [15] download_default_registries
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:95 [inlined]
  | [16] add(pkgs::Vector{Pkg.Types.PackageSpec}; io::IOStream, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ Pkg.API /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/API.jl:146
  | [17] add(pkgs::Vector{Pkg.Types.PackageSpec})
  | @ Pkg.API /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/API.jl:145
  | [18] add(; name::Nothing, uuid::Nothing, version::Nothing, url::Nothing, rev::Nothing, path::String, mode::Pkg.Types.PackageMode, subdir::Nothing, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ Pkg.API ./boot.jl:0
  | [19] add
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/API.jl:162 [inlined]
  | [20] #736
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2849 [inlined]
  | [21] cd(f::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#736#739", dir::String)
  | @ Base.Filesystem ./file.jl:112
  | [22] (::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#735#738")(tmp::String)
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2848
  | [23] mktempdir(fn::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#735#738", parent::String; prefix::String)
  | @ Base.Filesystem ./file.jl:760
  | [24] mktempdir (repeats 2 times)
  | @ ./file.jl:756 [inlined]
  | [25] #734
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2841 [inlined]
  | [26] (::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils.var"#6#7"{Bool, Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#734#737"})()
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/utils.jl:79
  | [27] withenv(::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils.var"#6#7"{Bool, Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#734#737"}, ::Pair{String, Nothing}, ::Vararg{Pair{String, Nothing}})
  | @ Base ./env.jl:172
  | [28] isolate(fn::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#734#737"; loaded_depot::Bool, linked_reg::Bool)
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/utils.jl:70
  | [29] kwcall(::NamedTuple{(:loaded_depot,), Tuple{Bool}}, ::typeof(Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils.isolate), fn::Function)
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/utils.jl:46
  | [30] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2840 [inlined]
  | [31] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1496 [inlined]
  | [32] top-level scope
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2840
  | [33] include(mod::Module, _path::String)
  | @ Base ./Base.jl:450
  | [34] include
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:9 [inlined]
  | [35] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:70 [inlined]
  | [36] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1584 [inlined]
  | [37] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:52 [inlined]
  | [38] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1496 [inlined]
  | [39] (::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.var"#1#2")()
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:51
  | [40] with_logstate(f::Function, logstate::Any)
  | @ Base.CoreLogging ./logging.jl:514
  | [41] with_logger(f::Function, logger::Base.CoreLogging.NullLogger)
  | @ Base.CoreLogging ./logging.jl:626
  | [42] top-level scope
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:49
  | [43] include
  | @ ./Base.jl:450 [inlined]
  | [44] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:29 [inlined]
  | [45] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1496 [inlined]
  | [46] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:23 [inlined]
  | [47] macro expansion
  | @ ./timing.jl:474 [inlined]
  | [48] runtests(name::String, path::String, isolate::Bool; seed::UInt128)
  | @ Main /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:21
  | [49] runtests
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:5 [inlined]
  | [50] kwcall(::NamedTuple{(:seed,), Tuple{UInt128}}, ::typeof(runtests), name::String, path::String)
  | @ Main /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:5
  | [51] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, UInt128, Tuple{Symbol}, NamedTuple{(:seed,), Tuple{UInt128}}})
  | @ Base ./essentials.jl:812
  | [52] kwcall(::NamedTuple{(:seed,), Tuple{UInt128}}, ::typeof(invokelatest), ::Any, ::Any, ::Vararg{Any})
  | @ Base ./essentials.jl:807
  | [53] (::Distributed.var"#110#112"{Distributed.CallMsg{:call_fetch}})()
  | @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:285
  | [54] run_work_thunk(thunk::Distributed.var"#110#112"{Distributed.CallMsg{:call_fetch}}, print_error::Bool)
  | @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:70
  | [55] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:285 [inlined]
  |  
  | caused by: GitError(Code:ENOTFOUND, Class:Repository, could not find repository from '/private/var/tmp/agent-tempdirs/default-macmini-aarch64-2.0/tmp/jl_TlE4la/registry_depot/registries/General')
  | Stacktrace:
  | [1] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/LibGit2/src/error.jl:111 [inlined]
  | [2] clone(repo_url::SubString{String}, repo_path::String, clone_opts::LibGit2.CloneOptions)
  | @ LibGit2 /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/LibGit2/src/repository.jl:459
  | [3] clone(repo_url::SubString{String}, repo_path::String; branch::String, isbare::Bool, remote_cb::Ptr{Nothing}, credentials::LibGit2.CachedCredentials, callbacks::Dict{Symbol, Tuple{Ptr{Nothing}, Any}})
  | @ LibGit2 /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/LibGit2/src/LibGit2.jl:583
  | [4] clone
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/LibGit2/src/LibGit2.jl:556 [inlined]
  | [5] clone(io::IOStream, url::String, source_path::String; header::String, credentials::Nothing, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ Pkg.GitTools /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/GitTools.jl:115
  | [6] clone
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/GitTools.jl:88 [inlined]
  | [7] (::Pkg.Registry.var"#40#43"{Pkg.Registry.RegistrySpec, Nothing, IOStream, String})(tmp::String)
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:226
  | [8] mktempdir(fn::Pkg.Registry.var"#40#43"{Pkg.Registry.RegistrySpec, Nothing, IOStream, String}, parent::String; prefix::String)
  | @ Base.Filesystem ./file.jl:760
  | [9] mktempdir(fn::Function, parent::String)
  | @ Base.Filesystem ./file.jl:756
  | [10] mktempdir
  | @ ./file.jl:756 [inlined]
  | [11] (::Pkg.Registry.var"#38#41"{IOStream, Vector{Pkg.Registry.RegistrySpec}, String})()
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:196
  | [12] mkpidlock(f::Pkg.Registry.var"#38#41"{IOStream, Vector{Pkg.Registry.RegistrySpec}, String}, at::String, pid::Int32; kwopts::Base.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:stale_age,), Tuple{Int64}}})
  | @ FileWatching.Pidfile /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:82
  | [13] mkpidlock
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:79 [inlined]
  | [14] #mkpidlock#6
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:77 [inlined]
  | [15] mkpidlock
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/FileWatching/src/pidfile.jl:77 [inlined]
  | [16] download_registries(io::IOStream, regs::Vector{Pkg.Registry.RegistrySpec}, depot::String)
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:165
  | [17] download_default_registries(io::IOStream; only_if_empty::Bool, depot::String)
  | @ Pkg.Registry /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:108
  | [18] download_default_registries
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:95 [inlined]
  | [19] add(pkgs::Vector{Pkg.Types.PackageSpec}; io::IOStream, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ Pkg.API /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/API.jl:146
  | [20] add(pkgs::Vector{Pkg.Types.PackageSpec})
  | @ Pkg.API /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/API.jl:145
  | [21] add(; name::Nothing, uuid::Nothing, version::Nothing, url::Nothing, rev::Nothing, path::String, mode::Pkg.Types.PackageMode, subdir::Nothing, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
  | @ Pkg.API ./boot.jl:0
  | [22] add
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/src/API.jl:162 [inlined]
  | [23] #736
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2849 [inlined]
  | [24] cd(f::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#736#739", dir::String)
  | @ Base.Filesystem ./file.jl:112
  | [25] (::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#735#738")(tmp::String)
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2848
  | [26] mktempdir(fn::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#735#738", parent::String; prefix::String)
  | @ Base.Filesystem ./file.jl:760
  | [27] mktempdir (repeats 2 times)
  | @ ./file.jl:756 [inlined]
  | [28] #734
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2841 [inlined]
  | [29] (::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils.var"#6#7"{Bool, Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#734#737"})()
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/utils.jl:79
  | [30] withenv(::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils.var"#6#7"{Bool, Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#734#737"}, ::Pair{String, Nothing}, ::Vararg{Pair{String, Nothing}})
  | @ Base ./env.jl:172
  | [31] isolate(fn::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.NewTests.var"#734#737"; loaded_depot::Bool, linked_reg::Bool)
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/utils.jl:70
  | [32] kwcall(::NamedTuple{(:loaded_depot,), Tuple{Bool}}, ::typeof(Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils.isolate), fn::Function)
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.Utils /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/utils.jl:46
  | [33] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2840 [inlined]
  | [34] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1496 [inlined]
  | [35] top-level scope
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/new.jl:2840
  | [36] include(mod::Module, _path::String)
  | @ Base ./Base.jl:450
  | [37] include
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:9 [inlined]
  | [38] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:70 [inlined]
  | [39] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1584 [inlined]
  | [40] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:52 [inlined]
  | [41] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1496 [inlined]
  | [42] (::Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner.var"#1#2")()
  | @ Main.Test26Main_Pkg.PkgTestsOuter.PkgTestsInner /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:51
  | [43] with_logstate(f::Function, logstate::Any)
  | @ Base.CoreLogging ./logging.jl:514
  | [44] with_logger(f::Function, logger::Base.CoreLogging.NullLogger)
  | @ Base.CoreLogging ./logging.jl:626
  | [45] top-level scope
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Pkg/test/runtests.jl:49
  | [46] include
  | @ ./Base.jl:450 [inlined]
  | [47] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:29 [inlined]
  | [48] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Test/src/Test.jl:1496 [inlined]
  | [49] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:23 [inlined]
  | [50] macro expansion
  | @ ./timing.jl:474 [inlined]
  | [51] runtests(name::String, path::String, isolate::Bool; seed::UInt128)
  | @ Main /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:21
  | [52] runtests
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:5 [inlined]
  | [53] kwcall(::NamedTuple{(:seed,), Tuple{UInt128}}, ::typeof(runtests), name::String, path::String)
  | @ Main /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/test/testdefs.jl:5
  | [54] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, UInt128, Tuple{Symbol}, NamedTuple{(:seed,), Tuple{UInt128}}})
  | @ Base ./essentials.jl:812
  | [55] kwcall(::NamedTuple{(:seed,), Tuple{UInt128}}, ::typeof(invokelatest), ::Any, ::Any, ::Vararg{Any})
  | @ Base ./essentials.jl:807
  | [56] (::Distributed.var"#110#112"{Distributed.CallMsg{:call_fetch}})()
  | @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:285
  | [57] run_work_thunk(thunk::Distributed.var"#110#112"{Distributed.CallMsg{:call_fetch}}, print_error::Bool)
  | @ Distributed /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:70
  | [58] macro expansion
  | @ /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-macmini-aarch64-2.0/build/default-macmini-aarch64-2-0/julialang/julia-master/julia-c69dca46bf/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:285 [inlined]
  |  
```