### PR TITLE
Remove `VERSION` check for threadpools

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1660,18 +1660,12 @@ function gen_test_precompile_code(source_path::String; coverage, julia_args::Cmd
     return gen_subprocess_cmd(code, source_path; coverage, julia_args)
 end
 
-@static if VERSION >= v"1.9.0" # has threadpools
 function get_threads_spec()
     if Threads.nthreads(:interactive) > 0
         "$(Threads.nthreads(:default)),$(Threads.nthreads(:interactive))"
     else
         "$(Threads.nthreads(:default))"
     end
-end
-else # no threadpools
-function get_threads_spec()
-    "$(Threads.nthreads())"
-end
 end
 
 function gen_subprocess_cmd(code::String, source_path::String; coverage, julia_args)


### PR DESCRIPTION
We don't do this, so remove it. Ref: [comment](https://github.com/JuliaLang/julia/pull/49942#issuecomment-1560153612).