### PR TITLE
fixup jll versions that are supposed to stay fixed during e.g Pkg.add

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -2109,7 +2109,12 @@ function handle_package_input!(pkg::PackageSpec)
                          subdir = pkg.subdir)
     pkg.path = nothing
     pkg.tree_hash = nothing
-    pkg.version = pkg.version === nothing ? VersionSpec() : VersionSpec(pkg.version)
+    if pkg.version === nothing
+        pkg.version = VersionSpec()
+    end
+    if !(pkg.version isa VersionNumber)
+        pkg.version = VersionSpec(pkg.version)
+    end
     pkg.uuid = pkg.uuid isa String ? UUID(pkg.uuid) : pkg.uuid
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -402,7 +402,8 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
     vers_fix = copy(vers)
     for (uuid, vers) in vers
         old_v = get(jll_fix, uuid, nothing)
-        if old_v !== nothing
+        # We only fixup a JLL if the old major/minor/patch matches the new major/minor/patch
+        if old_v !== nothing && Base.thispatch(old_v) == Base.thispatch(vers_fix[uuid])
             vers_fix[uuid] = old_v
         end
     end

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -570,7 +570,9 @@ This includes:
   * The `name` of the package.
   * The package's unique `uuid`.
   * A `version` (for example when adding a package). When upgrading, can also be an instance of
-    the enum [`UpgradeLevel`](@ref).
+    the enum [`UpgradeLevel`](@ref). If the version is given as a `String`` this means that unspecified versions
+    are "free", for example `version="0.5"` allows any version `0.5.x` to be installed. If given as a `VersionNumber`,
+    the exact version is used, for example `version=v"0.5.3"`.
   * A `url` and an optional git `rev`ision. `rev` can be a branch name or a git commit SHA1.
   * A local `path`. This is equivalent to using the `url` argument but can be more descriptive.
   * A `subdir` which can be used when adding a package that is not in the root of a repository.
@@ -593,6 +595,7 @@ Below is a comparison between the REPL mode and the functional API:
 |:---------------------|:------------------------------------------------------|
 | `Package`            | `PackageSpec("Package")`                              |
 | `Package@0.2`        | `PackageSpec(name="Package", version="0.2")`          |
+| -                    | `PackageSpec(name="Package", version=v"0.2.1")`       |
 | `Package=a67d...`    | `PackageSpec(name="Package", uuid="a67d...")`         |
 | `Package#master`     | `PackageSpec(name="Package", rev="master")`           |
 | `local/path#feature` | `PackageSpec(path="local/path"; rev="feature")`       |

--- a/test/new.jl
+++ b/test/new.jl
@@ -685,7 +685,7 @@ end
 
     # helper for installing a specific JLL build, then moving the registry to a position where a new build exists
     function add_specific_jll_build()
-        cd(only(dirname(Pkg.Types.Context().registries.path))) do
+        cd(dirname(only(Pkg.Types.Context().registries).path)) do
             run(`git checkout ae8ec3b695efb04ddec4371b97477779b6c62549`) # where ImageMagick_jl 6.9.11+3 exists
             Pkg.add(name="ImageMagick_jll", version="6.9.11")
             @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
@@ -762,7 +762,7 @@ end
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     # reset registry state
-    cd(only(dirname(Pkg.Types.Context().registries.path))) do
+    cd(dirname(only(Pkg.Types.Context().registries).path)) do
         run(`git checkout master`)
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -680,55 +680,90 @@ end
             @test pkg.version == v"0.3.0"
         end
     end end
+
     # Preserve syntax
+
+    # helper for installing a specific JLL build, then moving the registry to a position where a new build exists
+    function add_specific_jll_build()
+        cd(only(dirname(Pkg.Types.Context().registries.path))) do
+            run(`git checkout ae8ec3b695efb04ddec4371b97477779b6c62549`) # where ImageMagick_jl 6.9.11+3 exists
+            Pkg.add(name="ImageMagick_jll", version="6.9.11")
+            @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+            run(`git checkout 3dd229c080a140cf67146ceb3ed6dba8add22ddf`) # where ImageMagick_jl 6.9.11+4 exists
+        end
+    end
+    imjll_uuid = "c73af94c-d91f-53ed-93a7-00f77d67a9d7"
+
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.
     isolate(loaded_depot=true) do
