### PR TITLE
Fix algorithmic complexity of cycle detection

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1210,10 +1210,9 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     circular_deps = Base.PkgId[]
     # Three states
     # !haskey -> never visited
-    # true -> could be part of a cycle
-    # false -> not part of a cycle
+    # true -> cannot be compiled due to a cycle (or not yet determined)
+    # false -> not depending on a cycle
     could_be_cycle = Dict{Base.PkgId, Bool}()
-    dfs_num = 0
     function scan_pkg!(pkg, dmap)
         did_visit_dep = true
         inpath = get!(could_be_cycle, pkg) do
@@ -1223,7 +1222,6 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
         if did_visit_dep ? inpath : scan_deps!(pkg, dmap)
             # Found a cycle. Delete this and all parents
             # to let this cycle be found again by another toplevel dep
-            delete!(could_be_cycle, pkg)
             return true
         end
         return false

--- a/src/API.jl
+++ b/src/API.jl
@@ -1221,7 +1221,6 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
         end
         if did_visit_dep ? inpath : scan_deps!(pkg, dmap)
             # Found a cycle. Delete this and all parents
-            # to let this cycle be found again by another toplevel dep
             return true
         end
         return false


### PR DESCRIPTION
The circular dependency detection in `precompile` has poor algorithmic complexity. In a project with deep and broad dependency trees of hundreds of packages, this introduces a significant delay before the start of precompilation work. Fix that by switching the cycle detection to a simple open-coded DFS walk.