### PR TITLE
prune manifest after the set of some deps have been "demoted" to weakdeps

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -242,6 +242,7 @@ function fixup_ext!(env, pkgs)
             end
         end
     end
+    prune_manifest(env)
 end
 
 ####################


### PR DESCRIPTION
Fixes the manifest pruning issue in https://github.com/JuliaLang/Pkg.jl/issues/3863.

Before we run this fixup code we do not know which deps are weak and not (all are considered normal deps). Or well, we kind of know but we don't have the information easily retrievable. Manifest pruning before this stage will not prune orphan entries which are weak deps of some package which is why in #3863 Enzyme was not pruned away (it is a weak dep of DiffEqBase).

Solve this by just pruning after we have categorized things into weak/normal deps.