### PR TITLE
handle git cli errors as pkgerrors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - run: julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
-          JULIA_PKG_TEST_QUIET: "false" # "true" is the default. i.e. tests are quiet when this env var isn't set
+          JULIA_PKG_TEST_QUIET: "true" # "true" is the default. i.e. tests are quiet when this env var isn't set
       - uses: julia-actions/julia-processcoverage@v1
         env:
             JULIA_PKG_SERVER: ${{ matrix.pkg-server }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - run: julia --project --color=yes --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
-          JULIA_PKG_TEST_QUIET: "true" # "true" is the default. i.e. tests are quiet when this env var isn't set
+          JULIA_PKG_TEST_QUIET: "false" # "true" is the default. i.e. tests are quiet when this env var isn't set
       - uses: julia-actions/julia-processcoverage@v1
         env:
             JULIA_PKG_SERVER: ${{ matrix.pkg-server }}

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -109,7 +109,12 @@ function clone(io::IO, url, source_path; header=nothing, credentials=nothing, kw
     end
     try
         if use_cli_git()
-            run(pipeline(`git clone --quiet $url $source_path`; stdout=devnull))
+            cmd = `git clone --quiet $url $source_path`
+            try
+                run(pipeline(cmd; stdout=devnull))
+            catch err
+                Pkg.Types.pkgerror("The command $(cmd) failed, error: $err")
+            end
             return LibGit2.GitRepo(source_path)
         else
             mkpath(source_path)
@@ -161,7 +166,12 @@ function fetch(io::IO, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing,
         if use_cli_git()
             let remoteurl=remoteurl
                 cd(LibGit2.path(repo)) do
-                    run(pipeline(`git fetch -q $remoteurl $(only(refspecs))`; stdout=devnull))
+                    cmd = `git fetch -q $remoteurl $(only(refspecs))`
+                    try
+                        run(pipeline(cmd; stdout=devnull))
+                    catch err
+                        Pkg.Types.pkgerror("The command $(cmd) failed, error: $err")
+                    end
                 end
             end
         else

--- a/test/new.jl
+++ b/test/new.jl
@@ -2689,7 +2689,7 @@ end
 # Note: these tests should be run on clean depots
 for v in (nothing, "true")
     withenv("JULIA_PKG_USE_CLI_GIT" => v) do
-        @testset "downloads" begin
+        @testset "downloads with JULIA_PKG_USE_CLI_GIT = $v" begin
             isolate() do
                 @testset "libgit2 downloads" begin
                     @testset "via name" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -2699,7 +2699,7 @@ for v in (nothing, "true")
                         @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                         Pkg.rm(TEST_PKG.name)
                     end
-                    if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Base.iswindows()) == false
+                    if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Sys.iswindows()) == false
                         # TODO: fix. on GH windows runners cli git will prompt for credentials here
                         @testset "via url" begin
                             Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
@@ -2708,7 +2708,7 @@ for v in (nothing, "true")
                         end
                     end
                 end
-                if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Base.iswindows()) == false
+                if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Sys.iswindows()) == false
                     # TODO: fix. on GH windows runners cli git will prompt for credentials here
                     @testset "libgit2 failures" begin
                         doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"

--- a/test/new.jl
+++ b/test/new.jl
@@ -2690,19 +2690,20 @@ end
 @testset "downloads" begin
     for v in (nothing, "true")
         withenv("JULIA_PKG_USE_CLI_GIT" => v) do
-            # libgit2 downloads
-            isolate() do
-                Pkg.add("Example"; use_git_for_all_downloads=true)
-                @test haskey(Pkg.dependencies(), exuuid)
-                @eval import $(Symbol(TEST_PKG.name))
-                @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
-                Pkg.rm(TEST_PKG.name)
-            end
             isolate() do
                 @testset "libgit2 downloads" begin
-                    Pkg.add(TEST_PKG.name; use_git_for_all_downloads=true)
-                    @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                    Pkg.rm(TEST_PKG.name)
+                    @testset "via name" begin
+                        Pkg.add(TEST_PKG.name; use_git_for_all_downloads=true)
+                        @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                        @eval import $(Symbol(TEST_PKG.name))
+                        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
+                        Pkg.rm(TEST_PKG.name)
+                    end
+                    @testset "via url" begin
+                        Pkg.add(url=TEST_PKG.url; use_git_for_all_downloads=true)
+                        @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                        Pkg.rm(TEST_PKG.name)
+                    end
                 end
                 @testset "libgit2 failures" begin
                     doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"

--- a/test/new.jl
+++ b/test/new.jl
@@ -2704,6 +2704,11 @@ end
                     @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
                     Pkg.rm(TEST_PKG.name)
                 end
+                @testset "libgit2 failures" begin
+                    doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
+                    @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
+                    @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))
+                end
                 @testset "tarball downloads" begin
                     Pkg.add("JSON"; use_only_tarballs_for_downloads=true)
                     @test "JSON" in [pkg.name for (uuid, pkg) in Pkg.dependencies()]

