### PR TITLE
[sources] is available in 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Pkg v1.12 Release Notes
 =======================
 
-- It is now possible to specify "sources" for packages in a `[sources]` section in Project.toml.
-  This can be used to add non-registered normal or test dependencies.
 - Pkg now has support for "workspaces" which is a way to resolve multiple project files into a single manifest.
   The functions `Pkg.status`, `Pkg.why`, `Pkg.instantiate`, `Pkg.precompile` (and their REPL variants) have been updated
   to take a `workspace` option. Read more about this feature in the manual about the TOML-files.
@@ -10,6 +8,8 @@ Pkg v1.12 Release Notes
 Pkg v1.11 Release Notes
 =======================
 
+- It is now possible to specify "sources" for packages in a `[sources]` section in Project.toml.
+  This can be used to add non-registered normal or test dependencies.
 - Pkg now obeys `[compat]` bounds for `julia` and raises an error if the version of the running Julia binary is incompatible with the bounds in `Project.toml`.
   Pkg has always obeyed this compat when working with Registry packages. This change affects mostly local packages. ([#3526])
 - `pkg> add` and `Pkg.add` will now add compat entries for new direct dependencies if the active environment is a


### PR DESCRIPTION
Move the remark in the changelog to 1.11

According to Kristoffer Carlsson at State of Julia 2024, this is in 1.11.
Confirmed by testing with 1.11-rc1

