### PR TITLE
Activate special environments similar to Julia's CLI arg `--project`

### DIFF
--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -91,6 +91,8 @@ In short, `instantiate` is your friend to make sure an environment is ready to u
     ```bash
     $ julia --project=. myscript.jl
     ```
+    For Julia 1.7 or later, `--project=@stdlib` activates stdlib environment.
+    For Julia 1.11 or later, `--project=@temp` activates temporary environment.
 
 
 ## Temporary environments
@@ -115,6 +117,13 @@ between several incompatible packages.
   [7876af07] + Example v0.5.3
 ```
 
+```julia-repl
+(@v1.11) pkg> activate @temp # requires Julia 1.11 or later
+  Activating new project at `/tmp/jl_OzBmCP`
+
+(jl_OzBmCP) pkg>
+```
+
 ## Shared environments
 
 A "shared" environment is simply an environment that exists in `~/.julia/environments`. The default `v1.9` environment is
@@ -135,6 +144,24 @@ Shared environments can be activated with the `--shared` flag to `activate`:
 ```
 
 Shared environments have a `@` before their name in the Pkg REPL prompt.
+
+Shared stdlib environment that exists in `Sys.STDLIB` can be activated as follows:
+```julia-repl
+(@v1.11) pkg> activate --shared stdlib
+  Activating project at `@stdlib/v1.11`
+
+(v1.11) pkg>
+```
+
+```julia-repl
+(@v1.11) pkg> activate @stdlib
+  Activating project at `@stdlib/v1.11`
+
+(v1.11) pkg>
+```
+
+!!! note
+    For Julia 1.11 or later `temp` is an invalid name for a shared environment as `activate @temp` creates temporary environments.
 
 
 ## Environment Precompilation

--- a/src/API.jl
+++ b/src/API.jl
@@ -1968,6 +1968,8 @@ function _activate_dep(dep_name::AbstractString)
 end
 function activate(path::AbstractString; shared::Bool=false, temp::Bool=false, io::IO=stderr_f())
     temp && pkgerror("Can not give `path` argument when creating a temporary environment")
+    shared && path == "temp" && pkgerror("""`temp` is an invalid name for a shared environment.
+        To create a temporary environment use `Pkg.activate(; temp = true)`""")
     if !shared
         # `pkg> activate path`/`Pkg.activate(path)` does the following
         # 1. if path exists, activate that

