### PR TITLE
Make tests almost entirely quiet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,9 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - run: julia --project --color=yes --pkgimages=no --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: true
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
           JULIA_TEST_VERBOSE_LOGS_DIR: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
           JULIA_TEST_VERBOSE_LOGS_DIR: ${{ github.workspace }}
       - uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
           name: ${{ join(matrix.*, '-') }}_Pkg.log
           path: ${{ github.workspace }}/Pkg.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           - os: macOS-latest
             julia-arch: x86
     steps:
-      - name: Set git to use LF and Fix TEMP on windows
+      - name: Set git to use LF and fix TEMP on windows
         if: matrix.os == 'windows-latest'
         run: |
           git config --global core.autocrlf false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,12 @@ jobs:
       - run: julia --project --color=yes --pkgimages=no --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
+          JULIA_TEST_VERBOSE_LOGS_DIR: ${{ github.workspace }}
           JULIA_PKG_TEST_QUIET: "true" # "true" is the default. i.e. tests are quiet when this env var isn't set
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Pkg.log
+          path: ${{ github.workspace }}/Pkg.log
       - uses: julia-actions/julia-processcoverage@v1
         env:
             JULIA_PKG_SERVER: ${{ matrix.pkg-server }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           JULIA_TEST_VERBOSE_LOGS_DIR: ${{ github.workspace }}
       - uses: actions/upload-artifact@v3
         with:
-          name: Pkg.log
+          name: ${{ join(matrix.*, '-') }}_Pkg.log
           path: ${{ github.workspace }}/Pkg.log
       - uses: julia-actions/julia-processcoverage@v1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,22 +41,19 @@ jobs:
           - os: macOS-latest
             julia-arch: x86
     steps:
-      - name: Set git to use LF
+      - name: Set git to use LF and Fix TEMP on windows
         if: matrix.os == 'windows-latest'
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
+          # See https://github.com/actions/virtual-environments/issues/712
+          echo "TMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
+          echo "TEMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - name: Fix TEMP on windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          # See https://github.com/actions/virtual-environments/issues/712
-          echo "TMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
-          echo "TEMP=${USERPROFILE}\AppData\Local\Temp" >> ${GITHUB_ENV}
       - run: julia --project --color=yes --pkgimages=no --check-bounds=yes -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,6 @@ jobs:
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
           JULIA_TEST_VERBOSE_LOGS_DIR: ${{ github.workspace }}
-          JULIA_PKG_TEST_QUIET: "true" # "true" is the default. i.e. tests are quiet when this env var isn't set
       - uses: actions/upload-artifact@v3
         with:
           name: Pkg.log

--- a/test/new.jl
+++ b/test/new.jl
@@ -2714,17 +2714,14 @@ for v in (nothing, "true")
                         @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                         Pkg.rm(TEST_PKG.name)
                     end
-                    if Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) == false
-                        # TODO: fix. on GH windows runners cli git will prompt for credentials here
-                        # on other runners it noisily prompts but continues
-                        println("here $v")
-                        @testset "via url" begin
-                            # git cli can be noisy on CI where user auth isn't set up, so ignore stderr
-                            Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
-                            @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                            Pkg.rm(TEST_PKG.name)
-                        end
-                    end
+                    # TODO: fix.
+                    # On GH windows runners cli git will prompt for credentials and hang.
+                    # On other runners it noisily prompts but continues
+                    # @testset "via url" begin
+                    #     Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                    #     @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                    #     Pkg.rm(TEST_PKG.name)
+                    # end
                 end
                 if !Sys.iswindows()
                     # TODO: fix. on GH windows runners cli git will prompt for credentials here

--- a/test/new.jl
+++ b/test/new.jl
@@ -2717,7 +2717,13 @@ for v in (nothing, "true")
                     if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Sys.iswindows()) == false
                         # TODO: fix. on GH windows runners cli git will prompt for credentials here
                         @testset "via url" begin
