### PR TITLE
Update manifest entry of project for non-local manifests

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -922,10 +922,15 @@ end
 project_rel_path(env::EnvCache, path::String) = normpath(joinpath(dirname(env.manifest_file), path))
 
 function prune_manifest(env::EnvCache)
-    # if project uses another manifest, don't prune
-    dirname(env.project_file) != dirname(env.manifest_file) && return env.manifest
-    keep = collect(values(env.project.deps))
-    env.manifest = prune_manifest(env.manifest, keep)
+    # if project uses another manifest, only prune project entry in manifest
+    if dirname(env.project_file) != dirname(env.manifest_file)
+        proj_entry = env.manifest[env.project.uuid]
+        proj_entry.deps = env.project.deps
+    else
+        keep = collect(values(env.project.deps))
+        env.manifest = prune_manifest(env.manifest, keep)
+    end
+    return env.manifest
 end
 
 function prune_manifest(manifest::Manifest, keep::Vector{UUID})

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -52,6 +52,7 @@ temp_pkg_dir() do project_path
             m = Pkg.Types.read_manifest(joinpath(dir, "monorepo", "Manifest.toml"))
             # currently, we don't prune dependencies from the root manifest since when rm-ing a dep
             # in a subpackage, we don't also do a full resolve at the root level
+            # https://github.com/JuliaLang/Pkg.jl/issues/3590
             @test_broken !haskey(m, UUID("bf733257-898a-45a0-b2f2-c1c188bdd870")) # D subpackage, but no direct dependency
             pkgC = m[UUID("4ee78ca3-4e78-462f-a078-747ed543fa86")]
             @test !haskey(pkgC.deps, "D")

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -1,7 +1,7 @@
 module ProjectManifestTest
 
 import ..Pkg # ensure we are using the correct Pkg
-using Test, Pkg
+using Test, Pkg, UUIDs
 using ..Utils
 
 temp_pkg_dir() do project_path
@@ -29,6 +29,12 @@ temp_pkg_dir() do project_path
                     Pkg.test()
                 end
             end
+            m = Pkg.Types.read_manifest(joinpath(dir, "monorepo", "Manifest.toml"))
+            @test haskey(m, UUID("dd0d8fba-d7c4-4f8e-a2bb-3a090b3e34f2")) # B subpackage
+            @test haskey(m, UUID("4ee78ca3-4e78-462f-a078-747ed543fa86")) # C subpackage
+            @test haskey(m, UUID("bf733257-898a-45a0-b2f2-c1c188bdd870")) # D subpackage, but no direct dependency
+            pkgC = m[UUID("4ee78ca3-4e78-462f-a078-747ed543fa86")]
+            @test haskey(pkgC.deps, "D")
             cd(joinpath(dir, "monorepo")) do
                 with_current_env() do
                     Pkg.develop(path="packages/C")
@@ -36,6 +42,19 @@ temp_pkg_dir() do project_path
                     Pkg.test()
                 end
             end
+            # now test removing a dependency from subpackage correctly updates root manifest
+            cd(joinpath(dir, "monorepo", "packages", "C")) do
+                with_current_env() do
+                    Pkg.rm("D")
+                    Pkg.test()
+                end
+            end
+            m = Pkg.Types.read_manifest(joinpath(dir, "monorepo", "Manifest.toml"))
+            # currently, we don't prune dependencies from the root manifest since when rm-ing a dep
+            # in a subpackage, we don't also do a full resolve at the root level
+            @test_broken !haskey(m, UUID("bf733257-898a-45a0-b2f2-c1c188bdd870")) # D subpackage, but no direct dependency
+            pkgC = m[UUID("4ee78ca3-4e78-462f-a078-747ed543fa86")]
+            @test !haskey(pkgC.deps, "D")
         end
     end
 end


### PR DESCRIPTION
Instead of just skipping manifest pruning all together (which is tricky because we're often _not_ operating in a root-level context which would _correctly_ prune everything), we can at least update the dependency list of the currently activated project in the root-level manifest.