### PR TITLE
Support a `[sources]` section in Project.toml for specifying paths and repo locations for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Pkg v1.12 Release Notes
+
+- It is now possible to specify "sources" for packages in a `[sources]` section in Project.toml.
+  This can be used to add non-registered normal or test dependencies. Packages will also automatically be added to `[sources]` when they are added by url or devved.
+
 Pkg v1.11 Release Notes
 =======================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Pkg v1.12 Release Notes
+=======================
 
 - It is now possible to specify "sources" for packages in a `[sources]` section in Project.toml.
-  This can be used to add non-registered normal or test dependencies. Packages will also automatically be added to `[sources]` when they are added by url or devved.
+  This can be used to add non-registered normal or test dependencies.
 
 Pkg v1.11 Release Notes
 =======================

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -91,6 +91,19 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Typically it is not needed to manually add entries to the `[deps]` section; this is instead
 handled by Pkg operations such as `add`.
 
+### The `[sources]` section
+
+Specifiying a path or repo (+ branch) for a dependency is done in the `[sources]` section.
+These are especially useful for controlling unregistered dependencies without having to bundle a
+corresponding manifest file.
+
+```toml
+[sources]
+Example = {url = "https://github.com/JuliaLang/Example.jl", rev = "custom_branch"}
+SomeDependency = {path = "deps/SomeDependency.jl"}
+```
+
+Note that this information is only used when this environment is active, i.e. it is not used if this project is a package that is being used as a dependency.
 
 ### The `[compat]` section
 
@@ -135,7 +148,7 @@ Julia will then preferentially use the version-specific manifest file if availab
 For example, if both `Manifest-v1.11.toml` and `Manifest.toml` exist, Julia 1.11 will prioritize using `Manifest-v1.11.toml`.
 However, Julia versions 1.10, 1.12, and all others will default to using `Manifest.toml`.
 This feature allows for easier management of different instantiated versions of dependencies for various Julia versions.
-Note that there can only be one `Project.toml` file. While `Manifest-v{major}.{minor}.toml` files are not automatically 
+Note that there can only be one `Project.toml` file. While `Manifest-v{major}.{minor}.toml` files are not automatically
 created by Pkg, users can manually rename a `Manifest.toml` file to match
 the versioned format, and Pkg will subsequently maintain it through its operations.
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -101,6 +101,7 @@ Base.@kwdef struct ProjectInfo
     version::Union{Nothing,VersionNumber}
     ispackage::Bool
     dependencies::Dict{String,UUID}
+    sources::Dict{String,Dict{String,String}}
     path::String
 end
 
@@ -113,6 +114,7 @@ function project(env::EnvCache)::ProjectInfo
         version      = pkg === nothing ? nothing : pkg.version::VersionNumber,
         ispackage    = pkg !== nothing,
         dependencies = env.project.deps,
+        sources      = env.project.sources,
         path         = env.project_file
     )
 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -189,16 +189,12 @@ function update_source_if_set(project, pkg)
     # This should probably not modify the dicts directly...
     if pkg.repo.source !== nothing
         source["url"] = pkg.repo.source
-        delete!(source, "path")
     end
     if pkg.repo.rev !== nothing
         source["rev"] = pkg.repo.rev
-        delete!(source, "path")
     end
     if pkg.path !== nothing
         source["path"] = pkg.path
-        delete!(source, "url")
-        delete!(source, "rev")
     end
     path, repo = get_path_repo(project, pkg.name)
     if path !== nothing

--- a/src/API.jl
+++ b/src/API.jl
@@ -189,12 +189,16 @@ function update_source_if_set(project, pkg)
     # This should probably not modify the dicts directly...
     if pkg.repo.source !== nothing
         source["url"] = pkg.repo.source
+        delete!(source, "path")
     end
     if pkg.repo.rev !== nothing
         source["rev"] = pkg.repo.rev
+        delete!(source, "path")
     end
     if pkg.path !== nothing
         source["path"] = pkg.path
