### PR TITLE
Revert #3273, unrestrict LLVM parallelism

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1435,11 +1435,8 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                     end
                     try
                         t = @elapsed ret = Logging.with_logger(Logging.NullLogger()) do
-                            # TODO: Explore allowing parallel LLVM image generation. Needs careful load balancing
-                            withenv("JULIA_IMAGE_THREADS" => "1") do
-                                # capture stderr, send stdout to devnull, don't skip loaded modules
-                                Base.compilecache(pkg, sourcepath, iob, devnull, false)
-                            end
+                            # capture stderr, send stdout to devnull, don't skip loaded modules
+                            Base.compilecache(pkg, sourcepath, iob, devnull, false)
                         end
                         t_str = timing ? string(lpad(round(t * 1e3, digits = 1), 9), " ms") : ""
                         if ret isa Base.PrecompilableError


### PR DESCRIPTION
Bad behavior from unrestricting LLVM image parallelism hasn't really been noticed, since the time spent in the parallel portion is so short and packages that benefit are typically at the tail end of precompilation. Therefore it should be a general speedup to simply allow LLVM to use as many threads as it wants, regardless of external parallelism. If bad behavior is noticed, setting `JULIA_IMAGE_THREADS=1` will return LLVM image compilation back to the original serial mode. 