+        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(name="JSON", version="0.18.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     # - `tiered` is the default option.
     isolate(loaded_depot=true) do
+        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_TIERED)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     # - `all` should succeed in the same way.
     isolate(loaded_depot=true) do
+        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_ALL)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     # - `direct` should also succeed in the same way.
     isolate(loaded_depot=true) do
+        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_DIRECT)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     # - `semver` should update `Example` to the highest semver compatible version.
     isolate(loaded_depot=true) do
+        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_SEMVER)
         @test Pkg.dependencies()[exuuid].version == v"0.3.3"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     #- `none` should update `Example` to the highest compatible version.
     isolate(loaded_depot=true) do
+        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_NONE)
         @test Pkg.dependencies()[exuuid].version == v"0.5.3"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+    end
+    # reset registry state
+    cd(only(dirname(Pkg.Types.Context().registries.path))) do
+        run(`git checkout master`)
     end
 end
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -681,9 +681,7 @@ end
             @test pkg.version == v"0.3.0"
         end
     end end
-
     # Preserve syntax
-
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.
     isolate(loaded_depot=true) do

--- a/test/new.jl
+++ b/test/new.jl
@@ -683,19 +683,13 @@ end
 
     # Preserve syntax
 
-    # helper for installing a specific JLL build, then moving the registry to a position where a new build exists
     imjll_uuid = UUID("c73af94c-d91f-53ed-93a7-00f77d67a9d7")
-    function add_specific_jll_build()
-        cd(dirname(only(Pkg.Types.Context().registries).path)) do
-            Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
-            @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
-        end
-    end
 
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.
     isolate(loaded_depot=true) do
-        add_specific_jll_build()
+        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
+        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
@@ -706,7 +700,7 @@ end
     end
     # - `tiered` is the default option.
     isolate(loaded_depot=true) do
-        add_specific_jll_build()
+        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
@@ -717,7 +711,7 @@ end
     end
     # - `all` should succeed in the same way.
     isolate(loaded_depot=true) do
-        add_specific_jll_build()
+        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
@@ -728,7 +722,7 @@ end
     end
     # - `direct` should also succeed in the same way.
     isolate(loaded_depot=true) do
-        add_specific_jll_build()
+        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
@@ -739,7 +733,6 @@ end
     end
     # - `semver` should update `Example` to the highest semver compatible version.
     isolate(loaded_depot=true) do
-        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
@@ -749,7 +742,6 @@ end
     end
     #- `none` should update `Example` to the highest compatible version.
     isolate(loaded_depot=true) do
-        add_specific_jll_build()
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"

--- a/test/new.jl
+++ b/test/new.jl
@@ -684,15 +684,13 @@ end
     # Preserve syntax
 
     # helper for installing a specific JLL build, then moving the registry to a position where a new build exists
+    imjll_uuid = UUID("c73af94c-d91f-53ed-93a7-00f77d67a9d7")
     function add_specific_jll_build()
         cd(dirname(only(Pkg.Types.Context().registries).path)) do
-            run(`git checkout ae8ec3b695efb04ddec4371b97477779b6c62549`) # where ImageMagick_jl 6.9.11+3 exists
-            Pkg.add(name="ImageMagick_jll", version="6.9.11")
+            Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
             @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
-            run(`git checkout 3dd229c080a140cf67146ceb3ed6dba8add22ddf`) # where ImageMagick_jl 6.9.11+4 exists
         end
     end
