### PR TITLE
Remove dead code in `registry_resolve!()`

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -912,9 +912,6 @@ registry_resolve!(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpe
 function registry_resolve!(registries::Vector{Registry.RegistryInstance}, pkgs::AbstractVector{PackageSpec})
     # if there are no half-specified packages, return early
     any(pkg -> has_name(pkg) ⊻ has_uuid(pkg), pkgs) || return
-    # collect all names and uuids since we're looking anyway
-    names = [pkg.name::String for pkg in pkgs if has_name(pkg)]
-    uuids = [pkg.uuid::UUID for pkg in pkgs if has_uuid(pkg)]
     for pkg in pkgs
         @assert has_name(pkg) || has_uuid(pkg)
         if has_name(pkg) && !has_uuid(pkg)


### PR DESCRIPTION
As far as I can tell, these vectors are not used anywhere.