### PR TITLE
Backports release 1.11

### DIFF
--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -192,6 +192,14 @@ force these packages to be retried, as `pkg> precompile` will always retry all p
 
 To disable the auto-precompilation, set `ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0`.
 
+The indicators next to the package names displayed during precompilation
+indicate the status of that package's precompilation. 
+
+- `[◐, ◓, ◑, ◒]` Animated "clock" characters indicate that the package is currently being precompiled.
+- `✓` A green checkmark indicates that the package has been successfully precompiled (after which that package will disappear from the list). If the checkmark is yellow it means that the package is currently loaded so the session will need to be restarted to access the version that was just precompiled.
+- `?` A question mark character indicates that a `PrecompilableError` was thrown, indicating that precompilation was disallowed, i.e. `__precompile__(false)` in that package.
+- `✗` A cross indicates that the package failed to precompile.
+
 ### Precompiling new versions of loaded packages
 
 If a package that has been updated is already loaded in the session, the precompilation process will go ahead and precompile

--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -311,7 +311,9 @@ function __init__()
             end
         end
     end
-    push!(empty!(REPL.install_packages_hooks), try_prompt_pkg_add)
+    if !in(try_prompt_pkg_add, REPL.install_packages_hooks)
+        push!(REPL.install_packages_hooks, try_prompt_pkg_add)
+    end
 end
 
 include("precompile.jl")

--- a/ext/REPLExt/completions.jl
+++ b/ext/REPLExt/completions.jl
@@ -194,6 +194,21 @@ complete_opt(opt_specs) =
 function complete_argument(spec::CommandSpec, options::Vector{String},
                            partial::AbstractString, offset::Int,
                            index::Int; hint::Bool)
+    if spec.completions isa Symbol
+        # if completions is a symbol, it is a function in REPLExt that needs to be forwarded
+        # to REPLMode (couldn't be linked there because REPLExt is not a dependency of REPLMode)
+        completions = try
+            getglobal(REPLExt, spec.completions)
+        catch
+            @error "REPLMode indicates a completion function called :$(spec.completions) that cannot be found in REPLExt"
+            rethrow()
+        end
+        spec.completions = function(opts, partial, offset, index; hint::Bool)
+                applicable(completions, opts, partial, offset, index) ?
+                    completions(opts, partial, offset, index; hint) :
+                    completions(opts, partial; hint)
+            end
+    end
     spec.completions === nothing && return String[]
     # finish parsing opts
     local opts

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -14,6 +14,7 @@ using Base.BinaryPlatforms
 import ...Pkg
 import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
+import ...Pkg: usable_io
 
 #########
 # Utils #
@@ -769,7 +770,7 @@ function download_artifacts(env::EnvCache;
             # For each Artifacts.toml, install each artifact we've collected from it
             for name in keys(artifacts)
                 ensure_artifact_installed(name, artifacts[name], artifacts_toml;
-                                            verbose, quiet_download=!(io isa Base.TTY), io=io)
+                                            verbose, quiet_download=!(usable_io(io)), io=io)
             end
             write_env_usage(artifacts_toml, "artifact_usage.toml")
         end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2293,6 +2293,7 @@ function status_ext_info(pkg::PackageSpec, env::EnvCache)
         v = ExtInfo[]
         for (ext, extdeps) in exts
             extdeps isa String && (extdeps = String[extdeps])
+            # Note: `get_extension` returns nothing for stdlibs that are loaded via `require_stdlib`
             ext_loaded = (Base.get_extension(Base.PkgId(pkg.uuid, pkg.name), Symbol(ext)) !== nothing)
             # Check if deps are loaded
             extdeps_info= Tuple{String, Bool}[]

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -56,7 +56,8 @@ stderr_f() = something(DEFAULT_IO[], unstableio(stderr))
 stdout_f() = something(DEFAULT_IO[], unstableio(stdout))
 const PREV_ENV_PATH = Ref{String}("")
 
