### PR TITLE
Make UnknownPlatform a wrapper of Platform

### DIFF
--- a/src/BinaryPlatforms_compat.jl
+++ b/src/BinaryPlatforms_compat.jl
@@ -12,10 +12,13 @@ import Base.BinaryPlatforms: libgfortran_version, libstdcxx_version, platform_na
                              cxxstring_abi
 
 struct UnknownPlatform <: AbstractPlatform
-    UnknownPlatform(args...; kwargs...) = new()
+    p::Platform
+    function UnknownPlatform(args...; kwargs...)
+        p = Platform("unknown", "unknown")
+        delete!(p.tags, "arch")
+        new(p)
+    end
 end
-tags(::UnknownPlatform) = Dict{String,String}("os"=>"unknown")
-
 
 struct CompilerABI
     libgfortran_version::Union{Nothing,VersionNumber}
@@ -62,7 +65,7 @@ for T in (:Linux, :Windows, :MacOS, :FreeBSD)
     end
 end
 
-const PlatformUnion = Union{Linux,MacOS,Windows,FreeBSD}
+const PlatformUnion = Union{UnknownPlatform,Linux,MacOS,Windows,FreeBSD}
 
 # First, methods we need to coerce to Symbol for backwards-compatibility
 for f in (:arch, :libc, :call_abi, :cxxstring_abi)


### PR DESCRIPTION
One source of invalidations results from defining `tags(::Pkg.BinaryPlatforms.UnknownPlatform)`.

This pull request homogenizes the issue so that `UnknownPlatform` is now a wrapper around `Platform` and is now part of the `PlatformUnion`.

```
 inserting tags(::Pkg.BinaryPlatforms.UnknownPlatform) @ Pkg.BinaryPlatforms ~/src/julia/usr/share/julia/stdlib/v1.11/Pkg/src/BinaryPlatforms_compat.jl:17 invalidated:
   mt_backedges:  1: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.triplet(::Base.BinaryPlatforms.AbstractPlatform) (0 children)
                  2: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.os_version(::Base.BinaryPlatforms.AbstractPlatform) (1 children)
                  3: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.libgfortran_version(::Base.BinaryPlatforms.AbstractPlatform) (1 children)
                  4: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.cxxstring_abi(::Base.BinaryPlatforms.AbstractPlatform) (1 children)
                  5: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.libstdcxx_version(::Base.BinaryPlatforms.AbstractPlatform) (1 children)
                  6: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.arch(::Base.BinaryPlatforms.AbstractPlatform) (2 children)
                  7: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.os(::Base.BinaryPlatforms.AbstractPlatform) (2 children)
                  8: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.libc(::Base.BinaryPlatforms.AbstractPlatform) (2 children)
                  9: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.call_abi(::Base.BinaryPlatforms.AbstractPlatform) (2 children)
                 10: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for Base.BinaryPlatforms.platforms_match(::Base.BinaryPlatforms.AbstractPlatform, ::Base.BinaryPlatforms.Platform) (17 children)
                 11: signature Tuple{typeof(Base.BinaryPlatforms.tags), Base.BinaryPlatforms.AbstractPlatform} triggered MethodInstance for (::Base.BinaryPlatforms.var"#match_loss#50")(::Base.BinaryPlatforms.AbstractPlatform, ::Base.BinaryPlatforms.Platform) (40 children)
```
