### PR TITLE
Change the default registry flavour from `conservative` to `eager`

### DIFF
--- a/docs/src/registries.md
+++ b/docs/src/registries.md
@@ -100,30 +100,12 @@ The default Pkg Server (`pkg.julialang.org`) offers two different "flavors" of r
 !!! compat "Julia 1.8"
     Registry flavors are only available starting with Julia 1.8.
 
-- `conservative`: suitable for most users; all packages and artifacts in this registry flavor are available from the Pkg Server, with no need to download from other sources
-- `eager`: this registry offers the latest versions of packages, even if the Pkg and Storage Servers have not finished processing them; thus, some packages and artifacts may not be available from the Pkg Server, and thus may need to be downloaded from other sources (such as GitHub)
+- `eager`: suitable for most users; all packages and artifacts in this registry flavor are available to download but it might not come from the Pkg Server
+- `conservative`: this registry only offers the versions of packages that have been proccesed by the Storage Servers; thus, the latest version of some packages and artifacts may not be availale.
 
-The default registry flavor is `conservative`. We recommend that most users stick to the `conservative` flavor unless they know that they need to use the `eager` flavor.
+The default registry flavor is `eager`. We recommend that most users stick to the `eager` flavor unless they know that they need to use the `conservative` flavor.
 
-To select the `eager` flavor:
-
-```julia
-ENV["JULIA_PKG_SERVER_REGISTRY_PREFERENCE"] = "eager"
-
-import Pkg
-
-Pkg.Registry.update()
-```
-
-To select the `conservative` flavor:
-
-```julia
-ENV["JULIA_PKG_SERVER_REGISTRY_PREFERENCE"] = "conservative"
-
-import Pkg
-
-Pkg.Registry.update()
-```
+To flavors are chosen by setting the environment variable `JULIA_PKG_SERVER_REGISTRY_PREFERENCE` to `eager` or `conservative`.
 
 ### Creating and maintaining registries
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -246,6 +246,7 @@ function get_metadata_headers(url::AbstractString)
         any(hdr == k for (k, v) in headers) && continue
         push!(headers, hdr => val)
     end
+    push!(headers, "JULIA_PKG_SERVER_REGISTRY_PREFERENCE" => get(ENV, "JULIA_PKG_SERVER_REGISTRY_PREFERENCE", "eager"))
     return headers
 end
 


### PR DESCRIPTION
I really think the current default flavour is wrong. I would argue that 99.99% of users do not care if they download a package / artifact from the Pkg server or GitHub. They much rather have the latest version and there are quite frequent questions about why a user gets an old version installed, even though it was x hours since it got registered. As it is right now, if the package server processes a package slowly, all registered versions after that are blocked for everyone which imo is quite unacceptable. The recent reported blockage was ~18 hours from what I recently read which imo is not really acceptable.

In special cases, where you are e.g. behind a fire wall so you cannot talk to GitHub you want to use the conservative version since otherwise you might fail the download. But this is the special case so imo it makes more sense for these people to have to set some option.

cc @StefanKarpinski, @DilumAluthge .