### PR TITLE
quick proof of concept of `down`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -140,7 +140,7 @@ function require_not_empty(pkgs, f::Symbol)
 end
 
 # Provide some convenience calls
-for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status, :why, :precompile)
+for f in (:develop, :add, :rm, :up, :down, :pin, :free, :test, :build, :status, :why, :precompile)
     @eval begin
         $f(pkg::Union{AbstractString, PackageSpec}; kwargs...) = $f([pkg]; kwargs...)
         $f(pkgs::Vector{<:AbstractString}; kwargs...)          = $f([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
@@ -156,8 +156,8 @@ for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status, :why, :
             pkgs = deepcopy(pkgs) # don't mutate input
             foreach(handle_package_input!, pkgs)
             ret = $f(ctx, pkgs; kwargs...)
-            $(f in (:up, :pin, :free, :build)) && Pkg._auto_precompile(ctx)
-            $(f in (:up, :pin, :free, :rm)) && Pkg._auto_gc(ctx)
+            $(f in (:up, :pin, :free, :build, :down)) && Pkg._auto_precompile(ctx)
+            $(f in (:up, :pin, :free, :rm, :down)) && Pkg._auto_gc(ctx)
             return ret
         end
         $f(ctx::Context; kwargs...) = $f(ctx, PackageSpec[]; kwargs...)
@@ -333,7 +333,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         printpkgstyle(ctx.io, :Update, "All dependencies are pinned - nothing to update.", color = Base.info_color())
         return
     end
-    if update_registry
+    if false # update_registry
         Registry.download_default_registries(ctx.io)
         Operations.update_registries(ctx; force=true)
     end
@@ -349,6 +349,14 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
     end
     Operations.up(ctx, pkgs, level; skip_writing_project, preserve)
     return
+end
+
+function down(ctx::Context, pkgs::Vector{PackageSpec};
+            kwargs...)
+    if !isempty(pkgs)
+        pkgerror("`down` can only be called without specifying packages")
+    end
+    return up(ctx, pkgs; level=UPLEVEL_DOWN)
 end
 
 resolve(; io::IO=stderr_f(), kwargs...) = resolve(Context(;io); kwargs...)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1480,10 +1480,38 @@ function up_load_versions!(ctx::Context, pkg::PackageSpec, entry::PackageEntry, 
         r = level == UPLEVEL_PATCH ? VersionRange(ver.major, ver.minor) :
             level == UPLEVEL_MINOR ? VersionRange(ver.major) :
             level == UPLEVEL_MAJOR ? VersionRange() :
-                error("unexpected upgrade level: $level")
+            level == UPLEVEL_DOWN ? begin
+                if !is_tracking_registry(pkg) || is_stdlib(pkg.uuid)
+                    VersionRange()
+                else
+                    compat = get(ctx.env.project.compat, pkg.name, nothing)
+                    vr = compat === nothing ? VersionRange() : compat.val
+                    lowest_version(pkg, ctx.registries, vr)
+                end
+            end :
+            error("unexpected upgrade level: $level")
         pkg.version = VersionSpec(r)
     end
     return false
+end
+
+function lowest_version(pkg, registries, vr::VersionSpec)
+    minv = nothing
+    for reg in registries
+        rpkg = get(reg, pkg.uuid, nothing)
+        rpkg === nothing && continue
+        pkginfo = Registry.registry_info(rpkg)
+        matching_versions = filter(in(vr), keys(pkginfo.version_info))
+        if !isempty(matching_versions)
+            min_match = minimum(matching_versions)
+            minv = minv === nothing ? min_match : minv < min_match ? minv : min_match
+        end
+    end
+    if minv === nothing
+        pkgerror("Did not find any version matching $vr in registries")
+    end
+    @info "Fixing $(pkg.name) to version $minv"
+    return minv
 end
 
 up_load_manifest_info!(pkg::PackageSpec, ::Nothing) = nothing

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -13,7 +13,7 @@ using Dates
 export @pkg_str
 export PackageSpec
 export PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT
-export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
+export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH, UPLEVEL_DOWN
 export PreserveLevel, PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 export Registry, RegistrySpec
 
@@ -68,7 +68,7 @@ include("API.jl")
 include("REPLMode/REPLMode.jl")
 
 import .REPLMode: @pkg_str
-import .Types: UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH, UPLEVEL_FIXED
+import .Types: UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH, UPLEVEL_FIXED, UPLEVEL_DOWN
 import .Types: PKGMODE_MANIFEST, PKGMODE_PROJECT
 import .Types: PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 
@@ -99,6 +99,7 @@ An enum with the instances
   * `UPLEVEL_PATCH`
   * `UPLEVEL_MINOR`
   * `UPLEVEL_MAJOR`
+  * `UPLEVEL_DOWN`
 
 Determines how much a package is allowed to be updated.
 Used as an argument to  [`PackageSpec`](@ref) or as an argument to [`Pkg.update`](@ref).

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -18,7 +18,7 @@ import FileWatching
 import Base: SHA1
 using SHA
 
-export UUID, SHA1, VersionRange, VersionSpec,
+export UUID, SHA1, VersionRange, VersionSpec, Compat,
     PackageSpec, PackageEntry, EnvCache, Context, GitRepo, Context!, Manifest, Project, err_rep,
     PkgError, pkgerror, PkgPrecompileError,
     has_name, has_uuid, is_stdlib, is_or_was_stdlib, stdlib_version, is_unregistered_stdlib, stdlibs, write_env, write_env_usage, parse_toml,
@@ -27,7 +27,7 @@ export UUID, SHA1, VersionRange, VersionSpec,
     manifest_info,
     read_project, read_package, read_manifest,
     PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT, PKGMODE_COMBINED,
-    UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR,
+    UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR, UPLEVEL_DOWN,
     PreserveLevel, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED,
     PRESERVE_TIERED_INSTALLED, PRESERVE_NONE,
     projectfile_path, manifestfile_path
@@ -82,7 +82,7 @@ Base.show(io::IO, err::PkgPrecompileError) = print(io, "PkgPrecompileError: ", e
 ###############
 # PackageSpec #
 ###############
-@enum(UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR)
+@enum(UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR, UPLEVEL_DOWN)
 @enum(PreserveLevel, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_TIERED, PRESERVE_TIERED_INSTALLED, PRESERVE_NONE)
 @enum(PackageMode, PKGMODE_PROJECT, PKGMODE_MANIFEST, PKGMODE_COMBINED)
 


### PR DESCRIPTION
Very quick implementation of https://github.com/JuliaLang/Pkg.jl/issues/1062#issuecomment-1952014608, (with some debug logging in it to show what happens), specifically:

> On the other hand, I wonder whether it would be best to simply call the solver with the versions of the explicitly required dependencies fixed to their declared lower bounds. In my mind, that would be simpler, safer, and more precise.
There would be no need to further increase the complexity of the resolver code, and it would actually test that the declared lower bounds work. After all, if the resolver finds that it cannot set a package version to its declared lower bound due to an incompatibility with some other required package, then the lower bound should be raised, no? Or am I missing something?


An example of its usage:

```
(PGFPlotsX) pkg> st
Project PGFPlotsX v1.6.1
...

julia> Pkg.API.down()
[ Info: Fixing OrderedCollections to version 1.4.0
[ Info: Fixing Tables to version 1.0.0
[ Info: Fixing DefaultApplication to version 1.0.0
[ Info: Fixing Parameters to version 0.12.0
[ Info: Fixing ArgCheck to version 1.0.0
[ Info: Fixing DocStringExtensions to version 0.8.0
[ Info: Fixing Requires to version 0.5.0
[ Info: Fixing MacroTools to version 0.5.0

    Updating `~/JuliaPkgs/PGFPlotsX.jl/Project.toml`
⌃ [dce04be8] ↓ ArgCheck v2.3.0 ⇒ v1.0.0
⌃ [3f0dd361] ↓ DefaultApplication v1.1.0 ⇒ v1.0.0
⌃ [ffbed154] ↓ DocStringExtensions v0.9.3 ⇒ v0.8.0
⌃ [1914dd2f] ↓ MacroTools v0.5.13 ⇒ v0.5.0
⌃ [bac558e1] ↓ OrderedCollections v1.6.3 ⇒ v1.4.0
⌃ [d96e819e] ↓ Parameters v0.12.3 ⇒ v0.12.0
⌃ [ae029012] ↓ Requires v1.3.0 ⇒ v0.5.0
⌃ [bd369af6] ↓ Tables v1.11.1 ⇒ v1.0.0
    Updating `~/JuliaPkgs/PGFPlotsX.jl/Manifest.toml`
⌃ [dce04be8] ↓ ArgCheck v2.3.0 ⇒ v1.0.0
⌅ [00ebfdb7] + CSTParser v0.6.2
⌅ [34da2185] + Compat v2.2.1
⌅ [864edb3b] + DataStructures v0.17.20
⌃ [3f0dd361] ↓ DefaultApplication v1.1.0 ⇒ v1.0.0
  [8bb1440f] + DelimitedFiles v1.9.1
⌃ [ffbed154] ↓ DocStringExtensions v0.9.3 ⇒ v0.8.0
⌃ [1914dd2f] ↓ MacroTools v0.5.13 ⇒ v0.5.0
⌃ [bac558e1] ↓ OrderedCollections v1.6.3 ⇒ v1.4.0
⌃ [d96e819e] ↓ Parameters v0.12.3 ⇒ v0.12.0
⌃ [ae029012] ↓ Requires v1.3.0 ⇒ v0.5.0
  [10745b16] + Statistics v1.11.1
⌃ [bd369af6] ↓ Tables v1.11.1 ⇒ v1.0.0
  [0796e94c] + Tokenize v0.5.28
  [3a884ed6] - UnPack v1.0.2
```

Trying this on Plots.jl we get the as @oxinabox predicted resolver errors:

```
pkg> activate ../Plots.jl/
  Activating project at `~/JuliaPkgs/Plots.jl`

julia> Pkg.API.down()
[ Info: Fixing Showoff to version 0.3.1
[ Info: Fixing GR to version 0.69.5
[ Info: Fixing Statistics to version 1.11.0
[ Info: Fixing FixedPointNumbers to version 0.6.0
[ Info: Fixing JLFzf to version 0.1.0
[ Info: Fixing PrecompileTools to version 1.0.0
[ Info: Fixing Unzip to version 0.1.0
[ Info: Fixing UnitfulLatexify to version 1.0.0
[ Info: Fixing RecipesPipeline to version 0.6.10
[ Info: Fixing LaTeXStrings to version 1.0.1
[ Info: Fixing PlotUtils to version 1.0.0
[ Info: Fixing JSON to version 0.21.0
[ Info: Fixing StatsBase to version 0.33.0
[ Info: Fixing RelocatableFolders to version 0.3.0
[ Info: Fixing Scratch to version 1.0.0
[ Info: Fixing Latexify to version 0.14.0
[ Info: Fixing FFMPEG to version 0.2.0
[ Info: Fixing Measures to version 0.3.0
[ Info: Fixing RecipesBase to version 1.3.1
[ Info: Fixing UnicodeFun to version 0.4.0
[ Info: Fixing PlotThemes to version 2.0.0
[ Info: Fixing Contour to version 0.5.0
[ Info: Fixing Reexport to version 0.2.0
[ Info: Fixing Requires to version 1.0.0
[ Info: Fixing NaNMath to version 0.3.2
ERROR: Unsatisfiable requirements detected for package Scratch [6c6a2e73]:
 Scratch [6c6a2e73] log:
 ├─possible versions are: 1.0.0 - 1.2.1 or uninstalled
 ├─restricted to versions 1 by Plots [91a5bcdd], leaving only versions: 1.0.0 - 1.2.1
 │ └─Plots [91a5bcdd] log:
 │   ├─possible versions are: 1.40.1 or uninstalled
 │   └─Plots [91a5bcdd] is fixed to version 1.40.1
 ├─restricted to versions 1.0.0 by an explicit requirement, leaving only versions: 1.0.0
 └─restricted by compatibility requirements with RelocatableFolders [05181044] to versions: 1.1.0 - 1.2.1 — no versions left
   └─RelocatableFolders [05181044] log:
     ├─possible versions are: 0.1.0 - 1.0.1 or uninstalled
     ├─restricted to versions [0.3, 1] by Plots [91a5bcdd], leaving only versions: 0.3.0 - 1.0.1
     │ └─Plots [91a5bcdd] log: see above
     └─restricted to versions 0.3.0 by an explicit requirement, leaving only versions: 0.3.0
```

cc @carlobaldassi, @oxinabox 