### PR TITLE
RFC: only auto precompile the added package (+ deps) after an `add` operation

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1424,7 +1424,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
         write_env(ctx.env) # write env before building
         show_update(ctx.env, ctx.registries; io=ctx.io)
         build_versions(ctx, union(new_apply, new_git))
-        Pkg._auto_precompile(ctx)
+        Pkg._auto_precompile(ctx, pkgs)
     else
         record_project_hash(ctx.env)
         write_env(ctx.env)


### PR DESCRIPTION
Many times in the global env I add some small package to try it out and then Pkg starts precompiling everything (even things I did not intend to load). This means I often have to interrupt it (which is a bit brittle) and it feels like it is doing something I didn't ask it to do.

With this, it will only compile the deps graph of the added packages. If a user want to load some other package later, the load precompile step will pick that up. 