### PR TITLE
precompile: shorten trailing task warning

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1355,7 +1355,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                                 anim_char = anim_chars[(i + Int(dep.name[1])) % length(anim_chars) + 1]
                                 anim_char_colored = dep in direct_deps ? anim_char : color_string(anim_char, :light_black)
                                 waiting = if dep in taskwaiting
-                                    color_string(" Waiting for background task, IO, or timer to finish. Interrupt to inspect", Base.warn_color())
+                                    color_string(" Waiting for background task / IO / timer. Interrupt to inspect", Base.warn_color())
                                 else
                                     ""
                                 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1285,7 +1285,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 stderr_outputs[pkg] = get(stderr_outputs, pkg, "") * str * "\n"
                 if !in(pkg, taskwaiting) && occursin("waiting for IO to finish", str)
                     !fancyprint && lock(print_lock) do
-                        println(io, pkg.name, color_string(" Waiting for background task, IO, or timer to finish.", Base.warn_color()))
+                        println(io, pkg.name, color_string(" Waiting for background task / IO / timer.", Base.warn_color()))
                     end
                     push!(taskwaiting, pkg)
                 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1355,7 +1355,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                                 anim_char = anim_chars[(i + Int(dep.name[1])) % length(anim_chars) + 1]
                                 anim_char_colored = dep in direct_deps ? anim_char : color_string(anim_char, :light_black)
                                 waiting = if dep in taskwaiting
-                                    color_string(" Waiting for background task, IO, or timer to finish. Use ctrl-c to interrupt and inspect warnings", Base.warn_color())
+                                    color_string(" Waiting for background task, IO, or timer to finish. Interrupt to inspect", Base.warn_color())
                                 else
                                     ""
                                 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -225,7 +225,7 @@ end
             Pkg.precompile(io=iob)
             str = String(take!(iob))
             @test occursin("Precompiling", str)
-            @test occursin("Waiting for background task, IO, or timer to finish.", str)
+            @test occursin("Waiting for background task / IO / timer.", str)
         end
     end end
     # ignoring circular deps, to avoid deadlock


### PR DESCRIPTION
Longer is more likely to wrap around and mess up the printing