### PR TITLE
Warn if sandbox has deps that have been yanked

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -454,6 +454,25 @@ end
 
 get_or_make!(d::Dict{K,V}, k::K) where {K,V} = get!(d, k) do; V() end
 
+isyanked(pkg::PackageSpec) = isyanked(pkg.uuid, pkg.version)
+function isyanked(uuid::UUID, version::VersionNumber)
+    found = false
+    yanked = true
+    for reg in Registry.reachable_registries()
+        pkg = get(reg, uuid, nothing)
+        if pkg isa Registry.PkgEntry
+            found = true
+            info = Registry.registry_info(pkg)
+            if !Registry.isyanked(info, version)
+                yanked = false
+                continue
+            end
+        end
+    end
+    found || error("Could not find package with uuid $(repr(uuid)) in any registry")
+    return yanked
+end
+
 const JULIA_UUID = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
 const PKGORIGIN_HAVE_VERSION = :version in fieldnames(Base.PkgOrigin)
 function deps_graph(env::EnvCache, registries::Vector{Registry.RegistryInstance}, uuid_to_name::Dict{UUID,String},
@@ -1803,6 +1822,20 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
                     target_name = target.name,
                     allow_earlier_backwards_compatible_versions,
                 )
+            end
+
+            yanked = ""
+            for (uuid, pkgentry) in temp_ctx.env.manifest.deps
+                if isyanked(uuid, pkgentry.version)
+                    yanked *= " - $(PkgId(pkg.uuid, pkg.name)) version $(pkg.version)\n"
+                end
+            end
+            if !isempty(yanked)
+                @warn """
+                The following package versions from the manifest have been yanked, which
+                means the current manifest cannot be resolved:
+                $yanked
+                """
             end
 
             try


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/Pkg.jl/issues/3649#issuecomment-1758756723 if the active manifest has a yanked version in it, the user can happily use it unless they resolve. When you `Pkg.build` or `Pkg.test` however, even if there's no build or test deps, it will throw a `Could not use exact versions of packages in manifest, re-resolving`.

When this happens it can be quite confusing.

This PR is the beginnings (untested) of an idea to guide the user better.
