### PR TITLE
[release-1.10] Backports release 1.10

### DIFF
--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -192,6 +192,14 @@ force these packages to be retried, as `pkg> precompile` will always retry all p
 
 To disable the auto-precompilation, set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`.
 
+The indicators next to the package names displayed during precompilation
+indicate the status of that package's precompilation. 
+
+- `[◐, ◓, ◑, ◒]` Animated "clock" characters indicate that the package is currently being precompiled.
+- `✓` A green checkmark indicates that the package has been successfully precompiled (after which that package will disappear from the list). If the checkmark is yellow it means that the package is currently loaded so the session will need to be restarted to access the version that was just precompiled.
+- `?` A question mark character indicates that a `PrecompilableError` was thrown, indicating that precompilation was disallowed, i.e. `__precompile__(false)` in that package.
+- `✗` A cross indicates that the package failed to precompile.
+
 ### Precompiling new versions of loaded packages
 
 If a package that has been updated is already loaded in the session, the precompilation process will go ahead and precompile

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -730,7 +730,9 @@ function __init__()
             end
         end
     end
-    push!(empty!(REPL.install_packages_hooks), REPLMode.try_prompt_pkg_add)
+    if !in(REPLMode.try_prompt_pkg_add, REPL.install_packages_hooks)
+        push!(REPL.install_packages_hooks, REPLMode.try_prompt_pkg_add)
+    end
     Base.PKG_PRECOMPILE_HOOK[] = precompile # allows Base to use Pkg.precompile during loading
     OFFLINE_MODE[] = Base.get_bool_env("JULIA_PKG_OFFLINE", false)
     return nothing

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -303,6 +303,7 @@ PSA[:name => "activate",
     activate
     activate [--shared] path
     activate --temp
+    activate - (activates the previously active environment)
 
 Activate the environment at the given `path`, or use the first project found in `LOAD_PATH` if no `path` is specified.
 The active environment is the environment that is modified by executing package commands.
@@ -311,6 +312,7 @@ When the option `--shared` is given, `path` will be assumed to be a directory na
 it will be placed in the first depot of the stack.
 Use the `--temp` option to create temporary environments which are removed when the julia
 process is exited.
+Use a single `-` to activate the previously active environment.
 """ ,
 ],
 PSA[:name => "update",

--- a/src/REPLMode/completions.jl
+++ b/src/REPLMode/completions.jl
@@ -37,7 +37,17 @@ function complete_expanded_local_dir(s, i1, i2, expanded_user, oldi2)
     cmp = REPL.REPLCompletions.complete_path(s, i2, shell_escape=true)
     cmp2 = cmp[2]
     completions = [REPL.REPLCompletions.completion_text(p) for p in cmp[1]]
-    completions = filter!(x -> isdir(s[1:prevind(s, first(cmp2)-i1+1)]*x), completions)
+    completions = filter!(completions) do x
+        try
+            isdir(s[1:prevind(s, first(cmp2)-i1+1)]*x)
+        catch e
+            if e isa Base.IOError && e.code == Base.UV_EACCES
+                return false
+            else
+                rethrow()
+            end
+        end
+    end
     if expanded_user
         if length(completions) == 1 && endswith(joinpath(homedir(), ""), first(completions))
             completions = [joinpath(s, "")]

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -560,8 +560,15 @@ function write_env_usage(source_file::AbstractString, usage_filepath::AbstractSt
             usage[k] = [Dict("time" => maximum(times))]
         end
 
-        open(usage_file, "w") do io
-            TOML.print(io, usage, sorted=true)
+        tempfile = tempname()
+        try
+            open(tempfile, "w") do io
+                TOML.print(io, usage, sorted=true)
+            end
+            TOML.parsefile(tempfile) # compare to `usage` ?
+            mv(tempfile, usage_file; force=true) # only mv if parse succeeds
+        catch err
+            @error "Failed to write valid usage file `$usage_file`" tempfile
         end
     end
     return

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -230,6 +230,12 @@ function find_project_file(env::Union{Nothing,String}=nothing)
                 abspath(env, Base.project_names[end])
         end
     end
+    if isfile(project_file) && !contains(basename(project_file), "Project")
+        pkgerror("""
+        The active project has been set to a file that isn't a Project file: $project_file
+        The project path must be to a Project file or directory.
+        """)
+    end
     @assert project_file isa String &&
         (isfile(project_file) || !ispath(project_file) ||
          isdir(project_file) && isempty(readdir(project_file)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ if Base.find_package("HistoricalStdlibVersions") === nothing
     iob = IOBuffer()
     Pkg.activate(; temp = true)
     try
-        Pkg.add("HistoricalStdlibVersions", io=iob) # Needed for custom julia version resolve tests
+        Pkg.add(name="HistoricalStdlibVersions", version="1.2", uuid="6df8b67a-e8a0-4029-b4b7-ac196fe72102", io=iob) # Needed for custom julia version resolve tests
     catch
         println(String(take!(iob)))
         rethrow()


### PR DESCRIPTION
Backported PRs:
- [x] #3877 <!-- guard against isdir EACESS in completions -->
- [x] #3888 <!-- add note about `activate -` to command help -->
- [x] #3928 <!-- check parse before moving usage file into place -->
- [x] #3894 <!-- catch if the active project is erroneously set to a manifest file -->
- [x] #3932 <!-- Don't retry artifact downloads on `SystemError`, like `no space left on device` -->
- [x] #3903 <!-- Add some documentation describing how to interpret the symbols shown during recompilation -->

Contains multiple commits, manual intervention needed:
- [x] #3930 <!-- Fix HistoricalStdlibVersions install to version -->
- [x] #3934 <!-- rm `empty!` on `install_packages_hooks` -->
- [ ] https://github.com/JuliaLang/Pkg.jl/pull/3950

Non-merged PRs with backport label:
- [ ] #3851 <!-- fix not hardcoding "Project.toml" when fixing up extensions in manifest -->