### PR TITLE
Make `Pkg.precompile` work with glue packages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -35,6 +35,7 @@ makedocs(
         "managing-packages.md",
         "environments.md",
         "creating-packages.md",
+        "gluedeps.md",
         "compatibility.md",
         "registries.md",
         "artifacts.md",

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -142,6 +142,15 @@ function update_manifest!(env::EnvCache, pkgs::Vector{PackageSpec}, deps_map, ju
         else
             entry.deps = deps_map[pkg.uuid]
         end
+        v = joinpath(source_path(env.project_file, pkg), "Project.toml")
+        if isfile(v)
+            p = Types.read_project(v)
+            entry.gluedeps = p.gluedeps
+            entry.gluepkgs = p.gluepkgs
+            for (name, _) in p.gluedeps
+                delete!(entry.deps, name)
+            end
+        end
         env.manifest[pkg.uuid] = entry
     end
     prune_manifest(env)
@@ -198,24 +207,29 @@ function reset_all_compat!(proj::Project)
     return nothing
 end
 
-function collect_project!(pkg::PackageSpec, path::String,
-                          deps_map::Dict{UUID,Vector{PackageSpec}})
-    deps_map[pkg.uuid] = PackageSpec[]
+function collect_project(pkg::PackageSpec, path::String)
+    deps = PackageSpec[]
+    glues = Set{UUID}()
     project_file = projectfile_path(path; strict=true)
     if project_file === nothing
         pkgerror("could not find project file for package $(err_rep(pkg)) at `$path`")
     end
     project = read_package(project_file)
-    julia_compat = get_compat(project, "julia")
     #=
     # TODO, this should either error or be quiet
+    julia_compat = get_compat(project, "julia")
     if julia_compat !== nothing && !(VERSION in julia_compat)
         println(io, "julia version requirement for package $(err_rep(pkg)) not satisfied")
     end
     =#
     for (name, uuid) in project.deps
         vspec = get_compat(project, name)
-        push!(deps_map[pkg.uuid], PackageSpec(name, uuid, vspec))
+        push!(deps, PackageSpec(name, uuid, vspec))
+    end
+    for (name, uuid) in project.gluedeps
+        vspec = get_compat(project, name)
+        push!(deps, PackageSpec(name, uuid, vspec))
+        push!(glues, uuid)
     end
     if project.version !== nothing
         pkg.version = project.version
@@ -223,7 +237,7 @@ function collect_project!(pkg::PackageSpec, path::String,
         # @warn("project file for $(pkg.name) is missing a `version` entry")
         pkg.version = VersionNumber(0)
     end
-    return
+    return deps, glues
 end
 
 is_tracking_path(pkg) = pkg.path !== nothing
@@ -258,9 +272,12 @@ end
 
 function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String})
     deps_map = Dict{UUID,Vector{PackageSpec}}()
+    glue_map = Dict{UUID,Set{UUID}}()
     if env.pkg !== nothing
         pkg = env.pkg
-        collect_project!(pkg, dirname(env.project_file), deps_map)
+        deps, glues = collect_project(pkg, dirname(env.project_file))
+        deps_map[pkg.uuid] = deps
+        glue_map[pkg.uuid] = glues
         names[pkg.uuid] = pkg.name
     end
     for pkg in pkgs
@@ -268,7 +285,9 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
         if !isdir(path)
             pkgerror("expected package $(err_rep(pkg)) to exist at path `$path`")
         end
-        collect_project!(pkg, path, deps_map)
+        deps, glues = collect_project(pkg, path)
+        deps_map[pkg.uuid] = deps
+        glue_map[pkg.uuid] = glues
     end
 
     fixed = Dict{UUID,Resolve.Fixed}()
@@ -285,7 +304,7 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
             idx = findfirst(pkg -> pkg.uuid == uuid, pkgs)
             fix_pkg = pkgs[idx]
         end
-        fixed[uuid] = Resolve.Fixed(fix_pkg.version, q)
+        fixed[uuid] = Resolve.Fixed(fix_pkg.version, q, glue_map[uuid])
     end
     return fixed
 end
@@ -407,6 +426,7 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
 
     # pkg -> version -> (dependency => compat):
     all_compat = Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}}()
