### PR TITLE
Add `PRESERVE_ALL_INSTALLED` and `PRESERVE_TIERED_INSTALLED` strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Pkg v1.9 Release Notes
   or `pkg> add https://github.com/Org/Package.jl/commit/bb9eb77e6dc`.
 - Timing of the precompilation of dependencies can now be reported via `Pkg.precompile(timing=true)` ([#3334])
 - Bug fix on `pin/free --all` which now correctly applies to all dependencies, not just direct dependencies ([#3346]).
+- To reduce the amount of time spent downloading and precompiling new package versions when working with multiple
+  environments, a new preserve strategy `PRESERVE_ALL_INSTALLED` has been added which will preserve all existing
+  dependencies and only add versions of the new packages that are already installed. i.e. `pkg> add --preserve=installed Foo`.
+  Also a new tiered resolve strategy `PRESERVE_TIERED_INSTALLED` that tries this first, which can be set to the default
+  strategy by setting the env var `JULIA_PKG_PRESERVE_TIERED_INSTALLED` to `true` ([#3378]).
 
 Pkg v1.8 Release Notes
 ======================

--- a/src/API.jl
+++ b/src/API.jl
@@ -180,7 +180,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status, :why, :
 end
 
 function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
-                 preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform(), kwargs...)
+                 preserve::PreserveLevel=Operations.default_preserve(), platform::AbstractPlatform=HostPlatform(), kwargs...)
     require_not_empty(pkgs, :develop)
     Context!(ctx; kwargs...)
 
@@ -223,7 +223,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
     return
 end
 
-function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PRESERVE_TIERED,
+function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=Operations.default_preserve(),
              platform::AbstractPlatform=HostPlatform(), kwargs...)
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -21,6 +21,14 @@ import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_
 # Utils #
 #########
 
+function default_preserve()
+    if Base.get_bool_env("JULIA_PKG_PRESERVE_TIERED_INSTALLED", false)
+        PRESERVE_TIERED_INSTALLED
+    else
+        PRESERVE_TIERED
+    end
+end
+
 function find_installed(name::String, uuid::UUID, sha1::SHA1)
     slug_default = Base.version_slug(uuid, sha1)
     # 4 used to be the default so look there first
@@ -52,7 +60,7 @@ function load_version(version, fixed, preserve::PreserveLevel)
         return VersionSpec() # some stdlibs dont have a version
     elseif fixed
         return version # dont change state if a package is fixed
-    elseif preserve == PRESERVE_ALL || preserve == PRESERVE_DIRECT
+    elseif preserve == PRESERVE_ALL || preserve == PRESERVE_ALL_INSTALLED || preserve == PRESERVE_DIRECT
         return something(version, VersionSpec())
     elseif preserve == PRESERVE_SEMVER && version != VersionSpec()
         return Types.semver_spec("$(version.major).$(version.minor).$(version.patch)")
@@ -337,7 +345,9 @@ dropbuild(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch, isempty(v
 # sets version to a VersionNumber
 # adds any other packages which may be in the dependency graph
 # all versioned packages should have a `tree_hash`
-function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
+function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
+                           installed_only::Bool)
+    installed_only = installed_only || OFFLINE_MODE[]
     # compatibility
     if julia_version !== nothing
         # only set the manifest julia_version if ctx.julia_version is not nothing
@@ -394,7 +404,7 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
     # happened on a different julia version / commit and the stdlib version in the manifest is not the current stdlib version
     unbind_stdlibs = julia_version === VERSION
     reqs = Resolve.Requires(pkg.uuid => is_stdlib(pkg.uuid) && unbind_stdlibs ? VersionSpec("*") : VersionSpec(pkg.version) for pkg in pkgs)
-    graph, compat_map = deps_graph(env, registries, names, reqs, fixed, julia_version)
+    graph, compat_map = deps_graph(env, registries, names, reqs, fixed, julia_version, installed_only)
     Resolve.simplify_graph!(graph)
     vers = Resolve.resolve(graph)
 
@@ -451,7 +461,8 @@ get_or_make!(d::Dict{K,V}, k::K) where {K,V} = get!(d, k) do; V() end
 const JULIA_UUID = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
 const PKGORIGIN_HAVE_VERSION = :version in fieldnames(Base.PkgOrigin)
 function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}, uuid_to_name::Dict{UUID,String},
-                    reqs::Resolve.Requires, fixed::Dict{UUID,Resolve.Fixed}, julia_version)
+                    reqs::Resolve.Requires, fixed::Dict{UUID,Resolve.Fixed}, julia_version,
+                    installed_only::Bool)
     uuids = Set{UUID}()
     union!(uuids, keys(reqs))
     union!(uuids, keys(fixed))
@@ -525,7 +536,7 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
                             # Filter yanked and if we are in offline mode also downloaded packages
                             # TODO, pull this into a function
                             Registry.isyanked(info, v) && continue
-                            if Pkg.OFFLINE_MODE[]
+                            if installed_only
                                 pkg_spec = PackageSpec(name=pkg.name, uuid=pkg.uuid, version=v, tree_hash=Registry.treehash(info, v))
                                 is_package_downloaded(env.project_file, pkg_spec) || continue
                             end
@@ -1302,46 +1313,64 @@ function assert_can_add(ctx::Context, pkgs::Vector{PackageSpec})
     end
 end
 
-function tiered_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
+function tiered_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
+                        try_all_installed::Bool)
+    if try_all_installed
+        try # do not modify existing subgraph and only add installed versions of the new packages
+            @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
+        catch err
+            err isa Resolve.ResolverError || rethrow()
+        end
+    end
     try # do not modify existing subgraph
