### PR TITLE
Parallelize artifact downloads. Update progress bar styling.

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1268,7 +1268,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     # Install all packages
     new_apply = Operations.download_source(ctx)
     # Install all artifacts
-    Operations.download_artifacts(ctx.env; platform, verbose, io=ctx.io)
+    Operations.download_artifacts(ctx; platform, verbose)
     # Run build scripts
     allow_build && Operations.build_versions(ctx, union(new_apply, new_git); verbose=verbose)
 

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -418,6 +418,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
         if isnothing(progress) || verbose == true
             return try_artifact_download_sources(name, hash, meta, artifacts_toml; platform, verbose, quiet_download, io)
         else
+            # if a custom progress handler is given it is taken to mean the caller wants to handle the download scheduling
             return () -> try_artifact_download_sources(name, hash, meta, artifacts_toml; platform, quiet_download=true, io, progress)
         end
     else

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -301,6 +301,7 @@ function download_artifact(
     verbose::Bool = false,
     quiet_download::Bool = false,
     io::IO=stderr_f(),
+    progress::Union{Function, Nothing} = nothing,
 )
     if artifact_exists(tree_hash)
         return true
@@ -323,8 +324,8 @@ function download_artifact(
     temp_dir = mktempdir(artifacts_dir)
 
     try
-        download_verify_unpack(tarball_url, tarball_hash, temp_dir, ignore_existence=true, verbose=verbose,
-                quiet_download=quiet_download, io=io)
+        download_verify_unpack(tarball_url, tarball_hash, temp_dir;
+                                ignore_existence=true, verbose, quiet_download, io, progress)
         calc_hash = SHA1(GitTools.tree_hash(temp_dir))
 
         # Did we get what we expected?  If not, freak out.
@@ -394,81 +395,99 @@ function ensure_artifact_installed(name::String, artifacts_toml::String;
                                    pkg_uuid::Union{Base.UUID,Nothing}=nothing,
                                    verbose::Bool = false,
                                    quiet_download::Bool = false,
+                                   progress::Union{Function,Nothing} = nothing,
                                    io::IO=stderr_f())
     meta = artifact_meta(name, artifacts_toml; pkg_uuid=pkg_uuid, platform=platform)
     if meta === nothing
         error("Cannot locate artifact '$(name)' in '$(artifacts_toml)'")
     end
 
-    return ensure_artifact_installed(name, meta, artifacts_toml; platform=platform,
-                                     verbose=verbose, quiet_download=quiet_download, io=io)
+    return ensure_artifact_installed(name, meta, artifacts_toml;
+                                    platform, verbose, quiet_download, progress, io)
 end
 
 function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::String;
                                    platform::AbstractPlatform = HostPlatform(),
                                    verbose::Bool = false,
                                    quiet_download::Bool = false,
+                                   progress::Union{Function,Nothing} = nothing,
                                    io::IO=stderr_f())
+
     hash = SHA1(meta["git-tree-sha1"])
-
     if !artifact_exists(hash)
-        errors = Any[]
-        # first try downloading from Pkg server
-        # TODO: only do this if Pkg server knows about this package
-        if (server = pkg_server()) !== nothing
-            url = "$server/artifact/$hash"
-            download_success = let url=url
-                @debug "Downloading artifact from Pkg server" name artifacts_toml platform url
-                with_show_download_info(io, name, quiet_download) do
-                    download_artifact(hash, url; verbose=verbose, quiet_download=quiet_download, io=io)
-                end
-            end
-            # download_success is either `true` or an error object
-            if download_success === true
-                return artifact_path(hash)
-            else
-                @debug "Failed to download artifact from Pkg server" download_success
-                push!(errors, (url, download_success))
-            end
+        if isnothing(progress) || verbose == true
+            return try_artifact_download_sources(name, hash, meta, artifacts_toml; platform, verbose, quiet_download, io)
+        else
+            return () -> try_artifact_download_sources(name, hash, meta, artifacts_toml; platform, quiet_download=true, io, progress)
         end
