### PR TITLE
Fix handling of `PackageSpec` with un-specified version

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1524,8 +1524,10 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
             compat_names = String[]
             for pkg in pkgs
                 haskey(ctx.env.project.compat, pkg.name) && continue
-                pkgversion = Base.thispatch(ctx.env.manifest[pkg.uuid].version)
-                set_compat(ctx.env.project, pkg.name, string(pkgversion))
+                v = ctx.env.manifest[pkg.uuid].version
+                v === nothing && continue
+                pkgversion = string(Base.thispatch(v))
+                set_compat(ctx.env.project, pkg.name, pkgversion)
                 push!(compat_names, pkg.name)
             end
             printpkgstyle(ctx.io, :Compat, """entries added for $(join(compat_names, ", "))""")


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/Pkg.jl/issues/3885.

I could use a bit of help to add an appropriate test - Looks like this was regressed in https://github.com/JuliaLang/Pkg.jl/pull/3732