--- a/test/new.jl
+++ b/test/new.jl
@@ -2708,7 +2708,7 @@ for v in (nothing, "true")
                         end
                     end
                 end
-                if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Sys.iswindows()) == false
+                if !Sys.iswindows()
                     # TODO: fix. on GH windows runners cli git will prompt for credentials here
                     @testset "libgit2 failures" begin
                         doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"

--- a/test/new.jl
+++ b/test/new.jl
@@ -2687,9 +2687,9 @@ end
 # # Other
 #
 # Note: these tests should be run on clean depots
-@testset "downloads" begin
-    for v in (nothing, "true")
-        withenv("JULIA_PKG_USE_CLI_GIT" => v) do
+for v in (nothing, "true")
+    withenv("JULIA_PKG_USE_CLI_GIT" => v) do
+        @testset "downloads" begin
             isolate() do
                 @testset "libgit2 downloads" begin
                     @testset "via name" begin
@@ -2700,7 +2700,7 @@ end
                         Pkg.rm(TEST_PKG.name)
                     end
                     @testset "via url" begin
-                        Pkg.add(url=TEST_PKG.url; use_git_for_all_downloads=true)
+                        Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
                         @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
                         Pkg.rm(TEST_PKG.name)
                     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2699,16 +2699,22 @@ for v in (nothing, "true")
                         @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                         Pkg.rm(TEST_PKG.name)
                     end
-                    @testset "via url" begin
-                        Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
-                        @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                        Pkg.rm(TEST_PKG.name)
+                    if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Base.iswindows()) == false
+                        # TODO: fix. on GH windows runners cli git will prompt for credentials here
+                        @testset "via url" begin
+                            Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                            @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                            Pkg.rm(TEST_PKG.name)
+                        end
                     end
                 end
-                @testset "libgit2 failures" begin
-                    doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
-                    @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
-                    @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))
+                if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Base.iswindows()) == false
+                    # TODO: fix. on GH windows runners cli git will prompt for credentials here
+                    @testset "libgit2 failures" begin
+                        doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
+                        @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
+                        @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))
+                    end
                 end
                 @testset "tarball downloads" begin
                     Pkg.add("JSON"; use_only_tarballs_for_downloads=true)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2688,7 +2688,7 @@ end
 #
 # Note: these tests should be run on clean depots
 for v in (nothing, "true")
-    withenv("JULIA_PKG_USE_CLI_GIT" => v) do
+    withenv("JULIA_PKG_USE_CLI_GIT" => v, "GIT_TERMINAL_PROMPT" => 0) do
         @testset "downloads with JULIA_PKG_USE_CLI_GIT = $v" begin
             isolate() do
                 @testset "libgit2 downloads" begin


