### PR TITLE
Docs: Specify that package registration requires compat upper bounds

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -21,6 +21,9 @@ The format of the version specifier is described in detail below.
 !!! info
     The rules below apply to the `Project.toml` file; for registries, see [Registry Compat.toml](@ref).
 
+!!! info
+    Note that registration into Julia's General Registry requires each dependency to have a `[compat`] entry with an upper bound.
+
 ## Version specifier format
 
 Similar to other package managers, the Julia package manager respects [semantic versioning](https://semver.org/) (semver).


### PR DESCRIPTION
Currently, `Pkg.jl`'s documentation does not make it clear that package registration in the General Registry requires upper bounds. I think it's worth it to include that information here, since often packages are developed with registration in mind.

This is an updated version of https://github.com/JuliaLang/Pkg.jl/pull/1852

[skipci]