### PR TITLE
REPLExt: add hint kwarg to `complete_line`

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -23,7 +23,7 @@ include("compat.jl")
 
 struct PkgCompletionProvider <: LineEdit.CompletionProvider end
 
-function LineEdit.complete_line(c::PkgCompletionProvider, s)
+function LineEdit.complete_line(c::PkgCompletionProvider, s; hint::Bool=false)
     partial = REPL.beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
     ret, range, should_complete = completions(full, lastindex(partial))


### PR DESCRIPTION
Unused here currently, but https://github.com/JuliaLang/julia/pull/54311 introduces it as part of the completion API