### PR TITLE
avoid registry warning during precompile

### DIFF
--- a/ext/REPLExt/precompile.jl
+++ b/ext/REPLExt/precompile.jl
@@ -10,14 +10,24 @@ let
     REPL.raw!(::FakeTerminal, raw::Bool) = raw
 
     function pkgreplmode_precompile()
+        original_depot_path = copy(DEPOT_PATH)
+        original_load_path = copy(LOAD_PATH)
         __init__()
         Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
-        try_prompt_pkg_add(Symbol[:notapackage])
-        promptf()
-        term = FakeTerminal()
-        repl = REPL.LineEditREPL(term, true)
-        REPL.run_repl(repl)
-        repl_init(repl)
+        Pkg.DEFAULT_IO[] = Pkg.UnstableIO(devnull)
+        withenv("JULIA_PKG_SERVER" => nothing, "JULIA_PKG_UNPACK_REGISTRY" => nothing) do
+            tmp = Pkg._run_precompilation_script_setup()
+            cd(tmp) do
+                try_prompt_pkg_add(Symbol[:notapackage])
+                promptf()
+                term = FakeTerminal()
+                repl = REPL.LineEditREPL(term, true)
+                REPL.run_repl(repl)
+                repl_init(repl)
+            end
+        end
+        copy!(DEPOT_PATH, original_depot_path)
+        copy!(LOAD_PATH, original_load_path)
     end
 
     if Base.generating_output()

--- a/ext/REPLExt/precompile.jl
+++ b/ext/REPLExt/precompile.jl
@@ -11,6 +11,7 @@ let
 
     function pkgreplmode_precompile()
         __init__()
+        Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
         try_prompt_pkg_add(Symbol[:notapackage])
         promptf()
         term = FakeTerminal()
@@ -23,4 +24,4 @@ let
         pkgreplmode_precompile()
     end
 
-    end # let
+end # let

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,102 +2,103 @@ using LibGit2: LibGit2
 using Tar: Tar
 using Downloads
 
-let
-    function _run_precompilation_script_setup()
-        tmp = mktempdir()
-        cd(tmp) do
-            empty!(DEPOT_PATH)
-            pushfirst!(DEPOT_PATH, tmp)
-            pushfirst!(LOAD_PATH, "@")
-            write(
-                "Project.toml",
-                """
-                name = "Hello"
-                uuid = "33cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-                """,
-            )
-            mkdir("src")
-            write(
-                "src/Hello.jl",
-                """
-                module Hello
-                end
-                """,
-            )
-            Pkg.activate(".")
-            Pkg.generate("TestPkg")
-            uuid = TOML.parsefile(joinpath("TestPkg", "Project.toml"))["uuid"]
-            mv("TestPkg", "TestPkg.jl")
-            tree_hash = cd("TestPkg.jl") do
-                sig = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time()), 0)
-                repo = LibGit2.init(".")
-                LibGit2.add!(repo, "")
-                commit =
-                    LibGit2.commit(repo, "initial commit"; author = sig, committer = sig)
-                th =
-                    LibGit2.peel(LibGit2.GitTree, LibGit2.GitObject(repo, commit)) |>
-                    LibGit2.GitHash |>
-                    string
-                close(repo)
-                th
+# used by REPLExt too
+function _run_precompilation_script_setup()
+    tmp = mktempdir()
+    cd(tmp) do
+        empty!(DEPOT_PATH)
+        pushfirst!(DEPOT_PATH, tmp)
+        pushfirst!(LOAD_PATH, "@")
+        write(
+            "Project.toml",
+            """
+            name = "Hello"
+            uuid = "33cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+            """,
+        )
+        mkdir("src")
+        write(
+            "src/Hello.jl",
+            """
+            module Hello
             end
-            # Prevent cloning the General registry by adding a fake one
-            mkpath("registries/Registry/T/TestPkg")
-            write(
-                "registries/Registry/Registry.toml",
-                """
-                name = "Registry"
-                uuid = "37c07fec-e54c-4851-934c-2e3885e4053e"
-                repo = "https://github.com/JuliaRegistries/Registry.git"
-                [packages]
-                $uuid = { name = "TestPkg", path = "T/TestPkg" }
-                """,
-            )
-            write(
-                "registries/Registry/T/TestPkg/Compat.toml",
-                """
-                ["0"]
-                julia = "1"
-                """,
-            )
-            write(
-                "registries/Registry/T/TestPkg/Deps.toml",
-                """
-                ["0"]
-                Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-                """,
-            )
-            write(
-                "registries/Registry/T/TestPkg/Versions.toml",
-                """
-                ["0.1.0"]
-                git-tree-sha1 = "$tree_hash"
-                """,
-            )
-            write(
-                "registries/Registry/T/TestPkg/Package.toml",
-                """
-                name = "TestPkg"
-                uuid = "$uuid"
-                repo = "$(escape_string(tmp))/TestPkg.jl"
-                """,
-            )
-            Tar.create("registries/Registry", "registries/Registry.tar")
-            cmd = `$(Pkg.PlatformEngines.exe7z()) a "registries/Registry.tar.gz" -tgzip "registries/Registry.tar"`
-            run(pipeline(cmd, stdout = stdout_f(), stderr = stderr_f()))
-            write(
-                "registries/Registry.toml",
-                """
-                git-tree-sha1 = "11b5fad51c4f98cfe0c145ceab0b8fb63fed6f81"
-                uuid = "37c07fec-e54c-4851-934c-2e3885e4053e"
-                path = "Registry.tar.gz"
-                """,
-            )
-            Base.rm("registries/Registry"; recursive = true)
+            """,
+        )
+        Pkg.activate(".")
+        Pkg.generate("TestPkg")
+        uuid = TOML.parsefile(joinpath("TestPkg", "Project.toml"))["uuid"]
+        mv("TestPkg", "TestPkg.jl")
+        tree_hash = cd("TestPkg.jl") do
+            sig = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time()), 0)
+            repo = LibGit2.init(".")
+            LibGit2.add!(repo, "")
+            commit =
+                LibGit2.commit(repo, "initial commit"; author = sig, committer = sig)
+            th =
+                LibGit2.peel(LibGit2.GitTree, LibGit2.GitObject(repo, commit)) |>
+                LibGit2.GitHash |>
+                string
+            close(repo)
+            th
         end
