### PR TITLE
only auto update registries on `add` once per day

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -256,7 +256,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
     # repo + unpinned -> name, uuid, repo.rev, repo.source, tree_hash
     # repo + pinned -> name, uuid, tree_hash
 
-    Operations.update_registries(ctx; force=false)
+    Operations.update_registries(ctx; force=false, update_cooldown=Day(1))
 
     project_deps_resolve!(ctx.env, pkgs)
     registry_resolve!(ctx.registries, pkgs)


### PR DESCRIPTION
I think it is fine to only do the auto registry update on `Pkg.add` ~ once per day. 