### PR TITLE
Fix pluralization when printing 2-1024 bytes

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -958,7 +958,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
     # Next, we calculate the space savings we're about to gain!
     pretty_byte_str = (size) -> begin
         bytes, mb = Base.prettyprint_getunits(size, length(Base._mem_units), Int64(1024))
-        return @sprintf("%.3f %s", bytes, Base._mem_units[mb])
+        return @sprintf("%.3f %s%s", bytes, Base._mem_units[mb], (mb == 1 && bytes>1) ? "s" : "")
     end
 
     function recursive_dir_size(path)

--- a/src/API.jl
+++ b/src/API.jl
@@ -958,7 +958,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
     # Next, we calculate the space savings we're about to gain!
     pretty_byte_str = (size) -> begin
         bytes, mb = Base.prettyprint_getunits(size, length(Base._mem_units), Int64(1024))
-        return @sprintf("%.3f %s%s", bytes, Base._mem_units[mb], (mb == 1 && bytes>1) ? "s" : "")
+        return @sprintf("%.3f %s%s", bytes, Base._mem_units[mb], (mb == 1 && bytes != 1) ? "s" : "")
     end
 
     function recursive_dir_size(path)


### PR DESCRIPTION
Alternative to #3763 that doesn't include any new private Base functions.

I prefer #3763, but this version might be easier to merge.

Closes #3763.