### PR TITLE
Allow `act` in place of `activate` at the REPL

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -107,7 +107,7 @@ Different environments can have different totally different packages and version
 The active environment is the environment that will be modified by Pkg commands such as `add`, `rm` and `update`.
 
 Let's set up a new environment so we may experiment.
-To set the active environment, use `activate`:
+To set the active environment, use `activate` (or the shorter `act` command) :
 
 ```julia-repl
 (@v1.8) pkg> activate tutorial

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -289,6 +289,7 @@ packages have changed causing the current Manifest to be out of sync.
 """,
 ],
 PSA[:name => "activate",
+    :short_name => "act",
     :api => API.activate,
     :arg_count => 0 => 1,
     :arg_parser => parse_activate,
@@ -299,9 +300,9 @@ PSA[:name => "activate",
     :completions => complete_activate,
     :description => "set the primary environment the package manager manipulates",
     :help => md"""
-    activate
-    activate [--shared] path
-    activate --temp
+    [act|activate]
+    [act|activate] [--shared] path
+    [act|activate] --temp
 
 Activate the environment at the given `path`, or the home project environment if no `path` is specified.
 The active environment is the environment that is modified by executing package commands.


### PR DESCRIPTION
The name says it all. I find I actually `activate` more than some of the other commands that are either already short like `add` or have short names like `st`.