### PR TITLE
precompile: try to prevent wrapping-caused mess during pretty printing

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1332,22 +1332,28 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                         end
                         bar.current = n_done - n_already_precomp
                         bar.max = n_total - n_already_precomp
-                        final_loop || print(iostr, sprint(io -> show_progress(io, bar; termwidth = displaysize(ctx.io)[2]); context=io), "\n")
+                        # when sizing to the terminal width subtract a little to give some tolerance to resizing the
+                        # window between print cycles
+                        termwidth = displaysize(io)[2] - 4
+                        if !final_loop
+                            str = sprint(io -> show_progress(io, bar; termwidth, carriagereturn=false); context=io)
+                            print(iostr, Base._truncate_at_width_or_chars(true, str, termwidth), "\n")
+                        end
                         for dep in pkg_queue_show
                             loaded = warn_loaded && haskey(Base.loaded_modules, dep)
                             _name = haskey(exts, dep) ? string(exts[dep], " → ", dep.name) : dep.name
                             name = dep in direct_deps ? _name : string(color_string(_name, :light_black))
-                            if dep in precomperr_deps
-                                print(iostr, color_string("  ? ", Base.warn_color()), name, "\n")
+                            line = if dep in precomperr_deps
+                                string(color_string("  ? ", Base.warn_color()), name)
                             elseif haskey(failed_deps, dep)
-                                print(iostr, color_string("  ✗ ", Base.error_color()), name, "\n")
+                                string(color_string("  ✗ ", Base.error_color()), name)
                             elseif was_recompiled[dep]
                                 !loaded && interrupted_or_done.set && continue
-                                print(iostr, color_string("  ✓ ", loaded ? Base.warn_color() : :green), name, "\n")
                                 loaded || @async begin # keep successful deps visible for short period
                                     sleep(1);
                                     filter!(!isequal(dep), pkg_queue)
                                 end
+                                string(color_string("  ✓ ", loaded ? Base.warn_color() : :green), name)
                             elseif started[dep]
                                 # Offset each spinner animation using the first character in the package name as the seed.
                                 # If not offset, on larger terminal fonts it looks odd that they all sync-up
@@ -1361,10 +1367,11 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                                 else
                                     ""
                                 end
-                                print(iostr, "  $anim_char_colored $name$waiting\n")
+                                string("  ", anim_char_colored, " ", name, waiting)
                             else
-                                print(iostr, "    $name\n")
+                                string("    ", name)
                             end
+                            println(iostr, Base._truncate_at_width_or_chars(true, line, termwidth))
                         end
                     end
                     last_length = length(pkg_queue_show)

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -26,7 +26,7 @@ function start_progress(io::IO, _::MiniProgressBar)
     print(io, ansi_disablecursor)
 end
 
-function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing)
+function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagereturn=true)
     if p.max == 0
         perc = 0.0
         prev_perc = 0.0
@@ -52,7 +52,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing)
     else
         string(p.current, "/",  p.max)
     end
-    termwidth = something(termwidth, displaysize(io)[2])
+    termwidth = @something termwidth displaysize(io)[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
     n_filled = ceil(Int, max_progress_width * perc / 100)
     n_left = max_progress_width - n_filled
@@ -63,7 +63,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing)
         print(io, "="^n_filled, ">")
         print(io, " "^n_left, "]  ", )
         print(io, progress_text)
-        print(io, "\r")
+        carriagereturn && print(io, "\r")
     end
     # Print everything in one call
     print(io, to_print)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3560 
Or more accurately makes it a lot less likely by truncating the lines during the fancy printing to a little less than terminal width.