### PR TITLE
Backport 1.9: remove recompilation dependency check in Pkg.precompile (#3696)

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1449,10 +1449,8 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 queued = precomp_queued(pkgspec)
 
                 circular = pkg in circular_deps
-                # skip stale checking and force compilation if any dep was recompiled in this session
-                any_dep_recompiled = any(map(dep->was_recompiled[dep], deps))
                 is_stale = true
-                if !circular && (queued || any_dep_recompiled || (!suspended && (is_stale = _is_stale!(stale_cache, paths, sourcepath))))
+                if !circular && (queued || (!suspended && (is_stale = _is_stale!(stale_cache, paths, sourcepath))))
                     Base.acquire(parallel_limiter)
                     is_direct_dep = pkg in direct_deps
                     iob = IOBuffer()


### PR DESCRIPTION
Co-authored-by: Ian Butterworth <i.r.butterworth@gmail.com>
(cherry picked from commit debc38b9a2d800f035a17f42a01c14a3775fa859)