### PR TITLE
precompile: stop swallowing internal errors

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1270,6 +1270,9 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 println(io, " Interrupted: Exiting precompilation...")
             end
             interrupted = true
+            return true
+        else
+            return false
         end
     end
 
@@ -1384,7 +1387,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 wait(t)
             end
         catch err
-            handle_interrupt(err, true)
+            handle_interrupt(err, true) || rethrow()
         finally
             fancyprint && print(io, ansi_enablecursor)
         end
@@ -1492,7 +1495,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 n_done += 1
                 notify(was_processed[pkg])
             catch err_outer
-                handle_interrupt(err_outer)
+                handle_interrupt(err_outer) || rethrow()
                 notify(was_processed[pkg])
             finally
                 filter!(!istaskdone, tasks)
@@ -1505,7 +1508,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     try
         wait(interrupted_or_done)
     catch err
-        handle_interrupt(err)
+        handle_interrupt(err) || rethrow()
     finally
         Base.LOADING_CACHE[] = nothing
     end


### PR DESCRIPTION
Somewhere throwing when internal errors occur was lost. This fixes that.