### PR TITLE
Disable parallel LLVM image generation for now

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1321,8 +1321,11 @@ function precompile(ctx::Context, pkgs::Vector{String}=String[]; internal_call::
                     end
                     try
                         ret = Logging.with_logger(Logging.NullLogger()) do
-                            # capture stderr, send stdout to devnull, don't skip loaded modules
-                            Base.compilecache(pkg, sourcepath, iob, devnull, false)
+                            # TODO: Explore allowing parallel LLVM image generation. Needs careful load balancing
+                            withenv("JULIA_IMAGE_THREADS" => "1") do
+                                # capture stderr, send stdout to devnull, don't skip loaded modules
+                                Base.compilecache(pkg, sourcepath, iob, devnull, false)
+                            end
                         end
                         if ret isa Base.PrecompilableError
                             push!(precomperr_deps, pkg)


### PR DESCRIPTION
This will likely be needed before https://github.com/JuliaLang/julia/pull/47797 can be merged, to avoid overloading the system.

This leaves speed improvements on the table, but figuring out the load balancing here shouldn't block that PR IMO.