### PR TITLE
precompile: also consider sysimage modules that activate extensions

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1119,7 +1119,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
             extdep_names = extdep_names isa String ? String[extdep_names] : extdep_names
             for extdep_name in extdep_names
                 extdep_uuid = weakdeps[extdep_name]
-                if extdep_uuid in keys(ctx.env.manifest.deps)
+                if extdep_uuid in keys(ctx.env.manifest.deps) || Base.in_sysimage(Base.PkgId(extdep_uuid, extdep_name))
                     push!(ext_deps, Base.PkgId(extdep_uuid, extdep_name))
                 else
                     all_extdeps_available = false


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3571

Before
```
shell> rm -rf ~/.julia/compiled/v1.11

(@v1.11) pkg> st
Status `~/.julia/environments/v1.11/Project.toml`
  [34da2185] Compat v4.9.0

(@v1.11) pkg> precompile
Precompiling project...
  1 dependency successfully precompiled in 1 seconds

julia> using Compat
[ Info: Precompiling CompatLinearAlgebraExt [dbe5ba0b-aecc-598a-a867-79051b540f49]
```

This PR
```
shell> rm -rf ~/.julia/compiled/v1.11

(@v1.11) pkg> st
Status `~/.julia/environments/v1.11/Project.toml`
  [34da2185] Compat v4.9.0

(@v1.11) pkg> precompile
Precompiling project...
  2 dependencies successfully precompiled in 1 seconds

julia> using Compat

julia> 
```
