### PR TITLE
Create autonames.jl

### DIFF
--- a/autonames.jl
+++ b/autonames.jl
@@ -1,0 +1,8 @@
+function generate_extension_name()
+    # Extract the package name from the current environment
+    pkgname = split.(keys(Base.loaded_modules))[end][1]
+    # Remove any leading or trailing whitespace and replace dashes with underscores
+    pkgname = replace(strip(pkgname), r"-" => "_")
+    # Return the extension name
+    return "$(pkgname)Ext"
+end


### PR DESCRIPTION
Implements https://github.com/JuliaLang/Pkg.jl/issues/3380

Currently, there are lots of unnecessary repetitions in the common case:

Project.toml [extensions]
extension name SomePkgExt
package name = SomePkg
Code
file name SomePkgExt.jl
module name module SomePkgExt

Automatic naming schemes might not always work for all packages, especially those with non-standard names or naming conventions. Define a function that takes the package name as input and returns the corresponding extension name