### PR TITLE
Fix usage instructions of weak deps with Requires.jl

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -394,6 +394,9 @@ This is done by making the following changes (using the example above):
   # This symbol is only defined on Julia versions that support extensions
   if !isdefined(Base, :get_extension)
   using Requires
+  end
+  
+  if !isdefined(Base, :get_extension)
   function __init__()
       @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")
   end

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -396,7 +396,7 @@ This is done by making the following changes (using the example above):
   using Requires
   end
   
-  if !isdefined(Base, :get_extension)
+  @static if !isdefined(Base, :get_extension)
   function __init__()
       @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")
   end


### PR DESCRIPTION
Doing both a top level in a single block yields a `LoadError: UndefVarError: @require not defined` (`@static` doesn't help there).