### PR TITLE
[release-1.9] 1.9 backports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           - "pkg.julialang.org"
         julia-version:
           # - '1.6'
-          - '1.9-nightly'
+          - '1.9'
         exclude:
           - os: macOS-latest
             julia-arch: x86

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,8 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
@@ -72,8 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
         with:
           # version: '1.6'
           version: '1.9-nightly'

--- a/src/API.jl
+++ b/src/API.jl
@@ -1230,13 +1230,32 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
 
     # find and guard against circular deps
     circular_deps = Base.PkgId[]
-    function in_deps(_pkgs, deps, dmap)
-        isempty(deps) && return false
-        !isempty(intersect(_pkgs, deps)) && return true
-        return any(dep->in_deps(vcat(_pkgs, dep), dmap[dep], dmap), deps)
+    # Three states
+    # !haskey -> never visited
+    # true -> cannot be compiled due to a cycle (or not yet determined)
+    # false -> not depending on a cycle
+    could_be_cycle = Dict{Base.PkgId, Bool}()
+    function scan_pkg!(pkg, dmap)
+        did_visit_dep = true
+        inpath = get!(could_be_cycle, pkg) do
+            did_visit_dep = false
+            return true
+        end
+        if did_visit_dep ? inpath : scan_deps!(pkg, dmap)
+            # Found a cycle. Delete this and all parents
+            return true
+        end
+        return false
     end
-    for (pkg, deps) in depsmap
-        if in_deps([pkg], deps, depsmap)
+    function scan_deps!(pkg, dmap)
+        for dep in dmap[pkg]
+            scan_pkg!(dep, dmap) && return true
+        end
+        could_be_cycle[pkg] = false
+        return false
+    end
+    for pkg in keys(depsmap)
+        if scan_pkg!(pkg, depsmap)
             push!(circular_deps, pkg)
             notify(was_processed[pkg])
         end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1248,19 +1248,21 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     # if a list of packages is given, restrict to dependencies of given packages
     if !isempty(pkgs)
         pkgs_names = [p.name for p in pkgs]
-        function collect_all_deps(depsmap, dep, alldeps=Base.PkgId[])
-            append!(alldeps, depsmap[dep])
+        function collect_all_deps(depsmap, dep, alldeps=Set{Base.PkgId}())
             for _dep in depsmap[dep]
-                collect_all_deps(depsmap, _dep, alldeps)
+                if !(_dep in alldeps)
+                    push!(alldeps, _dep)
+                    collect_all_deps(depsmap, _dep, alldeps)
+                end
             end
             return alldeps
         end
-        keep = Base.PkgId[]
+        keep = Set{Base.PkgId}()
         for dep in depsmap
             dep_pkgid = first(dep)
             if dep_pkgid.name in pkgs_names
                 push!(keep, dep_pkgid)
-                append!(keep, collect_all_deps(depsmap, dep_pkgid))
+                collect_all_deps(depsmap, dep_pkgid, keep)
             end
         end
         for ext in keys(exts)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1818,13 +1818,6 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
             end
 
             reset_all_compat!(temp_ctx.env.project)
-
-            # Absolutify stdlibs paths
-            for (uuid, entry) in temp_ctx.env.manifest
-                if is_stdlib(uuid)
-                    entry.path = Types.stdlib_path(entry.name)
-                end
-            end
             write_env(temp_ctx.env, update_undo = false)
 
             # Run sandboxed code

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2026,6 +2026,7 @@ end
 
 # Handles the interrupting of a subprocess gracefully to avoid orphaning
 function subprocess_handler(cmd::Cmd, ctx, sandbox_ctx, error_msg::String)
+    @debug "Running command" cmd
     p = run(pipeline(ignorestatus(cmd), stdout = sandbox_ctx.io, stderr = stderr_f()), wait = false)
     interrupted = false
     try

--- a/test/new.jl
+++ b/test/new.jl
@@ -904,7 +904,13 @@ end
 # ## Resolve tiers
 #
 @testset "add: resolve tiers" begin
-    isolate(loaded_depot=true) do; mktempdir() do tmp
+    # The MetaGraphs version tested below relied on a JLD2 version
+    # that couldn't actually be loaded on julia 1.9+ so General
+    # will be patched. This checks out a commit before then to maintain
+    # these tests.
+    registry_url = "https://github.com/JuliaRegistries/General.git"
+    registry_commit = "030d6dae0df2ad6c3b2f90d41749df3eedb8d1b1"
+    Utils.isolate_and_pin_registry(; registry_url, registry_commit) do; mktempdir() do tmp
         # All
         copy_test_package(tmp, "ShouldPreserveAll"; use_pkg=false)
         Pkg.activate(joinpath(tmp, "ShouldPreserveAll"))


### PR DESCRIPTION
Backported PRs:
- [x] #3640 <!-- remove writing out explicit stdlib paths for the temporary testing manifest -->
- [x] #3652 <!-- Switch datastructure Vector -> Set for algorithmic complexity -->
- [x] #3651 <!-- Fix algorithmic complexity of cycle detection -->
- [x] #3666 <!-- Pin registry for MetaGraph tests -->
- [x] #3671 <!-- `@debug` the command being run when `Pkg.test` runs the tests in a subprocess -->