+    glue_compat = Dict{UUID,Dict{VersionNumber,Set{UUID}}}()
 
     for (fp, fx) in fixed
         all_compat[fp]   = Dict(fx.version => Dict{UUID,VersionSpec}())
@@ -418,7 +438,8 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
         for uuid in unseen
             push!(seen, uuid)
             uuid in keys(fixed) && continue
-            all_compat_u = get_or_make!(all_compat,   uuid)
+            all_compat_u = get_or_make!(all_compat, uuid)
+            glue_compat_u = get_or_make!(glue_compat, uuid)
 
             uuid_is_stdlib = false
             stdlib_name = ""
@@ -446,35 +467,56 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
                     push!(uuids, other_uuid)
                     all_compat_u_vr[other_uuid] = VersionSpec()
                 end
+
+                if !isempty(proj.gluedeps)
+                    glue_all_compat_u_vr = get_or_make!(glue_compat_u, v)
+                    for (_, other_uuid) in proj.gluedeps
+                        push!(uuids, other_uuid)
+                        all_compat_u_vr[other_uuid] = VersionSpec()
+                        push!(glue_all_compat_u_vr, other_uuid)
+                    end
+                end
             else
                 for reg in registries
                     pkg = get(reg, uuid, nothing)
                     pkg === nothing && continue
                     info = Registry.registry_info(pkg)
-                    for (v, compat_info) in Registry.compat_info(info)
-                        # Filter yanked and if we are in offline mode also downloaded packages
-                        # TODO, pull this into a function
-                        Registry.isyanked(info, v) && continue
-                        if Pkg.OFFLINE_MODE[]
-                            pkg_spec = PackageSpec(name=pkg.name, uuid=pkg.uuid, version=v, tree_hash=Registry.treehash(info, v))
-                            is_package_downloaded(env.project_file, pkg_spec) || continue
-                        end
 
-                        # Skip package version that are not the same as external packages in sysimage
-                        if PKGORIGIN_HAVE_VERSION && RESPECT_SYSIMAGE_VERSIONS[] && julia_version == VERSION
-                            pkgid = Base.PkgId(uuid, pkg.name)
-                            if Base.in_sysimage(pkgid)
-                                pkgorigin = get(Base.pkgorigins, pkgid, nothing)
-                                if pkgorigin !== nothing && pkgorigin.version !== nothing
-                                    if v != pkgorigin.version
-                                        continue
+                    function add_compat!(d, cinfo)
+                        for (v, compat_info) in cinfo
+                            # Filter yanked and if we are in offline mode also downloaded packages
+                            # TODO, pull this into a function
+                            Registry.isyanked(info, v) && continue
+                            if Pkg.OFFLINE_MODE[]
+                                pkg_spec = PackageSpec(name=pkg.name, uuid=pkg.uuid, version=v, tree_hash=Registry.treehash(info, v))
+                                is_package_downloaded(env.project_file, pkg_spec) || continue
+                            end
+
+                            # Skip package version that are not the same as external packages in sysimage
+                            if PKGORIGIN_HAVE_VERSION && RESPECT_SYSIMAGE_VERSIONS[] && julia_version == VERSION
+                                pkgid = Base.PkgId(uuid, pkg.name)
+                                if Base.in_sysimage(pkgid)
+                                    pkgorigin = get(Base.pkgorigins, pkgid, nothing)
+                                    if pkgorigin !== nothing && pkgorigin.version !== nothing
+                                        if v != pkgorigin.version
+                                            continue
+                                        end
                                     end
                                 end
                             end
+                            dv = get_or_make!(d, v)
+                            merge!(dv, compat_info)
+                            union!(uuids, keys(compat_info))
                         end
-
-                        all_compat_u[v] = compat_info
-                        union!(uuids, keys(compat_info))
+                    end
+                    add_compat!(all_compat_u, Registry.compat_info(info))
+                    glue_compat_info = Registry.glue_compat_info(info)
+                    if glue_compat_info !== nothing
+                        add_compat!(all_compat_u, glue_compat_info)
+                        # Version to Set
+                        for (v, compat_info) in  glue_compat_info
+                            glue_compat_u[v] = keys(compat_info)
+                        end
                     end
                 end
             end
