### PR TITLE
fix suggestions threshold for printing

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1114,8 +1114,8 @@ function ensure_resolved(ctx::Context, manifest::Manifest,
                     join(io, what, ", ", " or ")
                     print(io, ")")
                     all_names = available_names(ctx; manifest, include_registries = registry)
-                    all_names_ranked, any_score_gt_zero = fuzzysort(name, all_names)
-                    if any_score_gt_zero
+                    all_names_ranked, any_score_gt_thresh = fuzzysort(name, all_names)
+                    if any_score_gt_thresh
                         println(io)
                         prefix = "   Suggestions:"
                         printstyled(io, prefix, color = Base.info_color())
@@ -1140,7 +1140,7 @@ end
 # copied from REPL to efficiently expose if any score is >0
 function fuzzysort(search::String, candidates::Vector{String})
     scores = map(cand -> (FuzzySorting.fuzzyscore(search, cand), -Float64(FuzzySorting.levenshtein(search, cand))), candidates)
-    candidates[sortperm(scores)] |> reverse, any(s -> s[1] > 0, scores)
+    candidates[sortperm(scores)] |> reverse, any(s -> s[1] >= 0.5, scores)
 end
 
 function available_names(ctx::Context = Context(); manifest::Manifest = ctx.env.manifest, include_registries::Bool = true)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1114,7 +1114,7 @@ function ensure_resolved(ctx::Context, manifest::Manifest,
                     join(io, what, ", ", " or ")
                     print(io, ")")
                     all_names = available_names(ctx; manifest, include_registries = registry)
-                    all_names_ranked, any_score_gt_thresh = fuzzysort(name, all_names)
+                    all_names_ranked, any_score_gt_thresh = FuzzySorting.fuzzysort(name, all_names)
                     if any_score_gt_thresh
                         println(io)
                         prefix = "   Suggestions:"
@@ -1135,12 +1135,6 @@ function ensure_resolved(ctx::Context, manifest::Manifest,
         end
     end
     pkgerror(msg)
-end
-
-# copied from REPL to efficiently expose if any score is >0
-function fuzzysort(search::String, candidates::Vector{String})
-    scores = map(cand -> (FuzzySorting.fuzzyscore(search, cand), -Float64(FuzzySorting.levenshtein(search, cand))), candidates)
-    candidates[sortperm(scores)] |> reverse, any(s -> s[1] >= 0.5, scores)
 end
 
 function available_names(ctx::Context = Context(); manifest::Manifest = ctx.env.manifest, include_registries::Bool = true)

--- a/src/fuzzysorting.jl
+++ b/src/fuzzysorting.jl
@@ -90,8 +90,8 @@ function fuzzyscore(needle::AbstractString, haystack::AbstractString)
 end
 
 function fuzzysort(search::String, candidates::Vector{String})
-    scores = map(cand -> fuzzyscore(search, cand), candidates)
-    candidates[sortperm(scores)] |> reverse
+    scores = map(cand -> (FuzzySorting.fuzzyscore(search, cand), -Float64(FuzzySorting.levenshtein(search, cand))), candidates)
+    candidates[sortperm(scores)] |> reverse, any(s -> s[1] >= print_score_threshold, scores)
 end
 
 # Levenshtein Distance
@@ -137,11 +137,13 @@ function printmatch(io::IO, word, match)
     end
 end
 
+const print_score_threshold = 0.5
+
 function printmatches(io::IO, word, matches; cols::Int = _displaysize(io)[2])
     total = 0
     for match in matches
         total + length(match) + 1 > cols && break
-        fuzzyscore(word, match) < 0.5 && break
+        fuzzyscore(word, match) < print_score_threshold && break
         print(io, " ")
         printmatch(io, word, match)
         total += length(match) + 1


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3958

IIUC `FuzzySorting.printmatches` uses a threshold of < 0.5 to ignore results, not zero.

https://github.com/JuliaLang/Pkg.jl/blob/a66ab60b9bd5e9ed5c147a82e0130d72863e40a8/src/fuzzysorting.jl#L144

```
(Pkg) pkg> up nomatchname
    Updating registry at `~/.julia/registries/General.toml`
ERROR: The following package names could not be resolved:
 * nomatchname (not found in project or manifest)
```
```
(jl_uMrfTz) pkg> add VideoIOI
ERROR: The following package names could not be resolved:
 * VideoIOI (not found in project, manifest or registry)
   Suggestions: VideoIO FileIO GeoIO
```