### PR TITLE
Add example of manually checking specifications

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -163,6 +163,28 @@ PkgA = "0.2 - 0.5"     # 0.2.0 - 0.5.* = [0.2.0, 0.6.0)
 PkgA = "0.2 - 0"       # 0.2.0 - 0.*.* = [0.2.0, 1.0.0)
 ```
 
+### Checking specification
+
+Pkg.jl parses a given version specification using `Pkg.Versions.semver_spec`.
+You can check if a particular version of a package is contained in a particular
+range by using this command. For example:
+
+```julia
+julia> v"0.1.0" in Pkg.Versions.semver_spec("=0.1")
+true
+
+julia> v"0.1.0" in Pkg.Versions.semver_spec("=0.1.1")
+false
+
+julia> v"0.1.0" in Pkg.Versions.semver_spec("0.1 - 0.2")
+true
+
+julia> v"0.3.0" in Pkg.Versions.semver_spec("~0.3.2")
+false
+
+julia> v"0.3.3" in Pkg.Versions.semver_spec("0.1 - 0.2, ~0.3.2")
+true
+```
 
 ## Fixing conflicts
 


### PR DESCRIPTION
While the Compatibility guide is very helpful, I find the syntax itself easy to forget, and find myself repeatedly checking this guide whenever I'm creating a complex version specification.

I recently found the `Pkg.Versions.semver_spec` as a way to manually parse the version string. I thought it would be helpful to give an example of how to use this to explicitly check versions, and make sure you aren't too constrained or too flexible in a given version spec.