@@ -493,7 +535,7 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
         end
     end
 
-    return Resolve.Graph(all_compat, uuid_to_name, reqs, fixed, false, julia_version),
+    return Resolve.Graph(all_compat, glue_compat, uuid_to_name, reqs, fixed, false, julia_version),
            all_compat
 end
 
@@ -1735,9 +1777,13 @@ function gen_target_project(ctx::Context, pkg::PackageSpec, source_path::String,
     test_project.deps = source_env.project.deps
     # collect test dependencies
     for name in get(source_env.project.targets, target, String[])
-        uuid = get(source_env.project.extras, name, nothing)
+        uuid = nothing
+        for list in [source_env.project.extras, source_env.project.gluedeps]
+            uuid = get(list, name, nothing)
+            uuid === nothing || break
+        end
         if uuid === nothing
-            pkgerror("`$name` declared as a `$target` dependency, but no such entry in `extras`")
+            pkgerror("`$name` declared as a `$target` dependency, but no such entry in `extras` or `gluedeps`")
         end
         test_project.deps[name] = uuid
     end
@@ -2083,6 +2129,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
     lpadding = 2
 
     package_statuses = PackageStatusData[]
+    installed_cache = Dict{Base.PkgId, Bool}()
     for (uuid, old, new) in xs
         if Types.is_project_uuid(env, uuid)
             continue
@@ -2116,6 +2163,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
         no_packages_upgradable &= (!changed || !pkg_upgradable)
         no_visible_packages_heldback &= (!changed || !pkg_heldback)
         no_packages_heldback &= !pkg_heldback
+
         push!(package_statuses, PackageStatusData(uuid, old, new, pkg_downloaded, pkg_upgradable, pkg_heldback, cinfo, changed))
     end
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -735,9 +735,9 @@ end
 # Precompilation #
 ##################
 
-function _auto_precompile(ctx::Types.Context; warn_loaded = true, already_instantiated = false)
+function _auto_precompile(ctx::Types.Context, pkgs::Vector{String}=String[]; warn_loaded = true, already_instantiated = false)
     if Base.JLOptions().use_compiled_modules == 1 && get_bool_env("JULIA_PKG_PRECOMPILE_AUTO"; default="true")
-        Pkg.precompile(ctx; internal_call=true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
+        Pkg.precompile(ctx, pkgs; internal_call=true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
     end
 end
 

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -236,13 +236,12 @@ mutable struct Graph
 
     function Graph(
             compat::Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}},
+            compat_glue::Dict{UUID,Dict{VersionNumber,Set{UUID}}},
             uuid_to_name::Dict{UUID,String},
             reqs::Requires,
             fixed::Dict{UUID,Fixed},
             verbose::Bool = false,
             julia_version::Union{VersionNumber,Nothing} = VERSION
-            ;
-            compat_weak::Dict{UUID,Dict{VersionNumber,Set{UUID}}} = Dict{UUID,Dict{VersionNumber,Set{UUID}}}(),
         )
 
         # Tell the resolver about julia itself
@@ -256,7 +255,6 @@ mutable struct Graph
 
         data = GraphData(compat, uuid_to_name, verbose)
         pkgs, np, spp, pdict, pvers, vdict, rlog = data.pkgs, data.np, data.spp, data.pdict, data.pvers, data.vdict, data.rlog
-
         extended_deps = let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
             [Vector{Dict{Int,BitVector}}(undef, spp[p0]-1) for p0 = 1:np]
         end
@@ -276,14 +274,14 @@ mutable struct Graph
             # Translate the requirements into bit masks
             # Hot code, measure performance before changing
             req_msk = Dict{Int,BitVector}()
-            maybe_weak = haskey(compat_weak, uuid0) && haskey(compat_weak[uuid0], vn)
+            maybe_weak = haskey(compat_glue, uuid0) && haskey(compat_glue[uuid0], vn)
             for (p1, vs) in req
                 pv = pvers[p1]
                 req_msk_p1 = BitVector(undef, spp[p1])
                 @inbounds for i in 1:spp[p1] - 1
                     req_msk_p1[i] = pv[i] ∈ vs
                 end
-                weak = maybe_weak && (pkgs[p1] ∈ compat_weak[uuid0][vn])
+                weak = maybe_weak && (pkgs[p1] ∈ compat_glue[uuid0][vn])
                 req_msk_p1[end] = weak
                 req_msk[p1] = req_msk_p1
             end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -239,6 +239,8 @@ Base.@kwdef mutable struct Project
     manifest::Union{String, Nothing} = nothing
     # Sections
     deps::Dict{String,UUID} = Dict{String,UUID}()
+    gluedeps::Dict{String,UUID} = Dict{String,UUID}()
+    gluepkgs::Dict{String,Union{Vector{String}, String}} = Dict{String,String}()
     extras::Dict{String,UUID} = Dict{String,UUID}()
     targets::Dict{String,Vector{String}} = Dict{String,Vector{String}}()
     compat::Dict{String,Compat} = Dict{String,Compat}()
@@ -262,6 +264,8 @@ Base.@kwdef mutable struct PackageEntry
     repo::GitRepo = GitRepo()
     tree_hash::Union{Nothing,SHA1} = nothing
     deps::Dict{String,UUID} = Dict{String,UUID}()
+    gluedeps::Dict{String,UUID} = Dict{String,UUID}()
+    gluepkgs::Dict{String,Union{Vector{String}, String}} = Dict{String,String}()
     uuid::Union{Nothing, UUID} = nothing
     other::Union{Dict,Nothing} = nothing
 end
@@ -272,9 +276,11 @@ Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
     t1.repo == t2.repo &&
     t1.tree_hash == t2.tree_hash &&
     t1.deps == t2.deps &&
+    t1.gluedeps == t2.gluedeps &&
+    t1.gluepkgs == t2.gluepkgs &&
     t1.uuid == t2.uuid
     # omits `other`
-Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps, x.uuid], init=h)  # omits `other`
+Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.pinned, x.repo, x.tree_hash, x.deps, x.gluedeps,x.gluepkgs, x.uuid], init=h)  # omits `other`
 
 Base.@kwdef mutable struct Manifest
     julia_version::Union{Nothing,VersionNumber} = nothing # only set to VERSION when resolving

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -83,19 +83,22 @@ struct Stage1
     uuid::UUID
     entry::PackageEntry
     deps::Union{Vector{String}, Dict{String,UUID}}
