### PR TITLE
Convert AbstractPlatform to Platform

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -211,6 +211,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
                  preserve::PreserveLevel=Operations.default_preserve(), platform::AbstractPlatform=HostPlatform(), kwargs...)
     require_not_empty(pkgs, :develop)
     Context!(ctx; kwargs...)
+    platform = convert(Platform, platform)::Platform
 
     for pkg in pkgs
         check_package_name(pkg.name, "develop")
@@ -257,6 +258,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=Op
              platform::AbstractPlatform=HostPlatform(), target::Symbol=:deps, kwargs...)
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)
+    platform = convert(Platform, platform)::Platform
 
     for pkg in pkgs
         check_package_name(pkg.name, "add")
@@ -1173,6 +1175,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
                      platform::AbstractPlatform=HostPlatform(), allow_build::Bool=true, allow_autoprecomp::Bool=true,
                      workspace::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
+    platform = convert(Platform, platform)::Platform
     if Registry.download_default_registries(ctx.io)
         copy!(ctx.registries, Registry.reachable_registries())
     end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -183,6 +183,9 @@ function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
                         download_info::Union{Vector{<:Tuple},Nothing} = nothing,
                         lazy::Bool = false,
                         force::Bool = false)
+    if !isnothing(platform)
+        platform = convert(Platform, platform)::Platform
+    end
     # First, check to see if this artifact is already bound:
     if isfile(artifacts_toml)
         artifact_dict = parse_toml(artifacts_toml)
@@ -263,6 +266,9 @@ Silently fails if no such binding exists within the file.
 """
 function unbind_artifact!(artifacts_toml::String, name::String;
                          platform::Union{AbstractPlatform,Nothing} = nothing)
+    if !isnothing(platform)
+        platform = convert(Platform, platform)::Platform
+    end
     artifact_dict = parse_toml(artifacts_toml)
     if !haskey(artifact_dict, name)
         return
@@ -395,6 +401,7 @@ function ensure_artifact_installed(name::String, artifacts_toml::String;
                                    verbose::Bool = false,
                                    quiet_download::Bool = false,
                                    io::IO=stderr_f())
+    platform = convert(Platform, platform)::Platform
     meta = artifact_meta(name, artifacts_toml; pkg_uuid=pkg_uuid, platform=platform)
     if meta === nothing
         error("Cannot locate artifact '$(name)' in '$(artifacts_toml)'")
@@ -409,6 +416,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
                                    verbose::Bool = false,
                                    quiet_download::Bool = false,
                                    io::IO=stderr_f())
+    platform = convert(Platform, platform)::Platform
     hash = SHA1(meta["git-tree-sha1"])
 
     if !artifact_exists(hash)
@@ -526,6 +534,7 @@ function ensure_all_artifacts_installed(artifacts_toml::String;
                                         verbose::Bool = false,
                                         quiet_download::Bool = false,
                                         io::IO=stderr_f())
+    platform = convert(Platform, platform)::Platform
     # This function should not be called anymore; use `select_downloadable_artifacts()` directly.
     Base.depwarn("`ensure_all_artifacts_installed()` is deprecated; iterate over `select_downloadable_artifacts()` output with `ensure_artifact_installed()`.", :ensure_all_artifacts_installed)
     # Collect all artifacts we're supposed to install
@@ -552,6 +561,7 @@ function extract_all_hashes(artifacts_toml::String;
                             platform::AbstractPlatform = HostPlatform(),
                             pkg_uuid::Union{Nothing,Base.UUID} = nothing,
                             include_lazy::Bool = false)
+    platform = convert(Platform, platform)::Platform
     hashes = Base.SHA1[]
     if !isfile(artifacts_toml)
         return hashes

--- a/src/BinaryPlatforms_compat.jl
+++ b/src/BinaryPlatforms_compat.jl
@@ -64,6 +64,8 @@ end
 
 const PlatformUnion = Union{Linux,MacOS,Windows,FreeBSD}
 
+Base.convert(::Type{Platform}, p::PlatformUnion) = p.p
+
 # First, methods we need to coerce to Symbol for backwards-compatibility
 for f in (:arch, :libc, :call_abi, :cxxstring_abi)
     @eval begin

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -788,6 +788,7 @@ function install_git(
 end
 
 function collect_artifacts(pkg_root::String; platform::AbstractPlatform=HostPlatform())
+    platform = convert(Platform, platform)::Platform
     # Check to see if this package has an (Julia)Artifacts.toml
     artifacts_tomls = Tuple{String,Base.TOML.TOMLDict}[]
     for f in artifact_names
@@ -825,6 +826,7 @@ function download_artifacts(env::EnvCache;
                             julia_version = VERSION,
                             verbose::Bool=false,
                             io::IO=stderr_f())
+    platform = convert(Platform, platform)::Platform
     pkg_roots = String[]
     for (uuid, pkg) in env.manifest
         pkg = manifest_info(env.manifest, uuid)
@@ -845,6 +847,7 @@ function download_artifacts(env::EnvCache;
 end
 
 function check_artifacts_downloaded(pkg_root::String; platform::AbstractPlatform=HostPlatform())
+    platform = convert(Platform, platform)::Platform
     for (artifacts_toml, artifacts) in collect_artifacts(pkg_root; platform)
         for name in keys(artifacts)
             if !artifact_exists(Base.SHA1(artifacts[name]["git-tree-sha1"]))
@@ -1481,6 +1484,7 @@ end
 function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
              preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform(),
              target::Symbol=:deps)
+    platform = convert(Platform, platform)::Platform
     assert_can_add(ctx, pkgs)
     # load manifest data
     for (i, pkg) in pairs(pkgs)
@@ -1544,6 +1548,7 @@ end
 # Input: name, uuid, and path
 function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Set{UUID};
                  preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform())
+    platform = convert(Platform, platform)::Platform
     assert_can_add(ctx, pkgs)
     # no need to look at manifest.. dev will just nuke whatever is there before
     for pkg in pkgs


### PR DESCRIPTION
This pull request hardens Pkg.jl from invalidations involving `AbstractPlatform`. When `AbstractPlatform` is used as the type of a keyword argument, Julia may not 
specialize on the type.

This pull request inserts `convert(Platform, platform)::Platform` to all functions that take `platform::AbstractPlatform` as a keyword argument.
