### PR TITLE
status: expand 2 symbol upgrade note to highlight *may* be upgradable

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2407,7 +2407,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
             printpkgstyle(io, :Info, "Packages marked with $heldback_indicator have new versions available but compatibility constraints restrict them from upgrading.$tip", color=Base.info_color(), ignore_indent)
         end
         if !no_visible_packages_heldback && !no_packages_upgradable
-            printpkgstyle(io, :Info, "Packages marked with $upgradable_indicator and $heldback_indicator have new versions available, but those with $heldback_indicator are restricted by compatibility constraints from upgrading.$tip", color=Base.info_color(), ignore_indent)
+            printpkgstyle(io, :Info, "Packages marked with $upgradable_indicator and $heldback_indicator have new versions available. Those with $upgradable_indicator may be upgradable, but those with $heldback_indicator are restricted by compatibility constraints from upgrading.$tip", color=Base.info_color(), ignore_indent)
         end
         if !manifest && hidden_upgrades_info && no_visible_packages_heldback && !no_packages_heldback
             # only warn if showing project and outdated indirect deps are hidden


### PR DESCRIPTION
Update: Now just a slight tweak to the original message to avoid duplication.

___

The combined Info tip skipped the key word "may" in `may be upgradable` which has been a common source of confusion.
I think it might just be better to show each tip individually if both symbols are present?

Before
<img width="1141" alt="Screenshot 2023-08-08 at 11 39 40 PM" src="https://github.com/JuliaLang/Pkg.jl/assets/1694067/4f01708f-17a8-4a70-a97f-c03511fde056">


This PR
<img width="1142" alt="Screenshot 2023-08-08 at 11 38 41 PM" src="https://github.com/JuliaLang/Pkg.jl/assets/1694067/f65c0790-6b81-440d-ac25-d7a761eea79d">
