### PR TITLE
try run dynamic artifact selector in Pkg process

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -803,7 +803,9 @@ function collect_artifacts(pkg_root::String; platform::AbstractPlatform=HostPlat
             if isfile(selector_path)
                 res = mktemp() do path, io
                     redirect_stdout(io) do
-                        include(selector_path)
+                        m = Module()
+                        @eval m include(x) = Base.include(@__MODULE__, x)
+                        Base.include(m, selector_path)
                     end
                     close(io)
                     meta_toml = read(path, String)


### PR DESCRIPTION
I don't really know what you are allowed to do in the dynamic artifact selector but this improves performance a lot at least (e.g. for `Pkg.status`) when packages using this are in the environment.