### PR TITLE
fix doc build by not `@ref`fing `Base.get_extension`

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -480,7 +480,7 @@ function plot end
 
 In other situations, one may need to define new symbols in the extension (types, structs, functions, etc.) instead of reusing those from the parent package.
 Such symbols are created in a separate module corresponding to the extension, namely `PlottingContourExt`, and thus not in `Plotting` itself.
-If extension symbols are needed in the parent package, one must call [`Base.get_extension`](@ref) to retrieve them.
+If extension symbols are needed in the parent package, one must call `Base.get_extension` to retrieve them.
 Here is an example showing how a custom type defined in `PlottingContourExt` can be accessed in `Plotting`:
 
 ```julia


### PR DESCRIPTION
Not sure why this breaks the docs but we can't merge anything without the docs building so just do the easy "fix".