### PR TITLE
Ensure `path_completions` uses shell mode escapes

### DIFF
--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -34,7 +34,7 @@ function complete_local_dir(s, i1, i2)
 end
 
 function complete_expanded_local_dir(s, i1, i2, expanded_user, oldi2)
-    cmp = REPL.REPLCompletions.complete_path(s, i2)
+    cmp = REPL.REPLCompletions.complete_path(s, i2, shell_escape=true)
     cmp2 = cmp[2]
     completions = [REPL.REPLCompletions.completion_text(p) for p in cmp[1]]
     completions = filter!(x -> isdir(s[1:prevind(s, first(cmp2)-i1+1)]*x), completions)


### PR DESCRIPTION
I think `path_completions` should use shell mode escapes, as Pkg repl mode is shell-like in argument splitting. At least, that's what the four trailing backslashes in the tests seem to indicate at https://github.com/JuliaLang/Pkg.jl/blob/9c01707a20478b859e6fd995b5e16c82e7096d92/test/repl.jl#L388

The current `REPLCompletions.path_completions` has a bug where the trailing double-escaped backslashes will be appended regardless of whether `shell_mode=true` or not. As part of fixing that bug which was exposed by the new parser in https://github.com/JuliaLang/julia/pull/46372 I found this bug in Pkg and now everything is hopelessly entangled because the Pkg tests are now failing over there. Yea, it's a long story :-(