-        return tmp
+        # Prevent cloning the General registry by adding a fake one
+        mkpath("registries/Registry/T/TestPkg")
+        write(
+            "registries/Registry/Registry.toml",
+            """
+            name = "Registry"
+            uuid = "37c07fec-e54c-4851-934c-2e3885e4053e"
+            repo = "https://github.com/JuliaRegistries/Registry.git"
+            [packages]
+            $uuid = { name = "TestPkg", path = "T/TestPkg" }
+            """,
+        )
+        write(
+            "registries/Registry/T/TestPkg/Compat.toml",
+            """
+            ["0"]
+            julia = "1"
+            """,
+        )
+        write(
+            "registries/Registry/T/TestPkg/Deps.toml",
+            """
+            ["0"]
+            Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+            """,
+        )
+        write(
+            "registries/Registry/T/TestPkg/Versions.toml",
+            """
+            ["0.1.0"]
+            git-tree-sha1 = "$tree_hash"
+            """,
+        )
+        write(
+            "registries/Registry/T/TestPkg/Package.toml",
+            """
+            name = "TestPkg"
+            uuid = "$uuid"
+            repo = "$(escape_string(tmp))/TestPkg.jl"
+            """,
+        )
+        Tar.create("registries/Registry", "registries/Registry.tar")
+        cmd = `$(Pkg.PlatformEngines.exe7z()) a "registries/Registry.tar.gz" -tgzip "registries/Registry.tar"`
+        run(pipeline(cmd, stdout = stdout_f(), stderr = stderr_f()))
+        write(
+            "registries/Registry.toml",
+            """
+            git-tree-sha1 = "11b5fad51c4f98cfe0c145ceab0b8fb63fed6f81"
+            uuid = "37c07fec-e54c-4851-934c-2e3885e4053e"
+            path = "Registry.tar.gz"
+            """,
+        )
+        Base.rm("registries/Registry"; recursive = true)
     end
+    return tmp
+end
 
+let
     function pkg_precompile()
         original_depot_path = copy(DEPOT_PATH)
         original_load_path = copy(LOAD_PATH)


### PR DESCRIPTION
Avoids 
```
    JULIA stdlib/REPLExt.release.image
    JULIA stdlib/LazyArtifacts.release.image
    JULIA stdlib/LazyArtifacts.release.image
 │ Attempted to find missing packages in package registries but no registries are installed.
 └ Use package mode to install a registry. `pkg> registry add` will install the default registries.

    JULIA stdlib/REPLExt.release.image
 │ Attempted to find missing packages in package registries but no registries are installed.
 └ Use package mode to install a registry. `pkg> registry add` will install the default registries.

```

Pkg.jl precompile.jl does this, which is why it didn't show before, I believe.

I guess it means the registry stuff isn't baked in properly.. but that would need a better fix i.e. https://github.com/JuliaLang/Pkg.jl/pull/2833