### PR TITLE
Append bundled depots to places where we empty it during tests

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -652,6 +652,7 @@ end
         old_depot_path = copy(DEPOT_PATH)
         empty!(DEPOT_PATH)
         append!(DEPOT_PATH, [depot1, depot2, depot3])
+        Base.append_bundled_depot_path!(DEPOT_PATH)
 
         # First sanity check; does our depot path searching code actually work properly?
         @test startswith(artifact_path(foo_hash), depot3)
@@ -784,6 +785,7 @@ end
         # reset DEPOT_PATH and force Pkg to reload what it knows about artifact overrides
         empty!(DEPOT_PATH)
         append!(DEPOT_PATH, old_depot_path)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         Pkg.Artifacts.load_overrides(;force=true)
     end
 end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -696,7 +696,6 @@ end
         # loads overridden package artifacts.
         Pkg.activate(depot_container) do
             copy_test_package(depot_container, "ArtifactOverrideLoading")
-            add_this_pkg()
             Pkg.develop(Pkg.Types.PackageSpec(
                 name="ArtifactOverrideLoading",
                 uuid=aol_uuid,
@@ -745,7 +744,6 @@ end
         # Verify that the name-based override worked; extract paths from module that
         # loads overridden package artifacts.
         Pkg.activate(depot_container) do
-            add_this_pkg()
             # TODO: This causes a loading.jl warning, probably Pkg is clashing because of a different UUID??
             (arty_path, barty_path) = Core.eval(Module(:__anon__), quote
                 using ArtifactOverrideLoading

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -53,7 +53,7 @@ using UUIDs
     end
 
     isolate(loaded_depot=false) do
-        depot = mktempdir(); empty!(DEPOT_PATH); push!(DEPOT_PATH, depot)
+        depot = mktempdir(); empty!(DEPOT_PATH); push!(DEPOT_PATH, depot); Base.append_bundled_depot_path!(DEPOT_PATH)
         Pkg.activate(; temp=true)
         Pkg.Registry.add(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "ExtensionRegistry"))
         Pkg.Registry.add("General")
@@ -65,7 +65,7 @@ using UUIDs
     end
     isolate(loaded_depot=false) do
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => 0) do
-            depot = mktempdir(); empty!(DEPOT_PATH); push!(DEPOT_PATH, depot)
+            depot = mktempdir(); empty!(DEPOT_PATH); push!(DEPOT_PATH, depot); Base.append_bundled_depot_path!(DEPOT_PATH)
             Pkg.activate(; temp=true)
             Pkg.Registry.add(path=joinpath(@__DIR__, "test_packages", "ExtensionExamples", "ExtensionRegistry"))
             Pkg.Registry.add("General")

--- a/test/new.jl
+++ b/test/new.jl
@@ -36,6 +36,7 @@ Pkg._auto_gc_enabled[] = false
         # And set the loaded depot as our working depot.
         empty!(DEPOT_PATH)
         push!(DEPOT_PATH, LOADED_DEPOT)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         # Now we double check we have a clean slate.
         @test isempty(Pkg.dependencies())
         # A simple `add` should set up some things for us:
@@ -556,6 +557,7 @@ end
     isolate() do; mktempdir() do tempdir
         empty!(DEPOT_PATH)
         push!(DEPOT_PATH, tempdir)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         rm(tempdir; force=true, recursive=true)
         @test !isdir(first(DEPOT_PATH))
         Pkg.add("JSON")
@@ -1195,6 +1197,7 @@ end
     isolate() do; cd_tempdir() do dir
         empty!(DEPOT_PATH)
         push!(DEPOT_PATH, "temp")
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         Pkg.develop("JSON")
         Pkg.dependencies(json_uuid) do pkg
             @test Base.samefile(pkg.source, abspath(joinpath("temp", "dev", "JSON")))

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -571,6 +571,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
     cd(tmp) do; @testset "instantiating updated repo" begin
         empty!(DEPOT_PATH)
         pushfirst!(DEPOT_PATH, depo1)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         LibGit2.close(LibGit2.clone(TEST_PKG.url, "Example.jl"))
         mkdir("machine1")
         cd("machine1")
@@ -580,6 +581,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
         cp("machine1", "machine2")
         empty!(DEPOT_PATH)
         pushfirst!(DEPOT_PATH, depo2)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         cd("machine2")
         Pkg.activate(".")
         Pkg.instantiate()
@@ -595,6 +597,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
         cd("../machine1")
         empty!(DEPOT_PATH)
         pushfirst!(DEPOT_PATH, depo1)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         Pkg.activate(".")
         Pkg.update()
         cd("..")
@@ -602,6 +605,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
         cd("machine2")
         empty!(DEPOT_PATH)
         pushfirst!(DEPOT_PATH, depo2)
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         Pkg.activate(".")
         Pkg.instantiate()
     end end

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -278,6 +278,7 @@ end
     # only clone default registry if there are no registries installed at all
     temp_pkg_dir() do depot1; mktempdir() do depot2
         append!(empty!(DEPOT_PATH), [depot1, depot2])
+        Base.append_bundled_depot_path!(DEPOT_PATH)
         @test length(Pkg.Registry.reachable_registries()) == 0
         Pkg.add("Example")
         @test length(Pkg.Registry.reachable_registries()) == 1

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -135,12 +135,14 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
                 write("Manifest.toml", manifest)
                 mktempdir() do depot_dir
                     pushfirst!(DEPOT_PATH, depot_dir)
+                    Base.append_bundled_depot_path!(DEPOT_PATH)
                     pkg"instantiate"
                     @test Pkg.dependencies()[pkg2_uuid].version == v"0.2.0"
                 end
             finally
                 empty!(DEPOT_PATH)
                 append!(DEPOT_PATH, old_depot)
+                Base.append_bundled_depot_path!(DEPOT_PATH)
             end
         end # cd_tempdir
     end # withenv
@@ -164,6 +166,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
             try
                 empty!(DEPOT_PATH)
                 pushfirst!(DEPOT_PATH, depot_dir)
+                Base.append_bundled_depot_path!(DEPOT_PATH)
                 withenv("JULIA_PKG_DEVDIR" => tmp) do
                     # Test an unregistered package
                     p1_path = joinpath(@__DIR__, "test_packages", "UnregisteredWithProject")
@@ -178,6 +181,7 @@ temp_pkg_dir() do project_path; cd(project_path) do
             finally
                 empty!(DEPOT_PATH)
                 append!(DEPOT_PATH, old_depot)
+                Base.append_bundled_depot_path!(DEPOT_PATH)
             end
         end # withenv
     end # mktempdir

--- a/test/test_packages/ArtifactOverrideLoading/Project.toml
+++ b/test/test_packages/ArtifactOverrideLoading/Project.toml
@@ -3,4 +3,4 @@ uuid = "7b879065-7f74-5fa4-bdd5-9b7a15df8941"
 version = "0.1.0"
 
 [deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/test/test_packages/ArtifactOverrideLoading/src/ArtifactOverrideLoading.jl
+++ b/test/test_packages/ArtifactOverrideLoading/src/ArtifactOverrideLoading.jl
@@ -1,6 +1,6 @@
 __precompile__(false)
 module ArtifactOverrideLoading
-using Pkg.Artifacts
+using Artifacts
 export arty_path, barty_path
 
 # These will fail (get set to `nothing`) unless they get redirected

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -76,6 +76,7 @@ function isolate(fn::Function; loaded_depot=false, linked_reg=true)
             target_depot = realpath(mktempdir())
             push!(LOAD_PATH, "@", "@v#.#", "@stdlib")
             push!(DEPOT_PATH, target_depot)
+            Base.append_bundled_depot_path!(DEPOT_PATH)
             loaded_depot && push!(DEPOT_PATH, LOADED_DEPOT)
             depot_mtimes = Dict(d => mtime(d) for d in DEPOT_PATH if isdir(d))
             try
@@ -153,6 +154,7 @@ function temp_pkg_dir(fn::Function;rm=true, linked_reg=true)
             try
                 push!(LOAD_PATH, "@", "@v#.#", "@stdlib")
                 push!(DEPOT_PATH, depot_dir)
+                Base.append_bundled_depot_path!(DEPOT_PATH)
                 fn(env_dir)
             finally
                 if rm && !haskey(ENV, "CI")

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -125,9 +125,9 @@ temp_pkg_dir() do project_path
 
             @test hash_1 == hash_2 == hash_3 == hash_4
 
-
             # Test that the subprojects are working
-            withenv("JULIA_DEPOT_PATH" => first(Base.DEPOT_PATH)) do
+            depot_path_string = join(Base.DEPOT_PATH, Sys.iswindows() ? ";" : ":")
+            withenv("JULIA_DEPOT_PATH" => depot_path_string) do
                 @test success(run(`$(Base.julia_cmd()) --startup-file=no --project="test" test/runtests.jl`))
                 @test success(run(`$(Base.julia_cmd()) --startup-file=no --project -e 'using MonorepoSub'`))
                 @test success(run(`$(Base.julia_cmd()) --startup-file=no --project="PrivatePackage" -e 'using PrivatePackage'`))


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3969

I am thinking we might be precompiling stdlibs over and over since we won't find the precompile files for those if we do not have the bundled depots in the depot path.

If this is useful this should have a bit smaller CI runtime.