### PR TITLE
Backports release 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Pkg v1.9 Release Notes
   or `pkg> add https://github.com/Org/Package.jl/commit/bb9eb77e6dc`.
 - Timing of the precompilation of dependencies can now be reported via `Pkg.precompile(timing=true)` ([#3334])
 - Bug fix on `pin/free --all` which now correctly applies to all dependencies, not just direct dependencies ([#3346]).
+- To reduce the amount of time spent downloading and precompiling new package versions when working with multiple
+  environments, a new preserve strategy `PRESERVE_ALL_INSTALLED` has been added which will preserve all existing
+  dependencies and only add versions of the new packages that are already installed. i.e. `pkg> add --preserve=installed Foo`.
+  Also a new tiered resolve strategy `PRESERVE_TIERED_INSTALLED` that tries this first, which can be set to the default
+  strategy by setting the env var `JULIA_PKG_PRESERVE_TIERED_INSTALLED` to `true` ([#3378]).
 
 Pkg v1.8 Release Notes
 ======================

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -414,9 +414,9 @@ This is done by making the following changes (using the example above):
   end
   ```
 - Make the following change in the conditionally-loaded code:
- ```julia
- isdefined(Base, :get_extension) ? (using Contour) : (using ..Contour)
- ```
+  ```julia
+  isdefined(Base, :get_extension) ? (using Contour) : (using ..Contour)
+  ```
 
 The package should now work with Requires.jl on Julia versions before extensions were introduced
 and with extensions on more recent Julia versions.

--- a/src/API.jl
+++ b/src/API.jl
@@ -1071,7 +1071,7 @@ function _is_stale!(stale_cache::Dict{StaleCacheKey,Bool}, paths::Vector{String}
             modpaths = Base.find_all_in_cache_path(modkey)
             for modpath_to_try in modpaths::Vector{String}
                 stale_cache_key = (modkey, modbuild_id, modpath, modpath_to_try)::StaleCacheKey
-                if get!(() -> Base.stale_cachefile(stale_cache_key...) === true,
+                if get!(() -> Base.stale_cachefile(stale_cache_key..., ignore_loaded=true) === true,
                         stale_cache, stale_cache_key)
                     continue
                 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1650,6 +1650,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
         # given no manifest exists, only allow invoking a registry update if there are project deps
         allow_registry_update = isfile(ctx.env.project_file) && !isempty(ctx.env.project.deps)
         up(ctx; update_registry = update_registry && allow_registry_update)
+        allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
         return
     end
     if !isfile(ctx.env.manifest_file) && manifest == true

--- a/src/API.jl
+++ b/src/API.jl
@@ -180,7 +180,7 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status, :why, :
 end
 
 function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
-                 preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform(), kwargs...)
+                 preserve::PreserveLevel=Operations.default_preserve(), platform::AbstractPlatform=HostPlatform(), kwargs...)
     require_not_empty(pkgs, :develop)
     Context!(ctx; kwargs...)
 
@@ -223,7 +223,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
     return
 end
 
-function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PRESERVE_TIERED,
+function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=Operations.default_preserve(),
              platform::AbstractPlatform=HostPlatform(), kwargs...)
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)

--- a/src/API.jl
+++ b/src/API.jl
@@ -256,7 +256,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=PR
     # repo + unpinned -> name, uuid, repo.rev, repo.source, tree_hash
     # repo + pinned -> name, uuid, tree_hash
 
-    Operations.update_registries(ctx; force=false)
+    Operations.update_registries(ctx; force=false, update_cooldown=Day(1))
 
     project_deps_resolve!(ctx.env, pkgs)
     registry_resolve!(ctx.registries, pkgs)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -14,12 +14,20 @@ import ..Artifacts: ensure_artifact_installed, artifact_names, extract_all_hashe
                     artifact_exists, select_downloadable_artifacts
 using Base.BinaryPlatforms
 import ...Pkg
-import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
+import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE, get_bool_env
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
 
 #########
 # Utils #
 #########
+
+function default_preserve()
+    if get_bool_env("JULIA_PKG_PRESERVE_TIERED_INSTALLED")
+        PRESERVE_TIERED_INSTALLED
+    else
+        PRESERVE_TIERED
+    end
+end
 
 function find_installed(name::String, uuid::UUID, sha1::SHA1)
     slug_default = Base.version_slug(uuid, sha1)
@@ -52,7 +60,7 @@ function load_version(version, fixed, preserve::PreserveLevel)
         return VersionSpec() # some stdlibs dont have a version
     elseif fixed
         return version # dont change state if a package is fixed
-    elseif preserve == PRESERVE_ALL || preserve == PRESERVE_DIRECT
+    elseif preserve == PRESERVE_ALL || preserve == PRESERVE_ALL_INSTALLED || preserve == PRESERVE_DIRECT
         return something(version, VersionSpec())
     elseif preserve == PRESERVE_SEMVER && version != VersionSpec()
         return Types.semver_spec("$(version.major).$(version.minor).$(version.patch)")
@@ -337,7 +345,9 @@ dropbuild(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch, isempty(v
 # sets version to a VersionNumber
 # adds any other packages which may be in the dependency graph
 # all versioned packages should have a `tree_hash`
-function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
+function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
+                           installed_only::Bool)
+    installed_only = installed_only || OFFLINE_MODE[]
     # compatibility
     if julia_version !== nothing
         # only set the manifest julia_version if ctx.julia_version is not nothing
@@ -394,7 +404,7 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
     # happened on a different julia version / commit and the stdlib version in the manifest is not the current stdlib version
     unbind_stdlibs = julia_version === VERSION
     reqs = Resolve.Requires(pkg.uuid => is_stdlib(pkg.uuid) && unbind_stdlibs ? VersionSpec("*") : VersionSpec(pkg.version) for pkg in pkgs)
-    graph, compat_map = deps_graph(env, registries, names, reqs, fixed, julia_version)
+    graph, compat_map = deps_graph(env, registries, names, reqs, fixed, julia_version, installed_only)
     Resolve.simplify_graph!(graph)
     vers = Resolve.resolve(graph)
 
@@ -451,7 +461,8 @@ get_or_make!(d::Dict{K,V}, k::K) where {K,V} = get!(d, k) do; V() end
 const JULIA_UUID = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
 const PKGORIGIN_HAVE_VERSION = :version in fieldnames(Base.PkgOrigin)
 function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}, uuid_to_name::Dict{UUID,String},
-                    reqs::Resolve.Requires, fixed::Dict{UUID,Resolve.Fixed}, julia_version)
+                    reqs::Resolve.Requires, fixed::Dict{UUID,Resolve.Fixed}, julia_version,
+                    installed_only::Bool)
     uuids = Set{UUID}()
     union!(uuids, keys(reqs))
     union!(uuids, keys(fixed))
@@ -525,7 +536,7 @@ function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}
                             # Filter yanked and if we are in offline mode also downloaded packages
                             # TODO, pull this into a function
                             Registry.isyanked(info, v) && continue
-                            if Pkg.OFFLINE_MODE[]
+                            if installed_only
                                 pkg_spec = PackageSpec(name=pkg.name, uuid=pkg.uuid, version=v, tree_hash=Registry.treehash(info, v))
                                 is_package_downloaded(env.project_file, pkg_spec) || continue
                             end
@@ -1302,46 +1313,64 @@ function assert_can_add(ctx::Context, pkgs::Vector{PackageSpec})
     end
 end
 
-function tiered_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version)
+function tiered_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
+                        try_all_installed::Bool)
+    if try_all_installed
+        try # do not modify existing subgraph and only add installed versions of the new packages
+            @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
+        catch err
+            err isa Resolve.ResolverError || rethrow()
+        end
+    end
     try # do not modify existing subgraph
+        @debug "tiered_resolve: trying PRESERVE_ALL"
         return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
+        @debug "tiered_resolve: trying PRESERVE_DIRECT"
         return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
+        @debug "tiered_resolve: trying PRESERVE_SEMVER"
         return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
+    @debug "tiered_resolve: trying PRESERVE_NONE"
     return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
 end
 
 function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
-    if preserve == PRESERVE_ALL
+    if preserve == PRESERVE_ALL || preserve == PRESERVE_ALL_INSTALLED
         pkgs = load_all_deps(env, pkgs; preserve)
     else
         pkgs = load_direct_deps(env, pkgs; preserve)
     end
     check_registered(registries, pkgs)
 
-    deps_map = resolve_versions!(env, registries, pkgs, julia_version)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED)
     return pkgs, deps_map
 end
 
-function _resolve(io::IO, env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
+function _resolve(io::IO, env::EnvCache, registries::Vector{Registry.RegistryInstance},
+                    pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
     printpkgstyle(io, :Resolving, "package versions...")
-    return preserve == PRESERVE_TIERED ?
-        tiered_resolve(env, registries, pkgs, julia_version) :
+    if preserve == PRESERVE_TIERED_INSTALLED
+        tiered_resolve(env, registries, pkgs, julia_version, true)
+    elseif preserve == PRESERVE_TIERED
+        tiered_resolve(env, registries, pkgs, julia_version, false)
+    else
         targeted_resolve(env, registries, pkgs, preserve, julia_version)
+    end
 end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
-             preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform())
+             preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform())
     assert_can_add(ctx, pkgs)
     # load manifest data
     for (i, pkg) in pairs(pkgs)
@@ -1367,7 +1396,7 @@ end
 
 # Input: name, uuid, and path
 function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Set{UUID};
-                 preserve::PreserveLevel=PRESERVE_TIERED, platform::AbstractPlatform=HostPlatform())
+                 preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform())
     assert_can_add(ctx, pkgs)
     # no need to look at manifest.. dev will just nuke whatever is there before
     for pkg in pkgs
@@ -1479,7 +1508,7 @@ end
 function targeted_resolve_up(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
     pkgs = load_manifest_deps_up(env, pkgs; preserve=preserve)
     check_registered(registries, pkgs)
-    deps_map = resolve_versions!(env, registries, pkgs, julia_version)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED)
     return pkgs, deps_map
 end
 
@@ -1501,7 +1530,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     else
         pkgs = load_direct_deps(ctx.env, pkgs; preserve = (level == UPLEVEL_FIXED ? PRESERVE_NONE : PRESERVE_DIRECT))
         check_registered(ctx.registries, pkgs)
-        deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version)
+        deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version, false)
     end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
@@ -1546,7 +1575,9 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
     foreach(pkg -> update_package_pin!(ctx.registries, pkg, manifest_info(ctx.env.manifest, pkg.uuid)), pkgs)
     pkgs = load_direct_deps(ctx.env, pkgs)
 
+    # TODO: change pin to not take a version and just have it pin on the current version. Then there is no need to resolve after a pin
     pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_TIERED, ctx.julia_version)
+
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new = download_source(ctx)
     fixup_ext!(ctx.env, pkgs)
@@ -1587,6 +1618,8 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free=true)
     if any(pkg -> pkg.version == VersionSpec(), pkgs)
         pkgs = load_direct_deps(ctx.env, pkgs)
         check_registered(ctx.registries, pkgs)
+
+        # TODO: change free to not take a version and just have it pin on the current version. Then there is no need to resolve after a pin
         pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, PRESERVE_TIERED, ctx.julia_version)
 
         update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -654,4 +654,22 @@ function verify(path::AbstractString, hash::AbstractString; verbose::Bool = fals
     end
 end
 
+# Verify the git-tree-sha1 hash of a compressed archive.
+function verify_archive_tree_hash(tar_gz::AbstractString, expected_hash::Base.SHA1)
+    # This can fail because unlike sha256 verification of the downloaded
+    # tarball, tree hash verification requires that the file can i) be
+    # decompressed and ii) is a proper archive.
+    calc_hash = try
+        Base.SHA1(open(Tar.tree_hash, `$(exe7z()) x $tar_gz -so`))
+    catch err
+        @warn "unable to decompress and read archive" exception=err
+        return false
+    end
+    if calc_hash != expected_hash
+        @warn "tarball content does not match expected git-tree-sha1"
+        return false
+    end
+    return true
+end
+
 end # module PlatformEngines

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -232,10 +232,12 @@ end
 # # Option Maps
 #
 function do_preserve(x::String)
-    x == "all"    && return Types.PRESERVE_ALL
-    x == "direct" && return Types.PRESERVE_DIRECT
-    x == "semver" && return Types.PRESERVE_SEMVER
-    x == "none"   && return Types.PRESERVE_NONE
-    x == "tiered" && return Types.PRESERVE_TIERED
+    x == "installed"        && return Types.PRESERVE_ALL_INSTALLED
+    x == "all"              && return Types.PRESERVE_ALL
+    x == "direct"           && return Types.PRESERVE_DIRECT
+    x == "semver"           && return Types.PRESERVE_SEMVER
+    x == "none"             && return Types.PRESERVE_NONE
+    x == "tiered_installed" && return Types.PRESERVE_TIERED_INSTALLED
+    x == "tiered"           && return Types.PRESERVE_TIERED
     pkgerror("`$x` is not a valid argument for `--preserve`.")
 end

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -123,15 +123,25 @@ If the package is not located at the top of the git repository, a subdirectory c
 The `--preserve` command line option allows you to key into a specific tier in the resolve algorithm.
 The following table describes the command line arguments to `--preserve` (in order of strictness).
 
-| Argument | Description                                                                         |
-|:---------|:------------------------------------------------------------------------------------|
-| `all`    | Preserve the state of all existing dependencies (including recursive dependencies)  |
-| `direct` | Preserve the state of all existing direct dependencies                              |
-| `semver` | Preserve semver-compatible versions of direct dependencies                          |
-| `none`   | Do not attempt to preserve any version information                                  |
-| `tiered` | Use the tier which will preserve the most version information (this is the default) |
+| Argument           | Description                                                                          |
+|:-------------------|:-------------------------------------------------------------------------------------|
+| `installed`        | Like `all` except also only add versions that are already installed                  |
+| `all`              | Preserve the state of all existing dependencies (including recursive dependencies)   |
+| `direct`           | Preserve the state of all existing direct dependencies                               |
+| `semver`           | Preserve semver-compatible versions of direct dependencies                           |
+| `none`             | Do not attempt to preserve any version information                                   |
+| `tiered_installed` | Like `tiered` except first try to add only installed versions                        |
+| `tiered`           | Use the tier which will preserve the most version information (this is the default)  |
+
+Note: To make the default strategy `tiered_installed` set the env var `JULIA_PKG_PRESERVE_TIERED_INSTALLED` to
+true.
 
 After the installation of new packages the project will be precompiled. For more information see `pkg> ?precompile`.
+
+With the `installed` strategy the newly added packages will likely already be precompiled, but if not this may be
+because either the combination of package versions resolved in this environment has not been resolved and
+precompiled before, or the precompile cache has been deleted by the LRU cache storage
+(see JULIA_MAX_NUM_PRECOMPILE_FILES).
 
 **Examples**
 ```
@@ -175,6 +185,9 @@ When `--local` is given, the clone is placed in a `dev` folder in the current pr
 is not supported for paths, only registered packages.
 
 This operation is undone by `free`.
+
+The preserve strategies offered by `add` are also available via the `preserve` argument.
+See `add` for more information.
 
 **Examples**
 ```jl

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -198,11 +198,10 @@ function init_package_info!(pkg::PkgEntry)
     compat_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Compat.toml")) ?
         parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Compat.toml")) : Dict{String, Any}()
     compat = Dict{VersionRange, Dict{String, VersionSpec}}()
-    for (v, _data) in compat_data_toml
-        # The Compat.toml file might have string or vector values
-        data = convert(Dict{String, Union{String, Vector{String}}}, _data::Dict)
+    for (v, data) in compat_data_toml
+        data = data::Dict{String, Any}
         vr = VersionRange(v)
-        d = Dict{String, VersionSpec}(dep => VersionSpec(vr_dep) for (dep, vr_dep) in data)
+        d = Dict{String, VersionSpec}(dep => VersionSpec(vr_dep) for (dep, vr_dep::Union{String, Vector{String}}) in data)
         compat[vr] = d
     end
 
@@ -210,11 +209,10 @@ function init_package_info!(pkg::PkgEntry)
     deps_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Deps.toml")) ?
         parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "Deps.toml")) : Dict{String, Any}()
     deps = Dict{VersionRange, Dict{String, UUID}}()
-    for (v, _data) in deps_data_toml
-        # But the Deps.toml only have strings as values
-        data = convert(Dict{String, String}, _data::Dict)
+    for (v, data) in deps_data_toml
+        data = data::Dict{String, Any}
         vr = VersionRange(v)
-        d = Dict{String, UUID}(dep => UUID(uuid) for (dep, uuid) in data)
+        d = Dict{String, UUID}(dep => UUID(uuid) for (dep, uuid::String) in data)
         deps[vr] = d
     end
     # All packages depend on julia
@@ -223,22 +221,22 @@ function init_package_info!(pkg::PkgEntry)
     # WeakCompat.toml
     weak_compat_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakCompat.toml")) ?
         parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakCompat.toml")) : Dict{String, Any}()
-    weak_compat_data_toml = convert(Dict{String, Dict{String, Union{String, Vector{String}}}}, weak_compat_data_toml)
     weak_compat = Dict{VersionRange, Dict{String, VersionSpec}}()
     for (v, data) in weak_compat_data_toml
+        data = data::Dict{String, Any}
         vr = VersionRange(v)
-        d = Dict{String, VersionSpec}(dep => VersionSpec(vr_dep) for (dep, vr_dep) in data)
+        d = Dict{String, VersionSpec}(dep => VersionSpec(vr_dep) for (dep, vr_dep::Union{String, Vector{String}}) in data)
         weak_compat[vr] = d
     end
 
     # WeakDeps.toml
     weak_deps_data_toml = custom_isfile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakDeps.toml")) ?
         parsefile(pkg.in_memory_registry, pkg.registry_path, joinpath(pkg.path, "WeakDeps.toml")) : Dict{String, Any}()
-    weak_deps_data_toml = convert(Dict{String, Dict{String, String}}, weak_deps_data_toml)
     weak_deps = Dict{VersionRange, Dict{String, UUID}}()
     for (v, data) in weak_deps_data_toml
+        data = data::Dict{String, Any}
         vr = VersionRange(v)
-        d = Dict{String, UUID}(dep => UUID(uuid) for (dep, uuid) in data)
+        d = Dict{String, UUID}(dep => UUID(uuid) for (dep, uuid::String) in data)
         weak_deps[vr] = d
     end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -29,7 +29,8 @@ export UUID, SHA1, VersionRange, VersionSpec,
     read_project, read_package, read_manifest,
     PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT, PKGMODE_COMBINED,
     UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR,
-    PreserveLevel, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_NONE,
+    PreserveLevel, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED,
+    PRESERVE_TIERED_INSTALLED, PRESERVE_NONE,
     projectfile_path, manifestfile_path
 
 # Load in data about historical stdlibs
@@ -73,7 +74,7 @@ Base.showerror(io::IO, err::PkgError) = print(io, err.msg)
 # PackageSpec #
 ###############
 @enum(UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR)
-@enum(PreserveLevel, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_NONE)
+@enum(PreserveLevel, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_TIERED_INSTALLED, PRESERVE_NONE)
 @enum(PackageMode, PKGMODE_PROJECT, PKGMODE_MANIFEST, PKGMODE_COMBINED)
 
 const VersionTypes = Union{VersionNumber,VersionSpec,UpgradeLevel}
@@ -141,7 +142,7 @@ isresolved(pkg::PackageSpec) = pkg.uuid !== nothing && pkg.name !== nothing
 function Base.show(io::IO, pkg::PackageSpec)
     vstr = repr(pkg.version)
     f = Pair{String, Any}[]
-    
+
     pkg.name !== nothing && push!(f, "name" => pkg.name)
     pkg.uuid !== nothing && push!(f, "uuid" => pkg.uuid)
     pkg.tree_hash !== nothing && push!(f, "tree_hash" => pkg.tree_hash)

--- a/test/api.jl
+++ b/test/api.jl
@@ -110,6 +110,8 @@ end
             Pkg.generate("Dep4")
             Pkg.generate("Dep5")
             Pkg.generate("Dep6")
+            Pkg.generate("Dep7")
+            Pkg.generate("Dep8")
             Pkg.generate("NoVersion")
             open(joinpath("NoVersion","Project.toml"), "w") do io
                 write(io, "name = \"NoVersion\"\nuuid = \"$(UUIDs.uuid4())\"")
@@ -207,6 +209,22 @@ end
             @test occursin("Dep6", str)
             Pkg.precompile(io=iob)
             @test !occursin("Precompiling", String(take!(iob))) # test that the previous precompile was a no-op
+        end
+
+        @testset "instantiate" begin
+            iob = IOBuffer()
+            Pkg.activate("packages/Dep7")
+            Pkg.resolve()
+            @test isfile("packages/Dep7/Project.toml")
+            @test isfile("packages/Dep7/Manifest.toml")
+            Pkg.instantiate(io=iob) # with a Project.toml and Manifest.toml
+            @test occursin("Precompiling", String(take!(iob)))
+
+            Pkg.activate("packages/Dep8")
+            @test isfile("packages/Dep8/Project.toml")
+            @test !isfile("packages/Dep8/Manifest.toml")
+            Pkg.instantiate(io=iob) # with only a Project.toml
+            @test occursin("Precompiling", String(take!(iob)))
         end
 
         ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0


### PR DESCRIPTION
Backported PRs:
- [x] #3399 <!-- Fix indentation in code-block -->
- [x] #3401 <!-- rejigger some code paths that handles untyped data to avoid invalidations -->
- [x] #3320 <!-- only auto update registries on `add` once per day -->
- [x] #3406 <!-- precompile: fix `_is_stale` not always ignoring loaded modules -->
- [x] #3409 <!-- add missing autoprecomp to Project instantiate path -->
- [x] #3408 <!-- Verify git-tree-sha1 of registry downloads -->

Contains multiple commits, manual intervention needed:
- [ ] #3378 <!-- Add `PRESERVE_ALL_INSTALLED` and `PRESERVE_TIERED_INSTALLED` strategies -->