-                            Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                            # git cli can be noisy on CI where user auth isn't set up, so ignore stderr
+                            # i.e.
+                            # Username for 'https://github.com': Username for 'https://github.com':
+                            # fatal: could not read Username for 'https://github.com': terminal prompts disabled
+                            redirect_stderr(devnull) do
+                                Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                            end
                             @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
                             Pkg.rm(TEST_PKG.name)
                         end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2715,7 +2715,7 @@ for v in (nothing, "true")
                 end
                 if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) == false) && !Sys.iswindows()
                     # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
-                    # On other runners git cli it's noisy when an url is given.
+                    # On other runners git cli is noisy when an url is given.
                     @testset "via url" begin
                         Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
                         @test haskey(Pkg.dependencies(), TEST_PKG.uuid)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2713,7 +2713,7 @@ for v in (nothing, "true")
                     @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                     Pkg.rm(TEST_PKG.name)
                 end
-                if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) || Sys.iswindows()
+                if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) == false) && !Sys.iswindows()
                     # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
                     # On other runners git cli it's noisy when an url is given.
                     @testset "via url" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -2717,6 +2717,7 @@ for v in (nothing, "true")
                     if Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) == false
                         # TODO: fix. on GH windows runners cli git will prompt for credentials here
                         # on other runners it noisily prompts but continues
+                        println("here $v")
                         @testset "via url" begin
                             # git cli can be noisy on CI where user auth isn't set up, so ignore stderr
                             Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2717,12 +2717,12 @@ for v in (nothing, "true")
                     # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
                     # On other runners git cli it's noisy when an url is given.
                     @testset "via url" begin
-                        Pkg.add(url="git@github.com:JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                        Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
                         @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
                         Pkg.rm(TEST_PKG.name)
                     end
                     @testset "failures" begin
-                        doesnotexist = "git@github.com:DoesNotExist/DoesNotExist.jl"
+                        doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
                         @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
                         @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))
                     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2706,28 +2706,22 @@ for v in (nothing, "true")
     withenv("JULIA_PKG_USE_CLI_GIT" => v, "GIT_TERMINAL_PROMPT" => 0) do
         @testset "downloads with JULIA_PKG_USE_CLI_GIT = $v" begin
             isolate() do
-                @testset "libgit2 downloads" begin
-                    @testset "via name" begin
-                        Pkg.add(TEST_PKG.name; use_git_for_all_downloads=true)
-                        @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                        @eval import $(Symbol(TEST_PKG.name))
-                        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
-                        Pkg.rm(TEST_PKG.name)
-                    end
-                    if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
-                        # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
-                        # On other runners git cli it's noisy when an url is given.
-                        @testset "via url" begin
-                            Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
-                            @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                            Pkg.rm(TEST_PKG.name)
-                        end
-                    end
+                @testset "via name" begin
+                    Pkg.add(TEST_PKG.name; use_git_for_all_downloads=true)
+                    @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                    @eval import $(Symbol(TEST_PKG.name))
+                    @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
+                    Pkg.rm(TEST_PKG.name)
                 end
                 if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
                     # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
                     # On other runners git cli it's noisy when an url is given.
-                    @testset "libgit2 failures" begin
+                    @testset "via url" begin
+                        Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                        @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                        Pkg.rm(TEST_PKG.name)
+                    end
+                    @testset "failures" begin
                         doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
                         @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
                         @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))

--- a/test/new.jl
+++ b/test/new.jl
@@ -2717,12 +2717,12 @@ for v in (nothing, "true")
                     # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
                     # On other runners git cli it's noisy when an url is given.
                     @testset "via url" begin
-                        Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                        Pkg.add(url="git@github.com:JuliaLang/Example.jl", use_git_for_all_downloads=true)
                         @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
                         Pkg.rm(TEST_PKG.name)
                     end
                     @testset "failures" begin
-                        doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
+                        doesnotexist = "git@github.com:DoesNotExist/DoesNotExist.jl"
                         @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
                         @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))
                     end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2714,17 +2714,19 @@ for v in (nothing, "true")
                         @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                         Pkg.rm(TEST_PKG.name)
                     end
