### PR TITLE
Ignore artifact hash mismatch if we cannot create symlinks on Windows and the tarball has symlinks

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -796,4 +796,20 @@ end
     end
 end
 
+@testset "installing artifacts when symlinks are copied" begin
+    # copy symlinks to simulate the typical Microsoft Windows user experience where
+    # developer mode is not enabled (no admin rights)
+    withenv("BINARYPROVIDER_COPYDEREF" => "true") do
+        temp_pkg_dir() do tmpdir
+            artifacts_toml = joinpath(tmpdir, "Artifacts.toml")
+            cp(joinpath(@__DIR__, "test_packages", "ArtifactInstallation", "Artifacts.toml"), artifacts_toml)
+            Pkg.activate(tmpdir)
+            cts_hash = artifact_hash("collapse_the_symlink", artifacts_toml)
+            @test !artifact_exists(cts_hash)
+            @test_logs (:error, r"Tree Hash Mismatch!") match_mode=:any Pkg.instantiate()
+            @test artifact_exists(cts_hash)
+        end
+    end
+end
+
 end # module

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -162,13 +162,21 @@ const collapse_hash = "956c1201405f64d3465cc28cb0dec9d63c11a08cad28c381e13bb22e1
 @testset "Copyderef unpacking" begin
     mktempdir() do prefix
         target_dir = joinpath(prefix, "target")
-        @test :changed_symlink === download_verify_unpack(
+        changed_symlinks_output = Pair{String,String}[]
+        download_verify_unpack(
             collapse_url,
             collapse_hash,
             target_dir;
             verbose=true,
             copy_symlinks=true,
+            changed_symlinks_output,
         )
+
+        @test changed_symlinks_output == [
+            "collapse_the_symlink/foo" => "foo.1"
+            "collapse_the_symlink/foo.1.1" => "foo.1"
+            "collapse_the_symlink/broken" => "obviously_broken"
+        ]
 
         # Test that we get the files we expect
         @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo"))

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -160,23 +160,27 @@ end
 const collapse_url = "https://github.com/staticfloat/small_bin/raw/master/collapse_the_symlink/collapse_the_symlink.tar.gz"
 const collapse_hash = "956c1201405f64d3465cc28cb0dec9d63c11a08cad28c381e13bb22e1fc469d3"
 @testset "Copyderef unpacking" begin
-    withenv("BINARYPROVIDER_COPYDEREF" => "true") do
-        mktempdir() do prefix
-            target_dir = joinpath(prefix, "target")
-            download_verify_unpack(collapse_url, collapse_hash, target_dir; verbose=true)
+    mktempdir() do prefix
+        target_dir = joinpath(prefix, "target")
+        @test :changed_symlink === download_verify_unpack(
+            collapse_url,
+            collapse_hash,
+            target_dir;
+            verbose=true,
+            copy_symlinks=true,
+        )
 
-            # Test that we get the files we expect
-            @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo"))
-            @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo.1"))
-            @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo.1.1"))
+        # Test that we get the files we expect
+        @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo"))
+        @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo.1"))
+        @test isfile(joinpath(target_dir, "collapse_the_symlink", "foo.1.1"))
 
-            # Test that these are definitely not links
-            @test !islink(joinpath(target_dir, "collapse_the_symlink", "foo"))
-            @test !islink(joinpath(target_dir, "collapse_the_symlink", "foo.1.1"))
+        # Test that these are definitely not links
+        @test !islink(joinpath(target_dir, "collapse_the_symlink", "foo"))
+        @test !islink(joinpath(target_dir, "collapse_the_symlink", "foo.1.1"))
 
-            # Test that broken symlinks get transparently dropped
-            @test !ispath(joinpath(target_dir, "collapse_the_symlink", "broken"))
-        end
+        # Test that broken symlinks get transparently dropped
+        @test !ispath(joinpath(target_dir, "collapse_the_symlink", "broken"))
     end
 end
 


### PR DESCRIPTION
Fixes #3643 using @staticfloat's approach in https://github.com/JuliaLang/Pkg.jl/issues/3643#issuecomment-1880111897

This PR moves the decision of whether to copy symlinks from https://github.com/JuliaIO/Tar.jl/blob/6269b5b8c4c863b1fe2beef53666273e3bbc021b/src/Tar.jl#L244-L246
and
https://github.com/JuliaLang/Pkg.jl/blob/3c86ba27e904807e13beb8cb0466ed70365b0b2d/src/PlatformEngines.jl#L385-L390
to inside the `download_artifact` function.

It also modifies `download_verify_unpack` to output which symlinks were not able to be created.

The error message added in #3745 is logged if there is a hash mismatch and symlinks were changed, but it is not an error, instead, the artifact is moved to the expected location.