### PR TITLE
[release-1.9] Backports for 1.9

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1874,7 +1874,7 @@ function compat(ctx::Context; io = nothing)
     compat_str = Operations.get_compat_str(ctx.env.project, "julia")
     push!(opt_strs, Operations.compat_line(io, "julia", nothing, compat_str, longest_dep_len, indent = ""))
     push!(opt_pkgs, "julia")
-    for (dep, uuid) in ctx.env.project.deps
+    for (dep, uuid) in sort(collect(ctx.env.project.deps); by = x->x.first)
         compat_str = Operations.get_compat_str(ctx.env.project, dep)
         push!(opt_strs, Operations.compat_line(io, dep, uuid, compat_str, longest_dep_len, indent = ""))
         push!(opt_pkgs, dep)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2410,7 +2410,7 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
             printpkgstyle(io, :Info, "Packages marked with $heldback_indicator have new versions available but compatibility constraints restrict them from upgrading.$tip", color=Base.info_color(), ignore_indent)
         end
         if !no_visible_packages_heldback && !no_packages_upgradable
-            printpkgstyle(io, :Info, "Packages marked with $upgradable_indicator and $heldback_indicator have new versions available, but those with $heldback_indicator are restricted by compatibility constraints from upgrading.$tip", color=Base.info_color(), ignore_indent)
+            printpkgstyle(io, :Info, "Packages marked with $upgradable_indicator and $heldback_indicator have new versions available. Those with $upgradable_indicator may be upgradable, but those with $heldback_indicator are restricted by compatibility constraints from upgrading.$tip", color=Base.info_color(), ignore_indent)
         end
         if !manifest && hidden_upgrades_info && no_visible_packages_heldback && !no_packages_heldback
             # only warn if showing project and outdated indirect deps are hidden


### PR DESCRIPTION
Backported PRs:
- [x] #3576 <!-- status: expand 2 symbol upgrade note to highlight *may* be upgradable -->
- [x] #3605 <!-- sort compat entries in `pkg> compat` -->

Need manual backport:
- [ ] #3561 <!-- precompile: try to prevent wrapping-caused mess during pretty printing -->