-can_fancyprint(io::IO) = ((io isa Base.TTY) || (io isa IOContext{IO} && io.io isa Base.TTY)) && (get(ENV, "CI", nothing) != "true")
+usable_io(io) = (io isa Base.TTY) || (io isa IOContext{IO} && io.io isa Base.TTY)
+can_fancyprint(io::IO) = (usable_io(io)) && (get(ENV, "CI", nothing) != "true")
 should_autoprecompile() = Base.JLOptions().use_compiled_modules == 1 && Base.get_bool_env("JULIA_PKG_PRECOMPILE_AUTO", true)
 
 include("utils.jl")

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -17,6 +17,9 @@ export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
 export PreserveLevel, PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 export Registry, RegistrySpec
 
+public activate, add, build, compat, develop, free, gc, generate, instantiate, 
+       pin, precompile, redo, rm, resolve, status, test, undo, update, why
+
 depots() = Base.DEPOT_PATH
 function depots1()
     d = depots()

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -17,7 +17,7 @@ export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
 export PreserveLevel, PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 export Registry, RegistrySpec
 
-public activate, add, build, compat, develop, free, gc, generate, instantiate, 
+public activate, add, build, compat, develop, free, gc, generate, instantiate,
        pin, precompile, redo, rm, resolve, status, test, undo, update, why
 
 depots() = Base.DEPOT_PATH
@@ -266,13 +266,17 @@ const update = API.up
     Pkg.test(pkgs::Union{PackageSpec, Vector{PackageSpec}}; kwargs...)
 
 **Keyword arguments:**
-  - `coverage::Bool=false`: enable or disable generation of coverage statistics.
+  - `coverage::Union{Bool,String}=false`: enable or disable generation of coverage statistics for the tested package.
+    If a string is passed it is passed directly to `--code-coverage` in the test process so e.g. "user" will test all user code.
   - `allow_reresolve::Bool=true`: allow Pkg to reresolve the package versions in the test environment
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
 
 !!! compat "Julia 1.9"
     `allow_reresolve` requires at least Julia 1.9.
+
+!!! compat "Julia 1.9"
+    Passing a string to `coverage` requires at least Julia 1.9.
 
 Run the tests for package `pkg`, or for the current project (which thus needs to be a package) if no
 positional argument is given to `Pkg.test`. A package is tested by running its

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -64,16 +64,16 @@ end
 # Commands #
 #----------#
 const CommandDeclaration = Vector{Pair{Symbol,Any}}
-struct CommandSpec
-    canonical_name::String
-    short_name::Union{Nothing,String}
-    api::Function
-    should_splat::Bool
-    argument_spec::ArgSpec
-    option_specs::Dict{String,OptionSpec}
-    completions::Union{Nothing,Function}
-    description::String
-    help::Union{Nothing,Markdown.MD}
+mutable struct CommandSpec
+    const canonical_name::String
+    const short_name::Union{Nothing,String}
+    const api::Function
+    const should_splat::Bool
+    const argument_spec::ArgSpec
+    const option_specs::Dict{String,OptionSpec}
+    completions::Union{Nothing,Symbol,Function} # Symbol is used as a marker for REPLExt to assign the function of that name
+    const description::String
+    const help::Union{Nothing,Markdown.MD}
 end
 
 default_parser(xs, options) = unwrap(xs)
@@ -84,7 +84,7 @@ function CommandSpec(;name::Union{Nothing,String}           = nothing,
                      option_spec::Vector{OptionDeclaration} = OptionDeclaration[],
                      help::Union{Nothing,Markdown.MD}       = nothing,
                      description::Union{Nothing,String}     = nothing,
-                     completions::Union{Nothing,Function}   = nothing,
+                     completions::Union{Nothing,Symbol,Function}   = nothing,
                      arg_count::Pair                        = (0=>0),
                      arg_parser::Function                   = default_parser,
                      )::CommandSpec

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -1,16 +1,5 @@
 const PSA = Pair{Symbol,Any}
 
