### PR TITLE
run artifact selection code with minimal compilation

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -804,7 +804,7 @@ function collect_artifacts(pkg_root::String; platform::AbstractPlatform=HostPlat
                 # Despite the fact that we inherit the project, since the in-memory manifest
                 # has not been updated yet, if we try to load any dependencies, it may fail.
                 # Therefore, this project inheritance is really only for Preferences, not dependencies.
-                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true)) -t1 --startup-file=no $(triplet(platform))`)
+                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true)) --compile=min -t1 --startup-file=no $(triplet(platform))`)
                 meta_toml = String(read(select_cmd))
                 res = TOML.tryparse(meta_toml)
                 if res isa TOML.ParserError


### PR DESCRIPTION
For example:

```
~/.julia/packages/CUDA_Runtime_jll/bmudn/.pkg
❯ julia +1.11 -e '@time include("select_artifacts.jl")'              
  0.683743 seconds (1.76 M allocations: 89.895 MiB, 4.46% gc time, 92.52% compilation time)

~/.julia/packages/CUDA_Runtime_jll/bmudn/.pkg
❯ julia +1.11 --compile=min -e '@time include("select_artifacts.jl")'
  0.068991 seconds (66.94 k allocations: 3.780 MiB, 18.29% compilation time)
```

However, this speedup is only achieved when this line fails: https://github.com/JuliaBinaryWrappers/CUDA_Runtime_jll.jl/blob/03e87cefa86f0d91b4a3fdf068c5474bdb13c4a1/.pkg/platform_augmentation.jl#L95-L99.
When this succeeds we get:

```
julia +1.11 --compile=min -e '@time include("select_artifacts.jl")'
...
  0.423333 seconds (612.17 k allocations: 36.343 MiB, 14.89% compilation time)

❯ julia +1.11 -e '@time include("select_artifacts.jl")' 
...
  0.960792 seconds (1.59 M allocations: 89.846 MiB, 6.47% gc time, 65.16% compilation time)
```

which is still better (and now dominated by load time (LazyArtifacts -> Pkg).)
