### PR TITLE
don't use `get_extension` to bridge REPLExt to REPLMode

### DIFF
--- a/ext/REPLExt/completions.jl
+++ b/ext/REPLExt/completions.jl
@@ -194,6 +194,21 @@ complete_opt(opt_specs) =
 function complete_argument(spec::CommandSpec, options::Vector{String},
                            partial::AbstractString, offset::Int,
                            index::Int; hint::Bool)
+    if spec.completions isa Symbol
+        # if completions is a symbol, it is a function in REPLExt that needs to be forwarded
+        # to REPLMode (couldn't be linked there because REPLExt is not a dependency of REPLMode)
+        completions = try
+            getglobal(REPLExt, spec.completions)
+        catch
+            @error "REPLMode indicates a completion function called :$(spec.completions) that cannot be found in REPLExt"
+            rethrow()
+        end
+        spec.completions = function(opts, partial, offset, index; hint::Bool)
+                applicable(completions, opts, partial, offset, index) ?
+                    completions(opts, partial, offset, index; hint) :
+                    completions(opts, partial; hint)
+            end
+    end
     spec.completions === nothing && return String[]
     # finish parsing opts
     local opts

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2410,6 +2410,7 @@ function status_ext_info(pkg::PackageSpec, env::EnvCache)
         v = ExtInfo[]
         for (ext, extdeps) in exts
             extdeps isa String && (extdeps = String[extdeps])
+            # Note: `get_extension` returns nothing for stdlibs that are loaded via `require_stdlib`
             ext_loaded = (Base.get_extension(Base.PkgId(pkg.uuid, pkg.name), Symbol(ext)) !== nothing)
             # Check if deps are loaded
             extdeps_info= Tuple{String, Bool}[]

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -64,16 +64,16 @@ end
 # Commands #
 #----------#
 const CommandDeclaration = Vector{Pair{Symbol,Any}}
-struct CommandSpec
-    canonical_name::String
-    short_name::Union{Nothing,String}
-    api::Function
-    should_splat::Bool
-    argument_spec::ArgSpec
-    option_specs::Dict{String,OptionSpec}
-    completions::Union{Nothing,Function}
-    description::String
-    help::Union{Nothing,Markdown.MD}
+mutable struct CommandSpec
+    const canonical_name::String
+    const short_name::Union{Nothing,String}
+    const api::Function
+    const should_splat::Bool
+    const argument_spec::ArgSpec
+    const option_specs::Dict{String,OptionSpec}
+    completions::Union{Nothing,Symbol,Function} # Symbol is used as a marker for REPLExt to assign the function of that name
+    const description::String
+    const help::Union{Nothing,Markdown.MD}
 end
 
 default_parser(xs, options) = unwrap(xs)
@@ -84,7 +84,7 @@ function CommandSpec(;name::Union{Nothing,String}           = nothing,
                      option_spec::Vector{OptionDeclaration} = OptionDeclaration[],
                      help::Union{Nothing,Markdown.MD}       = nothing,
                      description::Union{Nothing,String}     = nothing,
-                     completions::Union{Nothing,Function}   = nothing,
+                     completions::Union{Nothing,Symbol,Function}   = nothing,
                      arg_count::Pair                        = (0=>0),
                      arg_parser::Function                   = default_parser,
                      )::CommandSpec

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -1,16 +1,5 @@
 const PSA = Pair{Symbol,Any}
 
