### PR TITLE
Clarify handling of `LOAD_PATH` in docstring and REPL help

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -557,7 +557,9 @@ The logic for what path is activated is as follows:
     activate the environment at the tracked path.
   * Otherwise, `s` is interpreted as a non-existing path, which is then activated.
 
-If no argument is given to `activate`, then use the first project found in `LOAD_PATH`.
+If no argument is given to `activate`, then use the first project found in `LOAD_PATH`
+(ignoring `"@"`). For the default value of `LOAD_PATH`, the result is to activate the
+`@v#.#` environment.
 
 # Examples
 ```
@@ -566,6 +568,8 @@ Pkg.activate("local/path")
 Pkg.activate("MyDependency")
 Pkg.activate(; temp=true)
 ```
+
+See also [`LOAD_PATH`](https://docs.julialang.org/en/v1/base/constants/#Base.LOAD_PATH).
 """
 const activate = API.activate
 

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -304,7 +304,10 @@ PSA[:name => "activate",
     activate [--shared] path
     activate --temp
 
-Activate the environment at the given `path`, or use the first project found in `LOAD_PATH` if no `path` is specified.
+Activate the environment at the given `path`, or use the first project found in
+`LOAD_PATH` (ignoring `"@"`) if no `path` is specified.
+In the latter case, for the default value of `LOAD_PATH`, the result is to activate the
+`@v#.#` environment.
 The active environment is the environment that is modified by executing package commands.
 When the option `--shared` is given, `path` will be assumed to be a directory name and searched for in the
 `environments` folders of the depots in the depot stack. In case no such environment exists in any of the depots,


### PR DESCRIPTION
As discussed in #3547, this adds some clarification on how `LOAD_PATH` is used to set the active project when using the no-argument form of `Pkg.activate()`.