### PR TITLE
rm old manual handling of `--compiled-modules`

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1686,7 +1686,6 @@ function gen_subprocess_cmd(code::String, source_path::String; coverage, julia_a
         $(Base.julia_cmd())
         --code-coverage=$(coverage_arg)
         --color=$(Base.have_color === nothing ? "auto" : Base.have_color ? "yes" : "no")
-        --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
         --check-bounds=yes
         --warn-overwrite=yes
         --depwarn=$(Base.JLOptions().depwarn == 2 ? "error" : "yes")


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3737

`julia_cmd()` now handles this
https://github.com/JuliaLang/julia/blob/abb7e3074b75c85b409320ccc7d9f5e9e9adb4a3/base/util.jl#L208-L209

@maleadt 