### PR TITLE
Remove mentions of “home project” in documentation and comments

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -539,9 +539,8 @@ The logic for what path is activated is as follows:
     activate the environment at the tracked path.
   * Otherwise, `s` is interpreted as a non-existing path, which is then activated.
 
-If no argument is given to `activate`, then activate the home project.
-The home project is specified by either the `--project` command line option to
-the julia executable, or the `JULIA_PROJECT` environment variable.
+If no argument is given to `activate`, then use `LOAD_PATH` to determine the
+project to activate.
 
 # Examples
 ```

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -539,8 +539,7 @@ The logic for what path is activated is as follows:
     activate the environment at the tracked path.
   * Otherwise, `s` is interpreted as a non-existing path, which is then activated.
 
-If no argument is given to `activate`, then use `LOAD_PATH` to determine the
-project to activate.
+If no argument is given to `activate`, then use the first project found in `LOAD_PATH`.
 
 # Examples
 ```

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -304,7 +304,7 @@ PSA[:name => "activate",
     activate [--shared] path
     activate --temp
 
-Activate the environment at the given `path`, or use `LOAD_PATH` to determine the project to activate if no `path` is specified.
+Activate the environment at the given `path`, or use the first project found in `LOAD_PATH` if no `path` is specified.
 The active environment is the environment that is modified by executing package commands.
 When the option `--shared` is given, `path` will be assumed to be a directory name and searched for in the
 `environments` folders of the depots in the depot stack. In case no such environment exists in any of the depots,

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -304,7 +304,7 @@ PSA[:name => "activate",
     activate [--shared] path
     activate --temp
 
-Activate the environment at the given `path`, or the home project environment if no `path` is specified.
+Activate the environment at the given `path`, or use `LOAD_PATH` to determine the project to activate if no `path` is specified.
 The active environment is the environment that is modified by executing package commands.
 When the option `--shared` is given, `path` will be assumed to be a directory name and searched for in the
 `environments` folders of the depots in the depot stack. In case no such environment exists in any of the depots,

--- a/test/api.jl
+++ b/test/api.jl
@@ -38,7 +38,7 @@ using ..Utils
         cd(mkdir("tests"))
         Pkg.activate("Foo") # activate developed Foo from another directory
         @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
-        Pkg.activate() # activate home project
+        Pkg.activate() # activate LOAD_PATH project
         @test Base.ACTIVE_PROJECT[] === nothing
     end end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -53,7 +53,7 @@ Pkg._auto_gc_enabled[] = false
             source053 = pkg.source
             source053_time = mtime(pkg.source)
         end
-        # - The home project was automatically created.
+        # - The active project was automatically created.
         @test haskey(Pkg.project().dependencies, "Example")
         @test length(Pkg.project().dependencies) == 1
         # Now we install the same package at a different version:

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -260,7 +260,7 @@ temp_pkg_dir() do project_path
         pkg"activate --shared Foo" # activate existing shared Foo
         @test Base.active_project() == joinpath(tmpdir, "Project.toml")
         pop!(Base.DEPOT_PATH)
-        pkg"activate" # activate home project
+        pkg"activate" # activate LOAD_PATH project
         @test Base.ACTIVE_PROJECT[] === nothing
         # expansion of ~
         if !Sys.iswindows()


### PR DESCRIPTION
The concept of “home project” was removed in JuliaLang/julia#36434. Also see #1891.

Fixes #3127.