### PR TITLE
Fix inference for STDLIBS_BY_VERSION

### DIFF
--- a/src/HistoricalStdlibs.jl
+++ b/src/HistoricalStdlibs.jl
@@ -1,17 +1,19 @@
 using Base: UUID
 
+const DictStdLibs = Dict{UUID,Tuple{String,Union{VersionNumber,Nothing}}}
+
 # Julia standard libraries with duplicate entries removed so as to store only the
 # first release in a set of releases that all contain the same set of stdlibs.
 #
 # This needs to be populated via HistoricalStdlibVersions.jl by consumers
 # (e.g. BinaryBuilder) that want to use the "resolve things as if it were a
 # different Julia version than what is currently running" feature.
-const STDLIBS_BY_VERSION = Pair{VersionNumber, Dict{UUID}}[]
+const STDLIBS_BY_VERSION = Pair{VersionNumber, DictStdLibs}[]
 
 # This is a list of stdlibs that must _always_ be treated as stdlibs,
 # because they cannot be resolved in the registry; they have only ever existed within
 # the Julia stdlib source tree, and because of that, trying to resolve them will fail.
-const UNREGISTERED_STDLIBS = Dict{UUID,Tuple{String,Union{VersionNumber,Nothing}}}(
+const UNREGISTERED_STDLIBS = DictStdLibs(
     UUID("2a0f44e3-6c83-55bd-87e4-b1978d98bd5f") => ("Base64", nothing),
     UUID("8bf52ea8-c179-5cab-976a-9e18b702a9bc") => ("CRC32c", nothing),
     UUID("ade2ca70-3891-5945-98fb-dc099432e06a") => ("Dates", nothing),

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -241,7 +241,7 @@ Base.@kwdef mutable struct Project
     deps::Dict{String,UUID} = Dict{String,UUID}()
     # deps that are also in weakdeps for backwards compat
     # we do not store them in deps because we want to ignore them
-    # but for writing out the project file we need to remember them: 
+    # but for writing out the project file we need to remember them:
     _deps_weak::Dict{String,UUID} = Dict{String,UUID}()
     weakdeps::Dict{String,UUID} = Dict{String,UUID}()
     exts::Dict{String,Union{Vector{String}, String}} = Dict{String,String}()
@@ -407,9 +407,9 @@ is_project_uuid(env::EnvCache, uuid::UUID) = project_uuid(env) == uuid
 # Context #
 ###########
 
-const STDLIB = Ref{Dict{UUID,Tuple{String,Union{VersionNumber,Nothing}}}}()
+const STDLIB = Ref{DictStdLibs}()
 function load_stdlib()
-    stdlib = Dict{UUID,Tuple{String,Union{VersionNumber,Nothing}}}()
+    stdlib = DictStdLibs()
     for name in readdir(stdlib_dir())
         projfile = projectfile_path(stdlib_path(name); strict=true)
         nothing === projfile && continue


### PR DESCRIPTION
This fixes invalidations from loading JuliaData ecosystem packages (CSV and DataFrames). I can't remember if it's these changes or some I'll submit to Base shortly, but the invalidations fixed include `Base.require` which tank package load time. It's possible that accounts for the outlier noticed in https://github.com/JuliaLang/julia/pull/47184#issuecomment-1337118968, CC @giordano.
