### PR TITLE
Quick Fix: Typo in weakdeps Requires.jl fallback example

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -380,7 +380,7 @@ This is done by making the following changes (using the example above):
       # Other init functionality here
 
       @static if !isdefined(Base, :get_extension)
-          @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/ContourExt.jl)
+          @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/ContourExt.jl")
       end
   end
   ```


### PR DESCRIPTION
The final quote in `include("../ext/ContourExt.jl)` is missing, which is incorrect and makes the following syntax highlighting slightly funky.