### PR TITLE
fix handling of relative paths in `bind_artifact!`

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -223,7 +223,8 @@ function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
 
     # Spit it out onto disk
     let artifact_dict = artifact_dict
-        temp_artifacts_toml = tempname(dirname(artifacts_toml))
+        parent_dir = dirname(artifacts_toml)
+        temp_artifacts_toml = isempty(parent_dir) ? tempname(pwd()) : tempname(parent_dir)
         open(temp_artifacts_toml, "w") do io
             TOML.print(io, artifact_dict, sorted=true)
         end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -260,6 +260,26 @@ end
         meta = artifact_meta("foo_txt", artifacts_toml; platform=win32)
         @test meta["download"][1]["url"] == "http://google.com/hello_world"
         @test meta["download"][2]["sha256"] == "a"^64
+
+        rm(artifacts_toml)
+
+        # test relative Artifacts.toml paths (https://github.com/simeonschaub/ArtifactUtils.jl/issues/19)
+        cd(path) do
+            hash3 = create_artifact() do path
+                open(joinpath(path, "foo.txt"), "w") do io
+                    print(io, "bla bla")
+                end
+            end
+
+            # Bind this artifact to something
+            artifacts_toml = "Artifacts.toml" # no parent dir specified
+            @test artifact_hash("foo_txt", artifacts_toml) == nothing
+            bind_artifact!(artifacts_toml, "foo_txt", hash3)
+
+            # Test that this binding worked
+            @test artifact_hash("foo_txt", artifacts_toml) == hash3
+            @test ensure_artifact_installed("foo_txt", artifacts_toml) == artifact_path(hash3)
+        end
     end
 
     # Let's test some known-bad Artifacts.toml files


### PR DESCRIPTION
This got broken in #3235.

Fixes simeonschaub/ArtifactUtils.jl#19
