### PR TITLE
precompile: pipe error messages during autoprecompilation to Main.err for easier inspection

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1542,12 +1542,6 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                         " dependenc$(pluralpc) failed but may be precompilable after restarting julia"
                     )
                 end
-                if internal_call && !isempty(failed_deps)
-                    plural1 = length(failed_deps) == 1 ? "y" : "ies"
-                    plural2 = length(failed_deps) == 1 ? "" : "s"
-                    print(iostr, "\n  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural1) errored. ")
-                    print(iostr, "To see a full report either run `import Pkg; Pkg.precompile()` or load the package$(plural2)")
-                end
             end
             # show any stderr output, even if Pkg.precompile has been interrupted (quick_exit=true), given user may be
             # interrupting a hanging precompile job with stderr output. julia#48371
@@ -1568,20 +1562,32 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
             end
         end
         quick_exit && return
-        if !internal_call
-            err_str = ""
-            n_direct_errs = 0
-            for (dep, err) in failed_deps
-                if strict || (dep in direct_deps)
-                    err_str = string(err_str, "\n$dep\n\n$err", (n_direct_errs > 0 ? "\n" : ""))
-                    n_direct_errs += 1
-                end
+        err_str = ""
+        n_direct_errs = 0
+        for (dep, err) in failed_deps
+            if strict || (dep in direct_deps)
+                err_str = string(err_str, "\n$dep\n\n$err", (n_direct_errs > 0 ? "\n" : ""))
+                n_direct_errs += 1
             end
-            if err_str != ""
-                println(io, "")
-                pluralde = n_direct_errs == 1 ? "y" : "ies"
-                direct = strict ? "" : "direct "
-                pkgerror("The following $n_direct_errs $(direct)dependenc$(pluralde) failed to precompile:\n$(err_str[1:end-1])")
+        end
+        if err_str != ""
+            pluralde = n_direct_errs == 1 ? "y" : "ies"
+            direct = strict ? "" : "direct "
+            err_msg = "The following $n_direct_errs $(direct)dependenc$(pluralde) failed to precompile:\n$(err_str[1:end-1])"
+            if internal_call # aka. auto-precompilation
+                if isinteractive() && !get(ENV, "CI", false)
+                    plural1 = length(failed_deps) == 1 ? "y" : "ies"
+                    println(io, "  ", color_string("$(length(failed_deps))", Base.error_color()), " dependenc$(plural1) errored.")
+                    println(io, "  For a report of the errors see `julia> err`")
+                    setglobal!(Base.MainInclude, :err, PkgPrecompileError(err_msg))
+                else
+                    # auto-precompilation shouldn't throw but if the user can't easily access the
+                    # error messages, just show them
+                    print(io, "\n", err_msg)
+                end
+            else
+                println(io)
+                pkgerror(err_msg)
             end
         end
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -22,7 +22,8 @@ using SHA
 
 export UUID, SHA1, VersionRange, VersionSpec,
     PackageSpec, PackageEntry, EnvCache, Context, GitRepo, Context!, Manifest, Project, err_rep,
-    PkgError, pkgerror, has_name, has_uuid, is_stdlib, stdlib_version, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml,
+    PkgError, pkgerror, PkgPrecompileError,
+    has_name, has_uuid, is_stdlib, stdlib_version, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml,
     project_resolve!, project_deps_resolve!, manifest_resolve!, registry_resolve!, stdlib_resolve!, handle_repos_develop!, handle_repos_add!, ensure_resolved,
     registered_name,
     manifest_info,
@@ -68,6 +69,16 @@ struct PkgError <: Exception
 end
 pkgerror(msg::String...) = throw(PkgError(join(msg)))
 Base.showerror(io::IO, err::PkgError) = print(io, err.msg)
+
+#################
+# Pkg Precompile Error #
+#################
+struct PkgPrecompileError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, err::PkgPrecompileError) = print(io, err.msg)
+# This needs a show method to make `julia> err` show nicely
+Base.show(io::IO, err::PkgPrecompileError) = print(io, "PkgPrecompileError: ", err.msg)
 
 
 ###############


### PR DESCRIPTION
It seems the way auto-precompilation only summarizes which packages errored not the verbose error details is unpopular so this ~makes autoprecompilation show errors the way an explicit `Pkg.precompile` does.~

Updated: Now autoprecompilation pipes any errors to `Main.err`

```
Precompiling project...
  ✗ PNGFiles
  0 dependencies successfully precompiled in 1 seconds. 38 already precompiled.
  To see a full report use `julia> err`

julia> err
The following 1 direct dependency failed to precompile:

PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883]

Failed to precompile PNGFiles [f57f5aa1-a3ce-4bc8-8ab9-96f992907883] to "/Users/ian/.julia/compiled/v1.11/PNGFiles/jl_X0edfU".
ERROR: LoadError: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:44
 [2] top-level scope
   @ ~/Documents/GitHub/PNGFiles.jl/src/PNGFiles.jl:3
 [3] include
   @ Base ./Base.jl:493 [inlined]
 [4] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:2244
 [5] top-level scope
   @ stdin:3
in expression starting at /Users/ian/Documents/GitHub/PNGFiles.jl/src/PNGFiles.jl:1
in expression starting at stdin:3


julia> 
```

Also in noninteractive & CI modes it will always show errors now.

Closes https://github.com/JuliaLang/Pkg.jl/issues/3444
Closes https://github.com/JuliaLang/Pkg.jl/issues/3428