### PR TITLE
Prevent repl crash on invalid command

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -84,10 +84,11 @@ function promptf()
     return "$(prefix)pkg> "
 end
 
-do_cmds(repl::REPL.AbstractREPL, input::String) = do_cmds(repl, prepare_cmd(input))
-
-function do_cmds(repl::REPL.AbstractREPL, commands::Vector{Command})
+function do_cmds(repl::REPL.AbstractREPL, commands::Union{String, Vector{Command}})
     try
+        if commands isa String
+            commands = prepare_cmd(commands)
+        end
         return REPLMode.do_cmds(commands, repl.t.out_stream)
     catch err
         if err isa PkgError || err isa Resolve.ResolverError


### PR DESCRIPTION
Previously, `prepare_cmd` was outside the lock.
fixes https://github.com/JuliaLang/Pkg.jl/issues/3787