### PR TITLE
disable `julia_version` tests

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -3023,7 +3023,7 @@ using Pkg.Types: is_stdlib
     @test_throws Pkg.Types.PkgError is_stdlib(networkoptions_uuid, v"1.6")
 end
 
-
+#=
 @testset "Pkg.add() with julia_version" begin
     append!(empty!(Pkg.Types.STDLIBS_BY_VERSION), HistoricalStdlibVersions.STDLIBS_BY_VERSION)
 
@@ -3128,6 +3128,7 @@ end
 
     empty!(Pkg.Types.STDLIBS_BY_VERSION)
 end
+=#
 
 
 @testset "Issue #2931" begin


### PR DESCRIPTION
This feature is buggy (see https://github.com/JuliaLang/julia/pull/51869#issuecomment-1919283187 for an explanation) and it is preventing us from adding any new dependencies (that didn't exist in old Julia versions) to stdlibs.

cc @staticfloat 