+        @debug "tiered_resolve: trying PRESERVE_ALL"
         return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
+        @debug "tiered_resolve: trying PRESERVE_DIRECT"
         return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
+        @debug "tiered_resolve: trying PRESERVE_SEMVER"
         return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
+    @debug "tiered_resolve: trying PRESERVE_NONE"
     return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
 end
 
 function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
-    if preserve == PRESERVE_ALL
+    if preserve == PRESERVE_ALL || preserve == PRESERVE_ALL_INSTALLED
         pkgs = load_all_deps(env, pkgs; preserve)
     else
         pkgs = load_direct_deps(env, pkgs; preserve)
     end
     check_registered(registries, pkgs)
 
-    deps_map = resolve_versions!(env, registries, pkgs, julia_version)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED)
     return pkgs, deps_map
 end
 
-function _resolve(io::IO, env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
+function _resolve(io::IO, env::EnvCache, registries::Vector{Registry.RegistryInstance},
+                    pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
     printpkgstyle(io, :Resolving, "package versions...")
-    return preserve == PRESERVE_TIERED ?
-        tiered_resolve(env, registries, pkgs, julia_version) :
+    if preserve == PRESERVE_TIERED_INSTALLED
+        tiered_resolve(env, registries, pkgs, julia_version, true)
+    elseif preserve == PRESERVE_TIERED
+        tiered_resolve(env, registries, pkgs, julia_version, false)
+    else
         targeted_resolve(env, registries, pkgs, preserve, julia_version)
+    end
 end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
-             preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform())
+             preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform())
     assert_can_add(ctx, pkgs)
     # load manifest data
     for (i, pkg) in pairs(pkgs)
@@ -1367,7 +1396,7 @@ end
 
 # Input: name, uuid, and path
 function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Set{UUID};
-                 preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform())
+                 preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform())
     assert_can_add(ctx, pkgs)
     # no need to look at manifest.. dev will just nuke whatever is there before
     for pkg in pkgs
@@ -1479,7 +1508,7 @@ end
 function targeted_resolve_up(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
     pkgs = load_manifest_deps_up(env, pkgs; preserve=preserve)
     check_registered(registries, pkgs)
-    deps_map = resolve_versions!(env, registries, pkgs, julia_version)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED)
     return pkgs, deps_map
 end
 
@@ -1501,7 +1530,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     else
         pkgs = load_direct_deps(ctx.env, pkgs; preserve = (level == UPLEVEL_FIXED ? PRESERVE_NONE : PRESERVE_DIRECT))
         check_registered(ctx.registries, pkgs)
-        deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version)
+        deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version, false)
     end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
