### PR TITLE
precompile: include extensions when packages are specified

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1227,9 +1227,15 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
         end
         keep = Base.PkgId[]
         for dep in depsmap
-            if first(dep).name in pkgs_names
-                push!(keep, first(dep))
-                append!(keep, collect_all_deps(depsmap, first(dep)))
+            dep_pkgid = first(dep)
+            if dep_pkgid.name in pkgs_names
+                push!(keep, dep_pkgid)
+                append!(keep, collect_all_deps(depsmap, dep_pkgid))
+            end
+        end
+        for ext in keys(exts)
+            if issubset(collect_all_deps(depsmap, ext), keep) # if all extension deps are kept
+                push!(keep, ext)
             end
         end
         filter!(d->in(first(d), keep), depsmap)


### PR DESCRIPTION
Previously when specifying packages activated extensions were left off.
```
(@v1.10) pkg> precompile CSV
Precompiling environment...
  19 dependencies successfully precompiled in 30 seconds. 1 already precompiled.

julia> using CSV
[ Info: Precompiling CompatLinearAlgebraExt [dbe5ba0b-aecc-598a-a867-79051b540f49]

julia> 
```

This PR
```
(@v1.10) pkg> precompile CSV
Precompiling environment...
  20 dependencies successfully precompiled in 30 seconds. 1 already precompiled.

julia> using CSV

julia> 
```