### PR TITLE
Fix a minor manifest file detection issue

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -360,7 +360,8 @@ function EnvCache(env::Union{Nothing,String}=nothing)
     dir = abspath(project_dir)
     manifest_file = project.manifest
     manifest_file = manifest_file !== nothing ?
-        abspath(manifest_file) : manifestfile_path(dir)::String
+        (isabspath(manifest_file) ? manifest_file : abspath(dir, manifest_file)) :
+        manifestfile_path(dir)::String
     write_env_usage(manifest_file, "manifest_usage.toml")
     manifest = read_manifest(manifest_file)
 


### PR DESCRIPTION
This is due to an oversight on my part in https://github.com/JuliaLang/Pkg.jl/pull/3303 where I didn't realize you could be in a different directory than the currently activated environment. In such a setup, and if the project manually specified a manifest to use, we weren't getting the manifest file path _relative_ to the project directory if the provided path was indeed relative. The fix here is to first check if the manually provided manifest path is already abspath, and if not, ensure we get the abspath _relative_ to the the project directory.