@@ -1546,7 +1575,9 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
     foreach(pkg -> update_package_pin!(ctx.registries, pkg, manifest_info(ctx.env.manifest, pkg.uuid)), pkgs)
     pkgs = load_direct_deps(ctx.env, pkgs)
 
+    # TODO: maybe this needs to allow PRESERVE_ALL_INSTALLED
     pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_TIERED, ctx.julia_version)
+
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new = download_source(ctx)
     fixup_ext!(ctx.env, pkgs)
@@ -1587,6 +1618,8 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free=true)
     if any(pkg -> pkg.version == VersionSpec(), pkgs)
         pkgs = load_direct_deps(ctx.env, pkgs)
         check_registered(ctx.registries, pkgs)
+
+        # TODO: maybe this needs to allow PRESERVE_ALL_INSTALLED
         pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_TIERED, ctx.julia_version)
 
         update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1575,7 +1575,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
     foreach(pkg -> update_package_pin!(ctx.registries, pkg, manifest_info(ctx.env.manifest, pkg.uuid)), pkgs)
     pkgs = load_direct_deps(ctx.env, pkgs)
 
-    # TODO: maybe this needs to allow PRESERVE_ALL_INSTALLED
+    # TODO: change pin to not take a version and just have it pin on the current version. Then there is no need to resolve after a pin
     pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_TIERED, ctx.julia_version)
 
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
@@ -1619,7 +1619,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free=true)
         pkgs = load_direct_deps(ctx.env, pkgs)
         check_registered(ctx.registries, pkgs)
 
-        # TODO: maybe this needs to allow PRESERVE_ALL_INSTALLED
+        # TODO: change free to not take a version and just have it pin on the current version. Then there is no need to resolve after a pin
         pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_TIERED, ctx.julia_version)
 
         update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -15,7 +15,7 @@ export @pkg_str
 export PackageSpec
 export PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT
 export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
-export PreserveLevel, PRESERVE_TIERED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
+export PreserveLevel, PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 export Registry, RegistrySpec
 
 depots() = Base.DEPOT_PATH
@@ -66,7 +66,7 @@ include("REPLMode/REPLMode.jl")
 import .REPLMode: @pkg_str
 import .Types: UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH, UPLEVEL_FIXED
 import .Types: PKGMODE_MANIFEST, PKGMODE_PROJECT
-import .Types: PRESERVE_TIERED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
+import .Types: PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 
 # Import artifacts API
 using .Artifacts, .PlatformEngines
@@ -105,8 +105,8 @@ const PreserveLevel = Types.PreserveLevel
 
 # Define new variables so tab comleting Pkg. works.
 """
-    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED)
-    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED)
+    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, installed=false)
+    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, installed=false)
 
 Add a package to the current project. This package will be available by using the
 `import` and `using` keywords in the Julia REPL, and if the current project is
@@ -117,18 +117,34 @@ a package, also inside that package.
 The `preserve` keyword argument allows you to key into a specific tier in the resolve algorithm.
 The following table describes the argument values for `preserve` (in order of strictness):
 
-| Value             | Description                                                                         |
-|:------------------|:------------------------------------------------------------------------------------|
-| `PRESERVE_ALL`    | Preserve the state of all existing dependencies (including recursive dependencies)  |
-| `PRESERVE_DIRECT` | Preserve the state of all existing direct dependencies                              |
-| `PRESERVE_SEMVER` | Preserve semver-compatible versions of direct dependencies                          |
-| `PRESERVE_NONE`   | Do not attempt to preserve any version information                                  |
-| `PRESERVE_TIERED` | Use the tier which will preserve the most version information (this is the default) |
+| Value                       | Description                                                                          |
+|:----------------------------|:-------------------------------------------------------------------------------------|
+| `PRESERVE_ALL_INSTALLED`    | Like `PRESERVE_ALL` and only add those already installed                             |
+| `PRESERVE_ALL`              | Preserve the state of all existing dependencies (including recursive dependencies)   |
+| `PRESERVE_DIRECT`           | Preserve the state of all existing direct dependencies                               |
+| `PRESERVE_SEMVER`           | Preserve semver-compatible versions of direct dependencies                           |
+| `PRESERVE_NONE`             | Do not attempt to preserve any version information                                   |
+| `PRESERVE_TIERED_INSTALLED` | Like `PRESERVE_TIERED` except `PRESERVE_ALL_INSTALLED` is tried first                |
+| `PRESERVE_TIERED`           | Use the tier which will preserve the most version information (this is the default)  |
+
+!!! note
+    To change the default strategy to `PRESERVE_TIERED_INSTALLED` set the env var `JULIA_PKG_PRESERVE_TIERED_INSTALLED`
+    to true.
+
+After the installation of new packages the project will be precompiled. For more information see `pkg> ?precompile`.
+
+With the `PRESERVE_ALL_INSTALLED` strategy the newly added packages will likely already be precompiled, but if not this
+may be because either the combination of package versions resolved in this environment has not been resolved and
+precompiled before, or the precompile cache has been deleted by the LRU cache storage
+(see JULIA_MAX_NUM_PRECOMPILE_FILES).
+
+!!! compat "Julia 1.9"
+    The `PRESERVE_TIERED_INSTALLED` and `PRESERVE_ALL_INSTALLED` strategies requires at least Julia 1.9.
 
 # Examples
 ```julia
 Pkg.add("Example") # Add a package from registry
-Pkg.add("Example"; preserve=Pkg.PRESERVE_ALL) # Add the `Example` package and preserve existing dependencies
+Pkg.add("Example"; preserve=Pkg.PRESERVE_ALL) # Add the `Example` package and strictly preserve existing dependencies
 Pkg.add(name="Example", version="0.3") # Specify version; latest release in the 0.3 series
 Pkg.add(name="Example", version="0.3.1") # Specify version; exact release
 Pkg.add(url="https://github.com/JuliaLang/Example.jl", rev="master") # From url to remote gitrepo
@@ -333,8 +349,8 @@ const free = API.free
 
 
 """
