### PR TITLE
precompile: fix minor print bug

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1306,7 +1306,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
             wait(first_started)
             (isempty(pkg_queue) || interrupted_or_done.set) && return
             fancyprint && lock(print_lock) do
-                printpkgstyle(io, :Precompiling, "environment...")
+                printpkgstyle(io, :Precompiling, target)
                 print(io, ansi_disablecursor)
             end
             t = Timer(0; interval=1/10)


### PR DESCRIPTION
This was fixed in the non-pretty print version but missed here. Just prints `Precompiling Foo` when `pkg> precompile Foo` is requested