### PR TITLE
try_prompt_pkg_add: on "other" default to 2nd env

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -746,10 +746,11 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             push!(shown_envs, expanded_env)
         end
         menu = TerminalMenus.RadioMenu(option_list, keybindings=keybindings, pagesize=length(option_list))
+        default = min(2, length(option_list))
         print(ctx.io, "\e[1A\e[1G\e[0J") # go up one line, to the start, and clear it
         printstyled(ctx.io, " └ "; color=:green)
         choice = try
-            TerminalMenus.request("Select environment:", menu)
+            TerminalMenus.request("Select environment:", menu, cursor=default)
         catch err
             if err isa InterruptException # if ^C is entered
                 println(ctx.io)


### PR DESCRIPTION
When someone picks "o" from the y/n/o choices, they are explicitly skipping the first environment in the load path, so we should start at the second writable environment in the load path since that's usually the one someone wants to add the package to.
