### PR TITLE
Revise the API of is_manifest_current.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -455,7 +455,15 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
     return
 end
 
-is_manifest_current(ctx::Context = Context()) = Operations.is_manifest_current(ctx.env)
+is_manifest_current(ctx::Context) = Operations.is_manifest_current(ctx.env)
+function is_manifest_current(path::AbstractString)
+    project_file = projectfile_path(path, strict = true)
+    if project_file === nothing
+        pkgerror("could not find project file at `$path`")
+    end
+    env = EnvCache(project_file)
+    return Operations.is_manifest_current(env)
+end
 
 const UsageDict = Dict{String,DateTime}
 const UsageByDepotDict = Dict{String,UsageDict}

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -720,12 +720,17 @@ Upgrades the format of the current or specified manifest file from v1.0 to v2.0 
 const upgrade_manifest = API.upgrade_manifest
 
 """
-    is_manifest_current(ctx::Context = Context())
+    is_manifest_current(path::AbstractString)
 
-Returns whether the active manifest was resolved from the active project state.
+Returns whether the manifest for the project at `path` was resolved from the current project file.
 For instance, if the project had compat entries changed, but the manifest wasn't re-resolved, this would return false.
 
-If the manifest doesn't have the project hash recorded, `nothing` is returned.
+If the manifest doesn't have the project hash recorded, or if there is no manifest file, `nothing` is returned.
+
+This function can be used in tests to verify that the manifest is synchronized with the project file:
+
+    using Pkg, Test, Package
+    @test Pkg.is_manifest_current(pkgdir(Package))
 """
 const is_manifest_current = API.is_manifest_current
 

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -186,17 +186,17 @@ end
 
                 Pkg.activate(; temp=true)
                 Pkg.add("Example")
-                @test Pkg.is_manifest_current() === true
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === true
 
                 Pkg.compat("Example", "0.4")
-                @test Pkg.is_manifest_current() === false
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === false
                 Pkg.status(io = iob)
                 sync_msg_str = r"The project dependencies or compat requirements have changed since the manifest was last resolved."
                 @test occursin(sync_msg_str, String(take!(iob)))
                 @test_logs (:warn, sync_msg_str) Pkg.instantiate()
 
                 Pkg.update()
-                @test Pkg.is_manifest_current() === true
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === true
                 Pkg.status(io = iob)
                 @test !occursin(sync_msg_str, String(take!(iob)))
 
@@ -206,7 +206,7 @@ end
                 @test_logs (:warn, sync_msg_str) Pkg.instantiate()
 
                 Pkg.rm("Example")
-                @test Pkg.is_manifest_current() === true
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === true
                 Pkg.status(io = iob)
                 @test !occursin(sync_msg_str, String(take!(iob)))
             end


### PR DESCRIPTION
The API function `is_manifest_current` was not working as intended and was mostly useless for its intended purpose of verifying in tests that the manifest and project files of a package were synchronized. See 
https://github.com/JuliaLang/Pkg.jl/pull/2815#issuecomment-1819237619 for details.

This PR removes the zero-argument method of `is_manifest_current` and adds a new `is_manifest_current(::AbstractString)` method that can be used in tests in, e.g., the form
```
using Pkg, Test, Package
@test Pkg.is_manifest_current(pkgdir(Package))
```