-    Pkg.develop(pkg::Union{String, Vector{String}}; io::IO=stderr)
-    Pkg.develop(pkgs::Union{PackageSpec, Vector{PackageSpec}}; io::IO=stderr)
+    Pkg.develop(pkg::Union{String, Vector{String}}; io::IO=stderr, preserve=PRESERVE_TIERED, installed=false)
+    Pkg.develop(pkgs::Union{PackageSpec, Vector{PackageSpec}}; io::IO=stderr, preserve=PRESERVE_TIERED, installed=false)
 
 Make a package available for development by tracking it by path.
 If `pkg` is given with only a name or by a URL, the package will be downloaded
@@ -342,6 +358,9 @@ to the location specified by the environment variable `JULIA_PKG_DEVDIR`, with
 `joinpath(DEPOT_PATH[1],"dev")` being the default.
 
 If `pkg` is given as a local path, the package at that path will be tracked.
+
+The preserve strategies offered by `Pkg.add` are also available via the `preserve` kwarg.
+See [`Pkg.add`](@ref) for more information.
 
 # Examples
 ```julia

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -232,10 +232,12 @@ end
 # # Option Maps
 #
 function do_preserve(x::String)
-    x == "all"    && return Types.PRESERVE_ALL
-    x == "direct" && return Types.PRESERVE_DIRECT
-    x == "semver" && return Types.PRESERVE_SEMVER
-    x == "none"   && return Types.PRESERVE_NONE
-    x == "tiered" && return Types.PRESERVE_TIERED
+    x == "installed"        && return Types.PRESERVE_ALL_INSTALLED
+    x == "all"              && return Types.PRESERVE_ALL
+    x == "direct"           && return Types.PRESERVE_DIRECT
+    x == "semver"           && return Types.PRESERVE_SEMVER
+    x == "none"             && return Types.PRESERVE_NONE
+    x == "tiered_installed" && return Types.PRESERVE_TIERED_INSTALLED
+    x == "tiered"           && return Types.PRESERVE_TIERED
     pkgerror("`$x` is not a valid argument for `--preserve`.")
 end

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -123,15 +123,25 @@ If the package is not located at the top of the git repository, a subdirectory c
 The `--preserve` command line option allows you to key into a specific tier in the resolve algorithm.
 The following table describes the command line arguments to `--preserve` (in order of strictness).
 
-| Argument | Description                                                                         |
-|:---------|:------------------------------------------------------------------------------------|
-| `all`    | Preserve the state of all existing dependencies (including recursive dependencies)  |
-| `direct` | Preserve the state of all existing direct dependencies                              |
-| `semver` | Preserve semver-compatible versions of direct dependencies                          |
-| `none`   | Do not attempt to preserve any version information                                  |
-| `tiered` | Use the tier which will preserve the most version information (this is the default) |
+| Argument           | Description                                                                          |
+|:-------------------|:-------------------------------------------------------------------------------------|
+| `installed`        | Like `all` except also only add versions that are already installed                  |
+| `all`              | Preserve the state of all existing dependencies (including recursive dependencies)   |
+| `direct`           | Preserve the state of all existing direct dependencies                               |
+| `semver`           | Preserve semver-compatible versions of direct dependencies                           |
+| `none`             | Do not attempt to preserve any version information                                   |
+| `tiered_installed` | Like `tiered` except first try to add only installed versions                        |
+| `tiered`           | Use the tier which will preserve the most version information (this is the default)  |
+
+Note: To make the default strategy `tiered_installed` set the env var `JULIA_PKG_PRESERVE_TIERED_INSTALLED` to
+true.
 
 After the installation of new packages the project will be precompiled. For more information see `pkg> ?precompile`.
+
+With the `installed` strategy the newly added packages will likely already be precompiled, but if not this may be
+because either the combination of package versions resolved in this environment has not been resolved and
+precompiled before, or the precompile cache has been deleted by the LRU cache storage
+(see JULIA_MAX_NUM_PRECOMPILE_FILES).
 
 **Examples**
 ```
