### PR TITLE
Refactor Pkg.BinaryPlatforms to avoid invalidations, keep types

### DIFF
--- a/src/BinaryPlatforms_compat.jl
+++ b/src/BinaryPlatforms_compat.jl
@@ -165,6 +165,6 @@ BBP.platforms_match(a::AbstractPlatform, b::AbstractPlatform) =
 BBP.platforms_match(a::BBP.AbstractPlatform, b::AbstractPlatform) =
     BBP.platforms_match(a, b.p)
 BBP.select_platform(download_info::Dict, platform::AbstractPlatform) =
-    BBP.platforms_match(a, platform.p)
+    BBP.select_platform(download_info, platform.p)
 
 end # module BinaryPlatforms

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -42,6 +42,8 @@ const platform = @inferred Platform platform_key_abi()
         # Explicitly test that we can pass arguments to UnknownPlatform,
         # and it doesn't do anything.
         @test UnknownPlatform(:riscv; libc=:fuschia_libc) == UnknownPlatform()
+        @test arch(FreeBSD()) == :x86_64
+        @test arch(MacOS()) == :x86_64
     end
 
     @testset "Platform properties" begin
@@ -82,6 +84,7 @@ const platform = @inferred Platform platform_key_abi()
         @test triplet(MacOS()) == "x86_64-apple-darwin14"
         @test triplet(FreeBSD(:x86_64)) == "x86_64-unknown-freebsd11.1"
         @test triplet(FreeBSD(:i686)) == "i686-unknown-freebsd11.1"
+        @test platform_key_abi("i686-w64-mingw32") == Windows(:i686)
     end
 
     @testset "Valid DL paths" begin
@@ -109,6 +112,8 @@ const platform = @inferred Platform platform_key_abi()
                 cxxstring_abi=cxxstring_abi,
             )
             @test platforms_match(Linux(:x86_64), Linux(:x86_64, compiler_abi=cabi))
+            @test platforms_match(convert(Platform,Linux(:x86_64)), Linux(:x86_64, compiler_abi=cabi))
+            @test platforms_match(Linux(:x86_64), convert(Platform, Linux(:x86_64, compiler_abi=cabi)))
             @test platforms_match(Linux(:x86_64, compiler_abi=cabi), Linux(:x86_64))
 
             # Also test auto-string-parsing
@@ -137,6 +142,9 @@ const platform = @inferred Platform platform_key_abi()
 
             @test !platforms_match(Linux(arch, compiler_abi=base_cabi), Linux(arch, compiler_abi=cabi))
         end
+        @test platforms_match(triplet(Linux(:x86_64)), Linux(:x86_64))
+        @test platforms_match(@view(triplet(Linux(:x86_64))[1:end]), Linux(:x86_64))
+        @test Base.BinaryPlatforms.select_platform(Dict(Linux(:x86_64) => 5), Linux(:x86_64)) == 5
     end
 
     @testset "Sys.is* overloading" begin


### PR DESCRIPTION
This is my third attempt to address invalidations caused by Pkg.BinaryPlatforms.

The prior attempts were
* Move Pkg.BinaryPlatforms to Base https://github.com/JuliaLang/julia/pull/52249
* Refactor Pkg.BinaryPlatforms by eliminating the AbstractPlatform subtypes https://github.com/JuliaLang/Pkg.jl/pull/3736

In this pull request, I introduce a new `Pkg.BinaryPlatforms.AbstractPlatform` type
that is distinct from `Base.BinaryPlatforms.AbstractPlatform`. The types here, `Linux`,
`Windows`, `MacOS`, and `FreeBSD` subtype `Pkg.BinaryPlatforms.AbstractPlatform`.

Because of this, these types no longer invalidate any `Base` methods as detailed in
#3702

Fixes #3702 (in part).
