### PR TITLE
Simplify Pkg.Registry APIs.

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -643,8 +643,8 @@ For example, `Pkg.add` can be called either as the explicit or concise versions 
 | Explicit                                                            | Concise                                        |
 |:--------------------------------------------------------------------|:-----------------------------------------------|
 | `Pkg.add(PackageSpec(name="Package"))`                              | `Pkg.add(name = "Package")`                    |
-| `Pkg.add(PackageSpec(url="www.myhost.com/MyPkg")))`                 | `Pkg.add(name = "Package")`                    |
-|` Pkg.add([PackageSpec(name="Package"), PackageSpec(path="/MyPkg"])` | `Pkg.add([(;name="Package"), (;path="MyPkg")])`|
+| `Pkg.add(PackageSpec(url="www.myhost.com/MyPkg")))`                 | `Pkg.add(url="www.myhost.com/MyPkg")`                    |
+|` Pkg.add([PackageSpec(name="Package"), PackageSpec(path="/MyPkg"])` | `Pkg.add([(;name="Package"), (;path="/MyPkg")])`|
 
 Below is a comparison between the REPL mode and the functional API:
 
@@ -700,15 +700,27 @@ const redo = API.redo
 
 """
     RegistrySpec(name::String)
-    RegistrySpec(; name, url, path)
+    RegistrySpec(; name, uuid, url, path)
 
 A `RegistrySpec` is a representation of a registry with various metadata, much like
 [`PackageSpec`](@ref).
+This includes:
+
+  * The `name` of the registry.
+  * The registry's unique `uuid`.
+  * The `url` to the registry.
+  * A local `path`.
 
 Most registry functions in Pkg take a `Vector` of `RegistrySpec` and do the operation
 on all the registries in the vector.
 
-# Examples
+Many functions that take a `RegistrySpec` can be called with a more concise notation with keyword arguments.
+For example, `Pkg.Registry.add` can be called either as the explicit or concise versions as:
+
+| Explicit                                                            | Concise                                        |
+|:--------------------------------------------------------------------|:-----------------------------------------------|
+| `Pkg.Registry.add(RegistrySpec(name="General"))`                                        | `Pkg.Registry.add(name = "General")`                                      |
+| `Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaRegistries/General.git")))` | `Pkg.Registry.add(url = "https://github.com/JuliaRegistries/General.git")`|
 
 Below is a comparison between the REPL mode and the functional API::
 

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -33,13 +33,19 @@ The no-argument `Pkg.Registry.add()` will install the default registries.
 # Examples
 ```julia
 Pkg.Registry.add("General")
-Pkg.Registry.add(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
-Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
+Pkg.Registry.add(uuid = "23338594-aafe-5451-b93e-139f81909106")
+Pkg.Registry.add(url = "https://github.com/JuliaRegistries/General.git")
 ```
 """
 add(reg::Union{String,RegistrySpec}; kwargs...) = add([reg]; kwargs...)
 add(regs::Vector{String}; kwargs...) = add(RegistrySpec[RegistrySpec(name = name) for name in regs]; kwargs...)
-add(; kwargs...) = add(RegistrySpec[]; kwargs...)
+function add(; name=nothing, uuid=nothing, url=nothing, path=nothing, linked=nothing, kwargs...)
+    if all(isnothing, (name, uuid, url, path, linked))
+        add(RegistrySpec[]; kwargs...)
+    else
+        add([RegistrySpec(; name, uuid, url, path, linked)]; kwargs...)
+    end
+end
 function add(regs::Vector{RegistrySpec}; io::IO=stderr_f(), depot=depots1())
     if isempty(regs)
         download_default_registries(io, only_if_empty = false; depot)
@@ -280,11 +286,14 @@ Remove registries.
 # Examples
 ```julia
 Pkg.Registry.rm("General")
-Pkg.Registry.rm(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
+Pkg.Registry.rm(uuid = "23338594-aafe-5451-b93e-139f81909106")
 ```
 """
 rm(reg::Union{String,RegistrySpec}; kwargs...) = rm([reg]; kwargs...)
 rm(regs::Vector{String}; kwargs...) = rm([RegistrySpec(name = name) for name in regs]; kwargs...)
+function rm(; name=nothing, uuid=nothing, url=nothing, path=nothing, linked=nothing, kwargs...)
+    rm([RegistrySpec(; name, uuid, url, path, linked)]; kwargs...)
+end
 function rm(regs::Vector{RegistrySpec}; io::IO=stderr_f())
     for registry in find_installed_registries(io, regs; depots=first(Base.DEPOT_PATH))
         printpkgstyle(io, :Removing, "registry `$(registry.name)` from $(Base.contractuser(registry.path))")
@@ -364,12 +373,19 @@ all available registries.
 ```julia
 Pkg.Registry.update()
 Pkg.Registry.update("General")
-Pkg.Registry.update(RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"))
+Pkg.Registry.update(uuid = "23338594-aafe-5451-b93e-139f81909106")
 ```
 """
 update(reg::Union{String,RegistrySpec}; kwargs...) = update([reg]; kwargs...)
 update(regs::Vector{String}; kwargs...) = update([RegistrySpec(name = name) for name in regs]; kwargs...)