### PR DESCRIPTION
Without this if you're offline and using the git cli
```
(Pkg) pkg> up
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = RequestError: Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/Registry/Registry.jl:69
    Updating registry at `~/.julia/registries/HolyLabRegistry`
    Updating git-repo `git@github.com:HolyLab/HolyLabRegistry`
ssh: connect to host github.com port 22: Undefined error: 0
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
ERROR: failed process: Process(`git fetch -q git@github.com:HolyLab/HolyLabRegistry +refs/heads/master:refs/remotes/origin/master`, ProcessExited(128)) [128]

Stacktrace:
  [1] pipeline_error(proc::Base.Process)
    @ Base ./process.jl:565 [inlined]
  [2] run(::Base.CmdRedirect; wait::Bool)
    @ Base ./process.jl:480
  [3] run(::Base.CmdRedirect)
    @ Base ./process.jl:477 [inlined]
  [4] (::Pkg.GitTools.var"#6#8"{Vector{String}, SubString{String}})()
    @ Pkg.GitTools ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/GitTools.jl:164
  [5] cd(f::Pkg.GitTools.var"#6#8"{Vector{String}, SubString{String}}, dir::String)
    @ Base.Filesystem ./file.jl:112
  [6] fetch(io::Base.TTY, repo::LibGit2.GitRepo, remoteurl::Nothing; header::Nothing, credentials::Nothing, refspecs::Vector{String}, kwargs::@Kwargs{})
    @ Pkg.GitTools ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/GitTools.jl:163
  [7] kwcall(::NamedTuple, ::typeof(Pkg.GitTools.fetch), io::IO, repo::LibGit2.GitRepo) (repeats 2 times)
    @ Pkg.GitTools ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/GitTools.jl:135 [inlined]
  [8] (::Pkg.Registry.var"#77#82"{Pkg.Registry.RegistryInstance, Vector{Tuple{String, String}}, String, Base.TTY, Dict{String, Any}})(repo::LibGit2.GitRepo)
    @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/Registry/Registry.jl:464
  [9] with(f::Pkg.Registry.var"#77#82"{Pkg.Registry.RegistryInstance, Vector{Tuple{String, String}}, String, Base.TTY, Dict{String, Any}}, obj::LibGit2.GitRepo)
    @ LibGit2 ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/LibGit2/src/types.jl:1160
 [10] (::Pkg.Registry.var"#73#78"{Base.TTY, Dates.Day, Dict{String, Any}, String, Vector{Pkg.Registry.RegistryInstance}})()
    @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/Registry/Registry.jl:449
 [11] mkpidlock(f::Pkg.Registry.var"#73#78"{Base.TTY, Dates.Day, Dict{…}, String, Vector{…}}, at::String, pid::Int32; kwopts::@Kwargs{stale_age::Int64})
    @ FileWatching.Pidfile ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:92
 [12] mkpidlock(f::Pkg.Registry.var"#73#78"{Base.TTY, Dates.Day, Dict{String, Any}, String}, at::String; kwopts::@Kwargs{stale_age::Int64})
    @ FileWatching.Pidfile ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:87 [inlined]
 [13] mkpidlock
    @ FileWatching.Pidfile ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:87 [inlined]
 [14] update(regs::Vector{Pkg.Registry.RegistrySpec}; io::Base.TTY, force::Bool, depots::Vector{String}, update_cooldown::Dates.Day)
    @ Pkg.Registry ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/Registry/Registry.jl:379
 [15] update_registries(ctx::Pkg.Types.Context; force::Bool, kwargs::@Kwargs{update_cooldown::Dates.Day})
    @ Pkg.Operations ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:1266
 [16] add(ctx::Pkg.Types.Context, pkgs::Vector{…}; preserve::Pkg.Types.PreserveLevel, platform::Base.BinaryPlatforms.Platform, kwargs::@Kwargs{…})
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/API.jl:262
 [17] add(pkgs::Vector{Pkg.Types.PackageSpec}; io::Base.TTY, kwargs::@Kwargs{})
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/API.jl:159
 [18] add(pkgs::Vector{Pkg.Types.PackageSpec})
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/API.jl:148
 [19] add(pkgs::Vector{String}; kwargs::@Kwargs{})
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/API.jl:147 [inlined]
 [20] add
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/API.jl:147 [inlined]
 [21] try_prompt_pkg_add(pkgs::Vector{Symbol})
    @ Pkg.REPLMode ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Pkg/src/REPLMode/REPLMode.jl:729
 [22] invokelatest(f::Any, args::Vector{Symbol}; kwargs::@Kwargs{})
    @ Base ./essentials.jl:867 [inlined]
 [23] invokelatest(f::Any, args::Vector{Symbol})
    @ Base ./essentials.jl:864 [inlined]
 [24] check_for_missing_packages_and_run_hooks(ast::Any)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:174
 [25] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:145
 [26] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:246
 [27] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:231
 [28] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:376
 [29] run_repl(repl::REPL.AbstractREPL, consumer::Any)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:362
 [30] (::Base.var"#1010#1012"{Bool, Bool, Bool})(REPL::Module)
    @ Base ./client.jl:432
 [31] invokelatest(::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.AbstractLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::Symbol, ::Symbol, ::String, ::Int64; kwargs::@Kwargs{})
    @ Base ./essentials.jl:867 [inlined]
 [32] invokelatest(f::Base.var"#1010#1012"{Bool, Bool, Bool}, args::Module)
    @ Base ./essentials.jl:864 [inlined]
 [33] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
    @ Base ./client.jl:416
 [34] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:333
 [35] _start()
    @ Base ./client.jl:552
Some type information was truncated. Use `show(err)` to see complete types.

(Pkg) pkg> 
```

With this PR
```
(Pkg) pkg> up
┌ Warning: could not download https://pkg.julialang.org/registries
│   exception = RequestError: Could not resolve host: pkg.julialang.org while requesting https://pkg.julialang.org/registries
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:69
    Updating registry at `~/.julia/registries/HolyLabRegistry`
    Updating git-repo `git@github.com:HolyLab/HolyLabRegistry`
ssh: connect to host github.com port 22: Undefined error: 0
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
    Updating registry at `~/.julia/registries/General.toml`
┌ Error: Some registries failed to update:
│     — /Users/ian/.julia/registries/HolyLabRegistry — failed to fetch from repo: Git cli failed to fetch repository at 'git@github.com:HolyLab/HolyLabRegistry'
│ error: ProcessFailedException(Base.Process[Process(`git fetch -q git@github.com:HolyLab/HolyLabRegistry +refs/heads/master:refs/remotes/origin/master`, ProcessExited(128))])
└ @ Pkg.Registry ~/Documents/GitHub/Pkg.jl/src/Registry/Registry.jl:510
  No Changes to `~/Documents/GitHub/Pkg.jl/Project.toml`
  No Changes to `~/Documents/GitHub/Pkg.jl/Manifest.toml`

(Pkg) pkg> 
```

The 
```
ssh: connect to host github.com port 22: Undefined error: 0
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
is a little untidy but I thought it best to not capture stderr in case the git cli is asking the user for user credentials etc.