### PR TITLE
add ability to pin / free all deps in manifest

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -351,11 +351,11 @@ function resolve(ctx::Context; skip_writing_project::Bool=false, kwargs...)
     return nothing
 end
 
-function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwargs...)
+function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, all_pkgmode::PackageMode=PKGMODE_PROJECT, kwargs...)
     Context!(ctx; kwargs...)
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
-        append_all_pkgs!(pkgs, ctx, PKGMODE_PROJECT)
+        append_all_pkgs!(pkgs, ctx, all_pkgmode)
     else
         require_not_empty(pkgs, :pin)
     end
@@ -386,11 +386,11 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwar
     return
 end
 
-function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, kwargs...)
+function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool=false, all_pkgmode::PackageMode=PKGMODE_PROJECT, kwargs...)
     Context!(ctx; kwargs...)
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
-        append_all_pkgs!(pkgs, ctx, PKGMODE_PROJECT)
+        append_all_pkgs!(pkgs, ctx, all_pkgmode)
     else
         require_not_empty(pkgs, :free)
     end

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -191,16 +191,17 @@ PSA[:name => "free",
     :arg_count => 0 => Inf,
     :option_spec => [
         PSA[:name => "all", :api => :all_pkgs => true],
+        PSA[:name => "manifest", :short_name => "m", :api => :all_pkgmode => PKGMODE_MANIFEST],
     ],
     :arg_parser => parse_package,
     :completions => complete_installed_packages,
     :description => "undoes a `pin`, `develop`, or stops tracking a repo",
     :help => md"""
     free pkg[=uuid] ...
-    free [--all]
+    free [--all] [-m|--manifest]
 
 Free pinned packages, which allows it to be upgraded or downgraded again. If the package is checked out (see `help develop`) then this command
-makes the package no longer being checked out.
+makes the package no longer being checked out. `--all` frees all project packages, `--all -m` frees all manifest packages.
 """,
 ],
 PSA[:name => "why",
@@ -223,16 +224,18 @@ PSA[:name => "pin",
     :arg_count => 0 => Inf,
     :option_spec => [
         PSA[:name => "all", :api => :all_pkgs => true],
+        PSA[:name => "manifest", :short_name => "m", :api => :all_pkgmode => PKGMODE_MANIFEST],
     ],
     :arg_parser => parse_package,
     :completions => complete_installed_packages,
     :description => "pins the version of packages",
     :help => md"""
     pin pkg[=uuid] ...
-    pin [--all]
+    pin [--all] [-m|--manifest]
 
 Pin packages to given versions, or the current version if no version is specified. A pinned package has its version fixed and will not be upgraded or downgraded.
 A pinned package has the symbol `⚲` next to its version in the status list.
+`--all` pins all project packages, `--all -m` pins all manifest packages.
 
 **Examples**
 ```
@@ -240,6 +243,7 @@ pkg> pin Example
 pkg> pin Example@0.5.0
 pkg> pin Example=7876af07-990d-54b4-ab0e-23690620f79a@0.5.0
 pkg> pin --all
+pkg> pin --all -m
 ```
 """,
 ],

--- a/test/new.jl
+++ b/test/new.jl
@@ -1974,12 +1974,12 @@ end
             @test !pkg.is_pinned
         end
 
-        Pkg.pin(all_pkgs = true, all_pkgmode = PKGMODE_MANIFEST)
+        Pkg.pin(all_pkgs = true, all_pkgmode = Pkg.PKGMODE_MANIFEST)
         @test length(Pkg.dependencies()) > 1
         for pkg in Pkg.dependencies()
             @test pkg.is_pinned
         end
-        Pkg.free(all_pkgs = true, all_pkgmode = PKGMODE_MANIFEST)
+        Pkg.free(all_pkgs = true, all_pkgmode = Pkg.PKGMODE_MANIFEST)
         @test length(Pkg.dependencies()) > 1
         for pkg in Pkg.dependencies()
             @test !pkg.is_pinned
@@ -2006,7 +2006,7 @@ end
         api, args, opts = first(Pkg.pkg"pin --all -m")
         @test api == Pkg.pin
         @test isempty(args)
-        @test opts == Dict(:all_pkgs => true, :all_pkgmode => PKGMODE_MANIFEST)
+        @test opts == Dict(:all_pkgs => true, :all_pkgmode => Pkg.PKGMODE_MANIFEST)
 
         api, args, opts = first(Pkg.pkg"free --all")
         @test api == Pkg.free
@@ -2016,7 +2016,7 @@ end
         api, args, opts = first(Pkg.pkg"free --all -m")
         @test api == Pkg.free
         @test isempty(args)
-        @test opts == Dict(:all_pkgs => true, :all_pkgmode => PKGMODE_MANIFEST)
+        @test opts == Dict(:all_pkgs => true, :all_pkgmode => Pkg.PKGMODE_MANIFEST)
 
         api, args, opts = first(Pkg.pkg"rm --all")
         @test api == Pkg.rm


### PR DESCRIPTION
The idea came up [on discourse](https://discourse.julialang.org/t/first-pluto-notebook-launches-are-slower-on-julia-1-9-beta-3/93429/53) to be able to pin/free all the indirect deps too, for distribution of a locked down manifest that is harder to upgrade, for classes etc.

```
(jl_MRLBHQ) pkg> st
Status `/tmp/jl_MRLBHQ/Project.toml`
  [336ed68f] CSV v0.10.9

(jl_MRLBHQ) pkg> pin --all
   Resolving package versions...
    Updating `/tmp/jl_MRLBHQ/Project.toml`
  [336ed68f] ~ CSV v0.10.9 ⇒ v0.10.9 ⚲
    Updating `/tmp/jl_MRLBHQ/Manifest.toml`
  [336ed68f] ~ CSV v0.10.9 ⇒ v0.10.9 ⚲

(jl_MRLBHQ) pkg> pin --all -m
   Resolving package versions...
  No Changes to `/tmp/jl_MRLBHQ/Project.toml`
    Updating `/tmp/jl_MRLBHQ/Manifest.toml`
  [944b1d66] ~ CodecZlib v0.7.1 ⇒ v0.7.1 ⚲
  [34da2185] ~ Compat v4.5.0 ⇒ v4.5.0 ⚲
  [9a962f9c] ~ DataAPI v1.14.0 ⇒ v1.14.0 ⚲
  [e2d170a0] ~ DataValueInterfaces v1.0.0 ⇒ v1.0.0 ⚲
  [48062228] ~ FilePathsBase v0.9.20 ⇒ v0.9.20 ⚲
  [842dd82b] ~ InlineStrings v1.3.2 ⇒ v1.3.2 ⚲
  [82899510] ~ IteratorInterfaceExtensions v1.0.0 ⇒ v1.0.0 ⚲
  [bac558e1] ~ OrderedCollections v1.4.1 ⇒ v1.4.1 ⚲
  [69de0a69] ~ Parsers v2.5.3 ⇒ v2.5.3 ⚲
  [2dfb63ee] ~ PooledArrays v1.4.2 ⇒ v1.4.2 ⚲
  [21216c6a] ~ Preferences v1.3.0 ⇒ v1.3.0 ⚲
  [91c51154] ~ SentinelArrays v1.3.17 ⇒ v1.3.17 ⚲
  [66db9d55] ~ SnoopPrecompile v1.0.3 ⇒ v1.0.3 ⚲
  [3783bdb8] ~ TableTraits v1.0.1 ⇒ v1.0.1 ⚲
  [bd369af6] ~ Tables v1.10.0 ⇒ v1.10.0 ⚲
  [3bb67fe8] ~ TranscodingStreams v0.9.11 ⇒ v0.9.11 ⚲
  [ea10d353] ~ WeakRefStrings v1.4.2 ⇒ v1.4.2 ⚲
  [76eceee3] ~ WorkerUtilities v1.6.1 ⇒ v1.6.1 ⚲
  [56f22d72] ~ Artifacts ⇒ ⚲
  [2a0f44e3] ~ Base64 ⇒ ⚲
  [ade2ca70] ~ Dates ⇒ ⚲
  [9fa8497b] ~ Future ⇒ ⚲
  [b77e0a4c] ~ InteractiveUtils ⇒ ⚲
  [8f399da3] ~ Libdl ⇒ ⚲
  [37e2e46d] ~ LinearAlgebra ⇒ ⚲
  [56ddb016] ~ Logging ⇒ ⚲
  [d6f4376e] ~ Markdown ⇒ ⚲
  [a63ad114] ~ Mmap ⇒ ⚲
  [de0858da] ~ Printf ⇒ ⚲
  [9a3f8284] ~ Random ⇒ ⚲
  [ea8e919c] ~ SHA v0.7.0 ⇒ v0.7.0 ⚲
  [9e88b42a] ~ Serialization ⇒ ⚲
  [fa267f1f] ~ TOML v1.0.3 ⇒ v1.0.3 ⚲
  [8dfed614] ~ Test ⇒ ⚲
  [cf7118a7] ~ UUIDs ⇒ ⚲
  [4ec0a83e] ~ Unicode ⇒ ⚲
  [e66e0078] ~ CompilerSupportLibraries_jll v1.0.2+0 ⇒ v1.0.2+0 ⚲
  [4536629a] ~ OpenBLAS_jll v0.3.21+0 ⇒ v0.3.21+0 ⚲
  [83775a58] ~ Zlib_jll v1.2.13+0 ⇒ v1.2.13+0 ⚲
  [8e850b90] ~ libblastrampoline_jll v5.2.0+0 ⇒ v5.2.0+0 ⚲

(jl_MRLBHQ) pkg> free --all -m
   Resolving package versions...
    Updating `/tmp/jl_MRLBHQ/Project.toml`
  [336ed68f] ~ CSV v0.10.9 ⚲ ⇒ v0.10.9
    Updating `/tmp/jl_MRLBHQ/Manifest.toml`
  [336ed68f] ~ CSV v0.10.9 ⚲ ⇒ v0.10.9
  [944b1d66] ~ CodecZlib v0.7.1 ⚲ ⇒ v0.7.1
  [34da2185] ~ Compat v4.5.0 ⚲ ⇒ v4.5.0
  [9a962f9c] ~ DataAPI v1.14.0 ⚲ ⇒ v1.14.0
  [e2d170a0] ~ DataValueInterfaces v1.0.0 ⚲ ⇒ v1.0.0
  [48062228] ~ FilePathsBase v0.9.20 ⚲ ⇒ v0.9.20
  [842dd82b] ~ InlineStrings v1.3.2 ⚲ ⇒ v1.3.2
  [82899510] ~ IteratorInterfaceExtensions v1.0.0 ⚲ ⇒ v1.0.0
  [bac558e1] ~ OrderedCollections v1.4.1 ⚲ ⇒ v1.4.1
  [69de0a69] ~ Parsers v2.5.3 ⚲ ⇒ v2.5.3
  [2dfb63ee] ~ PooledArrays v1.4.2 ⚲ ⇒ v1.4.2
  [21216c6a] ~ Preferences v1.3.0 ⚲ ⇒ v1.3.0
  [91c51154] ~ SentinelArrays v1.3.17 ⚲ ⇒ v1.3.17
  [66db9d55] ~ SnoopPrecompile v1.0.3 ⚲ ⇒ v1.0.3
  [3783bdb8] ~ TableTraits v1.0.1 ⚲ ⇒ v1.0.1
  [bd369af6] ~ Tables v1.10.0 ⚲ ⇒ v1.10.0
  [3bb67fe8] ~ TranscodingStreams v0.9.11 ⚲ ⇒ v0.9.11
  [ea10d353] ~ WeakRefStrings v1.4.2 ⚲ ⇒ v1.4.2
  [76eceee3] ~ WorkerUtilities v1.6.1 ⚲ ⇒ v1.6.1
  [56f22d72] ~ Artifacts ⚲ ⇒ 
  [2a0f44e3] ~ Base64 ⚲ ⇒ 
  [ade2ca70] ~ Dates ⚲ ⇒ 
  [9fa8497b] ~ Future ⚲ ⇒ 
  [b77e0a4c] ~ InteractiveUtils ⚲ ⇒ 
  [8f399da3] ~ Libdl ⚲ ⇒ 
  [37e2e46d] ~ LinearAlgebra ⚲ ⇒ 
  [56ddb016] ~ Logging ⚲ ⇒ 
  [d6f4376e] ~ Markdown ⚲ ⇒ 
  [a63ad114] ~ Mmap ⚲ ⇒ 
  [de0858da] ~ Printf ⚲ ⇒ 
  [9a3f8284] ~ Random ⚲ ⇒ 
  [ea8e919c] ~ SHA v0.7.0 ⚲ ⇒ v0.7.0
  [9e88b42a] ~ Serialization ⚲ ⇒ 
  [fa267f1f] ~ TOML v1.0.3 ⚲ ⇒ v1.0.3
  [8dfed614] ~ Test ⚲ ⇒ 
  [cf7118a7] ~ UUIDs ⚲ ⇒ 
  [4ec0a83e] ~ Unicode ⚲ ⇒ 
  [e66e0078] ~ CompilerSupportLibraries_jll v1.0.2+0 ⚲ ⇒ v1.0.2+0
  [4536629a] ~ OpenBLAS_jll v0.3.21+0 ⚲ ⇒ v0.3.21+0
  [83775a58] ~ Zlib_jll v1.2.13+0 ⚲ ⇒ v1.2.13+0
  [8e850b90] ~ libblastrampoline_jll v5.2.0+0 ⚲ ⇒ v5.2.0+0
```

