### PR TITLE
do not precompile full env on `using` callback from REPL

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -250,7 +250,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
     resp = strip(resp)
     lower_resp = lowercase(resp)
     if lower_resp in ["y", "yes"]
-        API.add(string.(available_pkgs))
+        API.add(string.(available_pkgs); allow_autoprecomp=false)
     elseif lower_resp in ["o"]
         editable_envs = filter(v -> v != "@stdlib", LOAD_PATH)
         option_list = String[]
@@ -288,7 +288,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
         end
         choice == -1 && return false
         API.activate(shown_envs[choice]) do
-            API.add(string.(available_pkgs))
+            API.add(string.(available_pkgs); allow_autoprecomp=false)
         end
     elseif (lower_resp in ["n"])
         return false

--- a/src/API.jl
+++ b/src/API.jl
@@ -254,7 +254,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
 end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=Operations.default_preserve(),
-             platform::AbstractPlatform=HostPlatform(), target::Symbol=:deps, kwargs...)
+             platform::AbstractPlatform=HostPlatform(), target::Symbol=:deps, allow_autoprecomp::Bool=true, kwargs...)
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)
 
@@ -303,7 +303,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=Op
         update_source_if_set(ctx.env.project, pkg)
     end
 
-    Operations.add(ctx, pkgs, new_git; preserve, platform, target)
+    Operations.add(ctx, pkgs, new_git; allow_autoprecomp, preserve, platform, target)
     return
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1479,7 +1479,7 @@ function _resolve(io::IO, env::EnvCache, registries::Vector{Registry.RegistryIns
 end
 
 function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
-             preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform(),
+             allow_autoprecomp::Bool=true, preserve::PreserveLevel=default_preserve(), platform::AbstractPlatform=HostPlatform(),
              target::Symbol=:deps)
     assert_can_add(ctx, pkgs)
     # load manifest data
@@ -1531,7 +1531,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
         write_env(ctx.env) # write env before building
         show_update(ctx.env, ctx.registries; io=ctx.io)
         build_versions(ctx, union(new_apply, new_git))
-        Pkg._auto_precompile(ctx)
+        allow_autoprecomp && Pkg._auto_precompile(ctx)
     else
         record_project_hash(ctx.env)
         write_env(ctx.env)


### PR DESCRIPTION
@Keno was annoyed that calling `using` on some small package and having it auto install compiled the whole env. This disables that. I still think https://github.com/JuliaLang/Pkg.jl/pull/3848 is better but since that has some push back, this solves the immediate issue.