### PR TITLE
Remove outdated UUID instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ shipped with Julia v1.0 and above.
 If you want to develop this package do the following steps:
 - Make a fork and then clone the repo locally on your computer
 - Change the current directory to the Pkg repo you just cloned and start julia with `julia --project`.
-- `import Pkg` will now load the files in the cloned repo instead of the Pkg stdlib .
+- `import Pkg` will now load the files in the cloned repo instead of the Pkg stdlib.
 - To test your changes, simply do `include("test/runtests.jl")`.
-- Before you commit and push your changes, remember to change the UUID in the `Project.toml` file back to the original UUID
 
 If you need to build Julia from source with a Git checkout of Pkg, then instead use `make DEPS_GIT=Pkg` when building Julia. The `Pkg` repo is in `stdlib/Pkg`, and created initially with a detached `HEAD`. If you're doing this from a pre-existing Julia repository, you may need to `make clean` beforehand.
 


### PR DESCRIPTION
The comment about changing the UUID no longer applies.

It may also be worth removing these bullet points entirely since the Pkg dev workflow seems to be the same as every other package (except the paragraph about the julia source build with custom Pkg).