### PR TITLE
remove writing out explicit stdlib paths for the temporary testing manifest

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1819,13 +1819,6 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
             end
 
             reset_all_compat!(temp_ctx.env.project)
-
-            # Absolutify stdlibs paths
-            for (uuid, entry) in temp_ctx.env.manifest
-                if is_stdlib(uuid)
-                    entry.path = Types.stdlib_path(entry.name)
-                end
-            end
             write_env(temp_ctx.env, update_undo = false)
 
             # Run sandboxed code


### PR DESCRIPTION
this should not be needed after https://github.com/JuliaLang/julia/pull/39572 (I think)

Backporting because this fixes an issue that occurs when doing package management operations inside a test process for julia versions where an upgradable stdlib was a standard stdlib without a version entry. 