-
-        # If this artifact does not exist on-disk already, ensure it has download
-        # information, then download it!
-        if !haskey(meta, "download")
-            error("Cannot automatically install '$(name)'; no download section in '$(artifacts_toml)'")
-        end
-
-        # Attempt to download from all sources
-        for entry in meta["download"]
-            url = entry["url"]
-            tarball_hash = entry["sha256"]
-            download_success = let url=url
-                @debug "Downloading artifact" name artifacts_toml platform url
-                with_show_download_info(io, name, quiet_download) do
-                    download_artifact(hash, url, tarball_hash; verbose=verbose, quiet_download=quiet_download, io=io)
-                end
-            end
-            # download_success is either `true` or an error object
-            if download_success === true
-                return artifact_path(hash)
-            else
-                @debug "Failed to download artifact" download_success
-                push!(errors, (url, download_success))
-            end
-        end
-        errmsg = """
-        Unable to automatically download/install artifact '$(name)' from sources listed in '$(artifacts_toml)'.
-        Sources attempted:
-        """
-        for (url, err) in errors
-            errmsg *= "- $(url)\n"
-            errmsg *= "    Error: $(sprint(showerror, err))\n"
-        end
-        error(errmsg)
     else
         return artifact_path(hash)
     end
 end
+
+function try_artifact_download_sources(
+            name::String, hash::SHA1, meta::Dict, artifacts_toml::String;
+            platform::AbstractPlatform=HostPlatform(),
+            verbose::Bool=false,
+            quiet_download::Bool=false,
+            io::IO=stderr_f(),
+            progress::Union{Function,Nothing}=nothing)
+
+    errors = Any[]
+    # first try downloading from Pkg server
+    # TODO: only do this if Pkg server knows about this package
+    if (server = pkg_server()) !== nothing
+        url = "$server/artifact/$hash"
+        download_success = let url = url
+            @debug "Downloading artifact from Pkg server" name artifacts_toml platform url
+            with_show_download_info(io, name, quiet_download) do
+                download_artifact(hash, url; verbose, quiet_download, io, progress)
+            end
+        end
+        # download_success is either `true` or an error object
+        if download_success === true
+            return artifact_path(hash)
+        else
+            @debug "Failed to download artifact from Pkg server" download_success
+            push!(errors, (url, download_success))
+        end
+    end
+
+    # If this artifact does not exist on-disk already, ensure it has download
+    # information, then download it!
+    if !haskey(meta, "download")
+        error("Cannot automatically install '$(name)'; no download section in '$(artifacts_toml)'")
+    end
+
+    # Attempt to download from all sources
+    for entry in meta["download"]
+        url = entry["url"]
+        tarball_hash = entry["sha256"]
+        download_success = let url = url
+            @debug "Downloading artifact" name artifacts_toml platform url
+            with_show_download_info(io, name, quiet_download) do
+                download_artifact(hash, url, tarball_hash; verbose, quiet_download, io, progress)
+            end
+        end
+        # download_success is either `true` or an error object
+        if download_success === true
+            return artifact_path(hash)
+        else
+            @debug "Failed to download artifact" download_success
+            push!(errors, (url, download_success))
+        end
+    end
+    errmsg = """
+    Unable to automatically download/install artifact '$(name)' from sources listed in '$(artifacts_toml)'.
+    Sources attempted:
+    """
+    for (url, err) in errors
+        errmsg *= "- $(url)\n"
+        errmsg *= "    Error: $(sprint(showerror, err))\n"
+    end
+    error(errmsg)
+end
+
 
 function with_show_download_info(f, io, name, quiet_download)
     fancyprint = can_fancyprint(io)
@@ -485,7 +504,7 @@ function with_show_download_info(f, io, name, quiet_download)
         if !quiet_download
             fancyprint && print(io, "\033[1A") # move cursor up one line
             fancyprint && print(io, "\033[2K") # clear line
-            if success 
+            if success
                 fancyprint && printpkgstyle(io, :Downloaded, "artifact: $name")
             else
                 printpkgstyle(io, :Failure, "artifact: $name", color = :red)

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -77,7 +77,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     to_print = sprint(; context=io) do io
         print(io, " "^p.indent)
         if p.main
