### PR TITLE
Avoid deleting existing artifacts when ignoring hashes.

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -50,12 +50,6 @@ function create_artifact(f::Function)
         # unless the user has been very unwise, but let's be cautious.
         new_path = artifact_path(artifact_hash; honor_overrides=false)
         _mv_temp_artifact_dir(temp_dir, new_path)
-        if !isdir(new_path)
-            # Move this generated directory to its final destination, set it to read-only
-            mv(temp_dir, new_path)
-            chmod(new_path, filemode(dirname(new_path)))
-            set_readonly(new_path)
-        end
 
         # Give the people what they want
         return artifact_hash
@@ -364,13 +358,12 @@ function download_artifact(
                     ignoring hash mismatch and moving \
                     artifact to the expected location"
                 @error(msg)
-                # Move it to the location we expected
-                _mv_temp_artifact_dir(temp_dir, dst)
             else
                 error(msg)
             end
         end
-        return true
+        # Move it to the location we expected
+        _mv_temp_artifact_dir(temp_dir, dst)
     catch err
         @debug "download_artifact error" tree_hash tarball_url tarball_hash err
         if isa(err, InterruptException)
@@ -382,6 +375,7 @@ function download_artifact(
         # Always attempt to cleanup
         rm(temp_dir; recursive=true, force=true)
     end
+    return true
 end
 
 """

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -799,4 +799,30 @@ end
     end
 end
 
+@testset "installing artifacts when symlinks are copied" begin
+    # copy symlinks to simulate the typical Microsoft Windows user experience where
+    # developer mode is not enabled (no admin rights)
+    withenv("BINARYPROVIDER_COPYDEREF"=>"true", "JULIA_PKG_IGNORE_HASHES"=>"true") do
+        temp_pkg_dir() do tmpdir
+            artifacts_toml = joinpath(tmpdir, "Artifacts.toml")
+            cp(joinpath(@__DIR__, "test_packages", "ArtifactInstallation", "Artifacts.toml"), artifacts_toml)
+            Pkg.activate(tmpdir)
+            cts_real_hash = create_artifact() do dir
+                local meta = Artifacts.artifact_meta("collapse_the_symlink", artifacts_toml)
+                local collapse_url = meta["download"][1]["url"]
+                local collapse_hash = meta["download"][1]["sha256"]
+                # Because "BINARYPROVIDER_COPYDEREF"=>"true", this will copy symlinks.
+                download_verify_unpack(collapse_url, collapse_hash, dir; verbose=true, ignore_existence=true)
+            end
+            cts_hash = artifact_hash("collapse_the_symlink", artifacts_toml)
+            @test !artifact_exists(cts_hash)
+            @test artifact_exists(cts_real_hash)
+            @test_logs (:error, r"Tree Hash Mismatch!") match_mode=:any Pkg.instantiate()
+            @test artifact_exists(cts_hash)
+            # Make sure existing artifacts don't get deleted.
+            @test artifact_exists(cts_real_hash)
+        end
+    end
+end
+
 end # module


### PR DESCRIPTION
Followup to https://github.com/JuliaLang/Pkg.jl/pull/3764
Fixes bug reported in https://github.com/JuliaLang/Pkg.jl/issues/3643#issuecomment-1905048298

This PR modifies `download_artifact` to avoid calling `mv(src, dst; force=true)` where `src` and `dst` are both possible valid artifacts.

The main steps of `download_artifact` are
1. Return `true` if the artifact already exists.
1. Determine the expected artifact path and parent directory.
2. Make a temporary directory.
3. `download_verify_unpack` into the temporary directory.
4. Calculate the tree hash of the temporary directory.
5. If the tree hash doesn't match, either throw an error or log an error, depending on the enviroment.
6. Atomically move the temporary directory to the expected path.
7. Try to clean up the temporary directory.

If steps 4 to 7 throw an error, that error gets returned, otherwise `true` is returned.