### PR TITLE
Verify git-tree-sha1 of registry downloads

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -654,4 +654,22 @@ function verify(path::AbstractString, hash::AbstractString; verbose::Bool = fals
     end
 end
 
+# Verify the git-tree-sha1 hash of a compressed archive.
+function verify_archive_tree_hash(tar_gz::AbstractString, expected_hash::Base.SHA1)
+    # This can fail because unlike sha256 verification of the downloaded
+    # tarball, tree hash verification requires that the file can i) be
+    # decompressed and ii) is a proper archive.
+    calc_hash = try
+        Base.SHA1(open(Tar.tree_hash, `$(exe7z()) x $tar_gz -so`))
+    catch err
+        @warn "unable to decompress and read archive" exception=err
+        return false
+    end
+    if calc_hash != expected_hash
+        @warn "tarball content does not match expected git-tree-sha1"
+        return false
+    end
+    return true
+end
+
 end # module PlatformEngines

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -3,7 +3,7 @@ module Registry
 import ..Pkg
 using ..Pkg: depots1, printpkgstyle, stderr_f, isdir_nothrow, pathrepr, pkg_server,
              GitTools
-using ..Pkg.PlatformEngines: download_verify_unpack, download, download_verify, exe7z
+using ..Pkg.PlatformEngines: download_verify_unpack, download, download_verify, exe7z, verify_archive_tree_hash
 using UUIDs, LibGit2, TOML, Dates
 import FileWatching
 
@@ -184,13 +184,16 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             catch err
                 Pkg.Types.pkgerror("could not download $url \nException: $(sprint(showerror, err))")
             end
+            _hash = pkg_server_url_hash(url)
+            if !verify_archive_tree_hash(tmp, _hash)
+                Pkg.Types.pkgerror("unable to verify download from $url")
+            end
             if reg.name === nothing
                 # Need to look up the registry name here
                 reg_unc = uncompress_registry(tmp)
                 reg.name = TOML.parse(reg_unc["Registry.toml"])["name"]::String
             end
             mv(tmp, joinpath(regdir, reg.name * ".tar.gz"); force=true)
-            _hash = pkg_server_url_hash(url)
             reg_info = Dict("uuid" => string(reg.uuid), "git-tree-sha1" => string(_hash), "path" => reg.name * ".tar.gz")
             open(joinpath(regdir, reg.name * ".toml"), "w") do io
                 TOML.print(io, reg_info)
@@ -407,13 +410,17 @@ function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), 
                                         push!(errors, (reg.path, "failed to download from $(url). Exception: $(sprint(showerror, err))"))
                                         @goto done_tarball_read
                                     end
+                                    hash = pkg_server_url_hash(url)
+                                    if !verify_archive_tree_hash(tmp, hash)
+                                        push!(errors, (reg.path, "failed to verify download from $(url)"))
+                                        @goto done_tarball_read
+                                    end
                                     # If we have an uncompressed Pkg server registry, remove it and get the compressed version
                                     if isdir(reg.path)
                                         Base.rm(reg.path; recursive=true, force=true)
                                     end
                                     registry_path = dirname(reg.path)
                                     mv(tmp, joinpath(registry_path, reg.name * ".tar.gz"); force=true)
-                                    hash = pkg_server_url_hash(url)
                                     reg_info = Dict("uuid" => string(reg.uuid), "git-tree-sha1" => string(hash), "path" => reg.name * ".tar.gz")
                                     open(joinpath(registry_path, reg.name * ".toml"), "w") do io
                                         TOML.print(io, reg_info)


### PR DESCRIPTION
This patch adds verification of registries downloaded from Pkg server when using the default method of keeping registries as compressed tarballs. This verification is done before the registry is moved in place to ensure that a Pkg server that serves bad content does not also poison the users local machine.