### PR TITLE
`@debug` the command being run when `Pkg.test` runs the tests in a subprocess

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2027,6 +2027,7 @@ end
 
 # Handles the interrupting of a subprocess gracefully to avoid orphaning
 function subprocess_handler(cmd::Cmd, ctx, sandbox_ctx, error_msg::String)
+    @debug "Running command" cmd
     p = run(pipeline(ignorestatus(cmd), stdout = sandbox_ctx.io, stderr = stderr_f()), wait = false)
     interrupted = false
     try


### PR DESCRIPTION
I want to be able to reproduce the same command-line flags that `Pkg.test` uses when running the tests in a subprocess.

The easiest way to do so is to `@debug` log the command that is being run.

This will have no cost by default, since debug log messages are not show by default.