-function get_complete_function(f)
-    return function(opts, partial, offset, index; hint::Bool)
-        m = Base.get_extension(@__MODULE__, :REPLExt)
-        m === nothing && return String[]
-        completions = getglobal(m, f)
-        return applicable(completions, opts, partial, offset, index) ?
-            completions(opts, partial, offset, index; hint) :
-            completions(opts, partial; hint)
-    end
-end
-
 compound_declarations = [
 "package" => CommandDeclaration[
 PSA[:name => "test",
@@ -21,7 +10,7 @@ PSA[:name => "test",
     :option_spec => [
         PSA[:name => "coverage", :api => :coverage => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "run tests for packages",
     :help => md"""
     test [--coverage] pkg[=uuid] ...
@@ -37,7 +26,7 @@ PSA[:name => "help",
     :api => identity, # dummy API function
     :arg_count => 0 => Inf,
     :arg_parser => ((x,y) -> x),
-    :completions => get_complete_function(:complete_help),
+    :completions => :complete_help,
     :description => "show this message",
     :help => md"""
     [?|help]
@@ -80,7 +69,7 @@ PSA[:name => "remove",
         PSA[:name => "manifest", :short_name => "m", :api => :mode => PKGMODE_MANIFEST],
         PSA[:name => "all", :api => :all_pkgs => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "remove packages from project or manifest",
     :help => md"""
     [rm|remove] [-p|--project] pkg[=uuid] ...
@@ -115,7 +104,7 @@ PSA[:name => "add",
         PSA[:name => "weak", :short_name => "w", :api => :target => :weakdeps],
         PSA[:name => "extra", :short_name => "e", :api => :target => :extras],
     ],
-    :completions => get_complete_function(:complete_add_dev),
+    :completions => :complete_add_dev,
     :description => "add packages to project",
     :help => md"""
     add [--preserve=<opt>] [-w|--weak] [-e|--extra] pkg[=uuid] [@version] [#rev] ...
@@ -189,7 +178,7 @@ PSA[:name => "develop",
         PSA[:name => "shared", :api => :shared => true],
         PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
-    :completions => get_complete_function(:complete_add_dev),
+    :completions => :complete_add_dev,
     :description => "clone the full package repo locally for development",
     :help => md"""
     [dev|develop] [--preserve=<opt>] [--shared|--local] pkg[=uuid] ...
@@ -225,7 +214,7 @@ PSA[:name => "free",
         PSA[:name => "all", :api => :all_pkgs => true],
     ],
     :arg_parser => parse_package,
-    :completions => get_complete_function(:complete_fixed_packages),
+    :completions => :complete_fixed_packages,
     :description => "undoes a `pin`, `develop`, or stops tracking a repo",
     :help => md"""
     free pkg[=uuid] ...
@@ -240,7 +229,7 @@ PSA[:name => "why",
     :should_splat => false,
     :arg_count => 1 => 1,
     :arg_parser => parse_package,
-    :completions => get_complete_function(:complete_all_installed_packages),
+    :completions => :complete_all_installed_packages,
     :description => "shows why a package is in the manifest",
     :help => md"""
     why pkg[=uuid] ...
@@ -260,7 +249,7 @@ PSA[:name => "pin",
         PSA[:name => "all", :api => :all_pkgs => true],
     ],
     :arg_parser => parse_package,
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "pins the version of packages",
     :help => md"""
     pin pkg[=uuid] ...
@@ -286,7 +275,7 @@ PSA[:name => "build",
     :option_spec => [
         PSA[:name => "verbose", :short_name => "v", :api => :verbose => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "run the build script for packages",
     :help => md"""
     build [-v|--verbose] pkg[=uuid] ...
@@ -315,7 +304,7 @@ PSA[:name => "activate",
         PSA[:name => "shared", :api => :shared => true],
         PSA[:name => "temp", :api => :temp => true],
     ],
-    :completions => get_complete_function(:complete_activate),
+    :completions => :complete_activate,
     :description => "set the primary environment the package manager manipulates",
     :help => md"""
     activate
@@ -351,7 +340,7 @@ PSA[:name => "update",
         PSA[:name => "fixed", :api => :level => UPLEVEL_FIXED],
         PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "update packages in manifest",
     :help => md"""
     [up|update] [-p|--project]  [opts] pkg[=uuid] [@version] ...
@@ -386,7 +375,7 @@ Create a minimal project called `pkgname` in the current folder. For more featur
 PSA[:name => "precompile",
     :api => API.precompile,
     :arg_count => 0 => Inf,
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "precompile all the project dependencies",
     :help => md"""
     precompile
@@ -418,7 +407,7 @@ PSA[:name => "status",
         PSA[:name => "compat", :short_name => "c", :api => :compat => true],
         PSA[:name => "extensions", :short_name => "e", :api => :extensions => true],
     ],
-    :completions => get_complete_function(:complete_installed_packages),
+    :completions => :complete_installed_packages,
     :description => "summarize contents of and changes to environment",
     :help => md"""
     [st|status] [-d|--diff] [-o|--outdated] [pkgs...]
@@ -452,7 +441,7 @@ The `--compat` option alone shows project compat entries.
 PSA[:name => "compat",
     :api => API.compat,
     :arg_count => 0 => 2,
-    :completions => get_complete_function(:complete_installed_packages_and_compat),
+    :completions => :complete_installed_packages_and_compat,
     :description => "edit compat entries in the current Project and re-resolve",
     :help => md"""
     compat [pkg] [compat_string]

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -7,6 +7,8 @@ using ..Pkg.PlatformEngines: download_verify_unpack, download, download_verify, 
 using UUIDs, LibGit2, TOML, Dates
 import FileWatching
 
+public add, rm, status, update
+
 include("registry_instance.jl")
 
 mutable struct RegistrySpec

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -536,7 +536,12 @@ function write_env_usage(source_file::AbstractString, usage_filepath::AbstractSt
     ## Atomically write usage file using process id locking
     FileWatching.mkpidlock(usage_file * ".pid", stale_age = 3) do
         usage = if isfile(usage_file)
-            TOML.parsefile(usage_file)
+            try
+                TOML.parsefile(usage_file)
+            catch err
+                @warn "Failed to parse usage file `$usage_file`, ignoring." err
+                Dict{String, Any}()
+            end
         else
             Dict{String, Any}()
         end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -552,8 +552,15 @@ function write_env_usage(source_file::AbstractString, usage_filepath::AbstractSt
             usage[k] = [Dict("time" => maximum(times))]
         end
 
-        open(usage_file, "w") do io
-            TOML.print(io, usage, sorted=true)
+        tempfile = tempname()
+        try
+            open(tempfile, "w") do io
+                TOML.print(io, usage, sorted=true)
+            end
+            TOML.parsefile(tempfile) # compare to `usage` ?
+            mv(tempfile, usage_file; force=true) # only mv if parse succeeds
+        catch err
+            @error "Failed to write valid usage file `$usage_file`" tempfile
         end
     end
     return

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -217,6 +217,12 @@ function find_project_file(env::Union{Nothing,String}=nothing)
                 abspath(env, Base.project_names[end])
         end
     end
+    if isfile(project_file) && !contains(basename(project_file), "Project")
+        pkgerror("""
+        The active project has been set to a file that isn't a Project file: $project_file
+        The project path must be to a Project file or directory.
+        """)
+    end
     @assert project_file isa String &&
         (isfile(project_file) || !ispath(project_file) ||
          isdir(project_file) && isempty(readdir(project_file)))


### PR DESCRIPTION
Backported PRs:
- [x] #3934 <!-- rm `empty!` on `install_packages_hooks` -->
- [x] #3928 <!-- check parse before moving usage file into place -->
- [x] #3894 <!-- catch if the active project is erroneously set to a manifest file -->
- [x] #3932 <!-- Don't retry artifact downloads on `SystemError`, like `no space left on device` -->
- [x] #3903 <!-- Add some documentation describing how to interpret the symbols shown during recompilation -->
- [x] #3945 <!-- Mark API public -->
- [x] #3951 <!-- fix artifact printing quiet rule -->
- [x] #3959 <!-- don't use `get_extension` to bridge REPLExt to REPLMode -->
- [x] #3957 <!-- Pkg.test: document that coverage can be a string -->
- [x] #3962 <!-- Make manifest usage log errors non-fatal -->


