### PR TITLE
[release-1.10] Backports 1.10

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -165,19 +165,16 @@ end
 # This has to be done after the packages have been downloaded
 # since we need access to the Project file to read the information
 # about extensions
-function fixup_ext!(env, pkgs)
-    for pkg in pkgs
+function fixup_ext!(env::EnvCache)
+    for pkg in values(env.manifest)
         v = joinpath(source_path(env.manifest_file, pkg), "Project.toml")
-        if haskey(env.manifest, pkg.uuid)
-            entry = env.manifest[pkg.uuid]
-            if isfile(v)
-                p = Types.read_project(v)
-                entry.weakdeps = p.weakdeps
-                entry.exts = p.exts
-                for (name, _) in p.weakdeps
-                    if !haskey(p.deps, name)
-                        delete!(entry.deps, name)
-                    end
+        if isfile(v)
+            p = Types.read_project(v)
+            pkg.weakdeps = p.weakdeps
+            pkg.exts = p.exts
+            for (name, _) in p.weakdeps
+                if !haskey(p.deps, name)
+                    delete!(pkg.deps, name)
                 end
             end
         end
@@ -1388,7 +1385,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
     pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
-    fixup_ext!(ctx.env, pkgs)
+    fixup_ext!(ctx.env)
 
     # After downloading resolutionary packages, search for (Julia)Artifacts.toml files
     # and ensure they are all downloaded and unpacked as well:
@@ -1411,7 +1408,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Set{UUID};
     pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
-    fixup_ext!(ctx.env, pkgs)
+    fixup_ext!(ctx.env)
     download_artifacts(ctx.env; platform=platform, julia_version=ctx.julia_version, io=ctx.io)
     write_env(ctx.env) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io)
@@ -1539,7 +1536,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
     end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new_apply = download_source(ctx)
-    fixup_ext!(ctx.env, pkgs)
+    fixup_ext!(ctx.env)
     download_artifacts(ctx.env, julia_version=ctx.julia_version, io=ctx.io)
     write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io, hidden_upgrades_info = true)
@@ -1585,7 +1582,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec})
 
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
     new = download_source(ctx)
-    fixup_ext!(ctx.env, pkgs)
+    fixup_ext!(ctx.env)
     download_artifacts(ctx.env; julia_version=ctx.julia_version, io=ctx.io)
     write_env(ctx.env) # write env before building
     show_update(ctx.env, ctx.registries; io=ctx.io)
@@ -1629,7 +1626,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free=true)
 
         update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version)
         new = download_source(ctx)
-        fixup_ext!(ctx.env, pkgs)
+        fixup_ext!(ctx.env)
         download_artifacts(ctx.env, io=ctx.io)
         write_env(ctx.env) # write env before building
         show_update(ctx.env, ctx.registries; io=ctx.io)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -167,9 +167,11 @@ end
 # about extensions
 function fixup_ext!(env::EnvCache)
     for pkg in values(env.manifest)
-        v = joinpath(source_path(env.manifest_file, pkg), "Project.toml")
-        if isfile(v)
-            p = Types.read_project(v)
+        # isfile_casesenstive within locate_project_file used to error on Windows if given a
+        # relative path so abspath it to be extra safe https://github.com/JuliaLang/julia/pull/55220
+        project_file = Base.locate_project_file(abspath(source_path(env.manifest_file, pkg)))
+        if isfile(project_file)
+            p = Types.read_project(project_file)
             pkg.weakdeps = p.weakdeps
             pkg.exts = p.exts
             for (name, _) in p.weakdeps

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -170,7 +170,7 @@ function fixup_ext!(env::EnvCache)
         # isfile_casesenstive within locate_project_file used to error on Windows if given a
         # relative path so abspath it to be extra safe https://github.com/JuliaLang/julia/pull/55220
         project_file = Base.locate_project_file(abspath(source_path(env.manifest_file, pkg)))
-        if isfile(project_file)
+        if project_file isa String && isfile(project_file)
             p = Types.read_project(project_file)
             pkg.weakdeps = p.weakdeps
             pkg.exts = p.exts

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -242,13 +242,17 @@ const update = API.up
     Pkg.test(pkgs::Union{PackageSpec, Vector{PackageSpec}}; kwargs...)
 
 **Keyword arguments:**
-  - `coverage::Bool=false`: enable or disable generation of coverage statistics.
+  - `coverage::Union{Bool,String}=false`: enable or disable generation of coverage statistics for the tested package.
+    If a string is passed it is passed directly to `--code-coverage` in the test process so e.g. "user" will test all user code.
   - `allow_reresolve::Bool=true`: allow Pkg to reresolve the package versions in the test environment
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
 
 !!! compat "Julia 1.9"
     `allow_reresolve` requires at least Julia 1.9.
+
+!!! compat "Julia 1.9"
+    Passing a string to `coverage` requires at least Julia 1.9.
 
 Run the tests for package `pkg`, or for the current project (which thus needs to be a package) if no
 positional argument is given to `Pkg.test`. A package is tested by running its

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -544,7 +544,12 @@ function write_env_usage(source_file::AbstractString, usage_filepath::AbstractSt
     ## Atomically write usage file using process id locking
     FileWatching.mkpidlock(usage_file * ".pid", stale_age = 3) do
         usage = if isfile(usage_file)
-            TOML.parsefile(usage_file)
+            try
+                TOML.parsefile(usage_file)
+            catch err
+                @warn "Failed to parse usage file `$usage_file`, ignoring." err
+                Dict{String, Any}()
+            end
         else
             Dict{String, Any}()
         end


### PR DESCRIPTION
Backported PRs:
- [x] #3962 <!-- Make manifest usage log errors non-fatal -->
- [x] #3957 <!-- Pkg.test: document that coverage can be a string -->
- [x] #3851 <!-- fix not hardcoding "Project.toml" when fixing up extensions in manifest -->
- [x] #3720 <!-- extensions: fixup entire manifest -->
- [x] https://github.com/JuliaLang/Pkg.jl/pull/3967 (should fix the breakage)