### PR TITLE
ignore tree hashes on Windows w/o symlink capability

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -325,16 +325,16 @@ function download_artifact(
         # the artifact to the expected location and return true
         ignore_hash_env_set = get(ENV, "JULIA_PKG_IGNORE_HASHES", "") != ""
         if ignore_hash_env_set
-            # default: false except Windows users who can't symlink
-            ignore_hash = Sys.iswindows() &&
-                !mktempdir(can_symlink, dirname(src))
-        else
             ignore_hash = Base.get_bool_env("JULIA_PKG_IGNORE_HASHES", false)
             ignore_hash === nothing && @error(
                 "Invalid ENV[\"JULIA_PKG_IGNORE_HASHES\"] value",
                 ENV["JULIA_PKG_IGNORE_HASHES"],
             )
             ignore_hash = something(ignore_hash, false)
+        else
+            # default: false except Windows users who can't symlink
+            ignore_hash = Sys.iswindows() &&
+                !mktempdir(can_symlink, dirname(src))
         end
         if ignore_hash
             desc = ignore_hash_env_set ?

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -290,27 +290,20 @@ end
     @test_logs (:error, r"malformed, must be array or dict!") artifact_meta("broken_artifact", joinpath(badifact_dir, "not_a_table.toml"))
 
     # Next, test incorrect download errors
-    for ignore_hash in (false, true);
-        ignore_hash && ENV["JULIA_PKG_IGNORE_HASHES"] = "1"
-        try
-            mktempdir() do dir
-                with_artifacts_directory(dir) do
-                    @test artifact_meta("broken_artifact", joinpath(badifact_dir, "incorrect_gitsha.toml")) != nothing
-                    if !ignore_hash
-                        @test_throws ErrorException ensure_artifact_installed("broken_artifact", joinpath(badifact_dir, "incorrect_gitsha.toml"))
-                    else
-                        @test_logs (:error, r"Tree Hash Mismatch!") match_mode=:any  begin
-                            path = ensure_artifact_installed("broken_artifact", joinpath(badifact_dir, "incorrect_gitsha.toml"))
-                            @test endswith(path, "0000000000000000000000000000000000000000")
-                            @test isdir(path)
-                        end
+    for ignore_hash in (false, true); withenv("JULIA_PKG_IGNORE_HASHES" => ignore_hash ? "1" : nothing) do; mktempdir() do dir
+        with_artifacts_directory(dir) do
+            @test artifact_meta("broken_artifact", joinpath(badifact_dir, "incorrect_gitsha.toml")) != nothing
+            if !ignore_hash
+                @test_throws ErrorException ensure_artifact_installed("broken_artifact", joinpath(badifact_dir, "incorrect_gitsha.toml"))
+            else
+                @test_logs (:error, r"Tree Hash Mismatch!") match_mode=:any  begin
+                    path = ensure_artifact_installed("broken_artifact", joinpath(badifact_dir, "incorrect_gitsha.toml"))
+                    @test endswith(path, "0000000000000000000000000000000000000000")
+                    @test isdir(path)
                     end
                 end
             end
-        finally
-            ignore_hash && delete!(ENV, "JULIA_PKG_IGNORE_HASHES")
-        end
-    end
+    end end end
 
     mktempdir() do dir
         with_artifacts_directory(dir) do


### PR DESCRIPTION
Step one of addressing https://github.com/JuliaLang/Pkg.jl/issues/3643. I implemented this by providing a default for the `ignore_hash` value in `download_artifact`, namely the default value is false unless the OS is Windows and the user cannot create symlinks in the artifact directory, in which case we default `ignore_hash` to true instead. This still emits a warning, which seems desirable based on the discussion in #3643.