### PR TITLE
[release-1.10] Backports for 1.10

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1580,7 +1580,8 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                     else
                         join(split(strip(err), "\n"), color_string("\n│  ", Base.warn_color()))
                     end
-                    print(iostr, color_string("\n┌ ", Base.warn_color()), pkgid, color_string("\n│  ", Base.warn_color()), err, color_string("\n└  ", Base.warn_color()))
+                    name = haskey(exts, pkgid) ? string(exts[pkgid], " → ", pkgid.name) : pkgid.name
+                    print(iostr, color_string("\n┌ ", Base.warn_color()), name, color_string("\n│  ", Base.warn_color()), err, color_string("\n└  ", Base.warn_color()))
                 end
             end
         end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2411,7 +2411,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
             printpkgstyle(io, :Info, "Packages marked with $heldback_indicator have new versions available but compatibility constraints restrict them from upgrading.$tip", color=Base.info_color(), ignore_indent)
         end
         if !no_visible_packages_heldback && !no_packages_upgradable
-            printpkgstyle(io, :Info, "Packages marked with $upgradable_indicator and $heldback_indicator have new versions available, but those with $heldback_indicator are restricted by compatibility constraints from upgrading.$tip", color=Base.info_color(), ignore_indent)
+            printpkgstyle(io, :Info, "Packages marked with $upgradable_indicator and $heldback_indicator have new versions available. Those with $upgradable_indicator may be upgradable, but those with $heldback_indicator are restricted by compatibility constraints from upgrading.$tip", color=Base.info_color(), ignore_indent)
         end
         if !manifest && hidden_upgrades_info && no_visible_packages_heldback && !no_packages_heldback
             # only warn if showing project and outdated indirect deps are hidden

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -635,6 +635,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
             entry = manifest_info(ctx.env.manifest, uuid)
             if entry !== nothing
                 pkg.repo.source = entry.repo.source
+                pkg.repo.subdir = entry.repo.subdir
             end
         end
     end
@@ -738,8 +739,9 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
         manifest_resolve!(ctx.env.manifest, [pkg]; force=true)
         if isresolved(pkg)
             entry = manifest_info(ctx.env.manifest, pkg.uuid)
-            if entry !== nothing && entry.repo.source !== nothing # reuse source in manifest
+            if entry !== nothing
                 pkg.repo.source = entry.repo.source
+                pkg.repo.subdir = entry.repo.subdir
             end
         end
         if pkg.repo.source === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ module PkgTestsOuter
 original_depot_path = copy(Base.DEPOT_PATH)
 original_load_path = copy(Base.LOAD_PATH)
 original_env = copy(ENV)
+original_project = Base.active_project()
 
 module PkgTestsInner
 
@@ -14,6 +15,7 @@ import Pkg
 if Base.find_package("HistoricalStdlibVersions") === nothing
     @debug "Installing HistoricalStdlibVersions for Pkg tests"
     iob = IOBuffer()
+    Pkg.activate(; temp = true)
     try
         Pkg.add("HistoricalStdlibVersions", io=iob) # Needed for custom julia version resolve tests
     catch
@@ -108,5 +110,7 @@ end
 for (k, v) in pairs(original_env)
     ENV[k] = v
 end
+
+Base.set_active_project(original_project)
 
 end # module

--- a/test/subdir.jl
+++ b/test/subdir.jl
@@ -192,6 +192,10 @@ end
         @test isinstalled("Package")
         @test !isinstalled("Dep")
         @test isinstalled(dep)
+
+        # Test that adding a second time doesn't error (#3391)
+        pkg"add Package#master"
+        @test isinstalled("Package")
         pkg"rm Package"
 
         pkg"add Dep#master"
@@ -204,6 +208,10 @@ end
         @test isinstalled("Package")
         @test !isinstalled("Dep")
         @test isinstalled(dep)
+
+        # Test developing twice (#3391)
+        pkg"develop Package"
+        @test isinstalled("Package")
         pkg"rm Package"
 
         pkg"develop Dep"


### PR DESCRIPTION
Backported PRs:
- [x] #3597 <!-- Fix lacking `subdir` information when altering packages -->
- [x] #3602 <!-- Test suite: activate a temp project if we need to install HistoricalStdlibVersions during the test suite -->
- [x] #3603 <!-- precompile: show ext parent in output report -->
- [x] #3576 <!-- status: use full explanation for upgradable indicators -->

Non-merged PRs with backport label:
- [ ] #3574 <!-- Tweak test dep docs -->