### PR TITLE
Let the user disable Pkg's precompilation workload by setting the `JULIA_PKG_PRECOMPILATION_WORKLOAD` environment variable to `false` or `0`

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -108,5 +108,8 @@ function pkg_precompile()
     end
 end
 
-pkg_precompile()
+if Base.get_bool_env("JULIA_PKG_PRECOMPILATION_WORKLOAD", true)
+    pkg_precompile()
+end
+
 end


### PR DESCRIPTION
I need some way of disabling this precompilation workload so that I can fix the RegistryCI.jl test suite on Julia nightly.