-function update(regs::Vector{RegistrySpec} = RegistrySpec[]; io::IO=stderr_f(), force::Bool=true, depots = [depots1()], update_cooldown = Second(1))
+function update(; name=nothing, uuid=nothing, url=nothing, path=nothing, linked=nothing, kwargs...)
+    if all(isnothing, (name, uuid, url, path, linked))
+        update(RegistrySpec[]; kwargs...)
+    else
+        update([RegistrySpec(; name, uuid, url, path, linked)]; kwargs...)
+    end
+end
+function update(regs::Vector{RegistrySpec}; io::IO=stderr_f(), force::Bool=true, depots = [depots1()], update_cooldown = Second(1))
     registry_update_log = get_registry_update_log()
     for depot in depots
         depot_regs = isempty(regs) ? reachable_registries(; depots=depot) : regs

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -54,7 +54,7 @@ using Test
     isolate(loaded_depot=false) do
         depot = mktempdir(); empty!(DEPOT_PATH); push!(DEPOT_PATH, depot)
         Pkg.activate(; temp=true)
-        Pkg.Registry.add(Pkg.RegistrySpec(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "ExtensionRegistry")))
+        Pkg.Registry.add(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "ExtensionRegistry"))
         Pkg.Registry.add("General")
         Pkg.add("HasExtensions")
         Pkg.test("HasExtensions", julia_args=`--depwarn=no`) # OffsetArrays errors from depwarn
@@ -66,7 +66,7 @@ using Test
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0) do
             depot = mktempdir(); empty!(DEPOT_PATH); push!(DEPOT_PATH, depot)
             Pkg.activate(; temp=true)
-            Pkg.Registry.add(Pkg.RegistrySpec(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "ExtensionRegistry")))
+            Pkg.Registry.add(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "ExtensionRegistry"))
             Pkg.Registry.add("General")
             Pkg.add("HasDepWithExtensions")
         end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2751,7 +2751,7 @@ for v in (nothing, "true")
                     @testset "failures" begin
                         doesnotexist = "https://github.com/DoesNotExist/DoesNotExist.jl"
                         @test_throws Pkg.Types.PkgError Pkg.add(url=doesnotexist, use_git_for_all_downloads=true)
-                        @test_throws Pkg.Types.PkgError Pkg.Registry.add(Pkg.RegistrySpec(url=doesnotexist))
+                        @test_throws Pkg.Types.PkgError Pkg.Registry.add(url=doesnotexist)
                     end
                 end
                 @testset "tarball downloads" begin

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -136,11 +136,11 @@ end
         # reset installed registries
         rm.(joinpath.(Base.DEPOT_PATH[1:2], "registries"); force=true, recursive=true)
 
-        Registry.add(RegistrySpec(url = Foo1.url))
+        Registry.add(url = Foo1.url)
         test_installed([Foo1])
         @test is_pkg_available(Example1)
         @test !is_pkg_available(Example2)
-        with_depot2(() -> Registry.add(RegistrySpec(url = Foo2.url)))
+        with_depot2(() -> Registry.add(url = Foo2.url))
         test_installed([Foo1, Foo2])
         @test is_pkg_available(Example1)
         @test is_pkg_available(Example2)
@@ -148,15 +148,15 @@ end
 
         pkgstr("registry up $(Foo1.uuid)")
         pkgstr("registry update $(Foo1.name)=$(Foo1.uuid)")
-        Registry.update(RegistrySpec(uuid = Foo1.uuid))
-        Registry.update(RegistrySpec(name = Foo1.name, uuid = Foo1.uuid))
+        Registry.update(uuid = Foo1.uuid)
+        Registry.update(name = Foo1.name, uuid = Foo1.uuid)
 
         test_installed([Foo1, Foo2])
         pkgstr("registry rm $(Foo1.uuid)")
         test_installed([Foo2])
         @test !is_pkg_available(Example1)
         @test is_pkg_available(Example2)
