### PR TITLE
command_declarations.jl: add missing full stop in status command

### DIFF
--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -422,7 +422,7 @@ the output to the difference as compared to the last git commit.
 The `--compat` option alone shows project compat entries.
 
 !!! compat "Julia 1.8"
-    The `⌃` and `⌅` indicators were added in Julia 1.8
+    The `⌃` and `⌅` indicators were added in Julia 1.8.
     The `--outdated` and `--compat` options require at least Julia 1.8.
 """,
 ],


### PR DESCRIPTION
The API status function documentation (https://pkgdocs.julialang.org/v1/api/#Pkg.status) has a full stop after the first sentence of the 1.8 box, but in the REPL docs page it was missing. 