### PR TITLE
fix preferential Manifest.toml naming

### DIFF
--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -13,7 +13,10 @@ may optionally have a manifest file:
 
 - **Manifest file:** a file in the root directory of a project, named
   `Manifest.toml` (or `JuliaManifest.toml`), describing a complete dependency graph
-  and exact versions of each package and library used by a project.
+  and exact versions of each package and library used by a project. The file name may
+  also be suffixed by `-v{major}.{minor}.toml` which julia will prefer if the version
+  matches `VERSION`, allowing multiple environments to be maintained for different julia
+  versions.
 
 **Package:** a project which provides reusable functionality that can be used by
 other Julia projects via `import X` or `using X`. A package should have a

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -192,23 +192,20 @@ function projectfile_path(env_path::String; strict=false)
 end
 
 function manifestfile_path(env_path::String; strict=false)
-    man_names = @static Base.manifest_names isa Tuple ? Base.manifest_names : Base.manifest_names()
-    for name in man_names
+    for name in Base.manifest_names
         maybe_file = joinpath(env_path, name)
         isfile(maybe_file) && return maybe_file
     end
     if strict
         return nothing
     else
-        n_names = length(man_names)
-        if n_names == 1
-            return joinpath(env_path, only(man_name))
+        # given no matching manifest exists, if JuliaProject.toml is used,
+        # prefer to create JuliaManifest.toml, otherwise Manifest.toml
+        project, _ = splitext(basename(projectfile_path(env_path)::String))
+        if project == "JuliaProject"
+            return joinpath(env_path, "JuliaManifest.toml")
         else
-            project = basename(projectfile_path(env_path)::String)
-            idx = findfirst(x -> x == project, Base.project_names)
-            @assert idx !== nothing
-            idx = idx + (n_names - length(Base.project_names)) # ignore custom name if present
-            return joinpath(env_path, man_names[idx])
+            return joinpath(env_path, "Manifest.toml")
         end
     end
 end


### PR DESCRIPTION
Reverts https://github.com/JuliaLang/Pkg.jl/pull/3000
and adapts for the latest https://github.com/JuliaLang/julia/pull/43845

Because the lengths of the `Base.project_names` and `Base.manifest_names` tuples have diverged, we can no longer rely on idx lookups, so this just does a bit more hardcoding.