### PR TITLE
[release-1.9] 1.9.1 Backports

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -354,8 +354,8 @@ end
 end # module
 ```
 
-The name of the extension (here `PlottingContourExt`) is not very important but using something similar to the suggest here is likely a good
-idea.
+Extensions can have any arbitrary name (here `PlottingContourExt`), but using something similar to the format of
+this example that makes the extended functionality and dependency of the extension clear is likely a good idea.
 
 A user that depends only on `Plotting` will not pay the cost of the "extension" inside the `PlottingContourExt` module.
 It is only when the `Contour` package actually gets loaded that the `PlottingContourExt` extension is loaded

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -366,17 +366,6 @@ If one considers `PlottingContourExt` as a completely separate package, it could
 However, for extensions, it is ok to assume that the extension owns the methods in its parent package.
 In fact, this form of type piracy is one of the most standard use cases for extensions.
 
-!!! note
-    An extension will only be loaded if the extension dependencies are loaded from the same environment or environments 
-    higher in the environment stack than the package itself. This means that you can load a package having an extension
-    from your main/default environment, load another package required for the dependency from your active project, and
-    get the functionality from the extension. The other way round does not work, i.e., if you load a package having
-    an extension from a project environment and then load the package required for the extension from you main/default
-    environment, the extension will not be loaded. This is different from the behavior of Requires.jl where the 
-    conditional code is evaluated no matter from what environment the "extension dependency" is loaded.
-
-
-
 !!! compat
     Often you will put the extension dependencies into the `test` target so they are loaded when running e.g. `Pkg.test()`. On earlier Julia versions
     this requires you to also put the package in the `[extras]` section. This is unfortunate but the project verifier on older Julia versions will

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -366,7 +366,16 @@ If one considers `PlottingContourExt` as a completely separate package, it could
 However, for extensions, it is ok to assume that the extension owns the methods in its parent package.
 In fact, this form of type piracy is one of the most standard use cases for extensions.
 
-An extension will only be loaded if the extension dependencies are loaded from the same environment or environments higher in the environment stack than the package itself.
+!!! note
+    An extension will only be loaded if the extension dependencies are loaded from the same environment or environments 
+    higher in the environment stack than the package itself. This means that you can load a package having an extension
+    from your main/default environment, load another package required for the dependency from your active project, and
+    get the functionality from the extension. The other way round does not work, i.e., if you load a package having
+    an extension from a project environment and then load the package required for the extension from you main/default
+    environment, the extension will not be loaded. This is different from the behavior of Requires.jl where the 
+    conditional code is evaluated no matter from what environment the "extension dependency" is loaded.
+
+
 
 !!! compat
     Often you will put the extension dependencies into the `test` target so they are loaded when running e.g. `Pkg.test()`. On earlier Julia versions

--- a/src/API.jl
+++ b/src/API.jl
@@ -1261,7 +1261,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     printloop_should_exit::Bool = !fancyprint # exit print loop immediately if not fancy printing
     interrupted_or_done = Base.Event()
 
-    function color_string(cstr::String, col::Symbol)
+    function color_string(cstr::String, col::Union{Int64, Symbol})
         enable_ansi  = get(Base.text_colors, col, Base.text_colors[:default])
         disable_ansi = get(Base.disable_text_style, col, Base.text_colors[:default])
         return string(enable_ansi, cstr, disable_ansi)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1659,6 +1659,20 @@ function gen_test_precompile_code(source_path::String; coverage, julia_args::Cmd
     return gen_subprocess_cmd(code, source_path; coverage, julia_args)
 end
 
+@static if VERSION >= v"1.9.0" # has threadpools
+function get_threads_spec()
+    if Threads.nthreads(:interactive) > 0
+        "$(Threads.nthreads(:default)),$(Threads.nthreads(:interactive))"
+    else
+        "$(Threads.nthreads(:default))"
+    end
+end
+else # no threadpools
+function get_threads_spec()
+    "$(Threads.nthreads())"
+end
+end
+
 function gen_subprocess_cmd(code::String, source_path::String; coverage, julia_args)
     coverage_arg = if coverage isa Bool
         coverage ? string("@", source_path) : "none"
@@ -1677,7 +1691,7 @@ function gen_subprocess_cmd(code::String, source_path::String; coverage, julia_a
         --inline=$(Bool(Base.JLOptions().can_inline) ? "yes" : "no")
         --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         --track-allocation=$(("none", "user", "all")[Base.JLOptions().malloc_log + 1])
-        --threads=$(Threads.nthreads())
+        --threads=$(get_threads_spec())
         $(julia_args)
         --eval $(code)
     ```

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -589,7 +589,7 @@ This includes:
   * The `name` of the package.
   * The package's unique `uuid`.
   * A `version` (for example when adding a package). When upgrading, can also be an instance of
-    the enum [`UpgradeLevel`](@ref). If the version is given as a `String`` this means that unspecified versions
+    the enum [`UpgradeLevel`](@ref). If the version is given as a `String` this means that unspecified versions
     are "free", for example `version="0.5"` allows any version `0.5.x` to be installed. If given as a `VersionNumber`,
     the exact version is used, for example `version=v"0.5.3"`.
   * A `url` and an optional git `rev`ision. `rev` can be a branch name or a git commit SHA1.

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -746,7 +746,11 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             push!(shown_envs, expanded_env)
         end
         menu = TerminalMenus.RadioMenu(option_list, keybindings=keybindings, pagesize=length(option_list))
-        default = min(2, length(option_list))
+        default = something(
+            # select the first non-default env by default, if possible
+            findfirst(!=(Base.active_project()), shown_envs),
+            1
+        )
         print(ctx.io, "\e[1A\e[1G\e[0J") # go up one line, to the start, and clear it
         printstyled(ctx.io, " └ "; color=:green)
         choice = try


### PR DESCRIPTION
Backported PRs:
- [x] #3457 <!-- fix color_string -->
- [x] #3451 <!-- update note on package extensions -->
- [x] #3456 <!-- precompile: fix race in precompiling exts -->
- [x] #3473 <!-- try_prompt_pkg_add: on "other" preselect the first non-default env -->
- [x] #3476 <!-- remove comments about load paths in relation to extensions -->
- [x] #3474 <!-- extensions docs typo -->
- [x] #3467 <!-- Use correct threads specification for subprocess -->
- [x] #3478 <!-- remove double backquote -->
