### PR TITLE
add debug info to artifact downloads

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -373,6 +373,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
         if (server = pkg_server()) !== nothing
             url = "$server/artifact/$hash"
             download_success = let url=url
+                @debug "Downloading artifact from Pkg server" name artifacts_toml platform url
                 with_show_download_info(io, name, quiet_download) do
                     download_artifact(hash, url; verbose=verbose, quiet_download=quiet_download, io=io)
                 end
@@ -381,6 +382,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
             if download_success === true
                 return artifact_path(hash)
             else
+                @debug "Failed to download artifact from Pkg server" download_success
                 push!(errors, (url, download_success))
             end
         end
@@ -396,6 +398,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
             url = entry["url"]
             tarball_hash = entry["sha256"]
             download_success = let url=url
+                @debug "Downloading artifact" name artifacts_toml platform url
                 with_show_download_info(io, name, quiet_download) do
                     download_artifact(hash, url, tarball_hash; verbose=verbose, quiet_download=quiet_download, io=io)
                 end
@@ -404,6 +407,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
             if download_success === true
                 return artifact_path(hash)
             else
+                @debug "Failed to download artifact" download_success
                 push!(errors, (url, download_success))
             end
         end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -346,7 +346,12 @@ function download_verify(
 
     # Download the file, optionally continuing
     f = retry(delays = fill(1.0, 3)) do
-        download(url, dest; verbose=verbose || !quiet_download)
+        try
+            download(url, dest; verbose=verbose || !quiet_download)
+        catch err
+            @debug "download and verify failed" url dest err
+            rethrow()
+        end
     end
     f()
     if hash !== nothing && !verify(dest, hash; verbose=verbose)


### PR DESCRIPTION
Helps debug where artifacts are coming from etc.
```
  Downloaded artifact: CUDA_Driver
┌ Debug: Downloading artifact from Pkg server
│   name = "CUDA_Runtime"
│   artifacts_toml = "/home/ian/.julia/packages/CUDA_Runtime_jll/F1mcT/Artifacts.toml"
│   platform = Linux x86_64 {cxxstring_abi=cxx11, julia_version=1.10.0, libc=glibc, libgfortran_version=5.0.0, libstdcxx_version=3.4.30}
│   url = "https://pkg.julialang.org/artifact/ebadc1bf983003ca3f714f062af4451365761171"
└ @ Pkg.Artifacts ~/Documents/GitHub/Pkg.jl/src/Artifacts.jl:376
 Downloading artifact: CUDA_Runtime
┌ Debug: download and verify failed
│   err = RequestError: HTTP/2 200 (HTTP/2 stream 9 was not closed cleanly: INTERNAL_ERROR (err 2)) while requesting https://pkg.julialang.org/artifact/ebadc1bf983003ca3f714f062af4451365761171
└ @ Pkg.PlatformEngines ~/Documents/GitHub/Pkg.jl/src/PlatformEngines.jl:352
    Downloading [========>                               ] 25.9 %
```