-            printstyled(io, headers[1], " "; color=:light_green, bold=true)
+            printstyled(io, headers[1], " "; color=:green, bold=true)
             printstyled(io, join(headers[2:end], ' '))
         else
             print(io, p.header)

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -4,6 +4,18 @@ export MiniProgressBar, start_progress, end_progress, show_progress, print_progr
 
 using Printf
 
+# Until Base.format_bytes supports sigdigits
+function pkg_format_bytes(bytes; binary=true, sigdigits::Integer=3)
+    units = binary ? Base._mem_units : Base._cnt_units
+    factor = binary ? 1024 : 1000
+    bytes, mb = Base.prettyprint_getunits(bytes, length(units), Int64(factor))
+    if mb == 1
+        return string(Int(bytes), " ", Base._mem_units[mb], bytes==1 ? "" : "s")
+    else
+        return string(Base.Ryu.writefixed(Float64(bytes), sigdigits), binary ? " $(units[mb])" : "$(units[mb])B")
+    end
+end
+
 Base.@kwdef mutable struct MiniProgressBar
     max::Int = 1.0
     header::String = ""
@@ -16,6 +28,7 @@ Base.@kwdef mutable struct MiniProgressBar
     mode::Symbol = :percentage # :percentage :int :data
     always_reprint::Bool = false
     indent::Int = 4
+    main::Bool = true
 end
 
 const PROGRESS_BAR_TIME_GRANULARITY = Ref(1 / 30.0) # 30 fps
@@ -52,7 +65,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     elseif p.mode == :int
         string(p.current, "/",  p.max)
     elseif p.mode == :data
-        lpad(string(Base.format_bytes(p.current), "/", Base.format_bytes(p.max)), 23)
+        lpad(string(pkg_format_bytes(p.current; sigdigits=1), "/", pkg_format_bytes(p.max; sigdigits=1)), 20)
     else
         error("Unknown mode $(p.mode)")
     end
@@ -60,12 +73,19 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
     n_filled = ceil(Int, max_progress_width * perc / 100)
     n_left = max_progress_width - n_filled
+    headers = split(p.header)
     to_print = sprint(; context=io) do io
         print(io, " "^p.indent)
-        printstyled(io, p.header, color=p.color, bold=true)
-        print(io, " [")
-        print(io, "="^n_filled, ">")
-        print(io, " "^n_left, "]  ", )
+        if p.main
+            printstyled(io, headers[1], " "; color=:light_green, bold=true)
+            printstyled(io, join(headers[2:end], ' '))
+        else
+            print(io, p.header)
+        end
+        print(io, " ")
+        printstyled(io, "━"^n_filled; color=p.color)
+        printstyled(io, perc >= 95 ? "━" : "╸"; color=p.color)
+        printstyled(io, "━"^n_left, " "; color=:light_black)
         print(io, progress_text)
         carriagereturn && print(io, "\r")
     end
@@ -84,10 +104,10 @@ end
 # prog = MiniProgressBar(...)
 # prog.end = n
 # for progress in 1:n
-#     print_progree_bottom(io)
+#     print_progress_bottom(io)
 #     println("stuff")
 #     prog.current = progress
-#     showproress(io, prog)
+#     showprogress(io, prog)
 #  end
 #
 function print_progress_bottom(io::IO)

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -9,11 +9,11 @@ Base.@kwdef mutable struct MiniProgressBar
     header::String = ""
     color::Symbol = :nothing
     width::Int = 40
-    current::Int = 0.0
-    prev::Int = 0.0
+    current::Int = 0
+    prev::Int = 0
     has_shown::Bool = false
     time_shown::Float64 = 0.0
-    percentage::Bool = true
+    mode::Symbol = :percentage # :percentage :int :data
     always_reprint::Bool = false
     indent::Int = 4
 end
@@ -47,10 +47,14 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     p.prev = p.current
     p.has_shown = true
 
-    progress_text = if p.percentage
+    progress_text = if p.mode == :percentage
         @sprintf "%2.1f %%" perc
-    else
+    elseif p.mode == :int
         string(p.current, "/",  p.max)