@@ -175,6 +185,9 @@ When `--local` is given, the clone is placed in a `dev` folder in the current pr
 is not supported for paths, only registered packages.
 
 This operation is undone by `free`.
+
+The preserve strategies offered by `add` are also available via the `preserve` argument.
+See `add` for more information.
 
 **Examples**
 ```jl

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -29,7 +29,8 @@ export UUID, SHA1, VersionRange, VersionSpec,
     read_project, read_package, read_manifest,
     PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT, PKGMODE_COMBINED,
     UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR,
-    PreserveLevel, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_NONE,
+    PreserveLevel, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED,
+    PRESERVE_TIERED_INSTALLED, PRESERVE_NONE,
     projectfile_path, manifestfile_path
 
 # Load in data about historical stdlibs
@@ -73,7 +74,7 @@ Base.showerror(io::IO, err::PkgError) = print(io, err.msg)
 # PackageSpec #
 ###############
 @enum(UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR)
-@enum(PreserveLevel, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_NONE)
+@enum(PreserveLevel, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_TIERED_INSTALLED, PRESERVE_NONE)
 @enum(PackageMode, PKGMODE_PROJECT, PKGMODE_MANIFEST, PKGMODE_COMBINED)
 
 const VersionTypes = Union{VersionNumber,VersionSpec,UpgradeLevel}
@@ -141,7 +142,7 @@ isresolved(pkg::PackageSpec) = pkg.uuid !== nothing && pkg.name !== nothing
 function Base.show(io::IO, pkg::PackageSpec)
     vstr = repr(pkg.version)
     f = Pair{String, Any}[]
-    
+
     pkg.name !== nothing && push!(f, "name" => pkg.name)
     pkg.uuid !== nothing && push!(f, "uuid" => pkg.uuid)
     pkg.tree_hash !== nothing && push!(f, "tree_hash" => pkg.tree_hash)


### PR DESCRIPTION
Updated:

New `PRESERVE_ALL_INSTALLED` preserve strategy that is like `PRESERVE_ALL` except it also only selects installed versions of the new packages. 

New `PRESERVE_TIERED_INSTALLED` strategy that tries `PRESERVE_ALL_INSTALLED` first.

To opt-in to `PRESERVE_TIERED_INSTALLED` being the default set the env var `JULIA_PKG_PRESERVE_TIERED_INSTALLED=true` 

Discussion in:
- https://discourse.julialang.org/t/first-pluto-notebook-launches-are-slower-on-julia-1-9-beta-3/93429/158
- https://github.com/JuliaLang/Pkg.jl/issues/3369