### PR TITLE
Respect manifest if provided in Project.toml

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -73,7 +73,7 @@ function package_info(env::EnvCache, pkg::PackageSpec, entry::PackageEntry)::Pac
         is_tracking_registry = Operations.is_tracking_registry(pkg),
         git_revision         = pkg.repo.rev,
         git_source           = git_source,
-        source               = Operations.project_rel_path(env, Operations.source_path(env.project_file, pkg)),
+        source               = Operations.project_rel_path(env, Operations.source_path(env.manifest_file, pkg)),
         dependencies         = copy(entry.deps), #TODO is copy needed?
     )
     return info
@@ -1607,7 +1607,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     for pkg in pkgs
         repo_source = pkg.repo.source
         repo_source !== nothing || continue
-        sourcepath = Operations.source_path(ctx.env.project_file, pkg, ctx.julia_version)
+        sourcepath = Operations.source_path(ctx.env.manifest_file, pkg, ctx.julia_version)
         isdir(sourcepath) && continue
         ## Download repo at tree hash
         # determine canonical form of repo source
@@ -1694,7 +1694,7 @@ function _activate_dep(dep_name::AbstractString)
     if uuid !== nothing
         entry = manifest_info(ctx.env.manifest, uuid)
         if entry.path !== nothing
-            return joinpath(dirname(ctx.env.project_file), entry.path::String)
+            return joinpath(dirname(ctx.env.manifest_file), entry.path::String)
         end
     end
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -128,6 +128,12 @@ end
 function update_manifest!(env::EnvCache, pkgs::Vector{PackageSpec}, deps_map, julia_version)
     manifest = env.manifest
     empty!(manifest)
+    # if we're updating env.pkg that refers to another manifest, we want to change
+    # pkg.path, if present, to be relative to the manifest instead of an abspath
+    if env.project.manifest !== nothing && env.pkg.path !== nothing
+        env.pkg.path = Types.relative_project_path(env.manifest_file,
+                        project_rel_path(env, source_path(env.manifest_file, env.pkg)))
+    end
     if env.pkg !== nothing
         pkgs = push!(copy(pkgs), env.pkg::PackageSpec)
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -587,9 +587,9 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
             resolve_projectfile!(ctx.env, pkg, dev_path)
             error_if_in_sysimage(pkg)
             if is_local_path
-                pkg.path = isabspath(dev_path) ? dev_path : relative_project_path(ctx.env.project_file, dev_path)
+                pkg.path = isabspath(dev_path) ? dev_path : relative_project_path(ctx.env.manifest_file, dev_path)
             else
-                pkg.path = shared ? dev_path : relative_project_path(ctx.env.project_file, dev_path)
+                pkg.path = shared ? dev_path : relative_project_path(ctx.env.manifest_file, dev_path)
             end
             return false
         end
@@ -648,7 +648,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
         resolve_projectfile!(ctx.env, pkg, dev_path)
     end
     error_if_in_sysimage(pkg)
-    pkg.path = shared ? dev_path : relative_project_path(ctx.env.project_file, dev_path)
+    pkg.path = shared ? dev_path : relative_project_path(ctx.env.manifest_file, dev_path)
     if pkg.repo.subdir !== nothing
         pkg.path = joinpath(pkg.path, pkg.repo.subdir)
     end
@@ -726,8 +726,8 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
                 pkgerror(msg)
             end
             LibGit2.with(GitTools.check_valid_HEAD, LibGit2.GitRepo(pkg.repo.source)) # check for valid git HEAD
-            pkg.repo.source = isabspath(pkg.repo.source) ? safe_realpath(pkg.repo.source) : relative_project_path(ctx.env.project_file, pkg.repo.source)
-            repo_source = normpath(joinpath(dirname(ctx.env.project_file), pkg.repo.source))
+            pkg.repo.source = isabspath(pkg.repo.source) ? safe_realpath(pkg.repo.source) : relative_project_path(ctx.env.manifest_file, pkg.repo.source)
+            repo_source = normpath(joinpath(dirname(ctx.env.manifest_file), pkg.repo.source))
         else
             pkgerror("Path `$(pkg.repo.source)` does not exist.")
         end

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -9,6 +9,11 @@ temp_pkg_dir() do project_path
         mktempdir() do dir
             path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "monorepo"))
             cp(path, joinpath(dir, "monorepo"))
