### PR TITLE
Fix Markdown syntax in docstring

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -135,7 +135,7 @@ After the installation of new packages the project will be precompiled. For more
 With the `PRESERVE_ALL_INSTALLED` strategy the newly added packages will likely already be precompiled, but if not this
 may be because either the combination of package versions resolved in this environment has not been resolved and
 precompiled before, or the precompile cache has been deleted by the LRU cache storage
-(see JULIA_MAX_NUM_PRECOMPILE_FILES).
+(see `JULIA_MAX_NUM_PRECOMPILE_FILES`).
 
 !!! compat "Julia 1.9"
     The `PRESERVE_TIERED_INSTALLED` and `PRESERVE_ALL_INSTALLED` strategies requires at least Julia 1.9.

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -142,7 +142,7 @@ After the installation of new packages the project will be precompiled. For more
 With the `installed` strategy the newly added packages will likely already be precompiled, but if not this may be
 because either the combination of package versions resolved in this environment has not been resolved and
 precompiled before, or the precompile cache has been deleted by the LRU cache storage
-(see JULIA_MAX_NUM_PRECOMPILE_FILES).
+(see `JULIA_MAX_NUM_PRECOMPILE_FILES`).
 
 **Examples**
 ```


### PR DESCRIPTION
Without the backticks, the underscores toggles underscores on/off:
![image](https://github.com/JuliaLang/Pkg.jl/assets/23193950/977c76ba-a4d6-41ed-b277-e0bf463b7d33)
