### PR TITLE
[release-1.10] Backports for 1.10

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -191,7 +191,7 @@ load when the package is tested).
 #### `target` based test specific dependencies
 
 Using this method of adding test-specific dependencies, the packages are added under an `[extras]` section and to a test target,
-e.g. to add `Markdown` and `Test` as test dependencies, add the following:
+e.g. to add `Markdown` and `Test` as test dependencies, add the following to the `Project.toml` file:
 
 ```toml
 [extras]
@@ -202,19 +202,19 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Markdown", "Test"]
 ```
 
-to the `Project.toml` file. There are no other "targets" than `test`.
+Note that the only supported targets are `test` and `build`, the latter of which (not recommended) can be used
+for any `deps/build.jl` scripts.
 
-#### `test/Project.toml` file test specific dependencies
+#### Alternative approach: `test/Project.toml` file test specific dependencies
 
 !!! note
     The exact interaction between `Project.toml`, `test/Project.toml` and their corresponding
     `Manifest.toml`s are not fully worked out and may be subject to change in future versions.
-    The old method of adding test-specific dependencies, described in the next section, will
-    therefore be supported throughout all Julia 1.X releases.
+    The older method of adding test-specific dependencies, described in the previous section,
+    will therefore be supported throughout all Julia 1.X releases.
 
- is given by `test/Project.toml`. Thus, when running
-tests, this will be the active project, and only dependencies to the `test/Project.toml` project
-can be used. Note that Pkg will add the tested package itself implicitly.
+In Julia 1.2 and later test dependencies can be declared in `test/Project.toml`. When running
+tests, Pkg will automatically merge this and the package Projects to create the test environment.
 
 !!! note
     If no `test/Project.toml` exists Pkg will use the `target` based test specific dependencies.
@@ -393,7 +393,7 @@ This is done by making the following changes (using the example above):
   if !isdefined(Base, :get_extension)
   using Requires
   end
-  
+
   @static if !isdefined(Base, :get_extension)
   function __init__()
       @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")

--- a/src/API.jl
+++ b/src/API.jl
@@ -1352,22 +1352,28 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                         end
                         bar.current = n_done - n_already_precomp
                         bar.max = n_total - n_already_precomp
-                        final_loop || print(iostr, sprint(io -> show_progress(io, bar; termwidth = displaysize(ctx.io)[2]); context=io), "\n")
+                        # when sizing to the terminal width subtract a little to give some tolerance to resizing the
+                        # window between print cycles
+                        termwidth = displaysize(io)[2] - 4
+                        if !final_loop
+                            str = sprint(io -> show_progress(io, bar; termwidth, carriagereturn=false); context=io)
+                            print(iostr, Base._truncate_at_width_or_chars(true, str, termwidth), "\n")
+                        end
                         for dep in pkg_queue_show
                             loaded = warn_loaded && haskey(Base.loaded_modules, dep)
                             _name = haskey(exts, dep) ? string(exts[dep], " → ", dep.name) : dep.name
                             name = dep in direct_deps ? _name : string(color_string(_name, :light_black))
-                            if dep in precomperr_deps
-                                print(iostr, color_string("  ? ", Base.warn_color()), name, "\n")
+                            line = if dep in precomperr_deps
+                                string(color_string("  ? ", Base.warn_color()), name)
                             elseif haskey(failed_deps, dep)
-                                print(iostr, color_string("  ✗ ", Base.error_color()), name, "\n")
+                                string(color_string("  ✗ ", Base.error_color()), name)
                             elseif was_recompiled[dep]
                                 !loaded && interrupted_or_done.set && continue
-                                print(iostr, color_string("  ✓ ", loaded ? Base.warn_color() : :green), name, "\n")
                                 loaded || @async begin # keep successful deps visible for short period
                                     sleep(1);
                                     filter!(!isequal(dep), pkg_queue)
                                 end
+                                string(color_string("  ✓ ", loaded ? Base.warn_color() : :green), name)
                             elseif started[dep]
                                 # Offset each spinner animation using the first character in the package name as the seed.
                                 # If not offset, on larger terminal fonts it looks odd that they all sync-up
@@ -1381,10 +1387,11 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                                 else
                                     ""
                                 end
-                                print(iostr, "  $anim_char_colored $name$waiting\n")
+                                string("  ", anim_char_colored, " ", name, waiting)
                             else
-                                print(iostr, "    $name\n")
+                                string("    ", name)
                             end
+                            println(iostr, Base._truncate_at_width_or_chars(true, line, termwidth))
                         end
                     end
                     last_length = length(pkg_queue_show)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1951,7 +1951,7 @@ function compat(ctx::Context; io = nothing)
     compat_str = Operations.get_compat_str(ctx.env.project, "julia")
     push!(opt_strs, Operations.compat_line(io, "julia", nothing, compat_str, longest_dep_len, indent = ""))
     push!(opt_pkgs, "julia")
-    for (dep, uuid) in ctx.env.project.deps
+    for (dep, uuid) in sort(collect(ctx.env.project.deps); by = x->x.first)
         compat_str = Operations.get_compat_str(ctx.env.project, dep)
         push!(opt_strs, Operations.compat_line(io, dep, uuid, compat_str, longest_dep_len, indent = ""))
         push!(opt_pkgs, dep)

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -26,7 +26,7 @@ function start_progress(io::IO, _::MiniProgressBar)
     print(io, ansi_disablecursor)
 end
 
-function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing)
+function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagereturn=true)
     if p.max == 0
         perc = 0.0
         prev_perc = 0.0
@@ -52,7 +52,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing)
     else
         string(p.current, "/",  p.max)
     end
-    termwidth = something(termwidth, displaysize(io)[2])
+    termwidth = @something termwidth displaysize(io)[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
     n_filled = ceil(Int, max_progress_width * perc / 100)
     n_left = max_progress_width - n_filled
@@ -63,7 +63,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing)
         print(io, "="^n_filled, ">")
         print(io, " "^n_left, "]  ", )
         print(io, progress_text)
-        print(io, "\r")
+        carriagereturn && print(io, "\r")
     end
     # Print everything in one call
     print(io, to_print)


### PR DESCRIPTION
Backported PRs:
- [x] #3561 <!-- precompile: try to prevent wrapping-caused mess during pretty printing -->
- [x] #3574 <!-- Tweak test dep docs -->
- [x] #3605 <!-- sort compat entries in `pkg> compat` -->