### PR TITLE
try_prompt_pkg_add: on "other" preselect the first non-default env

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -746,7 +746,11 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             push!(shown_envs, expanded_env)
         end
         menu = TerminalMenus.RadioMenu(option_list, keybindings=keybindings, pagesize=length(option_list))
-        default = min(2, length(option_list))
+        default = something(
+            # select the first non-default env by default, if possible
+            findfirst(!=(Base.active_project()), shown_envs),
+            1
+        )
         print(ctx.io, "\e[1A\e[1G\e[0J") # go up one line, to the start, and clear it
         printstyled(ctx.io, " └ "; color=:green)
         choice = try


### PR DESCRIPTION
When someone picks "o" from the y/n/o choices, they most likely want to choose a different environment than the env affected by the default "y" choice. So, we should start at the first non-default writable environment in the load path.

Recently, #3429 changed the preselection from first to second item. Depending on the LOAD_PATH order, that could select the same env as affected by pressing `y`.