### PR TITLE
Fix broken source_path handling. Explicitly test for coverage files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
@@ -65,7 +65,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         env:
             JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
   docs:

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -2,9 +2,12 @@ using  .Utils
 using Test
 
 @testset "weak deps" begin
+    he_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl")
+    hdwe_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasDepWithExtensions.jl")
     isolate(loaded_depot=true) do
-        he_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl")
-        recursive_rm_cov_files(he_root) # clean out any .cov files from previous test runs
+        # clean out any .cov files from previous test runs
+        recursive_rm_cov_files(he_root)
+        recursive_rm_cov_files(hdwe_root)
 
         Pkg.activate(; temp=true)
         Pkg.develop(path=he_root)
@@ -17,8 +20,9 @@ using Test
         @test !any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
     end
     isolate(loaded_depot=true) do
-        hdwe_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasDepWithExtensions.jl")
-        recursive_rm_cov_files(hdwe_root) # clean out any .cov files from previous test runs
+        # clean out any .cov files from previous test runs
+        recursive_rm_cov_files(he_root)
+        recursive_rm_cov_files(hdwe_root)
 
         Pkg.activate(; temp=true)
         Pkg.develop(path=hdwe_root)
@@ -29,11 +33,13 @@ using Test
         str = String(take!(io))
         @test contains(str, "└─ OffsetArraysExt [OffsetArrays]" )
         @test !any(endswith(".cov"), readdir(joinpath(hdwe_root, "src")))