--- a/src/API.jl
+++ b/src/API.jl
@@ -1984,20 +1984,24 @@ function activate(path::AbstractString; shared::Bool=false, temp::Bool=false, io
             end
         end
     else
-        # initialize `fullpath` in case of empty `Pkg.depots()`
-        fullpath = ""
-        # loop over all depots to check if the shared environment already exists
-        for depot in Pkg.depots()
-            fullpath = joinpath(Pkg.envdir(depot), path)
-            isdir(fullpath) && break
-        end
-        # this disallows names such as "Foo/bar", ".", "..", etc
-        if basename(abspath(fullpath)) != path
-            pkgerror("not a valid name for a shared environment: $(path)")
-        end
-        # unless the shared environment already exists, place it in the first depots
-        if !isdir(fullpath)
-            fullpath = joinpath(Pkg.envdir(Pkg.depots1()), path)
+        if path == "stdlib"
+            fullpath = Sys.STDLIB
+        else
+            # initialize `fullpath` in case of empty `Pkg.depots()`
+            fullpath = ""
+            # loop over all depots to check if the shared environment already exists
+            for depot in Pkg.depots()
+                fullpath = joinpath(Pkg.envdir(depot), path)
+                isdir(fullpath) && break
+            end
+            # this disallows names such as "Foo/bar", ".", "..", etc
+            if basename(abspath(fullpath)) != path
+                pkgerror("not a valid name for a shared environment: $(path)")
+            end
+            # unless the shared environment already exists, place it in the first depots
+            if !isdir(fullpath)
+                fullpath = joinpath(Pkg.envdir(Pkg.depots1()), path)
+            end
         end
     end
     if !isnothing(Base.active_project())

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -218,6 +218,15 @@ function parse_activate(args::Vector{QString}, options)
         if x == "-"
             options[:prev] = true
             return []
+        elseif x == "@temp"
+            options[:temp] = true
+            return []
+        elseif x == "@stdlib"
+            return [Sys.STDLIB]
+        elseif x == "@."
+            return [Base.current_project()]
+        elseif x == "@"
+            return [Base.active_project()]
         elseif first(x) == '@'
             options[:shared] = true
             return [x[2:end]]

--- a/test/api.jl
+++ b/test/api.jl
@@ -39,6 +39,8 @@ using ..Utils
         Pkg.activate("Foo") # activate developed Foo from another directory
         @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
         @test_throws PkgError Pkg.activate("temp"; shared = true) # Disallow naming a shared env as `temp`.
+        Pkg.activate("stdlib"; shared = true) # activate `@stdlib/Project.toml`
+        @test Base.active_project() == joinpath(Sys.STDLIB, "Project.toml")
         Pkg.activate() # activate LOAD_PATH project
         @test Base.ACTIVE_PROJECT[] === nothing
     end end

--- a/test/api.jl
+++ b/test/api.jl
@@ -38,6 +38,7 @@ using ..Utils
         cd(mkdir("tests"))
         Pkg.activate("Foo") # activate developed Foo from another directory
         @test Base.active_project() == joinpath(path, "modules", "Foo", "Project.toml")
+        @test_throws PkgError Pkg.activate("temp"; shared = true) # Disallow naming a shared env as `temp`.
         Pkg.activate() # activate LOAD_PATH project
         @test Base.ACTIVE_PROJECT[] === nothing
     end end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -240,6 +240,8 @@ temp_pkg_dir() do project_path
         pkg"activate ."
         #=@test_logs (:info, r"activating new environment at ")))=# pkg"activate --shared Foo" # activate shared Foo
         @test Base.active_project() == joinpath(Pkg.envdir(), "Foo", "Project.toml")
+        pkg"activate --shared stdlib" # activate shared STDLIB
+        @test Base.active_project() == joinpath(Sys.STDLIB, "Project.toml")
         pkg"activate ."
         rm("Foo"; force=true, recursive=true)
         pkg"activate Foo" # activate path from developed Foo

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -265,6 +265,15 @@ temp_pkg_dir() do project_path
         pop!(Base.DEPOT_PATH)
         pkg"activate" # activate LOAD_PATH project
         @test Base.ACTIVE_PROJECT[] === nothing
+        pkg"activate @temp" # activate a temporary environment
+        @test dirname(Base.ACTIVE_PROJECT[]) == tempdir()
+        pkg"activate @stdlib" # activate the STDLIB environment
+        @test Base.ACTIVE_PROJECT[] == Sys.STDLIB
+        pkg"activate @." # activate current project
+        @test Base.ACTIVE_PROJECT[] == Base.current_project()
+        pkg"activate @" # activate active project
+        @test Base.ACTIVE_PROJECT[] === Base.active_project()
+
         # expansion of ~
         if !Sys.iswindows()
             pkg"activate ~/Foo_lzTkPF6N"

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -227,6 +227,7 @@ temp_pkg_dir() do project_path
         @test_throws Pkg.Types.PkgError pkg"activate --shared ./Foo"
         @test_throws Pkg.Types.PkgError pkg"activate --shared Foo/Bar"
         @test_throws Pkg.Types.PkgError pkg"activate --shared ../Bar"
+        @test_throws Pkg.Types.PkgError pkg"activate --shared temp"
         # check that those didn't change the environment
         @test Base.active_project() == joinpath(path, "Project.toml")
         mkdir("Foo")


### PR DESCRIPTION
Similar to Julia's command line argument `--project`,
- `activate @temp` activates temp environment
(See https://github.com/JuliaLang/julia/pull/51149)
- `activate @stdlib` activates `Sys.STDLIB`
- `activate @.` activates current project
- `activate @` activates active project

This also changes how Pkg.activate behaves wrt `temp` (disallows) and `stdlib` (activates `@stdlib/Project.toml`)

Related to these, the PR adds tests and updates docs.