### PR TITLE
[release-1.10] Backports for 1.10

### DIFF
--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -30,8 +30,8 @@ identify the package in projects that depend on it.
 to be reused by other Julia projects. For example a web application or a
 command-line utility, or simulation/analytics code accompanying a scientific paper.
 An application may have a UUID but does not need one.
-An application may also provide global configuration options for packages it
-depends on. Packages, on the other hand, may not provide global configuration
+An application may also set and change the global configurations of packages it
+depends on. Packages, on the other hand, may not change the global state of their dependencies
 since that could conflict with the configuration of the main application.
 
 !!! note

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -273,7 +273,25 @@ test = ["Test"]
 The tests are executed in a new process with `check-bounds=yes` and by default `startup-file=no`.
 If using the startup file (`~/.julia/config/startup.jl`) is desired, start julia with `--startup-file=yes`.
 Inlining of functions during testing can be disabled (for better coverage accuracy)
-by starting julia with `--inline=no`.
+by starting julia with `--inline=no`. The tests can be run as if different command line arguments were
+passed to julia by passing the arguments instead to the `julia_args` keyword argument, e.g.
+
+```
+Pkg.test("foo"; julia_args=["--inline"])
+```
+
+To pass some command line arguments to be used in the tests themselves, pass the arguments to the
+`test_args` keyword argument. These could be used to control the code being tested, or to control the
+tests in some way. For example, the tests could have optional additional tests:
+```
+if "--extended" in ARGS
+    @test some_function()
+end
+```
+which could be enabled by testing with
+```
+Pkg.test("foo"; test_args=["--extended"])
+```
 """
 const test = API.test
 


### PR DESCRIPTION
Missed a few off because these PRs are older than the backporter was searching for

Backported PRs:
- [x] #1800 <!-- Clarify "Providing global configuration options" in docs -->
- [x] #2673 <!-- Give examples of using `julia_args`, `test_args` -->

Non-merged PRs with backport label:
- [ ] #3576 <!-- status: use full explanation for upgradable indicators -->