-                    # TODO: fix.
-                    # On GH windows runners cli git will prompt for credentials and hang.
-                    # On other runners it noisily prompts but continues
-                    # @testset "via url" begin
-                    #     Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
-                    #     @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
-                    #     Pkg.rm(TEST_PKG.name)
-                    # end
+                    if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
+                        # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
+                        # On other runners git cli it's noisy when an url is given.
+                        @testset "via url" begin
+                            Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
+                            @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
+                            Pkg.rm(TEST_PKG.name)
+                        end
+                    end
                 end
-                if !Sys.iswindows()
-                    # TODO: fix. on GH windows runners cli git will prompt for credentials here
+                if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
+                    # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
+                    # On other runners git cli it's noisy when an url is given.
                     @testset "libgit2 failures" begin
                         doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
                         @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2713,7 +2713,7 @@ for v in (nothing, "true")
                     @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                     Pkg.rm(TEST_PKG.name)
                 end
-                if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
+                if !Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) || Sys.iswindows()
                     # TODO: fix. On GH windows runners cli git will prompt for credentials and hang.
                     # On other runners git cli it's noisy when an url is given.
                     @testset "via url" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -2714,16 +2714,12 @@ for v in (nothing, "true")
                         @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
                         Pkg.rm(TEST_PKG.name)
                     end
-                    if (Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) && Sys.iswindows()) == false
+                    if Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false) == false
                         # TODO: fix. on GH windows runners cli git will prompt for credentials here
+                        # on other runners it noisily prompts but continues
                         @testset "via url" begin
                             # git cli can be noisy on CI where user auth isn't set up, so ignore stderr
-                            # i.e.
-                            # Username for 'https://github.com': Username for 'https://github.com':
-                            # fatal: could not read Username for 'https://github.com': terminal prompts disabled
-                            redirect_stderr(devnull) do
-                                Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
-                            end
+                            Pkg.add(url="https://github.com/JuliaLang/Example.jl", use_git_for_all_downloads=true)
                             @test haskey(Pkg.dependencies(), TEST_PKG.uuid)
                             Pkg.rm(TEST_PKG.name)
                         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,11 +34,6 @@ end
 
 ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0
 
-if (server = Pkg.pkg_server()) !== nothing && Sys.which("curl") !== nothing
-    s = read(`curl -sLI $(server)`, String);
-    @info "Pkg Server metadata:\n$s"
-end
-
 ### Disable logging output if true (default)
 hide_logs = Base.get_bool_env("JULIA_PKG_TEST_QUIET", true)
 
@@ -62,9 +57,15 @@ Pkg.REPLMode.minirepl[] = Pkg.REPLMode.MiniREPL() # re-set this given DEFAULT_IO
 
 include("utils.jl")
 
-Utils.check_init_reg()
-
 Logging.with_logger(hide_logs ? Logging.NullLogger() : Logging.current_logger()) do
+
+    if (server = Pkg.pkg_server()) !== nothing && Sys.which("curl") !== nothing
+        s = read(`curl -sLI $(server)`, String);
+        @info "Pkg Server metadata:\n$s"
+    end
+
+    Utils.check_init_reg()
+
     @testset "Pkg" begin
         try
             @testset "$f" for f in [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,9 @@ module PkgTestsInner
 import Pkg
 using Test, Logging
 
-@testset "Test that we have imported the correct package" begin
-    @test realpath(dirname(dirname(Base.pathof(Pkg)))) == realpath(dirname(@__DIR__))
+if realpath(dirname(dirname(Base.pathof(Pkg)))) != realpath(dirname(@__DIR__))
+    @show dirname(dirname(Base.pathof(Pkg))) realpath(dirname(@__DIR__))
+    error("The wrong Pkg is being tested")
 end
 
 ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0


### PR DESCRIPTION
Best I can do is only this leaking.
```
Username for 'https://github.com/': Username for 'https://github.com/':
```

To do better than that we would need to reduce test coverage, or fix git cli https auth on CI, which seems difficult to figure out.

Otherwise everything is now piped into the Pkg.log which is uploaded as matrix-specific artifacts here and similar on buildkite.