### PR TITLE
[release-1.8] Cleanup before exit after tests (#3176)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,8 @@ Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger())
     end
 end
 
+@showtime Base.Filesystem.temp_cleanup_purge(force=true)
+
 end # module
 
 empty!(Base.DEPOT_PATH)


### PR DESCRIPTION
This should fix the timeout errors we see on release-1.8 on windows, where the filesystem is so slow that cleanups are exceeding our 30s worker exit timeout.

Co-authored-by: Dilum Aluthge <dilum@aluthge.com>
Co-authored-by: Ian Butterworth <i.r.butterworth@gmail.com>
(cherry picked from commit 5b365c3c02ec718680ba744a9f48900fb5304951)