### PR TITLE
[release-1.10] Backports 1.10

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -476,13 +476,20 @@ function with_show_download_info(f, io, name, quiet_download)
         fancyprint && print_progress_bottom(io)
         printpkgstyle(io, :Downloading, "artifact: $name")
     end
+    success = false
     try
-        return f()
+        result = f()
+        success = result === true
+        return result
     finally
         if !quiet_download
             fancyprint && print(io, "\033[1A") # move cursor up one line
             fancyprint && print(io, "\033[2K") # clear line
-            fancyprint && printpkgstyle(io, :Downloaded, "artifact: $name")
+            if success 
+                fancyprint && printpkgstyle(io, :Downloaded, "artifact: $name")
+            else
+                printpkgstyle(io, :Failure, "artifact: $name", color = :red)
+            end
         end
     end
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -182,6 +182,7 @@ function fixup_ext!(env, pkgs)
             end
         end
     end
+    prune_manifest(env)
 end
 
 ####################


### PR DESCRIPTION
Backported PRs:
- [x] #3771 <!-- why: show all paths when package is both a direct and indirect dep -->
- [x] #3860 <!-- Report failures to download artifacts as failures -->
- [x] #3864 <!-- prune manifest after the set of some deps have been "demoted" to weakdeps -->

Non-merged PRs with backport label:
- [ ] #3851 <!-- fix not hardcoding "Project.toml" when fixing up extensions in manifest -->
- [ ] #3790 <!-- if re-resolve is needed instead run update and show diff -->
- [ ] #3782 <!-- use the correct `TOML.Parser` coupled to `Base.TOMLCache` -->