### PR TITLE
Clarify rationale for package extension naming

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -356,6 +356,8 @@ end # module
 
 Extensions can have any arbitrary name (here `PlottingContourExt`), but using something similar to the format of
 this example that makes the extended functionality and dependency of the extension clear is likely a good idea.
+Encoding in the extension name both the name of the main package and of the package that triggers loading the
+extension can be very helpful especially when encountering and debugging errors.
 
 A user that depends only on `Plotting` will not pay the cost of the "extension" inside the `PlottingContourExt` module.
 It is only when the `Contour` package actually gets loaded that the `PlottingContourExt` extension is loaded


### PR DESCRIPTION
Especially in light of issues such as https://github.com/JuliaLang/julia/issues/50873, where users are faced with warnings such as
```
Precompiling project...
  194 dependencies successfully precompiled in 92 seconds. 10 already precompiled.
  3 dependencies had warnings during precompilation:
┌ SummationByPartsOperatorsDiffEqCallbacksExt [82d7d246-636b-5c42-a4f7-7a8a453087a7]
│  [pid 720185] waiting for IO to finish:
│   TYPE[FD/PID]       @UV_HANDLE_T->DATA
│   timer              @0x107c040->0x7f8e2e0e9060
└
┌ LinearMapsStatisticsExt [364b1850-867c-5a65-9f2f-642d093ba2f6]
│  [pid 704422] waiting for IO to finish:
│   TYPE[FD/PID]       @UV_HANDLE_T->DATA
│   timer              @0x261b550->0x7f6d92ae8f10
└
┌ ExponentialUtilities [d4d017d3-3776-5f7e-afef-a10c40355c18]
│  [pid 712737] waiting for IO to finish:
│   TYPE[FD/PID]       @UV_HANDLE_T->DATA
│   timer              @0x955b000->0x7f9e61c56230
└
```
it would be very helpful to have both the main package name and the extension trigger package encoded in the extension name (in this example here, it is already done so for `SummationByPartsOperatorsDiffEqCallbacksExt` and `LinearMapsStatisticsExt`). This PR adds a sentence to the docs to clarify the rationale for the recommendation to further nudge pkg devs to stick to this convention.