### PR TITLE
precompile: show ext parent in output report

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1587,7 +1587,8 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                     else
                         join(split(strip(err), "\n"), color_string("\n│  ", Base.warn_color()))
                     end
-                    print(iostr, color_string("\n┌ ", Base.warn_color()), pkgid, color_string("\n│  ", Base.warn_color()), err, color_string("\n└  ", Base.warn_color()))
+                    name = haskey(exts, pkgid) ? string(exts[pkgid], " → ", pkgid.name) : pkgid.name
+                    print(iostr, color_string("\n┌ ", Base.warn_color()), name, color_string("\n│  ", Base.warn_color()), err, color_string("\n└  ", Base.warn_color()))
                 end
             end
         end


### PR DESCRIPTION
Related to https://github.com/JuliaLang/Pkg.jl/pull/3600

This is one place where it seems good to add the extension parent name as it's shown in the precompile output.

This also removes the uuid from the report to avoid being too long.

```
(@v1.11) pkg> precompile
Precompiling project...
  10 dependencies successfully precompiled in 6 seconds. 22 already precompiled.
  2 dependencies had output during precompilation:
┌ PGFPlotsX → ColorsExt
│  some stdout
│  some stderr
└  
┌ PGFPlotsX
│  some other stdout
│  some other stderr
└  
```