### PR TITLE
improve precompilation for `st` in the Pkg REPL

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -106,6 +106,16 @@ function do_cmds(repl::REPL.AbstractREPL, commands::Union{String, Vector{Command
     end
 end
 
+function on_done(s, buf, ok, repl)
+    ok || return REPL.transition(s, :abort)
+    input = String(take!(buf))
+    REPL.reset(repl)
+    do_cmds(repl, input)
+    REPL.prepare_next(repl)
+    REPL.reset_state(s)
+    s.current_mode.sticky || REPL.transition(s, main)
+end
+
 # Set up the repl Pkg REPLMode
 function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
     pkg_mode = LineEdit.Prompt(promptf;
@@ -122,15 +132,7 @@ function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
     search_prompt, skeymap = LineEdit.setup_search_keymap(hp)
     prefix_prompt, prefix_keymap = LineEdit.setup_prefix_keymap(hp, pkg_mode)
 
-    pkg_mode.on_done = (s, buf, ok) -> begin
-        ok || return REPL.transition(s, :abort)
-        input = String(take!(buf))
-        REPL.reset(repl)
-        do_cmds(repl, input)
-        REPL.prepare_next(repl)
-        REPL.reset_state(s)
-        s.current_mode.sticky || REPL.transition(s, main)
-    end
+    pkg_mode.on_done = (s, buf, ok) -> Base.@invokelatest(on_done(s, buf, ok, repl))
 
     mk = REPL.mode_keymap(main)
 

--- a/ext/REPLExt/precompile.jl
+++ b/ext/REPLExt/precompile.jl
@@ -28,6 +28,10 @@ let
         end
         copy!(DEPOT_PATH, original_depot_path)
         copy!(LOAD_PATH, original_load_path)
+
+        Base.precompile(Tuple{typeof(REPL.LineEdit.complete_line), REPLExt.PkgCompletionProvider, REPL.LineEdit.PromptState})
+        Base.precompile(Tuple{typeof(REPL.REPLCompletions.completion_text), REPL.REPLCompletions.PackageCompletion})
+        Base.precompile(Tuple{typeof(REPLExt.on_done), REPL.LineEdit.MIState, Base.GenericIOBuffer{Memory{UInt8}}, Bool, REPL.LineEditREPL})
     end
 
     if Base.generating_output()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -152,6 +152,13 @@ let
             Base.precompile(Tuple{typeof(Pkg.API.status)})
             Base.precompile(Tuple{typeof(Pkg.Types.read_project_compat),Base.Dict{String,Any},Pkg.Types.Project,},)
             Base.precompile(Tuple{typeof(Pkg.Versions.semver_interval),Base.RegexMatch})
+
+            Base.precompile(Tuple{typeof(Pkg.REPLMode.do_cmds), Array{Pkg.REPLMode.Command, 1}, Base.TTY})
+
+            Base.precompile(Tuple{typeof(Pkg.Types.read_project_workspace), Base.Dict{String, Any}, Pkg.Types.Project})
+            Base.precompile(Tuple{Type{Pkg.REPLMode.QString}, String, Bool})
+            Base.precompile(Tuple{typeof(Pkg.REPLMode.parse_package), Array{Pkg.REPLMode.QString, 1}, Base.Dict{Symbol, Any}})
+            Base.precompile(Tuple{Type{Pkg.REPLMode.Command}, Pkg.REPLMode.CommandSpec, Base.Dict{Symbol, Any}, Array{Pkg.Types.PackageSpec, 1}})
         end
         copy!(DEPOT_PATH, original_depot_path)
         copy!(LOAD_PATH, original_load_path)


### PR DESCRIPTION
Measurement:

```
julia> using Pkg, REPL

julia> const REPLExt = Base.get_extension(Pkg, :REPLExt)
REPLExt

julia> @time @eval REPLExt.do_cmds(Base.active_repl, "st")
Project Pkg v1.12.0
Status `~/JuliaPkgs/Pkg.jl/Project.toml`
  [56f22d72] Artifacts v1.11.0
  [ade2ca70] Dates v1.11.0
  [f43a241f] Downloads v1.6.0
  [7b1f6079] FileWatching v1.11.0
  [76f85450] LibGit2 v1.11.0
  [8f399da3] Libdl v1.11.0
  [56ddb016] Logging v1.11.0
  [d6f4376e] Markdown v1.11.0
  [de0858da] Printf v1.11.0
  [9a3f8284] Random v1.11.0
  [ea8e919c] SHA v0.7.0
  [fa267f1f] TOML v1.0.3
  [a4e569a6] Tar v1.10.0
  [cf7118a7] UUIDs v1.11.0
  [3f19e933] p7zip_jll v17.5.0+0
```

Before:

```
  1.232465 seconds (4.30 M allocations: 254.177 MiB, 7.91% gc time, 79.78% compilation time: 3% of which was recompilation)
```

After

```
  0.629539 seconds (1.92 M allocations: 131.477 MiB, 15.28% gc time, 52.50% compilation time: 8% of which was recompilation)
```

On 1.10 we have

```
julia> @time @eval Pkg.REPLMode.do_cmd(Base.active_repl, "st")
  0.431920 seconds (2.05 M allocations: 163.018 MiB, 4.72% gc time, 18.10% compilation time)
```
