### PR TITLE
Precompile: tidier state cache file handling

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1515,9 +1515,13 @@ function save_precompile_state()
     path = Operations.pkg_scratchpath()
     for (prefix, store) in (("suspend_cache_", pkgs_precompile_suspended), ("pending_cache_", pkgs_precompile_pending))
         fpath = joinpath(path, string(prefix, hash(string(Base.active_project(), Base.VERSION))))
-        mkpath(path); Base.Filesystem.rm(fpath, force=true)
-        open(fpath, "w") do io
-            serialize(io, store)
+        if isempty(store)
+            Base.rm(fpath, force=true)
+        else
+            mkpath(path); Base.rm(fpath, force=true)
+            open(fpath, "w") do io
+                serialize(io, store)
+            end
         end
     end
     return nothing

--- a/src/API.jl
+++ b/src/API.jl
@@ -1538,6 +1538,7 @@ function recall_precompile_state()
                     empty!(store)
                 end
             end
+            Base.rm(fpath, force=true)
         else
             empty!(store)
         end


### PR DESCRIPTION
The Pkg scratchspace on my machine had accumulated 3258 of these precompile state cache files, even though they're specific to active project & VERSION.

- Be tidier.. only save them if they have content (🤦‍♂️)
- Let Pkg.gc tidy them up if older than 1 day

```
julia> import Pkg
[ Info: Precompiling Pkg [44cfe95a-1eb2-52ea-b672-e2afdf69b79f]

julia> Pkg.gc()
      Active manifest files: 85 found
      Active artifact files: 230 found
      Active scratchspaces: 41 found
     Deleted no artifacts, repos, packages or scratchspaces

julia> using Dates

julia> Pkg.gc(; collect_delay = Dates.Second(1))
      Active manifest files: 85 found
      Active artifact files: 230 found
      Active scratchspaces: 41 found
     Deleted 11 artifact installations (148.874 MiB)
     Deleted 3258 scratchspaces (236.042 KiB)
```