+            cd(joinpath(dir, "monorepo")) do
+                with_current_env() do
+                    Pkg.develop(path="packages/B")
+                end
+            end
             # test subpackage instantiates/tests
             # the order of operations here is important
             # when we instantiate and dev a dependency to the C subpackage
@@ -27,7 +32,6 @@ temp_pkg_dir() do project_path
             cd(joinpath(dir, "monorepo")) do
                 with_current_env() do
                     Pkg.develop(path="packages/C")
-                    Pkg.develop(path="packages/B")
                     Pkg.add("Test")
                     Pkg.test()
                 end

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -1,0 +1,46 @@
+module ProjectManifestTest
+
+import ..Pkg # ensure we are using the correct Pkg
+using Test, Pkg
+using ..Utils
+
+temp_pkg_dir() do project_path
+    @testset "test Project.toml manifest" begin
+        mktempdir() do dir
+            path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "monorepo"))
+            cp(path, joinpath(dir, "monorepo"))
+            cd(joinpath(dir, "monorepo")) do
+                with_current_env() do
+                    Pkg.add("Test") # test https://github.com/JuliaLang/Pkg.jl/issues/324
+                    Pkg.instantiate()
+                    Pkg.test()
+                end
+            end
+            # test subpackage instantiates/tests
+            cd(joinpath(dir, "monorepo", "packages", "C")) do
+                with_current_env() do
+                    Pkg.develop(path="../D") # add unregistered local dependency
+                    Pkg.test()
+                end
+            end
+            new_A_module = """
+            module A
+            using B, C
+            test() = true
+            end # module
+            """
+            open(joinpath(dir, "monorepo", "src", "A.jl"), "w") do io
+                write(io, new_A_module)
+            end
+            cd(joinpath(dir, "monorepo")) do
+                with_current_env() do
+                    Pkg.develop(path="packages/C")
+                    Pkg.develop(path="packages/B")
+                    Pkg.test()
+                end
+            end
+        end
+    end
+end
+
+end # module

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -9,33 +9,26 @@ temp_pkg_dir() do project_path
         mktempdir() do dir
             path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "monorepo"))
             cp(path, joinpath(dir, "monorepo"))
-            cd(joinpath(dir, "monorepo")) do
-                with_current_env() do
-                    Pkg.add("Test") # test https://github.com/JuliaLang/Pkg.jl/issues/324
-                    Pkg.instantiate()
-                    Pkg.test()
-                end
-            end
             # test subpackage instantiates/tests
+            # the order of operations here is important
+            # when we instantiate and dev a dependency to the C subpackage
+            # the changes are being written to the monorepo/Manifest.toml
+            # but are not "sticky" in that if we ran a resolve a the monorepo/
+            # level, the C & D packages would be pruned since there's no direct
+            # dependency at the monorepo project level yet, so we first build up
+            # C's dependencies, then at the monorepo level, we need to dev C *first*
+            # to make those Manifest changes "stick" before devving B or adding Test
             cd(joinpath(dir, "monorepo", "packages", "C")) do
                 with_current_env() do
                     Pkg.develop(path="../D") # add unregistered local dependency
                     Pkg.test()
                 end
             end
-            new_A_module = """
-            module A
-            using B, C
-            test() = true
-            end # module
-            """
-            open(joinpath(dir, "monorepo", "src", "A.jl"), "w") do io
-                write(io, new_A_module)
-            end
             cd(joinpath(dir, "monorepo")) do
                 with_current_env() do
                     Pkg.develop(path="packages/C")
                     Pkg.develop(path="packages/B")
+                    Pkg.add("Test")
                     Pkg.test()
                 end
             end

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -18,11 +18,11 @@ temp_pkg_dir() do project_path
             # the order of operations here is important
             # when we instantiate and dev a dependency to the C subpackage
             # the changes are being written to the monorepo/Manifest.toml
-            # but are not "sticky" in that if we ran a resolve a the monorepo/
+            # but are not "sticky" in that if we ran a resolve at the monorepo/
             # level, the C & D packages would be pruned since there's no direct
             # dependency at the monorepo project level yet, so we first build up
             # C's dependencies, then at the monorepo level, we need to dev C *first*
-            # to make those Manifest changes "stick" before devving B or adding Test
+            # to make those Manifest changes "stick" before adding Test.
             cd(joinpath(dir, "monorepo", "packages", "C")) do
                 with_current_env() do
                     Pkg.develop(path="../D") # add unregistered local dependency

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,7 @@ Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger())
                 "misc.jl",
                 "force_latest_compatible_version.jl",
                 "manifests.jl",
