### PR TITLE
Use `Base.TOML.Parser{Dates}` for TOML parsing w/ Dates support

### DIFF
--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -1,5 +1,6 @@
 using Base: UUID, SHA1
 using TOML
+using Dates
 using Tar
 using ..Versions: VersionSpec, VersionRange
 
@@ -15,8 +16,7 @@ function to_tar_path_format(file::AbstractString)
 end
 
 # See loading.jl
-const TOML_CACHE = let parser = Base.TOML.Parser()
-    parser.Dates = Dates
+const TOML_CACHE = let parser = Base.TOML.Parser{Dates}()
     Base.TOMLCache(parser, Dict{String, Dict{String, Any}}())
 end
 const TOML_LOCK = ReentrantLock()
@@ -26,8 +26,7 @@ function parsefile(in_memory_registry::Union{Dict, Nothing}, folder::AbstractStr
         return _parsefile(joinpath(folder, file))
     else
         content = in_memory_registry[to_tar_path_format(file)]
-        parser = Base.TOML.Parser(content; filepath=file)
-        parser.Dates = Dates
+        parser = Base.TOML.Parser{Dates}(content; filepath=file)
         return Base.TOML.parse(parser)
     end
 end

--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -16,9 +16,7 @@ function to_tar_path_format(file::AbstractString)
 end
 
 # See loading.jl
-const TOML_CACHE = let parser = Base.TOML.Parser{Dates}()
-    Base.TOMLCache(parser, Dict{String, Dict{String, Any}}())
-end
+const TOML_CACHE = Base.TOMLCache(Base.TOML.Parser{Dates}())
 const TOML_LOCK = ReentrantLock()
 _parsefile(toml_file::AbstractString) = Base.parsed_toml(toml_file, TOML_CACHE, TOML_LOCK)
 function parsefile(in_memory_registry::Union{Dict, Nothing}, folder::AbstractString, file::AbstractString)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -53,9 +53,7 @@ function deepcopy_toml(x::Dict{String, Any})
 end
 
 # See loading.jl
-const TOML_CACHE = let parser = Base.TOML.Parser{Dates}()
-    Base.TOMLCache(parser, Dict{String, Dict{String, Any}}())
-end
+const TOML_CACHE = Base.TOMLCache(Base.TOML.Parser{Dates}())
 const TOML_LOCK = ReentrantLock()
 # Some functions mutate the returning Dict so return a copy of the cached value here
 parse_toml(toml_file::AbstractString) =

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -53,8 +53,7 @@ function deepcopy_toml(x::Dict{String, Any})
 end
 
 # See loading.jl
-const TOML_CACHE = let parser = Base.TOML.Parser()
-    parser.Dates = Dates
+const TOML_CACHE = let parser = Base.TOML.Parser{Dates}()
     Base.TOMLCache(parser, Dict{String, Dict{String, Any}}())
 end
 const TOML_LOCK = ReentrantLock()


### PR DESCRIPTION
Adapting to https://github.com/JuliaLang/julia/pull/54755/ and https://github.com/JuliaLang/julia/pull/55017