-        Registry.add(RegistrySpec(url = Foo1.url))
+        Registry.add(url = Foo1.url)
         test_installed([Foo1, Foo2])
         @test is_pkg_available(Example1)
         @test is_pkg_available(Example2)
@@ -171,25 +171,25 @@ end
         @test !is_pkg_available(Example1)
         @test !is_pkg_available(Example2)
 
-        Registry.add(RegistrySpec(url = Foo1.url))
-        with_depot2(() -> Registry.add(RegistrySpec(url = Foo2.url)))
+        Registry.add(url = Foo1.url)
+        with_depot2(() -> Registry.add(url = Foo2.url))
         test_installed([Foo1, Foo2])
         @test is_pkg_available(Example1)
         @test is_pkg_available(Example2)
-        Registry.rm(RegistrySpec(uuid = Foo1.uuid))
+        Registry.rm(uuid = Foo1.uuid)
         test_installed([Foo2])
         @test !is_pkg_available(Example1)
         @test is_pkg_available(Example2)
-        Registry.add(RegistrySpec(url = Foo1.url))
+        Registry.add(url = Foo1.url)
         test_installed([Foo1, Foo2])
         @test is_pkg_available(Example1)
         @test is_pkg_available(Example2)
-        Registry.rm(RegistrySpec(name = Foo1.name, uuid = Foo1.uuid))
+        Registry.rm(name = Foo1.name, uuid = Foo1.uuid)
         test_installed([Foo2])
         @test !is_pkg_available(Example1)
         @test is_pkg_available(Example2)
         with_depot2() do
-            Registry.rm(RegistrySpec(Foo2.name))
+            Registry.rm(Foo2.name)
         end
         test_installed([])
         @test !is_pkg_available(Example1)
@@ -226,7 +226,7 @@ end
                      RegistrySpec(uuid = Foo1.uuid),
                      ])
         with_depot2() do
-            Registry.rm(RegistrySpec(name = Foo2.name, uuid = Foo2.uuid))
+            Registry.rm(name = Foo2.name, uuid = Foo2.uuid)
         end
         test_installed([])
         @test !is_pkg_available(Example)
@@ -291,7 +291,7 @@ end
         uuid = Base.UUID("7876af07-990d-54b4-ab0e-23690620f79a") # Example
         # Tests that Example@0.5.1 does not get installed
         temp_pkg_dir() do env
-            Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/Test"))
+            Pkg.Registry.add(url = "https://github.com/JuliaRegistries/Test")
             Pkg.add("Example")
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             Pkg.update() # should not update Example
@@ -305,7 +305,7 @@ end
         end
         # Test that Example@0.5.1 can be obtained from an existing manifest
         temp_pkg_dir() do env
-            Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/Test"))
+            Pkg.Registry.add(url = "https://github.com/JuliaRegistries/Test")
             write(joinpath(env, "Project.toml"),"""
                 [deps]
                 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
@@ -321,7 +321,7 @@ end
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.1"
         end
         temp_pkg_dir() do env
-            Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/Test"))
+            Pkg.Registry.add(url = "https://github.com/JuliaRegistries/Test")
             write(joinpath(env, "Project.toml"),"""
                 [deps]
                 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -355,7 +355,7 @@ if Pkg.Registry.registry_use_pkg_server()
                 Pkg.Registry.DEFAULT_REGISTRIES[1].url = "https://github.com/JuliaRegistries/General.git"
 
                 # This should not uncompress the registry
-                Registry.add(RegistrySpec(uuid = UUID("23338594-aafe-5451-b93e-139f81909106")))
+                Registry.add(uuid = UUID("23338594-aafe-5451-b93e-139f81909106"))
                 @test isfile(joinpath(DEPOT_PATH[1], "registries", "General.tar.gz")) != something(unpack, false)
                 Pkg.add("Example")
 
@@ -374,7 +374,7 @@ if Pkg.Registry.registry_use_pkg_server()
                         """)
                 end
                 Pkg.update()
-                Pkg.Registry.rm(RegistrySpec(name = "General"))
+                Pkg.Registry.rm(name = "General")
                 @test isempty(readdir(joinpath(DEPOT_PATH[1], "registries")))
             end
         end


### PR DESCRIPTION
From https://github.com/JuliaLang/Pkg.jl/pull/1358#issue-490784060:
>  ideally this should be added for the Pkg.Registry module as well but that might be a later project...

Well, here it is.

This is done without metaprogramming since there are only three functions and the method for interpreting a vector of named tuples as a vector of `RegistrySpec` is not included, and I'm not sure it's worth adding it for the `Registry` functions.
