### PR TITLE
Send verbose test output to devnull by default

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,13 +30,13 @@ if islogging
     Pkg.DEFAULT_IO[] = open(logfile, "a")
     @info "Pkg test output is being logged to file" logfile
 else
-    Pkg.DEFAULT_IO[] = stdout
+    Pkg.DEFAULT_IO[] = devnull # or stdout
 end
 
 Pkg.REPLMode.minirepl[] = Pkg.REPLMode.MiniREPL() # re-set this given DEFAULT_IO has changed
 
 include("utils.jl")
-Logging.with_logger(islogging ? Logging.ConsoleLogger(Pkg.DEFAULT_IO[]) : Logging.current_logger()) do
+Logging.with_logger((islogging || Pkg.DEFAULT_IO[] == devnull) ? Logging.ConsoleLogger(Pkg.DEFAULT_IO[]) : Logging.current_logger()) do
 
     # Because julia CI doesn't run stdlib tests via `Pkg.test` test deps must be manually installed if missing
     if Base.find_package("HistoricalStdlibVersions") === nothing


### PR DESCRIPTION
So that `make testall` is reasonable by default