-function get_complete_function(f)
-    return function(opts, partial, offset, index; hint::Bool)
-        m = Base.get_extension(@__MODULE__, :REPLExt)
-        m === nothing && return String[]
-        completions = getglobal(m, f)
-        return applicable(completions, opts, partial, offset, index) ?
-            completions(opts, partial, offset, index; hint) :
-            completions(opts, partial; hint)
-    end
-end
-
 compound_declarations = [
 "package" => CommandDeclaration[
 PSA[:name => "test",
@@ -21,7 +10,7 @@ PSA[:name => "test",
     :option_spec => [
         PSA[:name => "coverage", :api => :coverage => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "run tests for packages",
     :help => md"""
     test [--coverage] [pkg[=uuid]] ...
@@ -38,7 +27,7 @@ PSA[:name => "help",
     :api => identity, # dummy API function
     :arg_count => 0 => Inf,
     :arg_parser => ((x,y) -> x),
-    :completions => get_complete_function(:complete_help),
+    :completions => :complete_help,
     :description => "show this message",
     :help => md"""
     [?|help]
@@ -83,7 +72,7 @@ PSA[:name => "remove",
         PSA[:name => "manifest", :short_name => "m", :api => :mode => PKGMODE_MANIFEST],
         PSA[:name => "all", :api => :all_pkgs => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "remove packages from project or manifest",
     :help => md"""
     [rm|remove] [-p|--project] pkg[=uuid] ...
@@ -118,7 +107,7 @@ PSA[:name => "add",
         PSA[:name => "weak", :short_name => "w", :api => :target => :weakdeps],
         PSA[:name => "extra", :short_name => "e", :api => :target => :extras],
     ],
-    :completions => get_complete_function(:complete_add_dev),
+    :completions => :complete_add_dev,
     :description => "add packages to project",
     :help => md"""
     add [--preserve=<opt>] [-w|--weak] [-e|--extra] pkg[=uuid] [@version] [#rev] ...
@@ -192,7 +181,7 @@ PSA[:name => "develop",
         PSA[:name => "shared", :api => :shared => true],
         PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
-    :completions => get_complete_function(:complete_add_dev),
+    :completions => :complete_add_dev,
     :description => "clone the full package repo locally for development",
     :help => md"""
     [dev|develop] [--preserve=<opt>] [--shared|--local] pkg[=uuid] ...
@@ -228,7 +217,7 @@ PSA[:name => "free",
         PSA[:name => "all", :api => :all_pkgs => true],
     ],
     :arg_parser => parse_package,
-    :completions => get_complete_function(:complete_fixed_packages),
+    :completions => :complete_fixed_packages,
     :description => "undoes a `pin`, `develop`, or stops tracking a repo",
     :help => md"""
     free pkg[=uuid] ...
@@ -246,7 +235,7 @@ PSA[:name => "why",
         PSA[:name => "workspace", :api => :workspace => true],
     ],
     :arg_parser => parse_package,
-    :completions => get_complete_function(:complete_all_installed_packages),
+    :completions => :complete_all_installed_packages,
     :description => "shows why a package is in the manifest",
     :help => md"""
     why [--workspace] pkg[=uuid] ...
@@ -268,7 +257,7 @@ PSA[:name => "pin",
         PSA[:name => "all", :api => :all_pkgs => true],
     ],
     :arg_parser => parse_package,
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "pins the version of packages",
     :help => md"""
     pin pkg[=uuid] ...
@@ -294,7 +283,7 @@ PSA[:name => "build",
     :option_spec => [
         PSA[:name => "verbose", :short_name => "v", :api => :verbose => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "run the build script for packages",
     :help => md"""
     build [-v|--verbose] pkg[=uuid] ...
@@ -323,7 +312,7 @@ PSA[:name => "activate",
         PSA[:name => "shared", :api => :shared => true],
         PSA[:name => "temp", :api => :temp => true],
     ],
-    :completions => get_complete_function(:complete_activate),
+    :completions => :complete_activate,
     :description => "set the primary environment the package manager manipulates",
     :help => md"""
     activate
@@ -359,7 +348,7 @@ PSA[:name => "update",
         PSA[:name => "fixed", :api => :level => UPLEVEL_FIXED],
         PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "update packages in manifest",
     :help => md"""
     [up|update] [-p|--project]  [opts] pkg[=uuid] [@version] ...
@@ -394,7 +383,7 @@ Create a minimal project called `pkgname` in the current folder. For more featur
 PSA[:name => "precompile",
     :api => API.precompile,
     :arg_count => 0 => Inf,
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "precompile all the project dependencies",
     :option_spec => [
         PSA[:name => "workspace", :api => :workspace => true],
@@ -431,7 +420,7 @@ PSA[:name => "status",
         PSA[:name => "extensions", :short_name => "e", :api => :extensions => true],
         PSA[:name => "workspace", :api => :workspace => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "summarize contents of and changes to environment",
     :help => md"""
     [st|status] [-d|--diff] [--workspace] [-o|--outdated] [pkgs...]
@@ -466,7 +455,7 @@ The `--workspace` option shows the (merged) status of packages in the workspace.
 PSA[:name => "compat",
     :api => API.compat,
     :arg_count => 0 => 2,
-    :completions => get_complete_function(:complete_installed_packages_and_compat),
+    :completions => :complete_installed_packages_and_compat,
     :description => "edit compat entries in the current Project and re-resolve",
     :help => md"""
     compat [pkg] [compat_string]


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/54906

The problem was that `get_extension` is failing to find REPLExt when Pkg is loaded via `require_stdlib`.

![Screenshot 2024-07-21 at 6 31 19 PM](https://github.com/user-attachments/assets/802668c9-2f65-41bb-b36e-a43a2a642751)
