### PR TITLE
Enable JLL tests again

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -2921,7 +2921,7 @@ using Pkg.Types: is_stdlib
     @test_throws Pkg.Types.PkgError is_stdlib(networkoptions_uuid, v"1.6")
 end
 
-#=
+
 @testset "Pkg.add() with julia_version" begin
     append!(empty!(Pkg.Types.STDLIBS_BY_VERSION), HistoricalStdlibVersions.STDLIBS_BY_VERSION)
 
@@ -3026,7 +3026,7 @@ end
 
     empty!(Pkg.Types.STDLIBS_BY_VERSION)
 end
-=#
+
 
 @testset "Issue #2931" begin
     isolate(loaded_depot=false) do


### PR DESCRIPTION
Let's continue to exercise these codepaths, now that workarounds have been merged.