### PR TITLE
catch if the active project is erroneously set to a manifest file

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -216,7 +216,7 @@ function find_project_file(env::Union{Nothing,String}=nothing)
     end
     if isfile(project_file) && !contains(basename(project_file), "Project")
         pkgerror("""
-        The active project has been set to toml file that isn't a Project file: $project_file
+        The active project has been set to a file that isn't a Project file: $project_file
         The project path must be to a Project file or directory.
         """)
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -214,6 +214,12 @@ function find_project_file(env::Union{Nothing,String}=nothing)
                 abspath(env, Base.project_names[end])
         end
     end
+    if isfile(project_file) && !contains(basename(project_file), "Project")
+        pkgerror("""
+        The active project has been set to toml file that isn't a Project file: $project_file
+        The project path must be to a Project file or directory.
+        """)
+    end
     @assert project_file isa String &&
         (isfile(project_file) || !ispath(project_file) ||
          isdir(project_file) && isempty(readdir(project_file)))


### PR DESCRIPTION
Before
```
(@v1.12) pkg> activate /Users/ian/Documents/Foo.jl/Manifest.toml
  Activating project at `~/Documents/Foo.jl`
ERROR: MethodError: Cannot `convert` an object of type Vector{Any} to an object of type UInt128
The function `convert` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  convert(::Type{T}, ::T) where T<:Number
   @ Base number.jl:6
  convert(::Type{T}, ::T) where T
   @ Base Base.jl:126
  convert(::Type{T}, ::Number) where T<:Number
   @ Base number.jl:7
  ...

Stacktrace:
  [1] Base.UUID(value::Vector{Any})
    @ Base ./uuid.jl:9
  [2] read_project_deps(raw::Dict{String, Any}, section_name::String)
    @ Pkg.Types ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/project.jl:52
  [3] Pkg.Types.Project(raw::Dict{String, Any}; file::String)
    @ Pkg.Types ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/project.jl:191
  [4] Project
    @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/project.jl:180 [inlined]
  [5] read_project(f_or_io::String)
    @ Pkg.Types ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/project.jl:220
  [6] Pkg.Types.EnvCache(env::Nothing)
    @ Pkg.Types ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/Types.jl:371
  [7] EnvCache
    @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/Types.jl:367 [inlined]
  [8] add_snapshot_to_undo(env::Nothing)
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/API.jl:1503
  [9] add_snapshot_to_undo
    @ ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/API.jl:1499 [inlined]
 [10] activate(path::String; shared::Bool, temp::Bool, io::IOContext{IO})
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/API.jl:1371
 [11] activate(path::String)
    @ Pkg.API ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/API.jl:1330
 [12] do_cmd(command::Pkg.REPLMode.Command, io::Base.TTY)
    @ Pkg.REPLMode ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/REPLMode/REPLMode.jl:404
 [13] do_cmds(commands::Vector{Pkg.REPLMode.Command}, io::Base.TTY)
    @ Pkg.REPLMode ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/src/REPLMode/REPLMode.jl:393
 [14] do_cmds(repl::REPL.LineEditREPL, commands::String)
    @ REPLExt ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/ext/REPLExt/REPLExt.jl:99
 [15] (::REPLExt.var"#32#35"{REPL.LineEditREPL, REPL.LineEdit.Prompt})(s::REPL.LineEdit.MIState, buf::IOBuffer, ok::Bool)
    @ REPLExt ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/Pkg/ext/REPLExt/REPLExt.jl:129
 [16] #invokelatest#2
    @ ./essentials.jl:1032 [inlined]
 [17] invokelatest
    @ ./essentials.jl:1029 [inlined]
 [18] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2747
 [19] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/REPL/src/REPL.jl:1446
 [20] (::REPL.var"#75#81"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.12/REPL/src/REPL.jl:496

```

This PR
```
(Pkg) pkg> activate /Users/ian/Documents/Foo.jl/Manifest.toml
  Activating project at `~/Documents/Foo.jl`
ERROR: The active project has been set to a file that isn't a Project file: /Users/ian/Documents/Foo.jl/Manifest.toml
The project path must be to a Project file or directory.
```