### PR TITLE
Disallow re-resolution in `Pkg.build`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1101,7 +1101,7 @@ function build_versions(ctx::Context, uuids::Set{UUID}; verbose=false)
         fancyprint && show_progress(ctx.io, bar)
 
         let log_file=log_file
-            sandbox(ctx, pkg, source_path, builddir(source_path), build_project_override; preferences=build_project_preferences) do
+            sandbox(ctx, pkg, source_path, builddir(source_path), build_project_override; preferences=build_project_preferences, allow_reresolve=false) do
                 flush(ctx.io)
                 ok = open(log_file, "w") do log
                     std = verbose ? ctx.io : log


### PR DESCRIPTION
Closes #3329 

In `Pkg.test`, we need to have the ability for the user to allow or disallow re-resolution. This is because `Pkg.test` will add the test-only dependencies, which may come with their own `[compat]` constraints, which may conflict with the existing manifest. Therefore, the `Pkg.test` function has the `allow_reresolve` kwarg.

However, I don't think we need to ever allow `Pkg.build` to re-resolve. If for some reason, the active manifest is not a valid resolution of the active project, then we should just print an error. This is fine, because it's really easy for the user to fix: just run `Pkg.resolve()`, and then run `Pkg.build()` again.