### PR TITLE
Add test for preference sandboxing of implicit test dependencies

### DIFF
--- a/test/sandbox.jl
+++ b/test/sandbox.jl
@@ -131,6 +131,20 @@ end
     end end
 end
 
+@testset "Preferences sandboxing of implicit test dependencies" begin
+    # Preferences of FooDep (implicit test dependency via Foo)
+    # should be copied over into sandbox
+    temp_pkg_dir() do project_path; mktempdir() do tmp
+        copy_test_package(tmp, "Sandbox_PreservePrefsImplicit")
+        Pkg.activate(joinpath(tmp, "Sandbox_PreservePrefsImplicit"))
+        test_test() do
+            uuid =  UUID("ecddbb86-518e-4a4d-b30b-c11ee99fa784")
+            @test !Preferences.has_preference(uuid, "does_not_exist")
+            @test_broken Preferences.load_preference(uuid, "weather") == "sunny"
+        end
+    end end
+end
+
 @testset "Nested Preferences sandboxing" begin
     # Preferences should be copied over into sandbox
     temp_pkg_dir() do project_path; mktempdir() do tmp

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/Manifest.toml
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/Manifest.toml
@@ -1,0 +1,39 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0-DEV"
+manifest_format = "2.0"
+project_hash = "e136fd416d7f0eac7db513d485d3aaa3148ab079"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Foo]]
+deps = ["FooDep"]
+path = "dev/Foo"
+uuid = "128bfcea-dc33-4310-8fcf-6a5a6a7c0677"
+version = "0.1.0"
+
+[[deps.FooDep]]
+deps = ["Preferences"]
+path = "dev/FooDep"
+uuid = "22d90790-ba35-49ef-9cc5-1d4fefcbe869"
+version = "0.1.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.3.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/Project.toml
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/Project.toml
@@ -1,0 +1,18 @@
+authors = ["Carsten Bauer <crstnbr@gmail.com>"]
+name = "Sandbox_PreservePrefsImplicit"
+uuid = "ecddbb86-518e-4a4d-b30b-c11ee99fa784"
+version = "0.1.0"
+
+[deps]
+Foo = "128bfcea-dc33-4310-8fcf-6a5a6a7c0677"
+
+[extras]
+FooDep = "22d90790-ba35-49ef-9cc5-1d4fefcbe869"
+Foo = "128bfcea-dc33-4310-8fcf-6a5a6a7c0677"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[preferences]
+FooDep.weather = "sunny"
+
+[targets]
+test = ["Test", "Foo"]

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/dev/Foo/Manifest.toml
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/dev/Foo/Manifest.toml
@@ -1,0 +1,10 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0-DEV"
+manifest_format = "2.0"
+project_hash = "9562b3808eb1a86b32d5877e169219af8bc5346a"
+
+[[deps.FooDep]]
+path = "../FooDep"
+uuid = "22d90790-ba35-49ef-9cc5-1d4fefcbe869"
+version = "0.1.0"

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/dev/Foo/Project.toml
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/dev/Foo/Project.toml
@@ -1,0 +1,7 @@
+name = "Foo"
+uuid = "128bfcea-dc33-4310-8fcf-6a5a6a7c0677"
+authors = ["Carsten Bauer <crstnbr@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+FooDep = "22d90790-ba35-49ef-9cc5-1d4fefcbe869"

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/dev/Foo/src/Foo.jl
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/dev/Foo/src/Foo.jl
@@ -1,0 +1,5 @@
+module Foo
+
+using FooDep
+
+end # module Foo

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/dev/FooDep/Manifest.toml
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/dev/FooDep/Manifest.toml
@@ -1,0 +1,27 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.0-DEV"
+manifest_format = "2.0"
+project_hash = "5784e7f1610542ec1dd97b517265a6694167840e"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.3.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/dev/FooDep/Project.toml
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/dev/FooDep/Project.toml
@@ -1,0 +1,7 @@
+name = "FooDep"
+uuid = "22d90790-ba35-49ef-9cc5-1d4fefcbe869"
+authors = ["Carsten Bauer <crstnbr@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/dev/FooDep/src/FooDep.jl
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/dev/FooDep/src/FooDep.jl
@@ -1,0 +1,8 @@
+module FooDep
+
+using Preferences
+
+set!(key, value) = @set_preferences!(key=>value)
+get(key) = @load_preference(key)
+
+end # module FooDep

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/src/Sandbox_PreservePrefsImplicit.jl
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/src/Sandbox_PreservePrefsImplicit.jl
@@ -1,0 +1,5 @@
+module Sandbox_PreservePrefsImplicit
+
+using Foo
+
+end # module Sandbox_PreservePrefsImplicit

--- a/test/test_packages/Sandbox_PreservePrefsImplicit/test/runtests.jl
+++ b/test/test_packages/Sandbox_PreservePrefsImplicit/test/runtests.jl
@@ -1,0 +1,2 @@
+# using Foo
+# @show Foo.FooDep.get("weather")


### PR DESCRIPTION
As per request by @vchuravy, in this PR I add a test that tries to cover issue #3389, i.e. that preferences of implicit test dependencies are currently not sandboxed, but should be. Specifically, I tried to create a minimal fake dependency structure that mimics the MPI.jl / MPIPreferences.jl setup (MPI -> Foo, MPIPreferences -> FooDep). I marked the relevant test as `@test_broken` to indicate the broken status and the expected result. (Note that one gets the desired result if one makes `FooDeps` an explicit test dependency for `Sandbox_PreservePrefsImplicit`.

cc @staticfloat 