### PR TITLE
Suggest using `compat` to choose versions of packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "Pkg"
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+uuid = "54cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."
@@ -10,6 +10,7 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -26,6 +27,7 @@ p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
 HistoricalStdlibVersions = "1.2"
+JSON = "0.21.4"
 
 [extras]
 HistoricalStdlibVersions = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "Pkg"
-uuid = "54cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."
@@ -10,7 +10,6 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -27,7 +26,6 @@ p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [compat]
 HistoricalStdlibVersions = "1.2"
-JSON = "0.21.4"
 
 [extras]
 HistoricalStdlibVersions = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -60,7 +60,7 @@ Status `~/environments/v1.9/Manifest.toml`
 
 Since standard libraries (e.g. ` Dates`) are shipped with Julia, they do not have a version.
 
-To specify that you need a particular version (or set of versions) of a package, use the `compat` commad. For example,
+To specify that you want a particular version (or set of versions) of a package, use the `compat` command. For example,
 to require any patch release of the v0.21 series of JSON after v0.21.4, call `compat JSON 0.21.4`:
 
 ```julia-repl

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -60,6 +60,27 @@ Status `~/environments/v1.9/Manifest.toml`
 
 Since standard libraries (e.g. ` Dates`) are shipped with Julia, they do not have a version.
 
+To specify that you need a particular version (or set of versions) of a package, use the `compat` commad. For example,
+to require any patch release of the v0.21 series of JSON after v0.21.4, call `compat JSON 0.21.4`:
+
+```julia-repl
+(@v1.8) pkg> compat JSON 0.21.4
+      Compat entry set:
+  JSON = "0.21.4"
+     Resolve checking for compliance with the new compat rules...
+       Error empty intersection between JSON@0.21.3 and project compatibility 0.21.4-0.21
+
+(@v1.8) pkg> up
+    Updating registry at `~/.julia/registries/General.toml`
+    Updating `~/.julia/environments/v1.8/Project.toml`
+  [682c06a0] ↑ JSON v0.21.3 ⇒ v0.21.4
+    Updating `~/.julia/environments/v1.8/Manifest.toml`
+  [682c06a0] ↑ JSON v0.21.3 ⇒ v0.21.4
+
+```
+
+See the section on [Compatibility](@ref) for more on using the compat system.
+
 After a package is added to the project, it can be loaded in Julia:
 
 ```julia-repl

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -40,7 +40,7 @@ It is possible to add multiple packages in one command as `pkg> add A B C`.
 The status output contains the packages you have added yourself, in this case, `JSON`:
 
 ```julia-repl
-(@v1.8) pkg> st
+(@v1.11) pkg> st
     Status `~/.julia/environments/v1.8/Project.toml`
   [682c06a0] JSON v0.21.3
 ```
@@ -48,7 +48,7 @@ The status output contains the packages you have added yourself, in this case, `
 The manifest status shows all the packages in the environment, including recursive dependencies:
 
 ```julia-repl
-(@v1.8) pkg> st -m
+(@v1.11) pkg> st -m
 Status `~/environments/v1.9/Manifest.toml`
   [682c06a0] JSON v0.21.3
   [69de0a69] Parsers v2.4.0
@@ -64,19 +64,19 @@ To specify that you want a particular version (or set of versions) of a package,
 to require any patch release of the v0.21 series of JSON after v0.21.4, call `compat JSON 0.21.4`:
 
 ```julia-repl
-(@v1.8) pkg> compat JSON 0.21.4
+(@1.11) pkg> compat JSON 0.21.4
       Compat entry set:
   JSON = "0.21.4"
      Resolve checking for compliance with the new compat rules...
-       Error empty intersection between JSON@0.21.3 and project compatibility 0.21.4-0.21
+       Error empty intersection between JSON@0.21.3 and project compatibility 0.21.4 - 0.21
+  Suggestion Call `update` to attempt to meet the compatibility requirements.
 
-(@v1.8) pkg> up
+(@1.11) pkg> up
     Updating registry at `~/.julia/registries/General.toml`
-    Updating `~/.julia/environments/v1.8/Project.toml`
+    Updating `~/.julia/environments/1.11/Project.toml`
   [682c06a0] ↑ JSON v0.21.3 ⇒ v0.21.4
-    Updating `~/.julia/environments/v1.8/Manifest.toml`
+    Updating `~/.julia/environments/1.11/Manifest.toml`
   [682c06a0] ↑ JSON v0.21.3 ⇒ v0.21.4
-
 ```
 
 See the section on [Compatibility](@ref) for more on using the compat system.

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -71,7 +71,7 @@ to require any patch release of the v0.21 series of JSON after v0.21.4, call `co
        Error empty intersection between JSON@0.21.3 and project compatibility 0.21.4 - 0.21
   Suggestion Call `update` to attempt to meet the compatibility requirements.
 
-(@1.11) pkg> up
+(@1.11) pkg> update
     Updating registry at `~/.julia/registries/General.toml`
     Updating `~/.julia/environments/1.11/Project.toml`
   [682c06a0] ↑ JSON v0.21.3 ⇒ v0.21.4

--- a/src/API.jl
+++ b/src/API.jl
@@ -2103,6 +2103,7 @@ function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io
         catch e
             if e isa ResolverError
                 printpkgstyle(io, :Error, string(e.msg), color = Base.warn_color())
+                printpkgstyle(io, :Hint, "Call `update` to attempt to meet the compatibility requirements.", color = Base.info_color())
             else
                 rethrow()
             end

--- a/src/API.jl
+++ b/src/API.jl
@@ -2103,7 +2103,7 @@ function compat(ctx::Context, pkg::String, compat_str::Union{Nothing,String}; io
         catch e
             if e isa ResolverError
                 printpkgstyle(io, :Error, string(e.msg), color = Base.warn_color())
-                printpkgstyle(io, :Hint, "Call `update` to attempt to meet the compatibility requirements.", color = Base.info_color())
+                printpkgstyle(io, :Suggestion, "Call `update` to attempt to meet the compatibility requirements.", color = Base.info_color())
             else
                 rethrow()
             end


### PR DESCRIPTION
I think this should be emphasized as "the" way to get the versions you want. Many times folks fight with the resolver to get it to resolve they way they want, when the declarative approach with compat is better. Therefore I think `compat` belongs in the basic starting instructions.