### PR TITLE
RFC: set `max_methods` to 1 in Pkg

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -2,6 +2,10 @@
 
 module Pkg
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
+    @eval Base.Experimental.@max_methods 2
+end
+
 import Random
 import REPL
 import TOML

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -3,7 +3,7 @@
 module Pkg
 
 if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
-    @eval Base.Experimental.@max_methods 2
+    @eval Base.Experimental.@max_methods 1
 end
 
 import Random


### PR DESCRIPTION
We quite frequently see Pkg be a source of invalidations in other packages. This should reduce the likelihood of that. The cost is worse inference in Pkg in presence of non precise type information. However, running a workload with:

```
using Pkg, BenchmarkTools
ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0
Pkg.activate(; temp=true)
@btime Pkg.add("DifferentialEquations")
```

I cannot see any difference between master and this PR.