### PR TITLE
if re-resolve is needed instead run update and show diff

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1982,9 +1982,9 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec,
                 err isa Resolve.ResolverError || rethrow()
                 allow_reresolve || rethrow()
                 @debug err
-                printpkgstyle(ctx.io, :Sandbox, "Could not use exact versions of packages in manifest. Re-resolving dependencies", color=Base.warn_color())
+                printpkgstyle(ctx.io, :Test, "Could not use exact versions of packages in manifest. Re-resolving dependencies", color=Base.warn_color())
                 Pkg.update(temp_ctx; skip_writing_project=true, update_registry=false, io=ctx.io)
-                printpkgstyle(ctx.io, :Sandbox, "Successfully re-resolved")
+                printpkgstyle(ctx.io, :Test, "Successfully re-resolved")
                 @debug "Using _clean_ dep graph"
             end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1982,8 +1982,9 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec,
                 err isa Resolve.ResolverError || rethrow()
                 allow_reresolve || rethrow()
                 @debug err
-                printpkgstyle(ctx.io, :Sandbox, "Could not use exact versions of packages in manifest. Updating depdencencies", color=Base.warn_color())
-                Pkg.update(temp_ctx; skip_writing_project=true)
+                printpkgstyle(ctx.io, :Sandbox, "Could not use exact versions of packages in manifest. Re-resolving dependencies", color=Base.warn_color())
+                Pkg.update(temp_ctx; skip_writing_project=true, update_registry=false, io=ctx.io)
+                printpkgstyle(ctx.io, :Sandbox, "Successfully re-resolved")
                 @debug "Using _clean_ dep graph"
             end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1983,7 +1983,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec,
                 allow_reresolve || rethrow()
                 @debug err
                 @warn "Could not use exact versions of packages in manifest, re-resolving"
-                Pkg.up(temp_ctx; skip_writing_project=true)
+                Pkg.update(temp_ctx; skip_writing_project=true)
                 @debug "Using _clean_ dep graph"
             end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1983,8 +1983,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec,
                 allow_reresolve || rethrow()
                 @debug err
                 @warn "Could not use exact versions of packages in manifest, re-resolving"
-                temp_ctx.env.manifest.deps = Dict(uuid => entry for (uuid, entry) in temp_ctx.env.manifest.deps if isfixed(entry))
-                Pkg.resolve(temp_ctx; io=devnull, skip_writing_project=true)
+                Pkg.up(temp_ctx; skip_writing_project=true)
                 @debug "Using _clean_ dep graph"
             end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1982,7 +1982,7 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec,
                 err isa Resolve.ResolverError || rethrow()
                 allow_reresolve || rethrow()
                 @debug err
-                @warn "Could not use exact versions of packages in manifest, re-resolving"
+                printpkgstyle(ctx.io, :Sandbox, "Could not use exact versions of packages in manifest. Updating depdencencies", color=Base.warn_color())
                 Pkg.update(temp_ctx; skip_writing_project=true)
                 @debug "Using _clean_ dep graph"
             end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3789

Simplifies by calling `up` on the temp env, and shows the diff.

There are two status prints if this happens. 

```
(Foo) pkg> test
     Testing Foo
     Sandbox Could not use exact versions of packages in manifest. Re-resolving dependencies
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_BtmYKR/Project.toml`
  [5d742f6a] + CSVFiles v1.0.2
  [324d217c] + ReferenceTests v0.10.3
  [860ef19b] + StableRNGs v1.0.1
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_BtmYKR/Manifest.toml`
  [fbe9abb3] + AWS v1.90.4
...
⌃ [b22a6f82] ↓ FFMPEG_jll v4.4.4+1 ⇒ v4.4.2+2
⌃ [0234f1f7] ↓ HDF5_jll v1.14.2+1 ⇒ v1.12.2+2
  [e33a78d0] - Hwloc_jll v2.10.0+0
  [7cb0a576] - MPICH_jll v4.1.2+1
  [f1f71cc9] - MPItrampoline_jll v5.3.1+1
⌅ [aabc7e14] + MariaDB_Connector_C_jll v3.1.12+0
  [9237b28f] - MicrosoftMPI_jll v10.1.4+1
  [fe0851c0] - OpenMPI_jll v5.0.2+0
⌅ [458c3c95] ↓ OpenSSL_jll v3.0.13+0 ⇒ v1.1.23+0
  [32165bc3] - PMIx_jll v4.2.7+0
  [477f73a3] - libaec_jll v1.0.6+1
  [1080aeaf] - libevent_jll v2.1.13+1
  [a9144af2] + libsodium_jll v1.0.20+0
  [eb928a42] - prrte_jll v3.0.2+0
        Info Packages marked with ⌃ and ⌅ have new versions available. Those with ⌃ may be upgradable, but those with ⌅ are restricted by compatibility constraints from upgrading. To see why use `status --outdated -m`
     Sandbox Successfully re-resolved
      Status `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_BtmYKR/Project.toml`
  [5d742f6a] CSVFiles v1.0.2
...
```