+    gluedeps::Union{Vector{String}, Dict{String,UUID}}
 end
 
-normalize_deps(name, uuid, deps, manifest) = deps
-function normalize_deps(name, uuid, deps::Vector{String}, manifest::Dict{String,Vector{Stage1}})
+normalize_deps(name, uuid, deps, manifest; isglue=false) = deps
+function normalize_deps(name, uuid, deps::Vector{String}, manifest::Dict{String,Vector{Stage1}}; isglue=false)
     if length(deps) != length(unique(deps))
         pkgerror("Duplicate entry in `$name=$uuid`'s `deps` field.")
     end
     final = Dict{String,UUID}()
     for dep in deps
         infos = get(manifest, dep, nothing)
-        if infos === nothing
-            pkgerror("`$name=$uuid` depends on `$dep`, ",
-                     "but no such entry exists in the manifest.")
+        if !isglue
+            if infos === nothing
+                pkgerror("`$name=$uuid` depends on `$dep`, ",
+                        "but no such entry exists in the manifest.")
+            end
         end
         # should have used dict format instead of vector format
         length(infos) == 1 || pkgerror("Invalid manifest format. ",
@@ -110,21 +113,30 @@ function validate_manifest(julia_version::Union{Nothing,VersionNumber}, manifest
     for (name, infos) in stage1, info in infos
         info.entry.deps = normalize_deps(name, info.uuid, info.deps, stage1)
     end
+    for (name, infos) in stage1, info in infos
+        info.entry.gluedeps = normalize_deps(name, info.uuid, info.gluedeps, stage1; isglue=true)
+    end
     # invariant: all dependencies are now normalized to Dict{String,UUID}
     deps = Dict{UUID, PackageEntry}()
     for (name, infos) in stage1, info in infos
         deps[info.uuid] = info.entry
     end
     # now just verify the graph structure
-    for (entry_uuid, entry) in deps, (name, uuid) in entry.deps
-        dep_entry = get(deps, uuid, nothing)
-        if dep_entry === nothing
-            pkgerror("`$(entry.name)=$(entry_uuid)` depends on `$name=$uuid`, ",
-                     "but no such entry exists in the manifest.")
-        end
-        if dep_entry.name != name
-            pkgerror("`$(entry.name)=$(entry_uuid)` depends on `$name=$uuid`, ",
-                     "but entry with UUID `$uuid` has name `$(dep_entry.name)`.")
+    for (entry_uuid, entry) in deps
+        for (deptype, isglue) in [(entry.deps, false), (entry.gluedeps, true)]
+            for (name, uuid) in deptype
+                dep_entry = get(deps, uuid, nothing)
+                if !isglue
+                    if dep_entry === nothing
+                        pkgerror("`$(entry.name)=$(entry_uuid)` depends on `$name=$uuid`, ",
+                                "but no such entry exists in the manifest.")
+                    end
+                    if dep_entry.name != name
+                        pkgerror("`$(entry.name)=$(entry_uuid)` depends on `$name=$uuid`, ",
+                                "but entry with UUID `$uuid` has name `$(dep_entry.name)`.")
+                    end
+                end
+            end
         end
     end
     return Manifest(; julia_version, manifest_format, deps, other)
@@ -147,6 +159,7 @@ function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
             entry.name = name
             uuid = nothing
             deps = nothing
+            gluedeps = nothing
             try
                 entry.pinned      = read_pinned(get(info, "pinned", nothing))
                 uuid              = read_field("uuid",          nothing, info, safe_uuid)::UUID
@@ -158,13 +171,15 @@ function Manifest(raw::Dict, f_or_io::Union{String, IO})::Manifest
                 entry.tree_hash   = read_field("git-tree-sha1", nothing, info, safe_SHA1)
                 entry.uuid        = uuid
                 deps = read_deps(get(info::Dict, "deps", nothing))
+                gluedeps = read_deps(get(info::Dict, "gluedeps", nothing))
+                entry.gluepkgs = get(Dict{String, String}, info::Dict, "gluepkgs")
             catch
                 # TODO: Should probably not unconditionally log something
                 @debug "Could not parse manifest entry for `$name`" f_or_io
                 rethrow()
             end
             entry.other = info::Union{Dict,Nothing}
-            stage1[name] = push!(get(stage1, name, Stage1[]), Stage1(uuid, entry, deps))
+            stage1[name] = push!(get(stage1, name, Stage1[]), Stage1(uuid, entry, deps, gluedeps))
         end
         # by this point, all the fields of the `PackageEntry`s have been type casted
         # but we have *not* verified the _graph_ structure of the manifest
@@ -257,17 +272,24 @@ function destructure(manifest::Manifest)::Dict
         entry!(new_entry, "repo-url", repo_source)
         entry!(new_entry, "repo-rev", entry.repo.rev)
         entry!(new_entry, "repo-subdir", entry.repo.subdir)
-        if isempty(entry.deps)
-            delete!(new_entry, "deps")
-        else
-            if all(dep -> unique_name[first(dep)], entry.deps)
-                new_entry["deps"] = sort(collect(keys(entry.deps)))
+        for (deptype, depname) in [(entry.deps, "deps"), (entry.gluedeps, "gluedeps")]
+            if isempty(deptype)
+                delete!(new_entry, depname)
             else
-                new_entry["deps"] = Dict{String,String}()
-                for (name, uuid) in entry.deps
-                    new_entry["deps"][name] = string(uuid)
+                if all(dep -> haskey(unique_name, first(dep)), deptype) && all(dep -> unique_name[first(dep)], deptype)
+                    new_entry[depname] = sort(collect(keys(deptype)))
+                else
+                    new_entry[depname] = Dict{String,String}()
+                    for (name, uuid) in deptype
+                        new_entry[depname][name] = string(uuid)
+                    end
                 end
             end
+        end
+
+        # TODO: Write this inline
+        if !isempty(entry.gluepkgs)
+            entry!(new_entry, "gluepkgs", entry.gluepkgs)
         end
         if manifest.manifest_format.major == 1
             push!(get!(raw, entry.name, Dict{String,Any}[]), new_entry)

--- a/test/gluedeps.jl
+++ b/test/gluedeps.jl
@@ -1,0 +1,21 @@
+using  .Utils
+using Test
+
+@testset "weak deps" begin
+    isolate(loaded_depot=true) do
+        Pkg.activate(; temp=true)
+        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "GluePkgExamples", "HasGluePkgs.jl"))
+        Pkg.test("HasGluePkgs")
+    end
+    isolate(loaded_depot=true) do
+        Pkg.activate(; temp=true)
+        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "GluePkgExamples", "HasDepWithGluePkgs.jl"))
+        Pkg.test("HasDepWithGluePkgs")
+    end
+
+    isolate(loaded_depot=true) do
+        Pkg.activate(; temp=true)
+        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "GluePkgExamples", "HasGluePkgs.jl"))
+        @test_throws Pkg.Resolve.ResolverError Pkg.add(; name = "OffsetArrays", version = "0.9.0")
+    end
+end

