### PR TITLE
Don't clean test temp files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,9 +28,9 @@ p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 HistoricalStdlibVersions = "1.2"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 HistoricalStdlibVersions = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Preferences", "HistoricalStdlibVersions"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,12 @@ Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger())
     end
 end
 
-@showtime Base.Filesystem.temp_cleanup_purge(force=true)
+if haskey(ENV, "CI")
+    # if CI don't clean up as it will be slower than the runner filesystem reset
+    empty!(Base.TEMP_CLEANUP)
+else
+    @showtime Base.Filesystem.temp_cleanup_purge(force=true)
+end
 
 end # module
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,7 +97,7 @@ end
 
 if haskey(ENV, "CI")
     # if CI don't clean up as it will be slower than the runner filesystem reset
-    empty!(Base.TEMP_CLEANUP)
+    empty!(Base.Filesystem.TEMP_CLEANUP)
 else
     @showtime Base.Filesystem.temp_cleanup_purge(force=true)
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -81,7 +81,7 @@ function isolate(fn::Function; loaded_depot=false, linked_reg=true)
                 loaded_depot && push!(DEPOT_PATH, LOADED_DEPOT)
                 fn()
             finally
-                if target_depot !== nothing && isdir(target_depot)
+                if !haskey(ENV, "CI") && target_depot !== nothing && isdir(target_depot)
                     try
                         Base.rm(target_depot; force=true, recursive=true)
                     catch err
@@ -148,12 +148,14 @@ function temp_pkg_dir(fn::Function;rm=true, linked_reg=true)
                 push!(DEPOT_PATH, depot_dir)
                 fn(env_dir)
             finally
-                try
-                    rm && Base.rm(env_dir; force=true, recursive=true)
-                    rm && Base.rm(depot_dir; force=true, recursive=true)
-                catch err
-                    # Avoid raising an exception here as it will mask the original exception
-                    println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
+                if !haskey(ENV, "CI")
+                    try
+                        rm && Base.rm(env_dir; force=true, recursive=true)
+                        rm && Base.rm(depot_dir; force=true, recursive=true)
+                    catch err
+                        # Avoid raising an exception here as it will mask the original exception
+                        println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
+                    end
                 end
             end
         end
@@ -175,11 +177,13 @@ function cd_tempdir(f; rm=true)
     cd(tmp) do
         f(tmp)
     end
-    try
-        rm && Base.rm(tmp; force = true, recursive = true)
-    catch err
-        # Avoid raising an exception here as it will mask the original exception
-        println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
+    if !haskey(ENV, "CI")
+        try
+            rm && Base.rm(tmp; force = true, recursive = true)
+        catch err
+            # Avoid raising an exception here as it will mask the original exception
+            println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
+        end
     end
 end
 
@@ -212,11 +216,13 @@ function with_temp_env(f, env_name::AbstractString="Dummy"; rm=true)
         applicable(f, env_path) ? f(env_path) : f()
     finally
         Base.ACTIVE_PROJECT[] = prev_active
-        try
-            rm && Base.rm(env_path; force = true, recursive = true)
-        catch err
-            # Avoid raising an exception here as it will mask the original exception
-            println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
+        if !haskey(ENV, "CI")
+            try
+                rm && Base.rm(env_path; force = true, recursive = true)
+            catch err
+                # Avoid raising an exception here as it will mask the original exception
+                println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
+            end
         end
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -148,10 +148,10 @@ function temp_pkg_dir(fn::Function;rm=true, linked_reg=true)
                 push!(DEPOT_PATH, depot_dir)
                 fn(env_dir)
             finally
-                if !haskey(ENV, "CI")
+                if rm && !haskey(ENV, "CI")
                     try
-                        rm && Base.rm(env_dir; force=true, recursive=true)
-                        rm && Base.rm(depot_dir; force=true, recursive=true)
+                        Base.rm(env_dir; force=true, recursive=true)
+                        Base.rm(depot_dir; force=true, recursive=true)
                     catch err
                         # Avoid raising an exception here as it will mask the original exception
                         println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
@@ -177,9 +177,9 @@ function cd_tempdir(f; rm=true)
     cd(tmp) do
         f(tmp)
     end
-    if !haskey(ENV, "CI")
+    if rm && !haskey(ENV, "CI")
         try
-            rm && Base.rm(tmp; force = true, recursive = true)
+            Base.rm(tmp; force = true, recursive = true)
         catch err
             # Avoid raising an exception here as it will mask the original exception
             println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")
@@ -216,9 +216,9 @@ function with_temp_env(f, env_name::AbstractString="Dummy"; rm=true)
         applicable(f, env_path) ? f(env_path) : f()
     finally
         Base.ACTIVE_PROJECT[] = prev_active
-        if !haskey(ENV, "CI")
+        if rm && !haskey(ENV, "CI")
             try
-                rm && Base.rm(env_path; force = true, recursive = true)
+                Base.rm(env_path; force = true, recursive = true)
             catch err
                 # Avoid raising an exception here as it will mask the original exception
                 println(stderr_f(), "Exception in finally: $(sprint(showerror, err))")


### PR DESCRIPTION
Both GitHub CI here and buildkite CI on the julia repo restore the fs to a clean state, likely faster than doing it within the julia process, so we don't need to spend time tidying up.