### PR TITLE
Disallow Pkg.precompile during precompilation

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1115,6 +1115,14 @@ end
 function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool=false,
                     strict::Bool=false, warn_loaded = true, already_instantiated = false, timing::Bool = false,
                     _from_loading::Bool=false, kwargs...)
+
+    if ccall(:jl_generating_output, Cint, ()) == 1
+        if !internal_call
+            @warn "Pkg.precompile cannot be called during package precompilation"
+        end
+        return
+    end
+
     Context!(ctx; kwargs...)
     already_instantiated || instantiate(ctx; allow_autoprecomp=false, kwargs...)
     time_start = time_ns()


### PR DESCRIPTION
Proposed fix for #3458 

Basically make it noop during precompilation, and noisy if it's specifically called, silent if it's autoprecompilation.

But I'm not sure if this would prevent `Pkg.precompile` being baked into the julia sysimage, and I'm pretty sure it will stop it from being baked into a Pkg pkgimage.

@vchuravy 