--- a/test/resolve_utils.jl
+++ b/test/resolve_utils.jl
@@ -81,7 +81,7 @@ function graph_from_data(deps_data)
             end
         end
     end
-    return Graph(all_compat, uuid_to_name, Requires(), fixed, VERBOSE; compat_weak=all_compat_w)
+    return Graph(all_compat, all_compat_w, uuid_to_name, Requires(), fixed, VERBOSE)
 end
 function reqs_from_data(reqs_data, graph::Graph)
     reqs = Dict{UUID,VersionSpec}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger())
                 "api.jl",
                 "registry.jl",
                 "subdir.jl",
+                "gluedeps.jl",
                 "artifacts.jl",
                 "binaryplatforms.jl",
                 "platformengines.jl",

--- a/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/Manifest.toml
+++ b/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/Manifest.toml
@@ -1,0 +1,57 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0-DEV"
+manifest_format = "2.0"
+project_hash = "1af04d62b804224fdf802daf4a4b96e213299d30"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "195c5505521008abea5aee4f96930717958eac6f"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.4.0"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.1+0"
+
+[[deps.Example]]
+git-tree-sha1 = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.3"
+
+[[deps.HasGluePkgs]]
+deps = ["Example"]
+path = "../HasGluePkgs.jl"
+uuid = "4d3288b3-3afc-4bb6-85f3-489fffe514c8"
+version = "0.1.0"
+gluedeps = ["OffsetArrays"]
+
+    [deps.HasGluePkgs.gluepkgs]
+    GlueOffsetArrays = "OffsetArrays"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.OffsetArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "f71d8950b724e9ff6110fc948dff5a329f901d64"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.12.8"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.21+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.2.0+0"

