### PR TITLE
Download progress fixes. Show compressed registry add confirmation.

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -279,7 +279,7 @@ function download(
             end
         end
     else
-        (total, now) -> nothing
+        nothing
     end
     try
         Downloads.download(url, dest; headers, progress)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -275,7 +275,11 @@ function download(
             (total, now) -> begin
                 bar.max = total
                 bar.current = now
-                show_progress(io, bar)
+                # Downloads.download attatches the progress indicator to the header request too
+                # which is only ~100 bytes, and will report as 0 - 100% progress immediately
+                # then dip down to 0 before the actual download starts. So we only show the
+                # progress bar once the real download starts.
+                total > 1000 && show_progress(io, bar)
             end
         end
     else

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -206,6 +206,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depot::String=d
             open(joinpath(regdir, reg.name * ".toml"), "w") do io
                 TOML.print(io, reg_info)
             end
+            printpkgstyle(io, :Added, "`$(reg.name)` registry to $(Base.contractuser(regdir))")
         else
             mktempdir() do tmp
                 if reg.path !== nothing && reg.linked == true # symlink to local source


### PR DESCRIPTION
1) There was no confirmation after the compressed registry was downloaded

Fixes https://github.com/JuliaLang/Pkg.jl/issues/3747

___

2) Downloads.jl shortcuts creating an async task if progress == nothing  https://github.com/JuliaLang/Downloads.jl/blob/29954592f49052159af2cce536f0f4e11efe540b/src/Downloads.jl#L400
___

3) Skip showing the progress bar during the initial header download to prevent it looking glitchy

 Fixes #3977 

