### PR TITLE
Backport #3276 to 1.10

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1746,7 +1746,6 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
                  force_latest_compatible_version::Bool=false,
                  allow_earlier_backwards_compatible_versions::Bool=true,
                  allow_reresolve::Bool=true)
-    active_manifest = manifestfile_path(dirname(ctx.env.manifest_file))
     sandbox_project = projectfile_path(sandbox_path)
 
     mktempdir() do tmp
@@ -1768,15 +1767,15 @@ function sandbox(fn::Function, ctx::Context, target::PackageSpec, target_path::S
         # - copy over fixed subgraphs from test subgraph
         # really only need to copy over "special" nodes
         sandbox_env = Types.EnvCache(projectfile_path(sandbox_path))
-        sandbox_manifest = abspath!(sandbox_env, sandbox_env.manifest)
-        for (name, uuid) in sandbox_env.project.deps
-            entry = get(sandbox_manifest, uuid, nothing)
-            if entry !== nothing && isfixed(entry)
-                subgraph = prune_manifest(sandbox_manifest, [uuid])
-                for (uuid, entry) in subgraph
-                    if haskey(working_manifest, uuid)
-                        pkgerror("can not merge projects")
-                    end
+        abspath!(sandbox_env, sandbox_env.manifest)
+        for (uuid, entry) in sandbox_env.manifest.deps
+            entry_working = get(working_manifest, uuid, nothing)
+            if entry_working === nothing
+                working_manifest[uuid] = entry
+            else # Check for collision between the sandbox manifest and the "parent" manifest
+                if entry_working != entry && (ctx.env.pkg !== nothing && ctx.env.pkg.uuid != uuid)
+                    @warn "Entry in manifest at \"$sandbox_path\" for package \"$(entry_working.name)\" differs from that in \"$(ctx.env.manifest_file)\""
+                else
                     working_manifest[uuid] = entry
                 end
             end


### PR DESCRIPTION
Following a discussion on Slack with @KristofferC and @MasonProtter, it would be good to have better test env merging in the future LTS.

This PR takes the changes of #3276 and adds them to the `release-1.10` branch. Disclaimer: I have zero clue what this code does, this is pure copy-pasting.