### PR TITLE
precompile: improve no match error messaging

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1182,7 +1182,13 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     end
 
     # return early if no deps
-    isempty(depsmap) && return
+    if isempty(depsmap)
+        if isempty(pkgs)
+            return
+        else
+            pkgerror("No direct dependencies outside of the sysimage found matching $(repr([p.name for p in pkgs]))")
+        end
+    end
 
     # initialize signalling
     started = Dict{Base.PkgId,Bool}()
@@ -1240,7 +1246,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
             end
         end
         filter!(d->in(first(d), keep), depsmap)
-        isempty(depsmap) && pkgerror("No direct dependencies found matching $(repr(pkgs_names))")
+        isempty(depsmap) && pkgerror("No direct dependencies outside of the sysimage found matching $(repr(pkgs_names))")
         target = join(pkgs_names, ", ")
     else
         target = "project..."

--- a/test/api.jl
+++ b/test/api.jl
@@ -282,6 +282,15 @@ end
         Pkg.activate(".")
         Pkg.activate("CircularDep3")
         @test_logs (:warn, r"Circular dependency detected") Pkg.precompile()
+
+        Pkg.activate(temp=true)
+        Pkg.precompile() # precompile an empty env should be a no-op
+        @test_throws Pkg.Types.PkgError Pkg.precompile("DoesNotExist") # fail to find a nonexistant dep in an empty env
+
+        Pkg.add("Random")
+        @test_throws Pkg.Types.PkgError Pkg.precompile("Random") # Random is a dep but in the sysimage
+        @test_throws Pkg.Types.PkgError Pkg.precompile("DoesNotExist")
+        Pkg.precompile() # should be a no-op
     end end
     @testset "Issue 3359: Recurring precompile" begin
         isolate() do; cd_tempdir() do tmp


### PR DESCRIPTION
Fixes two bugs:

1. Not erroring if the requested package can't be found if the env is empty
```
(@v1.8) pkg> activate --temp
  Activating new project at `/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_COUhTY`

(jl_COUhTY) pkg> precompile DoesNotExist
  No Changes to `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_COUhTY/Project.toml`
  No Changes to `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_COUhTY/Manifest.toml`

(jl_COUhTY) pkg> precompile DoesNotExist

(jl_COUhTY) pkg> 
```

2. Claiming to not find a direct dep but not explaining that its because it was in the sysimage
```
(jl_ucKMh9) pkg> st
Status `/private/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_ucKMh9/Project.toml`
  [9a3f8284] Random

(jl_ucKMh9) pkg> precompile Random
ERROR: No direct dependencies found matching ["Random"]
```