### PR TITLE
Ensure that `string(::VersionSpec)` is compatible with `semver_spec()`

### DIFF
--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -161,15 +161,15 @@ function Base.print(io::IO, r::VersionRange)
     if (m, n) == (0, 0)
         print(io, '*')
     elseif m == 0
-        print(io, "0-")
+        print(io, "0 -")
         join(io, r.upper.t, '.')
     elseif n == 0
         join(io, r.lower.t, '.')
-        print(io, "-*")
+        print(io, " - *")
     else
         join(io, r.lower.t[1:m], '.')
         if r.lower != r.upper
-            print(io, '-')
+            print(io, " - ")
             join(io, r.upper.t[1:n], '.')
         end
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -140,6 +140,7 @@ import Pkg.Types: semver_spec, VersionSpec
     @test !(v"0.3" in semver_spec("0.1 - 0.2"))
     @test v"0.2.99" in semver_spec("0.1 - 0.2")
     @test v"0.3" in semver_spec("0.1 - 0")
+    @test semver_spec(string(VersionSpec("1-2"))) == VersionSpec("1-2")
 
     @test_throws ErrorException semver_spec("^^0.2.3")
     @test_throws ErrorException semver_spec("^^0.2.3.4")
@@ -152,7 +153,7 @@ end
 
 # TODO: Should rewrite these tests not to rely on internals like field names
 @testset "union, isjoinable" begin
-    @test sprint(print, VersionRange("0-0.3.2")) == "0-0.3.2"
+    @test sprint(print, VersionRange("0-0.3.2")) == "0 - 0.3.2"
     # test missing paths on union! and isjoinable
     # there's no == for VersionBound or VersionRange
     unified_vr = union!([VersionRange("1.5-2.8"), VersionRange("2.5-3")])[1]


### PR DESCRIPTION
It is an unfortunate coincidence that if you try to print out a `VersionSpec` to a project's `compat` field, it can be in a format that `semver_spec()` rejects due to the ambiguity of `1.2.0-1.4.0` being either a prerelease with a very strange prerelease tag, or a range of versions.  We reduce the ambiguity by changing `VersionSpec` to always print its bounds with a separating space.