### PR TITLE
rm `empty!` on `install_packages_hooks`

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -318,7 +318,7 @@ function __init__()
             end
         end
     end
-    push!(empty!(REPL.install_packages_hooks), try_prompt_pkg_add)
+    pushfirst!(REPL.install_packages_hooks, try_prompt_pkg_add)
 end
 
 include("precompile.jl")

--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -318,7 +318,9 @@ function __init__()
             end
         end
     end
-    pushfirst!(REPL.install_packages_hooks, try_prompt_pkg_add)
+    if !in(try_prompt_pkg_add, REPL.install_packages_hooks)
+        push!(REPL.install_packages_hooks, try_prompt_pkg_add)
+    end
 end
 
 include("precompile.jl")


### PR DESCRIPTION
Re. https://github.com/JuliaLang/Pkg.jl/issues/3933#issuecomment-2184088297

This was here because I wasn't sure whether it was possible for the `__init__` to be run multiple times. But that seems to be guaranteed to not be allowed.