--- a/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/Project.toml
+++ b/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/Project.toml
@@ -1,0 +1,17 @@
+name = "HasDepWithGluePkgs"
+uuid = "d4ef3d4a-8e22-4710-85d8-c6cf2eb9efca"
+version = "0.1.0"
+
+[deps]
+HasGluePkgs = "4d3288b3-3afc-4bb6-85f3-489fffe514c8"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+
+[compat]
+HasGluePkgs = "0.1"
+OffsetArrays = "1.12"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/src/HasDepWithGluePkgs.jl
+++ b/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/src/HasDepWithGluePkgs.jl
@@ -1,0 +1,15 @@
+module HasDepWithGluePkgs
+
+using HasGluePkgs
+using OffsetArrays: OffsetArray
+# Loading OffsetArrays makes the glue module "GlueOffsetArrays" to load
+
+function do_something()
+    # @info "First do something with the basic array support in B"
+    HasGluePkgs.foo(rand(Float64, 2))
+
+    # @info "Now do something with extended OffsetArray support in B"
+    HasGluePkgs.foo(OffsetArray(rand(Float64, 2), 0:1))
+end
+
+end # module

--- a/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/test/runtests.jl
+++ b/test/test_packages/GluePkgExamples/HasDepWithGluePkgs.jl/test/runtests.jl
@@ -1,0 +1,5 @@
+using HasDepWithGluePkgs
+using Test
+
+@test HasDepWithGluePkgs.HasGluePkgs.offsetarrays_loaded
+HasDepWithGluePkgs.do_something()

