### PR TITLE
Fix lacking `subdir` information when altering packages

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -635,6 +635,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
             entry = manifest_info(ctx.env.manifest, uuid)
             if entry !== nothing
                 pkg.repo.source = entry.repo.source
+                pkg.repo.subdir = entry.repo.subdir
             end
         end
     end
@@ -738,8 +739,9 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
         manifest_resolve!(ctx.env.manifest, [pkg]; force=true)
         if isresolved(pkg)
             entry = manifest_info(ctx.env.manifest, pkg.uuid)
-            if entry !== nothing && entry.repo.source !== nothing # reuse source in manifest
+            if entry !== nothing
                 pkg.repo.source = entry.repo.source
+                pkg.repo.subdir = entry.repo.subdir
             end
         end
         if pkg.repo.source === nothing

--- a/test/subdir.jl
+++ b/test/subdir.jl
@@ -192,6 +192,10 @@ end
         @test isinstalled("Package")
         @test !isinstalled("Dep")
         @test isinstalled(dep)
+
+        # Test that adding a second time doesn't error (#3391)
+        pkg"add Package#master"
+        @test isinstalled("Package")
         pkg"rm Package"
 
         pkg"add Dep#master"
@@ -204,6 +208,10 @@ end
         @test isinstalled("Package")
         @test !isinstalled("Dep")
         @test isinstalled(dep)
+
+        # Test developing twice (#3391)
+        pkg"develop Package"
+        @test isinstalled("Package")
         pkg"rm Package"
 
         pkg"develop Dep"


### PR DESCRIPTION
If a package we're altering is already in the manifest, we try to load some information from the manifest, but we forgot to load `subdir` in these two cases.

This fixes #3391.