### PR TITLE
add support for `Pkg.add(path="/path/to/git-submodule.jl")` directly.

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -874,7 +874,8 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
     repo_source = pkg.repo.source
     if !isurl(pkg.repo.source)
         if isdir(pkg.repo.source)
-            if !isdir(joinpath(pkg.repo.source, ".git"))
+            git_info_path   =   (path -> !isfile(path) ? path : joinpath(dirname(path), (last∘split∘readline)(path)))(joinpath(pkg.repo.source, ".git"))
+            if !isdir(git_info_path)
                 msg = "Did not find a git repository at `$(pkg.repo.source)`"
                 if isfile(joinpath(pkg.repo.source, "Project.toml")) || isfile(joinpath(pkg.repo.source, "JuliaProject.toml"))
                     msg *= ", perhaps you meant `Pkg.develop`?"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -874,7 +874,15 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
     repo_source = pkg.repo.source
     if !isurl(pkg.repo.source)
         if isdir(pkg.repo.source)
-            git_info_path   =   (path -> !isfile(path) ? path : joinpath(dirname(path), (last∘split∘readline)(path)))(joinpath(pkg.repo.source, ".git"))
+            git_path = joinpath(pkg.repo.source, ".git")
+            if isfile(git_path)
+                # Git submodule: .git is a file containing path to actual git directory
+                git_ref_content = readline(git_path)
+                git_info_path = joinpath(dirname(git_path), last(split(git_ref_content)))
+            else
+                # Regular git repo: .git is a directory
+                git_info_path = git_path
+            end
             if !isdir(git_info_path)
                 msg = "Did not find a git repository at `$(pkg.repo.source)`"
                 if isfile(joinpath(pkg.repo.source, "Project.toml")) || isfile(joinpath(pkg.repo.source, "JuliaProject.toml"))


### PR DESCRIPTION
For #3340.

It seems the `ERROR: Did not find a git repository at /path/to/git-submodule.jl` is generated from the code of
```julia
if !isdir(joinpath(pkg.repo.source, ".git"))
    ...
end
```
Then I suggest that the modification as
```julia
git_info_path   =   (path -> !isfile(path) ? path : joinpath(dirname(path), (last∘split∘readline)(path)))(joinpath(pkg.repo.source, ".git"))
if !isdir(git_info_path)
    ...
end
```
which can resolve the real path to the directory `.git/` (generally `/path-to-super-git-repository/.git/modules/name-of-git-submodule.jl`) of the git submodule.

I have tested this modification at 
```log
Julia Version 1.8.5
Commit 17cfb8e65ea (2023-01-08 06:45 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin21.5.0)
  CPU: 8 × Apple M1
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, apple-m1)
  Threads: 1 on 4 virtual cores
```
It works as my expectation.
Further tests may be required.