### PR TITLE
release-1.6: undeprecate `generate`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,8 @@ jobs:
       - uses: actions/checkout@v1.0.0
       - uses: julia-actions/setup-julia@latest
         with:
-          # version: '1.6'
-          version: 'nightly'
+          version: '1.6'
+          # version: 'nightly'
       - name: Generate docs
         run: |
           julia --color=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"))'

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -292,7 +292,7 @@ packages will not be upgraded at all.
 """,
 ],
 PSA[:name => "generate",
-    :api => API.generate_deprecated,
+    :api => API.generate,
     :arg_count => 1 => 1,
     :arg_parser => ((x,y) -> map(expanduser, unwrap(x))),
     :description => "generate files for a new project",

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -1,10 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-function generate_deprecated(varargs...; kwargs...)
-    Base.depwarn("Pkg.generate is deprecated. Please use PkgTemplates.jl instead.", Symbol("Pkg.generate"))
-    return generate(varargs...; kwargs...)
-end
-
 generate(path::String; kwargs...) = generate(Context(), path; kwargs...)
 function generate(ctx::Context, path::String; kwargs...)
     Context!(ctx; kwargs...)

--- a/test/new.jl
+++ b/test/new.jl
@@ -1869,7 +1869,7 @@ end
     isolate() do
         Pkg.REPLMode.TEST_MODE[] = true
         api, arg, opts = first(Pkg.pkg"generate Foo")
-        @test api == Pkg.API.generate_deprecated
+        @test api == Pkg.API.generate
         @test arg == "Foo"
         @test isempty(opts)
         mktempdir() do dir


### PR DESCRIPTION
To fix CI on buildkite. 