+                "project_manifest.jl"
                 ]
                 @info "==== Testing `test/$f`"
                 flush(Pkg.DEFAULT_IO[])

--- a/test/test_packages/monorepo/Project.toml
+++ b/test/test_packages/monorepo/Project.toml
@@ -1,0 +1,5 @@
+name = "A"
+uuid = "0829fd7c-1e7e-4927-9afa-b8c61d5e0e42"
+version = "0.0.0"
+
+[deps]

--- a/test/test_packages/monorepo/packages/B/Project.toml
+++ b/test/test_packages/monorepo/packages/B/Project.toml
@@ -1,0 +1,4 @@
+name = "B"
+uuid = "dd0d8fba-d7c4-4f8e-a2bb-3a090b3e34f2"
+version = "0.0.0"
+manifest = "../../Manifest.toml"

--- a/test/test_packages/monorepo/packages/B/src/B.jl
+++ b/test/test_packages/monorepo/packages/B/src/B.jl
@@ -1,0 +1,5 @@
+module B
+
+b() = println("B.b")
+
+end # module

--- a/test/test_packages/monorepo/packages/C/Project.toml
+++ b/test/test_packages/monorepo/packages/C/Project.toml
@@ -1,0 +1,7 @@
+name = "C"
+uuid = "4ee78ca3-4e78-462f-a078-747ed543fa86"
+version = "0.0.0"
+manifest = "../../Manifest.toml"
+
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_packages/monorepo/packages/C/src/C.jl
+++ b/test/test_packages/monorepo/packages/C/src/C.jl
@@ -1,0 +1,5 @@
+module C
+
+test() = true
+
+end # module

--- a/test/test_packages/monorepo/packages/C/test/runtests.jl
+++ b/test/test_packages/monorepo/packages/C/test/runtests.jl
@@ -1,0 +1,3 @@
+using Test, C
+
+@test C.test()

--- a/test/test_packages/monorepo/packages/D/Project.toml
+++ b/test/test_packages/monorepo/packages/D/Project.toml
@@ -1,0 +1,4 @@
+name = "D"
+uuid = "bf733257-898a-45a0-b2f2-c1c188bdd870"
+version = "0.0.0"
+manifest = "../../Manifest.toml"

--- a/test/test_packages/monorepo/packages/D/src/D.jl
+++ b/test/test_packages/monorepo/packages/D/src/D.jl
@@ -1,0 +1,5 @@
+module D
+
+greet() = print("Hello World!")
+
+end # module

--- a/test/test_packages/monorepo/src/A.jl
+++ b/test/test_packages/monorepo/src/A.jl
@@ -1,3 +1,5 @@
 module A
+using B, C
 test() = true
+testC() = C.test()
 end # module

--- a/test/test_packages/monorepo/src/A.jl
+++ b/test/test_packages/monorepo/src/A.jl
@@ -1,0 +1,3 @@
+module A
+test() = true
+end # module

--- a/test/test_packages/monorepo/test/runtests.jl
+++ b/test/test_packages/monorepo/test/runtests.jl
@@ -1,0 +1,3 @@
+using Test, A
+
+@test A.test()

--- a/test/test_packages/monorepo/test/runtests.jl
+++ b/test/test_packages/monorepo/test/runtests.jl
@@ -1,3 +1,4 @@
 using Test, A
 
 @test A.test()
+@test A.testC()


### PR DESCRIPTION
I recently discovered that loading in Base supports specifying an alternative `Manifest.toml` in a `Project.toml`. While playing around with this though, I discovered that Pkg.jl doesn't play as nice with this. It supports the parsing/storing of it, but gets confused often because so many path calculations are made relative to the _project file_ instead of the now-different manifest file.

This is relevant when there are devv-ed packages in the specified Manifest and the relative path calculations should be made wrt to the _manifest_ not the _project_.

The changes here, hence, are mainly about auditing uses of `env.project_file` and changing them to `env.manifest_file` if necessary. The cases where `manifest_file` should be used, as far as I understand, are where the `PackageSpec` we're computing a path for came from a manifest entry instead of a project dep or elsewhere.

The other change in this PR is in `prune_manifest` where we actually _don't_ want to prune the manifest if the project doesn't "own" it. I'm calculating that by checking `dirname(env.manifest_file) != dirname(env.project_file)`, but we could also potentially just check `env.pkg.manifest` if it's populated, but it wasn't clear if that would be a more sure thing since we're trying to query if the Manifest isn't the default.