### PR TITLE
Fix HistoricalStdlibVersions install to version

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ Logging.with_logger((islogging || Pkg.DEFAULT_IO[] == devnull) ? Logging.Console
         iob = IOBuffer()
         Pkg.activate(; temp = true)
         try
-            Pkg.add("HistoricalStdlibVersions", io=iob) # Needed for custom julia version resolve tests
+            Pkg.add(name="HistoricalStdlibVersions", version="1.2", io=iob) # Needed for custom julia version resolve tests
         catch
             println(String(take!(iob)))
             rethrow()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ Logging.with_logger((islogging || Pkg.DEFAULT_IO[] == devnull) ? Logging.Console
         iob = IOBuffer()
         Pkg.activate(; temp = true)
         try
-            Pkg.add(name="HistoricalStdlibVersions", version="1.2", io=iob) # Needed for custom julia version resolve tests
+            Pkg.add(name="HistoricalStdlibVersions", version="1.2", uuid="6df8b67a-e8a0-4029-b4b7-ac196fe72102", io=iob) # Needed for custom julia version resolve tests
         catch
             println(String(take!(iob)))
             rethrow()


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3929

Given this branch isn't touched on this CI
```
% julia  
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.4 (2024-06-04)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.10) pkg> activate --temp
  Activating new project at `/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_0iHV55`

julia> import Pkg

julia> Pkg.add(name="HistoricalStdlibVersions", version="1.2")
   Resolving package versions...
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_0iHV55/Project.toml`
⌃ [6df8b67a] + HistoricalStdlibVersions v1.2.4
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_0iHV55/Manifest.toml`
⌃ [6df8b67a] + HistoricalStdlibVersions v1.2.4
        Info Packages marked with ⌃ have new versions available and may be upgradable.

julia> 
```
```
julia> Pkg.add(name="HistoricalStdlibVersions", version="1.2", io=iob)

julia>
```