-    imjll_uuid = "c73af94c-d91f-53ed-93a7-00f77d67a9d7"
 
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.
@@ -748,7 +746,6 @@ end
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_SEMVER)
         @test Pkg.dependencies()[exuuid].version == v"0.3.3"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
     #- `none` should update `Example` to the highest compatible version.
     isolate(loaded_depot=true) do
@@ -759,12 +756,9 @@ end
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_NONE)
         @test Pkg.dependencies()[exuuid].version == v"0.5.3"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
     end
-    # reset registry state
-    cd(dirname(only(Pkg.Types.Context().registries).path)) do
-        run(`git checkout master`)
-    end
+    Pkg.add(name="ImageMagick_jll", version=v"6.9.11+4")
+    @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+4"
 end
 
 #

--- a/test/new.jl
+++ b/test/new.jl
@@ -18,6 +18,7 @@ test_stdlib_uuid = UUID("8dfed614-e22c-5e08-85e1-65c5234f0b40")
 unicode_uuid = UUID("4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5")
 unregistered_uuid = UUID("dcb67f36-efa0-11e8-0cef-2fc465ed98ae")
 simple_package_uuid = UUID("fc6b7c0f-8a2f-4256-bbf4-8c72c30df5be")
+pngjll_uuid = UUID("b53b4c65-9356-5827-b1ea-8c7a1a84506f")
 
 # Disable auto-gc for these tests
 Pkg._auto_gc_enabled[] = false
@@ -683,74 +684,78 @@ end
 
     # Preserve syntax
 
-    imjll_uuid = UUID("c73af94c-d91f-53ed-93a7-00f77d67a9d7")
-
     # These tests mostly check the REPL side correctness.
     # - Normal add should not change the existing version.
     isolate(loaded_depot=true) do
-        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        Pkg.add(name="libpng_jll", version=v"1.6.37+4")
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(name="JSON", version="0.18.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
     end
     # - `tiered` is the default option.
     isolate(loaded_depot=true) do
-        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
+        Pkg.add(name="libpng_jll", version=v"1.6.37+4")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_TIERED)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
     end
     # - `all` should succeed in the same way.
     isolate(loaded_depot=true) do
-        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
+        Pkg.add(name="libpng_jll", version=v"1.6.37+4")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_ALL)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
     end
     # - `direct` should also succeed in the same way.
     isolate(loaded_depot=true) do
-        Pkg.add(name="ImageMagick_jll", version=v"6.9.11+3")
+        Pkg.add(name="libpng_jll", version=v"1.6.37+4")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_DIRECT)
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
     end
-    # - `semver` should update `Example` to the highest semver compatible version.
+    # - `semver` should update `Example` and the jll to the highest semver compatible version.
     isolate(loaded_depot=true) do
+        Pkg.add(name="libpng_jll", version=v"1.6.37+4")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_SEMVER)
         @test Pkg.dependencies()[exuuid].version == v"0.3.3"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[pngjll_uuid].version > v"1.6.37+4"
     end
-    #- `none` should update `Example` to the highest compatible version.
+    #- `none` should update `Example` and the jll to the highest compatible version.
     isolate(loaded_depot=true) do
+        Pkg.add(name="libpng_jll", version=v"1.6.37+4")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
-        @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+3"
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_NONE)
         @test Pkg.dependencies()[exuuid].version == v"0.5.3"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
+        @test Pkg.dependencies()[pngjll_uuid].version > v"1.6.37+4"
     end
-    Pkg.add(name="ImageMagick_jll", version=v"6.9.11+4")
-    @test Pkg.dependencies()[imjll_uuid].version == v"6.9.11+4"
+    isolate(loaded_depot=true) do
+        Pkg.add(name="libpng_jll", version=v"1.6.37+5")
+        @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+5"
+    end
 end
 
 #


### PR DESCRIPTION
Alternative to https://github.com/JuliaLang/Pkg.jl/pull/3368. This is a bit of a more "surgical" fix to the issue of jlls getting updated from e.g. `Pkg.add` than trying to fully support build numbers in the resolver etc. 