### PR TITLE
Use `startup=no` during `build` unless julia session explicitly set `startup=yes`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1028,7 +1028,7 @@ function gen_build_code(build_file::String; inherit_project::Bool = false)
         include($(repr(build_file)))
         """
     return ```
-        $(Base.julia_cmd()) -O0 --color=no --history-file=no
+        $(Base.julia_cmd()) -O0 --color=no --history-file=no --startup=no
         $(inherit_project ? `--project=$(Base.active_project())` : ``)
         --eval $code
         ```

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1027,9 +1027,12 @@ function gen_build_code(build_file::String; inherit_project::Bool = false)
         cd($(repr(dirname(build_file))))
         include($(repr(build_file)))
         """
+    # This will make it so that running Pkg.build runs the build in a session with --startup=no
+    # *unless* the parent julia session is started with --startup=yes explicitly.
+    start_flag = Base.JLOptions().startupfile == 1 ? "yes" : "no"
     return ```
         $(Base.julia_cmd()) -O0 --color=no --history-file=no
-        --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
+        --startup-file=$(startup_flag)
         $(inherit_project ? `--project=$(Base.active_project())` : ``)
         --eval $code
         ```

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1029,10 +1029,10 @@ function gen_build_code(build_file::String; inherit_project::Bool = false)
         """
     # This will make it so that running Pkg.build runs the build in a session with --startup=no
     # *unless* the parent julia session is started with --startup=yes explicitly.
-    start_flag = Base.JLOptions().startupfile == 1 ? "yes" : "no"
+    startup_flag = Base.JLOptions().startupfile == 1 ? "yes" : "no"
     return ```
         $(Base.julia_cmd()) -O0 --color=no --history-file=no
-        --startup-file=$(startup_flag)
+        --startup-file=$startup_flag
         $(inherit_project ? `--project=$(Base.active_project())` : ``)
         --eval $code
         ```

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1028,7 +1028,8 @@ function gen_build_code(build_file::String; inherit_project::Bool = false)
         include($(repr(build_file)))
         """
     return ```
-        $(Base.julia_cmd()) -O0 --color=no --history-file=no --startup=no
+        $(Base.julia_cmd()) -O0 --color=no --history-file=no
+        --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
         $(inherit_project ? `--project=$(Base.active_project())` : ``)
         --eval $code
         ```


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3687 (identified by @KristofferC on Slack)

Before:
```julia
(@v1.10) pkg> build ModernGL
    Building ModernGL → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/b76ea40b5c0f45790ae09492712dd326208c28b2/build.log`
ERROR: Error building `ModernGL`: 
ERROR: LoadError: ArgumentError: Package LinearAlgebra not found in current path.
- Run `import Pkg; Pkg.add("LinearAlgebra")` to install the LinearAlgebra package.
Stacktrace:
 [1] macro expansion
   @ Base ./loading.jl:1766 [inlined]
 [2] macro expansion
   @ Base ./lock.jl:267 [inlined]
 [3] __require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1747
 [4] #invoke_in_world#3
   @ Base ./essentials.jl:921 [inlined]
 [5] invoke_in_world
   @ Base ./essentials.jl:918 [inlined]
 [6] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1740
in expression starting at /home/mason/.julia/config/startup.jl:1
```
Attempted fix:
```julia
julia> @eval Pkg.Operations begin
           function gen_build_code(build_file::String; inherit_project::Bool = false)
           code = """
               $(Base.load_path_setup_code(false))
               cd($(repr(dirname(build_file))))
               include($(repr(build_file)))
               """
           return ```
               $(Base.julia_cmd()) -O0 --color=no --history-file=no --startup=no
               $(inherit_project ? `--project=$(Base.active_project())` : ``)
               --eval $code
              ```
           end
       end

(@v1.10) pkg> build ModernGL
    Building ModernGL → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/b76ea40b5c0f45790ae09492712dd326208c28b2/build.log`
Precompiling project...
  2 dependencies successfully precompiled in 28 seconds. 461 already precompiled.
```