### PR TITLE
Automatically add compat entries when adding deps to a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Pkg v1.11 Release Notes
 
 - Pkg now obeys `[compat]` bounds for `julia` and raises an error if the version of the running Julia binary is incompatible with the bounds in `Project.toml`.
   Pkg has always obeyed this compat when working with Registry packages. This change affects mostly local packages. ([#3526])
+- `pkg> add` and `Pkg.add` will now add compat entries for new direct dependencies if the active environment is a
+  package (has a `name` and `uuid` entry) ([#3732])
 
 Pkg v1.10 Release Notes
 =======================

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1386,14 +1386,27 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
     end
     foreach(pkg -> ctx.env.project.deps[pkg.name] = pkg.uuid, pkgs) # update set of deps
     # resolve
-    pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
-    update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
+    man_pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
+    update_manifest!(ctx.env, man_pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
-    fixup_ext!(ctx.env, pkgs)
+    fixup_ext!(ctx.env, man_pkgs)
 
     # After downloading resolutionary packages, search for (Julia)Artifacts.toml files
     # and ensure they are all downloaded and unpacked as well:
     download_artifacts(ctx.env, platform=platform, julia_version=ctx.julia_version, io=ctx.io)
+
+    # if env is a package add compat entries
+    if ctx.env.project.name !== nothing && ctx.env.project.uuid !== nothing
+        compat_names = String[]
+        for pkg in pkgs
+            haskey(ctx.env.project.compat, pkg.name) && continue
+            pkgversion = Base.thispatch(ctx.env.manifest[pkg.uuid].version)
+            set_compat(ctx.env.project, pkg.name, string(pkgversion))
+            push!(compat_names, pkg.name)
+        end
+        printpkgstyle(ctx.io, :Compat, """entries added for $(join(compat_names, ", "))""")
+    end
+    record_project_hash(ctx.env) # compat entries changed the hash after it was last recorded in update_manifest!
 
     write_env(ctx.env) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -117,6 +117,9 @@ Add a package to the current project. This package will be available by using th
 `import` and `using` keywords in the Julia REPL, and if the current project is
 a package, also inside that package.
 
+If the active environment is a package  (has both `name` and `uuid` fields) compat entries will be added automatically
+with a lower bound of the added version.
+
 ## Resolution Tiers
 `Pkg` resolves the set of packages in your environment using a tiered algorithm.
 The `preserve` keyword argument allows you to key into a specific tier in the resolve algorithm.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -117,8 +117,8 @@ Add a package to the current project. This package will be available by using th
 `import` and `using` keywords in the Julia REPL, and if the current project is
 a package, also inside that package.
 
-If the active environment is a package  (has both `name` and `uuid` fields) compat entries will be added automatically
-with a lower bound of the added version.
+If the active environment is a package (the Project has both `name` and `uuid` fields) compat entries will be
+added automatically with a lower bound of the added version.
 
 ## Resolution Tiers
 `Pkg` resolves the set of packages in your environment using a tiered algorithm.

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -114,8 +114,8 @@ are of the form `@1`, `@1.2` or `@1.2.3`, allowing any version with a prefix
 that matches, or ranges thereof, such as `@1.2-3.4.5`. A git revision can be
 specified by `#branch` or `#commit`.
 
-If the active environment is a package (has both `name` and `uuid` fields) compat entries will be added automatically
-with a lower bound of the added version.
+If the active environment is a package (the Project has both `name` and `uuid` fields) compat entries will be
+added automatically with a lower bound of the added version.
 
 If a local path is used as an argument to `add`, the path needs to be a git repository.
 The project will then track that git repository just like it would track a remote repository online.

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -114,6 +114,9 @@ are of the form `@1`, `@1.2` or `@1.2.3`, allowing any version with a prefix
 that matches, or ranges thereof, such as `@1.2-3.4.5`. A git revision can be
 specified by `#branch` or `#commit`.
 
+If the active environment is a package (has both `name` and `uuid` fields) compat entries will be added automatically
+with a lower bound of the added version.
+
 If a local path is used as an argument to `add`, the path needs to be a git repository.
 The project will then track that git repository just like it would track a remote repository online.
 If the package is not located at the top of the git repository, a subdirectory can be specified with

--- a/test/new.jl
+++ b/test/new.jl
@@ -577,10 +577,13 @@ end
     end
     # Double add should not change state, this would be an unnecessary change.
     isolate(loaded_depot=true) do
+        @test !haskey(Pkg.Types.Context().env.project.compat, "Example")
         Pkg.add(name="Example", version="0.3.0")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.Types.Context().env.project.compat["Example"] == "0.3.0"
         Pkg.add("Example")
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
+        @test Pkg.Types.Context().env.project.compat["Example"] == "0.3.0"
     end
     # Adding a new package should not alter the version of existing packages.
     isolate(loaded_depot=true) do

--- a/test/new.jl
+++ b/test/new.jl
@@ -2428,7 +2428,7 @@ end
         Pkg.status(; outdated=true, io=io)
         str = String(take!(io))
         @test occursin(Regex("⌃\\s*\\[7876af07\\] Example\\s*v0.4.0\\s*\\(<v$v\\)"), str)
-        compat("Example", "0.4.1")
+        Pkg.compat("Example", "0.4.1")
         Pkg.status(; outdated=true, io=io)
         str = String(take!(io))
         @test occursin(Regex("⌃\\s*\\[7876af07\\] Example\\s*v0.4.0\\s*\\[<v0.4.1\\], \\(<v$v\\)"), str)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2428,12 +2428,7 @@ end
         Pkg.status(; outdated=true, io=io)
         str = String(take!(io))
         @test occursin(Regex("⌃\\s*\\[7876af07\\] Example\\s*v0.4.0\\s*\\(<v$v\\)"), str)
-        open(Base.active_project(), "a") do io
-            write(io, """
-                  [compat]
-                  Example = "0.4.1"
-            """)
-        end
+        compat("Example", "0.4.1")
         Pkg.status(; outdated=true, io=io)
         str = String(take!(io))
         @test occursin(Regex("⌃\\s*\\[7876af07\\] Example\\s*v0.4.0\\s*\\[<v0.4.1\\], \\(<v$v\\)"), str)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -483,14 +483,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
             json_uuid = Pkg.project().dependencies["JSON"]
             current_json = Pkg.dependencies()[json_uuid].version
             old_project = read("Project.toml", String)
-            open("Project.toml"; append=true) do io
-                print(io, """
-
-                [compat]
-                JSON = "0.18.0"
-                """
-                )
-            end
+            compat("JSON", "0.18.0")
             pkg"up"
             @test Pkg.dependencies()[json_uuid].version.minor == 18
             write("Project.toml", old_project)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -483,7 +483,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
             json_uuid = Pkg.project().dependencies["JSON"]
             current_json = Pkg.dependencies()[json_uuid].version
             old_project = read("Project.toml", String)
-            compat("JSON", "0.18.0")
+            Pkg.compat("JSON", "0.18.0")
             pkg"up"
             @test Pkg.dependencies()[json_uuid].version.minor == 18
             write("Project.toml", old_project)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/Pkg.jl/issues/776

If the current environment is a package this makes `pkg> add` auto add compat entries for the new direct dependencies.

I don't think we'd want to make this standard practice for the default envs, hence being specific to packages, but maybe there's an argument that it should be done for unnamed environments other than the defaults? Like the envs stored alongside scripts.

The compat entries are set to be lower-bounded by the installed patch version (which makes this work for JLLs).  
It feels safer than relying on semver and setting it to `Base.thisminor(v)`.