+        delete!(source, "url")
+        delete!(source, "rev")
     end
     path, repo = get_path_repo(project, pkg.name)
     if path !== nothing

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1111,7 +1111,6 @@ function write_env(env::EnvCache; update_undo=true,
             @assert entry.path == path
         end
         if repo != GitRepo()
-            @show repo, entry.repo
             @assert entry.repo.source == repo.source
             if repo.rev !== nothing
                 @assert entry.repo.rev == repo.rev
@@ -1119,6 +1118,13 @@ function write_env(env::EnvCache; update_undo=true,
             if entry.repo.subdir !== nothing
                 @assert entry.repo.subdir == repo.subdir
             end
+        end
+        if entry.path !== nothing
+            env.project.sources[pkg] = Dict("path" => entry.path)
+        elseif entry.repo != GitRepo()
+            d = Dict("url" => entry.repo.source)
+            entry.repo.rev !== nothing && (d["rev"] = entry.repo.rev)
+            env.project.sources[pkg] = d
         end
     end
     if (env.project != env.original_project) && (!skip_writing_project)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1119,13 +1119,6 @@ function write_env(env::EnvCache; update_undo=true,
                 @assert entry.repo.subdir == repo.subdir
             end
         end
-        if entry.path !== nothing
-            env.project.sources[pkg] = Dict("path" => entry.path)
-        elseif entry.repo != GitRepo()
-            d = Dict("url" => entry.repo.source)
-            entry.repo.rev !== nothing && (d["rev"] = entry.repo.rev)
-            env.project.sources[pkg] = d
-        end
     end
     if (env.project != env.original_project) && (!skip_writing_project)
         write_project(env)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -159,6 +159,6 @@ let
     end
 
     if Base.generating_output()
-        pkg_precompile()
+        # pkg_precompile()
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,7 @@ Logging.with_logger((islogging || Pkg.DEFAULT_IO[] == devnull) ? Logging.Console
 
     @testset "Pkg" begin
         try
-            @testset "$f" for f in [
+        @testset "$f" for f in [
                 "new.jl",
                 "pkg.jl",
                 "repl.jl",
@@ -76,7 +76,8 @@ Logging.with_logger((islogging || Pkg.DEFAULT_IO[] == devnull) ? Logging.Console
                 "misc.jl",
                 "force_latest_compatible_version.jl",
                 "manifests.jl",
-                "project_manifest.jl"
+                "project_manifest.jl",
+                "sources.jl"
                 ]
                 @info "==== Testing `test/$f`"
                 flush(Pkg.DEFAULT_IO[])

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -12,6 +12,18 @@ temp_pkg_dir() do project_path
             cd(joinpath(dir, "WithSources")) do
                 with_current_env() do
                     Pkg.resolve()
+                    @test !isempty(Pkg.project().sources["Example"])
+                    project_backup = cp("Project.toml", "Project.toml.bak"; force=true)
+                    Pkg.free("Example")
+                    @test !haskey(Pkg.project().sources, "Example")
+                    cp("Project.toml.bak", "Project.toml"; force=true)
+                    Pkg.add(; url="https://github.com/JuliaLang/Example.jl/", rev="78406c204b8")
+                    @test Pkg.project().sources["Example"] == Dict("url" => "https://github.com/JuliaLang/Example.jl/", "rev" => "78406c204b8")
+                    cp("Project.toml.bak", "Project.toml"; force=true)
+                    cp("BadManifest.toml", "Manifest.toml"; force=true)
+                    Pkg.resolve()
+                    @test Pkg.project().sources["Example"] == Dict("url" => "https://github.com/JuliaLang/Example.jl")
+                    @test Pkg.project().sources["LocalPkg"] == Dict("path" => "LocalPkg")
                 end
             end
 

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -1,0 +1,27 @@
+module SourcesTest
+
+import ..Pkg # ensure we are using the correct Pkg
+using Test, Pkg
+using ..Utils
+
+temp_pkg_dir() do project_path
+    @testset "test Project.toml [sources]" begin
+        mktempdir() do dir
+            path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "WithSources"))
+            cp(path, joinpath(dir, "WithSources"))
+            cd(joinpath(dir, "WithSources")) do
+                with_current_env() do
+                    Pkg.resolve()
+                end
+            end
+
+            cd(joinpath(dir, "WithSources", "TestWithUnreg")) do
+                with_current_env() do
+                    Pkg.test()
+                end
+            end
+        end
+    end
+end
+
+end # module

--- a/test/test_packages/WithSources/BadManifest.toml
+++ b/test/test_packages/WithSources/BadManifest.toml
@@ -1,0 +1,17 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.0-DEV"
+manifest_format = "2.0"
+project_hash = "65567d20ea33b8d376b53b9e9e96938f75d0fab1"
+
+[[deps.Example]]
+git-tree-sha1 = "e64c907c88640c370060a89aaae1b641eedc3dfc"
+repo-rev = "master"
+repo-url = "https://what.is.this.url???"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.4"
+
+[[deps.LocalPkg]]
+path = "what/is/this/path???"
+uuid = "fcf55292-0d03-4e8a-9e0b-701580031fc3"
+version = "0.1.0"

--- a/test/test_packages/WithSources/LocalPkg/Project.toml
+++ b/test/test_packages/WithSources/LocalPkg/Project.toml
@@ -1,0 +1,4 @@
+name = "LocalPkg"
+uuid = "fcf55292-0d03-4e8a-9e0b-701580031fc3"
+authors = ["KristofferC <kristoffer.carlsson@juliacomputing.com>"]
+version = "0.1.0"

--- a/test/test_packages/WithSources/LocalPkg/src/LocalPkg.jl
+++ b/test/test_packages/WithSources/LocalPkg/src/LocalPkg.jl
@@ -1,0 +1,5 @@
+module LocalPkg
+
+greet() = print("Hello World!")
+
+end # module LocalPkg

--- a/test/test_packages/WithSources/Project.toml
+++ b/test/test_packages/WithSources/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+LocalPkg = "fcf55292-0d03-4e8a-9e0b-701580031fc3"
+
+[sources]
+Example = {url = "https://github.com/JuliaLang/Example.jl"}
+LocalPkg = {path = "LocalPkg"}

--- a/test/test_packages/WithSources/TestWithUnreg/Project.toml
+++ b/test/test_packages/WithSources/TestWithUnreg/Project.toml
@@ -1,0 +1,15 @@
+name = "TestWithUnreg"
+uuid = "b22516cc-aa7b-4e1f-935d-71632a5f0028"
+authors = ["KristofferC <kristoffer.carlsson@juliacomputing.com>"]
+version = "0.1.0"
+
+[extras]
+LocalPkg = "fcf55292-0d03-4e8a-9e0b-701580031fc3"
+Unregistered = "dcb67f36-efa0-11e8-0cef-2fc465ed98ae"
+
+[sources]
+LocalPkg = {path = "../LocalPkg"}
+Unregistered = {url = "https://github.com/00vareladavid/Unregistered.jl", rev = "1b7a462"}
+
+[targets]
+test = ["LocalPkg", "Unregistered"]

--- a/test/test_packages/WithSources/TestWithUnreg/src/TestWithUnreg.jl
+++ b/test/test_packages/WithSources/TestWithUnreg/src/TestWithUnreg.jl
@@ -1,0 +1,5 @@
+module TestWithUnreg
+
+greet() = print("Hello World!")
+
+end # module TestWithUnreg

--- a/test/test_packages/WithSources/TestWithUnreg/test/runtests.jl
+++ b/test/test_packages/WithSources/TestWithUnreg/test/runtests.jl
@@ -1,0 +1,2 @@
+using LocalPkg
+using Unregistered


### PR DESCRIPTION
Extracted and tweaked based on https://github.com/JuliaLang/Pkg.jl/pull/3263.

Currently requires https://github.com/JuliaLang/julia/pull/53233

Some questions:

- What happens if you have a source for a URL and then you `add` the package with another URL? Error or update the source?
- Same as above but with a `path`.
- What should `free` do when there is a source specified.

TODO:
- [ ] Docs
- [ ] More thorough tests
- [x] Verify parsing of source section in project file
- [x] remove source in `free` (`update_package_free`)
- [x] update source on `add` (`update_package_add`)
- [x] remove source in `rm`
- [x] Test when `resolve` with non source in manifest and source in project.
