### PR TITLE
Various updates to extension documentation

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -415,9 +415,12 @@ This is done by making the following changes (using the example above):
 
 #### Using an extension while supporting older Julia versions
 
-If you want to use an extension with compatibility constraints while supporting earlier Julia
-versions you have to duplicate the packages under `[weakdeps]` into `[extras]`. This is an unfortunate
-duplication, but without doing this the project verifier under older Julia versions will throw an error.
+In the case where one wants to use an extension (without worrying about the
+feature of the extension begin available on older Julia versions) while still
+supporting older Julia versions the packages under `[weakdeps]` should be
+duplicated into `[extras]`. This is an unfortunate duplication, but without
+doing this the project verifier under older Julia versions will throw an error
+if it finds packages under `[compat]` that is not listed in `[extras]`.
 
 ## Package naming guidelines
 

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -407,8 +407,6 @@ This is done by making the following changes (using the example above):
   end
   ```
 
-Note that changing behavior from automatic to conditional may be a breaking change, and may require a major version bump.
-
 #### Using an extension while supporting older Julia versions
 
 If you want to use an extension with compatibility constraints while supporting earlier Julia

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -306,7 +306,7 @@ Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 # name of extension to the left
 # extension dependencies required to load the extension to the right
 # use a list for multiple extension dependencies
-ContourExt = "Contour"
+PlottingContourExt = "Contour"
 
 [compat]
 Contour = "0.6.2"
@@ -323,9 +323,9 @@ end
 end # module
 ```
 
-`ext/ContourExt.jl` (can also be in `ext/ContourExt/ContourExt.jl`):
+`ext/PlottingContourExt.jl` (can also be in `ext/PlottingContourExt/PlottingContourExt.jl`):
 ```julia
-module ContourExt # Should be same name as the file (just like a normal package)
+module PlottingContourExt # Should be same name as the file (just like a normal package)
 
 using Plotting, Contour
 
@@ -336,12 +336,15 @@ end
 end # module
 ```
 
-A user that depends only on `Plotting` will not pay the cost of the "extension" inside the `ContourExt` module.
-It is only when the `Contour` package actually gets loaded that the `ContourExt` extension is loaded
+The name of the extension (here `PlottingContourExt`) is not very important but using something similar to the suggest here is likely a good
+idea.
+
+A user that depends only on `Plotting` will not pay the cost of the "extension" inside the `PlottingContourExt` module.
+It is only when the `Contour` package actually gets loaded that the `PlottingContourExt` extension is loaded
 and provides the new functionality.
 
-If one considers `ContourExt` as a completely separate package, it could be argued that defining `Plotting.plot(c::Contour.ContourCollection)` is
-[type piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) since `ContourExt` _owns_ neither the method `Plotting.plot` nor the type `Contour.ContourCollection`.
+If one considers `PlottingContourExt` as a completely separate package, it could be argued that defining `Plotting.plot(c::Contour.ContourCollection)` is
+[type piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) since `PlottingContourExt` _owns_ neither the method `Plotting.plot` nor the type `Contour.ContourCollection`.
 However, for extensions, it is ok to assume that the extension owns the methods in its parent package.
 In fact, this form of type piracy is one of the most standard use cases for extensions.
 
@@ -374,7 +377,7 @@ This is done by making the following changes (using the example above):
   if !isdefined(Base, :get_extension)
   using Requires
   function __init__()
-      @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/ContourExt.jl")
+      @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")
   end
   end
   ```
@@ -388,7 +391,7 @@ This is done by making the following changes (using the example above):
       # Other init functionality here
 
       @static if !isdefined(Base, :get_extension)
-          @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/ContourExt.jl")
+          @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")
       end
   end
   ```
@@ -409,7 +412,7 @@ This is done by making the following changes (using the example above):
 - Add the following to your main package file (typically at the bottom):
   ```julia
   if !isdefined(Base, :get_extension)
-    include("../ext/ContourExt.jl")
+    include("../ext/PlottingContourExt.jl")
   end
   ```
 

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -250,6 +250,9 @@ This is an important topic so there is a separate chapter about it: [Compatibili
 !!! note
     This is a somewhat advanced usage of Pkg which can be skipped for people new to Julia and Julia packages.
 
+!!! compat
+    The described feature requires Julia 1.9+.
+
 A weak dependency is a dependency that will not automatically install when the package is installed but
 you can still control what versions of that package are allowed to be installed by setting compatibility on it.
 These are listed in the project file under the `[weakdeps]` section:
@@ -268,6 +271,9 @@ The current usage of this is almost solely limited to "extensions" which is desc
 
 !!! note
     This is a somewhat advanced usage of Pkg which can be skipped for people new to Julia and Julia packages.
+
+!!! compat
+    The described feature requires Julia 1.9+.
 
 Sometimes one wants to make two or more packages work well together, but may be reluctant (perhaps due to increased load times) to make one an unconditional dependency of the other.
 A package *extension* is a module in a file (similar to a package) that is automatically loaded when *some other set of packages* are


### PR DESCRIPTION


- The breaking-changing note was too harsh IMO. It is unlikely that moving to an extension is breaking, at least in the typical usage of extensions.
- Suggest the name of the extension to be `[Parent][Weakdep]Ext`. Having the parent in the name will likely avoid ambiguities when the module is printed in various contexts.