-        @test !any(endswith(".cov"), readdir(joinpath(hdwe_root, "ext")))
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "src")))
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
 
         Pkg.test("HasDepWithExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
         @test any(endswith(".cov"), readdir(joinpath(hdwe_root, "src")))
-        @test any(endswith(".cov"), readdir(joinpath(hdwe_root, "ext")))
+        @test any(endswith(".cov"), readdir(joinpath(he_root, "src")))
+        @test any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
     end
 
     isolate(loaded_depot=true) do

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -3,21 +3,37 @@ using Test
 
 @testset "weak deps" begin
     isolate(loaded_depot=true) do
+        he_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl")
+        recursive_rm_cov_files(he_root) # clean out any .cov files from previous test runs
+
         Pkg.activate(; temp=true)
-        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl"))
+        Pkg.develop(path=he_root)
         Pkg.test("HasExtensions", julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "src")))
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
+
         Pkg.test("HasExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
+        @test any(endswith(".cov"), readdir(joinpath(he_root, "src")))
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
     end
     isolate(loaded_depot=true) do
+        hdwe_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasDepWithExtensions.jl")
+        recursive_rm_cov_files(hdwe_root) # clean out any .cov files from previous test runs
+
         Pkg.activate(; temp=true)
-        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasDepWithExtensions.jl"))
+        Pkg.develop(path=hdwe_root)
         Pkg.test("HasDepWithExtensions", julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
         io = IOBuffer()
         Pkg.status(; extensions=true, mode=Pkg.PKGMODE_MANIFEST, io)
          # TODO: Test output when ext deps are loaded etc.
         str = String(take!(io))
         @test contains(str, "└─ OffsetArraysExt [OffsetArrays]" )
+        @test !any(endswith(".cov"), readdir(joinpath(hdwe_root, "src")))
+        @test !any(endswith(".cov"), readdir(joinpath(hdwe_root, "ext")))
+
         Pkg.test("HasDepWithExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
+        @test any(endswith(".cov"), readdir(joinpath(hdwe_root, "src")))
+        @test any(endswith(".cov"), readdir(joinpath(hdwe_root, "ext")))
     end
 
     isolate(loaded_depot=true) do

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -38,8 +38,11 @@ using Test
 
         Pkg.test("HasDepWithExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
         @test any(endswith(".cov"), readdir(joinpath(hdwe_root, "src")))
-        @test any(endswith(".cov"), readdir(joinpath(he_root, "src")))
-        @test any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
+
+        # No coverage files should be in HasExtensions even though it's used because coverage
+        # was only requested by Pkg.test for the HasDepWithExtensions package dir
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "src")))
+        @test !any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
     end
 
     isolate(loaded_depot=true) do

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -44,7 +44,7 @@ using Test
 
     isolate(loaded_depot=true) do
         Pkg.activate(; temp=true)
-        Pkg.develop(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl"))
+        Pkg.develop(path=he_root)
         @test_throws Pkg.Resolve.ResolverError Pkg.add(; name = "OffsetArrays", version = "0.9.0")
     end
 

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -6,6 +6,7 @@ using Test
         Pkg.activate(; temp=true)
         Pkg.develop(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl"))
         Pkg.test("HasExtensions", julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
+        Pkg.test("HasExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
     end
     isolate(loaded_depot=true) do
         Pkg.activate(; temp=true)
@@ -16,6 +17,7 @@ using Test
          # TODO: Test output when ext deps are loaded etc.
         str = String(take!(io))
         @test contains(str, "└─ OffsetArraysExt [OffsetArrays]" )
+        Pkg.test("HasDepWithExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
     end
 
     isolate(loaded_depot=true) do

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -17,7 +17,7 @@ using Test
 
         Pkg.test("HasExtensions", coverage=true, julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
         @test any(endswith(".cov"), readdir(joinpath(he_root, "src")))
-        @test !any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
+        @test any(endswith(".cov"), readdir(joinpath(he_root, "ext")))
     end
     isolate(loaded_depot=true) do
         # clean out any .cov files from previous test runs

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -232,9 +232,12 @@ temp_pkg_dir() do project_path
     end
 
     @testset "testing" begin
-        pkgdir = Base.locate_package(Base.PkgId(TEST_PKG.uuid, TEST_PKG.name))
-        recursive_rm_cov_files(pkgdir) # clean out cov files from previous test runs
         Pkg.add(TEST_PKG.name)
+
+        pkgdir = Base.locate_package(Base.PkgId(TEST_PKG.uuid, TEST_PKG.name))
+        @test !isnothing(pkgdir)
+        recursive_rm_cov_files(pkgdir) # clean out cov files from previous test runs
+
         @test !any(endswith(".cov"), readdir(pkgdir)) # should be no cov files to start with
         Pkg.test(TEST_PKG.name; coverage=true)
         @test any(endswith(".cov"), readdir(pkgdir))

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -234,7 +234,7 @@ temp_pkg_dir() do project_path
     @testset "testing" begin
         Pkg.add(TEST_PKG.name)
 
-        pkgdir = Base.locate_package(Base.PkgId(TEST_PKG.uuid, TEST_PKG.name))
+        pkgdir = dirname(Base.locate_package(Base.PkgId(TEST_PKG.uuid, TEST_PKG.name)))
         @test !isnothing(pkgdir)
         recursive_rm_cov_files(pkgdir) # clean out cov files from previous test runs
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -232,11 +232,12 @@ temp_pkg_dir() do project_path
     end
 
     @testset "testing" begin
-        Pkg.add(TEST_PKG.name)
-        Pkg.test(TEST_PKG.name; coverage=true)
         pkgdir = Base.locate_package(Base.PkgId(TEST_PKG.uuid, TEST_PKG.name))
-        # No coverage files being generated?
-        @test_broken TEST_PKG.name * ".cov" in readdir(pkgdir)
+        recursive_rm_cov_files(pkgdir) # clean out cov files from previous test runs
+        Pkg.add(TEST_PKG.name)
+        @test !any(endswith(".cov"), readdir(pkgdir)) # should be no cov files to start with
+        Pkg.test(TEST_PKG.name; coverage=true)
+        @test any(endswith(".cov"), readdir(pkgdir))
         Pkg.rm(TEST_PKG.name)
     end
 

--- a/test/test_packages/ExtensionExamples/HasDepWithExtensions.jl/src/HasDepWithExtensions.jl
+++ b/test/test_packages/ExtensionExamples/HasDepWithExtensions.jl/src/HasDepWithExtensions.jl
@@ -6,10 +6,10 @@ using OffsetArrays: OffsetArray
 
 function do_something()
     # @info "First do something with the basic array support in B"
-    HasExtensions.foo(rand(Float64, 2))
+    HasExtensions.foo(rand(Float64, 2)) == 1 || error("Unexpected value")
 
     # @info "Now do something with extended OffsetArray support in B"
-    HasExtensions.foo(OffsetArray(rand(Float64, 2), 0:1))
+    HasExtensions.foo(OffsetArray(rand(Float64, 2), 0:1)) == 2 || error("Unexpected value")
 end
 
 end # module

--- a/test/test_packages/ExtensionExamples/HasExtensions.jl/ext/OffsetArraysExt.jl
+++ b/test/test_packages/ExtensionExamples/HasExtensions.jl/ext/OffsetArraysExt.jl
@@ -1,6 +1,7 @@
 module OffsetArraysExt
 
 using HasExtensions, OffsetArrays
+import HasExtensions: foo
 
 function foo(::OffsetArray)
     return 2

--- a/test/test_packages/ExtensionExamples/HasExtensions.jl/test/runtests.jl
+++ b/test/test_packages/ExtensionExamples/HasExtensions.jl/test/runtests.jl
@@ -2,9 +2,9 @@ using HasExtensions
 using Test
 
 @test !HasExtensions.offsetarrays_loaded
-@test foo(Int[1,2,3]) == 1
+@test HasExtensions.foo(rand(Float64, 2)) == 1
 
 using OffsetArrays
 
 @test HasExtensions.offsetarrays_loaded
-@test foo(OffsetArray(Int[1,2,3], -1:1)) == 2
+@test HasExtensions.foo(OffsetArray(rand(Float64, 2), 0:1)) == 2

--- a/test/test_packages/ExtensionExamples/HasExtensions.jl/test/runtests.jl
+++ b/test/test_packages/ExtensionExamples/HasExtensions.jl/test/runtests.jl
@@ -2,7 +2,9 @@ using HasExtensions
 using Test
 
 @test !HasExtensions.offsetarrays_loaded
+@test foo(Int[1,2,3]) == 1
 
 using OffsetArrays
 
 @test HasExtensions.offsetarrays_loaded
+@test foo(OffsetArray(Int[1,2,3], -1:1)) == 2

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -11,7 +11,7 @@ using UUIDs
 export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
        with_temp_env, with_pkg_env, git_init_and_commit, copy_test_package,
        git_init_package, add_this_pkg, TEST_SIG, TEST_PKG, isolate, LOADED_DEPOT,
-       list_tarball_files
+       list_tarball_files, recursive_rm_cov_files
 
 const CACHE_DIRECTORY = mktempdir(; cleanup = true)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -311,4 +311,12 @@ function show_output_if_command_errors(cmd::Cmd)
     return nothing
 end
 
+function recursive_rm_cov_files(rootdir::String)
+    for (root, dir, files) in walkdir(rootdir)
+        for file in files
+            endswith(file, ".cov") && rm(joinpath(root, dir, file))
+        end
+    end
+end
+
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -312,9 +312,9 @@ function show_output_if_command_errors(cmd::Cmd)
 end
 
 function recursive_rm_cov_files(rootdir::String)
-    for (root, dir, files) in walkdir(rootdir)
+    for (root, _, files) in walkdir(rootdir)
         for file in files
-            endswith(file, ".cov") && rm(joinpath(root, dir, file))
+            endswith(file, ".cov") && rm(joinpath(root, file))
         end
     end
 end


### PR DESCRIPTION
~~It's not clear to me why this didn't fail in #3281 .~~ Urgh.. it was picking up a function and string-ing the name 🤦‍♂️
```
julia> Pkg.Operations.source_path
source_path (generic function with 2 methods)

julia> string("@", Pkg.Operations.source_path)
"@source_path"
```

----

This fixes a rather nasty missing local var bug introduced by #3281 that broke coverage generation in `Pkg.test`, and reinstates and expands testing for coverage files where they should and shouldn't be generated