--- a/test/test_packages/GluePkgExamples/HasGluePkgs.jl/Manifest.toml
+++ b/test/test_packages/GluePkgExamples/HasGluePkgs.jl/Manifest.toml
@@ -1,0 +1,10 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0-DEV"
+manifest_format = "2.0"
+project_hash = "549efd0c32255f4b8717f50f49778e183bcc0e36"
+
+[[deps.Example]]
+git-tree-sha1 = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.3"

--- a/test/test_packages/GluePkgExamples/HasGluePkgs.jl/Project.toml
+++ b/test/test_packages/GluePkgExamples/HasGluePkgs.jl/Project.toml
@@ -1,0 +1,22 @@
+name = "HasGluePkgs"
+uuid = "4d3288b3-3afc-4bb6-85f3-489fffe514c8"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[gluedeps]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+
+[gluepkgs]
+GlueOffsetArrays = "OffsetArrays"
+
+[compat]
+Example = "0.5"
+OffsetArrays = "1.12"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["OffsetArrays", "Test"]

--- a/test/test_packages/GluePkgExamples/HasGluePkgs.jl/glue/GlueOffsetArrays.jl
+++ b/test/test_packages/GluePkgExamples/HasGluePkgs.jl/glue/GlueOffsetArrays.jl
@@ -1,0 +1,13 @@
+module GlueOffsetArrays
+
+using HasGluePkgs, OffsetArrays
+
+function foo(::OffsetArray)
+    return 2
+end
+
+function __init__()
+    HasGluePkgs.offsetarrays_loaded = true
+end
+
+end

--- a/test/test_packages/GluePkgExamples/HasGluePkgs.jl/src/HasGluePkgs.jl
+++ b/test/test_packages/GluePkgExamples/HasGluePkgs.jl/src/HasGluePkgs.jl
@@ -1,0 +1,11 @@
+module HasGluePkgs
+
+using Example
+
+function foo(::AbstractArray)
+    return 1
+end
+
+offsetarrays_loaded = false
+
+end # module

--- a/test/test_packages/GluePkgExamples/HasGluePkgs.jl/test/runtests.jl
+++ b/test/test_packages/GluePkgExamples/HasGluePkgs.jl/test/runtests.jl
@@ -1,0 +1,8 @@
+using HasGluePkgs
+using Test
+
+@test !HasGluePkgs.offsetarrays_loaded
+
+using OffsetArrays
+
+@test HasGluePkgs.offsetarrays_loaded


### PR DESCRIPTION
Builds on #3264 

(While I was here I added some comments to Pkg.precompile too, in a separate commit)

```
shell> rm -rf ~/.julia/compiled/v1.10

julia> import Pkg
[ Info: Precompiling Pkg [44cfe95a-1eb2-52ea-b672-e2afdf69b79f]

(Pkg) pkg> activate /Users/ian/Documents/GitHub/GluePkgExamples.jl/HasDepWithGluePkgs.jl
  Activating project at `~/Documents/GitHub/GluePkgExamples.jl/HasDepWithGluePkgs.jl`

(HasDepWithGluePkgs) pkg> precompile
Precompiling environment...
  6 dependencies successfully precompiled in 3 seconds

julia> using HasDepWithGluePkgs

julia> HasDepWithGluePkgs.do_something()
[ Info: First do something with the basic array support in B
┌ Info: HasGluePkgs.jl: A custom logging method for AbstractArray
│   x =
│    2-element Vector{Float64}:
│     0.22960852293312484
└     0.5867772603987441
[ Info: Now do something with extended OffsetArray support in B
┌ Info: HasGluePkgs.jl: A custom logging method for AbstractArray
│   x =
│    2-element OffsetArray(::Vector{Float64}, 0:1) with eltype Float64 with indices 0:1:
│     0.09267832976119839
└     0.38042557254693776
```

Tested on https://github.com/KristofferC/GluePkgExamples.jl/pull/1

Todo
- [ ] Add tests