### PR TITLE
Relax overly-specific manifest tests

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -2387,10 +2387,11 @@ end
         Pkg.add( name="Example", version="0.3.0")
         Pkg.add("Markdown")
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST)
-        @test occursin(r"Status `.+Manifest.toml`", readline(io))
-        @test occursin(r"\[7876af07\] Example\s*v0\.3\.0", readline(io))
-        @test occursin(r"\[2a0f44e3\] Base64", readline(io))
-        @test occursin(r"\[d6f4376e\] Markdown", readline(io))
+        statuslines = readlines(io)
+        @test occursin(r"Status `.+Manifest.toml`", first(statuslines))
+        @test any(l -> occursin(r"\[7876af07\] Example\s*v0\.3\.0", l), statuslines)
+        @test any(l -> occursin(r"\[2a0f44e3\] Base64", l), statuslines)
+        @test any(l -> occursin(r"\[d6f4376e\] Markdown", l), statuslines)
     end
     # Diff API
     isolate(loaded_depot=true) do
@@ -2428,11 +2429,12 @@ end
         @test occursin("Info Packages marked with ⌃ have new versions available and may be upgradable.", readline(io))
         ## diff manifest
         Pkg.status(; io=io, mode=Pkg.PKGMODE_MANIFEST, diff=true)
-        @test occursin(r"Diff `.+Manifest.toml`", readline(io))
-        @test occursin(r"\[7876af07\] \+ Example\s*v0\.3\.0", readline(io))
-        @test occursin(r"\[2a0f44e3\] - Base64", readline(io))
-        @test occursin(r"\[d6f4376e\] - Markdown", readline(io))
-        @test occursin("Info Packages marked with ⌃ have new versions available and may be upgradable.", readline(io))
+        statuslines = readlines(io)
+        @test occursin(r"Diff `.+Manifest.toml`", first(statuslines))
+        @test any(l -> occursin(r"\[7876af07\] \+ Example\s*v0\.3\.0", l), statuslines)
+        @test any(l -> occursin(r"\[2a0f44e3\] - Base64", l), statuslines)
+        @test any(l -> occursin(r"\[d6f4376e\] - Markdown", l), statuslines)
+        @test any(l -> occursin("Info Packages marked with ⌃ have new versions available and may be upgradable.", l), statuslines)
         ## diff project with filtering
         Pkg.status("Markdown"; io=io, diff=true)
         @test occursin(r"Diff `.+Project\.toml`", readline(io))


### PR DESCRIPTION
By testing line-by-line in this way, any change to the dependencies of these libraries becomes breaking. If we check all lines instead, new dependencies won't break these tests.

Specifically, this allows for Pkg's CI to succeed in the face of https://github.com/JuliaLang/julia/pull/51928.

I have verified that this change actually fixes the spurious CI errors by adding a test commit to that PR, bumping `Pkg.version` to this commit, and checking the CI output (no more Pkg errors).