+    elseif p.mode == :data
+        string(Base.format_bytes(p.current), "/", Base.format_bytes(p.max))
+    else
+        error("Unknown mode $(p.mode)")
     end
     termwidth = @something termwidth displaysize(io)[2]
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -52,7 +52,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     elseif p.mode == :int
         string(p.current, "/",  p.max)
     elseif p.mode == :data
-        string(Base.format_bytes(p.current), "/", Base.format_bytes(p.max))
+        lpad(string(Base.format_bytes(p.current), "/", Base.format_bytes(p.max)), 23)
     else
         error("Unknown mode $(p.mode)")
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -860,7 +860,7 @@ function download_artifacts(ctx::Context;
                         () -> begin
                             ret()
                             download_states[name] = (false, bar)
-                            fancyprint || @lock print_lock printpkgstyle(io, :Downloaded, "artifact $name $(pkg_format_bytes(bar.max))")
+                            fancyprint || @lock print_lock printpkgstyle(io, :Downloaded, "artifact $name $(MiniProgressBars.pkg_format_bytes(bar.max))")
                         end
                     )
                 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -844,6 +844,7 @@ function download_artifacts(ctx::Context;
     ansi_enablecursor = "\e[?25h"
     ansi_disablecursor = "\e[?25l"
 
+    longest_name = "" # will be updated later
     for pkg_root in pkg_roots
         for (artifacts_toml, artifacts) in collect_artifacts(pkg_root; platform)
             # For each Artifacts.toml, install each artifact we've collected from it
@@ -860,7 +861,10 @@ function download_artifacts(ctx::Context;
                         () -> begin
                             ret()
                             download_states[name] = (false, bar)
-                            fancyprint || @lock print_lock printpkgstyle(io, :Downloaded, "artifact $name $(MiniProgressBars.pkg_format_bytes(bar.max))")
+                            if !fancyprint
+                                rname = rpad(name, longest_name)
+                                @lock print_lock printpkgstyle(io, :Downloaded, "artifact $rname $(MiniProgressBars.pkg_format_bytes(bar.max; sigdigits=1))")
+                            end
                         end
                     )
                 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -849,7 +849,7 @@ function download_artifacts(ctx::Context;
             # For each Artifacts.toml, install each artifact we've collected from it
             for name in keys(artifacts)
                 is_done && break
-                bar = MiniProgressBar(; indent=2, color = Base.info_color(), mode=:data, always_reprint=true)
+                bar = MiniProgressBar(; main=false, indent=2, color = Base.info_color(), mode=:data, always_reprint=true)
                 progress = (total, current) -> (bar.max = total; bar.current = current)
                 # returns a string if exists, or function that downloads the artifact if not
                 ret = ensure_artifact_installed(name, artifacts[name], artifacts_toml;
@@ -1052,7 +1052,7 @@ function download_source(ctx::Context; readonly=true)
             end
         end
 
-        bar = MiniProgressBar(; indent=2, header = "Progress", color = Base.info_color(),
+        bar = MiniProgressBar(; indent=2, header = "Downloading packages", color = Base.info_color(),
                                   mode=:int, always_reprint=true)
         bar.max = length(pkgs_to_install)
         fancyprint = can_fancyprint(ctx.io)
@@ -1283,7 +1283,7 @@ function build_versions(ctx::Context, uuids::Set{UUID}; verbose=false)
     sort!(builds, by = build -> order[first(build)])
     max_name = maximum(build->textwidth(build[2]), builds; init=0)
 
-    bar = MiniProgressBar(; indent=2, header = "Progress", color = Base.info_color(),
+    bar = MiniProgressBar(; indent=2, header = "Building packages", color = Base.info_color(),
                               mode=:int, always_reprint=true)
     bar.max = length(builds)
     fancyprint = can_fancyprint(ctx.io)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -852,7 +852,7 @@ function download_artifacts(ctx::Context;
     ansi_enablecursor = "\e[?25h"
     ansi_disablecursor = "\e[?25l"
 
-    longest_name = "" # will be updated later
+    longest_name_length = 0 # will be updated later
     for pkg_root in pkg_roots
         for (artifacts_toml, artifacts) in collect_artifacts(pkg_root; platform)
             # For each Artifacts.toml, install each artifact we've collected from it
@@ -870,7 +870,7 @@ function download_artifacts(ctx::Context;
                                 download_states[name].state = :running
                                 ret()
                                 if !fancyprint
-                                    rname = rpad(name, longest_name)
+                                    rname = rpad(name, longest_name_length)
                                     @lock print_lock printpkgstyle(io, :Downloaded, "artifact $rname $(MiniProgressBars.pkg_format_bytes(bar.max; sigdigits=1))")
                                 end
                             catch
@@ -888,9 +888,9 @@ function download_artifacts(ctx::Context;
     end
 
     if !isempty(download_jobs)
-        longest_name = maximum(textwidth, keys(download_states))
+        longest_name_length = maximum(textwidth, keys(download_states))
         for (name, dstate) in download_states
-            dstate.bar.header = rpad(name, longest_name)
+            dstate.bar.header = rpad(name, longest_name_length)
         end
 
         if fancyprint

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -899,6 +899,7 @@ function download_artifacts(ctx::Context;
                     print(io, ansi_disablecursor)
                     first = true
                     timer = Timer(0, interval=1/10)
+                    # TODO: Implement as a new MiniMultiProgressBar
                     main_bar = MiniProgressBar(; indent=1, header = "Downloading artifacts", color = :green, mode = :int, always_reprint=true)
                     main_bar.max = length(download_states)
                     while !is_done

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -816,11 +816,12 @@ function collect_artifacts(pkg_root::String; platform::AbstractPlatform=HostPlat
     return artifacts_tomls
 end
 
-function download_artifacts(env::EnvCache;
+function download_artifacts(ctx::Context;
                             platform::AbstractPlatform=HostPlatform(),
                             julia_version = VERSION,
-                            verbose::Bool=false,
-                            io::IO=stderr_f())
+                            verbose::Bool=false)
+    env = ctx.env
+    io = ctx.io
     pkg_roots = String[]
     for (uuid, pkg) in env.manifest
         pkg = manifest_info(env.manifest, uuid)
@@ -828,15 +829,120 @@ function download_artifacts(env::EnvCache;
         pkg_root === nothing || push!(pkg_roots, pkg_root)
     end
     push!(pkg_roots, dirname(env.project_file))
+    used_artifact_tomls = Set{String}()
+    download_jobs = Channel{Function}(Inf) # ctx.num_concurrent_downloads
+
+    download_states = Dict{String, Tuple{Bool,MiniProgressBar}}()
+    is_done = false
+    ansi_moveup(n::Int) = string("\e[", n, "A")
+    ansi_movecol1 = "\e[1G"
+    ansi_cleartoend = "\e[0J"
+    ansi_cleartoendofline = "\e[0K"
+    ansi_enablecursor = "\e[?25h"
+    ansi_disablecursor = "\e[?25l"
+    termwidth = displaysize(io)[2]
+
+    longest_name = 0
+    for pkg_root in pkg_roots
+        for (artifacts_toml, artifacts) in collect_artifacts(pkg_root; platform)
+            for name in keys(artifacts)
+                longest_name = max(longest_name, textwidth(name))
+            end
+        end
+    end
+
     for pkg_root in pkg_roots
         for (artifacts_toml, artifacts) in collect_artifacts(pkg_root; platform)
             # For each Artifacts.toml, install each artifact we've collected from it
             for name in keys(artifacts)
-                ensure_artifact_installed(name, artifacts[name], artifacts_toml;
-                                            verbose, quiet_download=!(usable_io(io)), io=io)
+                is_done && break
+                bar = MiniProgressBar(; indent=2, color = Base.info_color(), mode=:data, always_reprint=true)
+                progress = (total, current) -> (bar.max = total; bar.current = current)
+                # returns a string if exists, or function that downloads the artifact if not
+                ret = ensure_artifact_installed(name, artifacts[name], artifacts_toml;
+                                            verbose, quiet_download=!(usable_io(io)), io, progress)
+                if ret isa Function
+                    download_states[name] = (true, bar)
+                    push!(download_jobs,
+                        () -> begin
+                            ret()
+                            download_states[name] = (false, bar)
+                        end
+                    )
+                end
             end
-            write_env_usage(artifacts_toml, "artifact_usage.toml")
+            push!(used_artifact_tomls, artifacts_toml)
         end
+    end
+    close(download_jobs)
+
+    if !isempty(download_states)
+
+        longest_name = maximum(textwidth, keys(download_states))
+        for (name, (running, bar)) in download_states
+            bar.header = rpad(name, longest_name)
+        end
+
+        @sync begin
+            t_print = Threads.@spawn begin
+                try
+                    print(io, ansi_disablecursor)
+                    first = true
+                    timer = Timer(0, interval=1/24)
+                    main_bar = MiniProgressBar(; indent=0, header = "Downloading artifacts", color = :green, mode = :int, always_reprint=true)
+                    main_bar.max = length(download_states)
+                    while !is_done
+                        main_bar.current = length(filter(x -> !x[2][1], download_states))
+                        str = sprint(context=io) do iostr
+                            first || print(iostr, ansi_cleartoend)
+                            n_printed = 1
+                            show_progress(iostr, main_bar; termwidth, carriagereturn=false)
+                            println(iostr)
+                            for (name, (running, bar)) in download_states
+                                running && bar.max > 1000 && bar.current > 0 || continue
+                                show_progress(iostr, bar; termwidth, carriagereturn=false)
+                                println(iostr)
+                                n_printed += 1
+                            end
+                            is_done || print(iostr, ansi_moveup(n_printed), ansi_movecol1)
+                            first = false
+                        end
+                        print(io, str)
+                        wait(timer)
+                    end
+                    print(io, ansi_cleartoend)
+                    main_bar.current = length(filter(x -> !x[2][1], download_states))
+                    show_progress(io, main_bar; termwidth, carriagereturn=false)
+                    println(io)
+                catch e
+                    e isa InterruptException || rethrow()
+                    is_done = true
+                finally
+                    print(io, ansi_enablecursor)
+                end
+            end
+            Base.errormonitor(t_print)
+
+            # TODO: figure out error handling/reporting
+            sema = Base.Semaphore(ctx.num_concurrent_downloads)
+            @sync for f in download_jobs
+                is_done && break
+                t = Threads.@spawn begin
+                    try
+                        Base.acquire(f, sema)
+                    catch e
+                        e isa InterruptException || rethrow()
+                        is_done = true
+                    end
+                end
+                Base.errormonitor(t)
+            end
+            is_done = true
+        end
+    end
+
+    for f in used_artifact_tomls
+        write_env_usage(f, "artifact_usage.toml")
     end
 end
 
@@ -949,7 +1055,7 @@ function download_source(ctx::Context; readonly=true)
         end
 
         bar = MiniProgressBar(; indent=2, header = "Progress", color = Base.info_color(),
-                                  percentage=false, always_reprint=true)
+                                  mode=:int, always_reprint=true)
         bar.max = length(pkgs_to_install)
         fancyprint = can_fancyprint(ctx.io)
         try
@@ -1180,7 +1286,7 @@ function build_versions(ctx::Context, uuids::Set{UUID}; verbose=false)
     max_name = maximum(build->textwidth(build[2]), builds; init=0)
 
     bar = MiniProgressBar(; indent=2, header = "Progress", color = Base.info_color(),
-                              percentage=false, always_reprint=true)
+                              mode=:int, always_reprint=true)
     bar.max = length(builds)
     fancyprint = can_fancyprint(ctx.io)
     fancyprint && start_progress(ctx.io, bar)
@@ -1509,7 +1615,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
 
         # After downloading resolutionary packages, search for (Julia)Artifacts.toml files
         # and ensure they are all downloaded and unpacked as well:
-        download_artifacts(ctx.env, platform=platform, julia_version=ctx.julia_version, io=ctx.io)
+        download_artifacts(ctx, platform=platform, julia_version=ctx.julia_version)
 
         # if env is a package add compat entries
         if ctx.env.project.name !== nothing && ctx.env.project.uuid !== nothing
@@ -1553,7 +1659,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Set{UUID};
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
     fixups_from_projectfile!(ctx.env)
-    download_artifacts(ctx.env; platform=platform, julia_version=ctx.julia_version, io=ctx.io)
+    download_artifacts(ctx; platform=platform, julia_version=ctx.julia_version)
     write_env(ctx.env) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io)
     build_versions(ctx, union(new_apply, new_git))
@@ -1694,7 +1800,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
     fixups_from_projectfile!(ctx.env)
-    download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)
+    download_artifacts(ctx, julia_version=ctx.julia_version)
     write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io, hidden_upgrades_info = true)
     build_versions(ctx, union(new_apply, new_git))
@@ -1740,7 +1846,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new = download_source(ctx)
     fixups_from_projectfile!(ctx.env)
-    download_artifacts(ctx.env; julia_version=ctx.julia_version, io=ctx.io)
+    download_artifacts(ctx; julia_version=ctx.julia_version)
     write_env(ctx.env) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io)
     build_versions(ctx, new)
@@ -1788,7 +1894,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free=true)
         update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
         new = download_source(ctx)
         fixups_from_projectfile!(ctx.env)
-        download_artifacts(ctx.env, io=ctx.io)
+        download_artifacts(ctx)
         write_env(ctx.env) # write env before building
         show_update(ctx.env, ctx.registries; io=ctx.io)
         build_versions(ctx, new)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -898,7 +898,7 @@ function download_artifacts(ctx::Context;
                             n_printed = 1
                             show_progress(iostr, main_bar; termwidth, carriagereturn=false)
                             println(iostr)
-                            for (name, (running, bar)) in download_states
+                            for (name, (running, bar)) in sort(collect(download_states), by=kv->kv[2][2].max, rev=true)
                                 running && bar.max > 1000 && bar.current > 0 || continue
                                 show_progress(iostr, bar; termwidth, carriagereturn=false)
                                 println(iostr)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -860,7 +860,7 @@ function download_artifacts(ctx::Context;
                         () -> begin
                             ret()
                             download_states[name] = (false, bar)
-                            fancyprint || @lock print_lock println(io, "Downloaded $name")
+                            fancyprint || @lock print_lock printpkgstyle(io, :Downloaded, "artifact $name $(pkg_format_bytes(bar.max))")
                         end
                     )
                 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -882,7 +882,7 @@ function download_artifacts(ctx::Context;
                         print(io, ansi_disablecursor)
                         first = true
                         timer = Timer(0, interval=1/10)
-                        main_bar = MiniProgressBar(; indent=0, header = "Downloading artifacts", color = :green, mode = :int, always_reprint=true)
+                        main_bar = MiniProgressBar(; indent=1, header = "Downloading artifacts", color = :green, mode = :int, always_reprint=true)
                         main_bar.max = length(download_states)
                         while !is_done
                             main_bar.current = count(x -> !x[2][1], download_states)
@@ -1052,7 +1052,7 @@ function download_source(ctx::Context; readonly=true)
             end
         end
 
-        bar = MiniProgressBar(; indent=2, header = "Downloading packages", color = Base.info_color(),
+        bar = MiniProgressBar(; indent=1, header = "Downloading packages", color = Base.info_color(),
                                   mode=:int, always_reprint=true)
         bar.max = length(pkgs_to_install)
         fancyprint = can_fancyprint(ctx.io)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -368,7 +368,8 @@ function download_verify(
             end
         end
     end
-    if hash !== nothing && !verify(dest, hash; verbose=verbose)
+    details = String[]
+    if hash !== nothing && !verify(dest, hash; verbose, details)
         # If the file already existed, it's possible the initially downloaded chunk
         # was bad.  If verification fails after downloading, auto-delete the file
         # and start over from scratch.
@@ -380,13 +381,15 @@ function download_verify(
 
             # Download and verify from scratch
             download(url, dest; verbose=verbose || !quiet_download)
-            if hash !== nothing && !verify(dest, hash; verbose=verbose)
-                error("Verification failed. Download does not match expected hash")
+            if hash !== nothing && !verify(dest, hash; verbose, details)
+                @goto verification_failed
             end
         else
+            @label verification_failed
             # If it didn't verify properly and we didn't resume, something is
             # very wrong and we must complain mightily.
-            error("Verification failed. Download does not match expected hash")
+            details_indented = join(map(s -> "      $s", split(join(details, "\n"), '\n')), "\n")
+            error("Verification failed:\n" * details_indented)
         end
     end
 
@@ -555,7 +558,8 @@ end
 
 """
     verify(path::AbstractString, hash::AbstractString;
-           verbose::Bool = false, report_cache_status::Bool = false)
+           verbose::Bool = false, report_cache_status::Bool = false,
+           details::Union{Vector{String},Nothing} = nothing)
 
 Given a file `path` and a `hash`, calculate the SHA256 of the file and compare
 it to `hash`.  This method caches verification results in a `"\$(path).sha256"`
@@ -571,9 +575,12 @@ If `report_cache_status` is set to `true`, then the return value will be a
 `Symbol` giving a granular status report on the state of the hash cache, in
 addition to the `true`/`false` signifying whether verification completed
 successfully.
+
+If `details` is provided, any pertinent detail will be pushed to it rather than logged.
 """
 function verify(path::AbstractString, hash::AbstractString; verbose::Bool = false,
-                report_cache_status::Bool = false, hash_path::AbstractString="$(path).sha256")
+                report_cache_status::Bool = false, hash_path::AbstractString="$(path).sha256",
+                details::Union{Vector{String},Nothing} = nothing)
 
     # Check hash string format
     if !occursin(r"^[0-9a-f]{64}$"i, hash)
@@ -643,7 +650,11 @@ function verify(path::AbstractString, hash::AbstractString; verbose::Bool = fals
         msg  = "Hash Mismatch!\n"
         msg *= "  Expected sha256:   $hash\n"
         msg *= "  Calculated sha256: $calc_hash"
-        @error(msg)
+        if isnothing(details)
+            @error(msg)
+        else
+            push!(details, msg)
+        end
         if report_cache_status
             return false, :hash_mismatch
         else

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -308,9 +308,7 @@ end
     mktempdir() do dir
         with_artifacts_directory(dir) do
             @test artifact_meta("broken_artifact", joinpath(badifact_dir, "incorrect_sha256.toml")) != nothing
-            @test_logs (:error, r"Hash Mismatch!") match_mode=:any begin
-                @test_throws ErrorException ensure_artifact_installed("broken_artifact", joinpath(badifact_dir, "incorrect_sha256.toml"))
-            end
+            @test_throws r"Hash Mismatch!" ensure_artifact_installed("broken_artifact", joinpath(badifact_dir, "incorrect_sha256.toml"))
 
             artifact_toml = joinpath(badifact_dir, "doesnotexist.toml")
             @test_throws ErrorException ensure_artifact_installed("does_not_exist", artifact_toml)


### PR DESCRIPTION
## This PR
```
% JULIA_DEPOT_PATH=$(mktemp -d): JULIA_PKG_PRECOMPILE_AUTO=0 ./julia --project=../Pkg.jl -t1 -e 'import Pkg; Pkg.activate(temp=true); @time Pkg.add("FFMPEG")'
...
 12.999424 seconds (9.81 M allocations: 915.741 MiB, 2.30% gc time, 73 lock conflicts, 11.69% compilation time: 16% of which was recompilation)
```

## Master
```
% JULIA_DEPOT_PATH=$(mktemp -d): JULIA_PKG_PRECOMPILE_AUTO=0 ./julia-t1 -e 'import Pkg; Pkg.activate(temp=true); @time Pkg.add("FFMPEG")'
...
 23.540455 seconds (9.37 M allocations: 887.289 MiB, 0.82% gc time, 123 lock conflicts, 5.85% compilation time: 18% of which was recompilation)

```

https://github.com/user-attachments/assets/8f1024d6-f255-420c-a70e-becdbfa1dd86


Todo
- [x] parallel progress printing 
- [ ] effective interrupt handling (proven to be hard to do because of Downloads.jl being so async)
  - [ ] needs testing
- [x] error handling & reporting
  - [x] needs testing
- [x] code tidy and remove duplication (will implement a new MiniMultiProgressBar type in a follow-on)
- [x] simple printing for CI etc.
- [x] show progress in bytes 
  - [ ] rate/s ?
  - [ ] total across all artifacts?