### PR TITLE
use the correct TOML.Parser coupled to Base.TOMLCache

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -53,7 +53,10 @@ function deepcopy_toml(x::Dict{String, Any})
 end
 
 # See loading.jl
-const TOML_CACHE = Base.TOMLCache(TOML.Parser(), Dict{String, Dict{String, Any}}())
+const TOML_CACHE = let parser = Base.TOML.Parser()
+    parser.Dates = Dates
+    Base.TOMLCache(parser, Dict{String, Dict{String, Any}}())
+end
 const TOML_LOCK = ReentrantLock()
 # Some functions mutate the returning Dict so return a copy of the cached value here
 parse_toml(toml_file::AbstractString) =


### PR DESCRIPTION
This assumption will be broken by #54739 and not recoverable, so we need to first fix this Pkg bug. Since print is only in TOML (the stdlib), this still needs the TOML package as well. Since some of the helpers are only in TOML, this only changes the places that use Base.TOMLCache features directly (not upgradable) with added Dates support, but uses TOML for everything else.

Fixes JuliaLang/julia#53196