### PR TITLE
remove recompilation dependency check in Pkg.precompile

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1079,11 +1079,11 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                     strict::Bool=false, warn_loaded = true, already_instantiated = false, timing::Bool = false,
                     _from_loading::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
-    if !already_instantiated 
+    if !already_instantiated
         instantiate(ctx; allow_autoprecomp=false, kwargs...)
         @debug "precompile: instantiated"
     end
-        
+
     time_start = time_ns()
 
     # Windows sometimes hits a ReadOnlyMemoryError, so we halve the default number of tasks. Issue #2323
@@ -1497,7 +1497,6 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 queued = precomp_queued(pkgspec)
 
                 circular = pkg in circular_deps
-                # skip stale checking and force compilation if any dep was recompiled in this session
                 is_stale = true
                 if !circular && (queued || (!suspended && (is_stale = !Base.isprecompiled(pkg; ignore_loaded=true, stale_cache, cachepaths, sourcepath))))
                     Base.acquire(parallel_limiter)

--- a/src/API.jl
+++ b/src/API.jl
@@ -1498,9 +1498,8 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
 
                 circular = pkg in circular_deps
                 # skip stale checking and force compilation if any dep was recompiled in this session
-                any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
                 is_stale = true
-                if !circular && (queued || any_dep_recompiled || (!suspended && (is_stale = !Base.isprecompiled(pkg; ignore_loaded=true, stale_cache, cachepaths, sourcepath))))
+                if !circular && (queued || (!suspended && (is_stale = !Base.isprecompiled(pkg; ignore_loaded=true, stale_cache, cachepaths, sourcepath))))
                     Base.acquire(parallel_limiter)
                     is_direct_dep = pkg in direct_deps
 


### PR DESCRIPTION
This check forced packages to recompile if triggers for extensions of their dependencies were added.

This could be reproduced the following way:

- Add `ColorSchemes`
- Precompile
- Add `SpecialFunctions`
- Notice that `ColorSchemes` now required precompilation again because the extension of SpecialFunctions in ColorVectorSpace is now "active".

The last step doesn't make sense because the extension SpecialFunctions doesn't influence ColorSchemes in any way.

This check should in theory just be removable since `Base.isprecompiled` should handle checking that all dependencies are valid for the package being precompiled.