### PR TITLE
Add `julia_version_strict` option to `instantiate`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1166,14 +1166,14 @@ instantiate(; kwargs...) = instantiate(Context(); kwargs...)
 function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
                      update_registry::Bool=true, verbose::Bool=false,
                      platform::AbstractPlatform=HostPlatform(), allow_build::Bool=true, allow_autoprecomp::Bool=true,
-                     workspace::Bool=false, kwargs...)
+                     workspace::Bool=false, julia_version_strict::Bool=false, kwargs...)
     Context!(ctx; kwargs...)
     if Registry.download_default_registries(ctx.io)
         copy!(ctx.registries, Registry.reachable_registries())
     end
     if !isfile(ctx.env.project_file) && isfile(ctx.env.manifest_file)
         _manifest = Pkg.Types.read_manifest(ctx.env.manifest_file)
-        Types.check_warn_manifest_julia_version_compat(_manifest, ctx.env.manifest_file)
+        Types.check_manifest_julia_version_compat(_manifest, ctx.env.manifest_file; julia_version_strict)
         deps = Dict{String,String}()
         for (uuid, pkg) in _manifest
             if pkg.name in keys(deps)
@@ -1195,7 +1195,7 @@ function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing,
     if !isfile(ctx.env.manifest_file) && manifest == true
         pkgerror("expected manifest file at `$(ctx.env.manifest_file)` but it does not exist")
     end
-    Types.check_warn_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file)
+    Types.check_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file; julia_version_strict)
 
     if Operations.is_manifest_current(ctx.env) === false
         @warn """The project dependencies or compat requirements have changed since the manifest was last resolved.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -485,7 +485,7 @@ Request a `ProjectInfo` struct which contains information about the active proje
 const project = API.project
 
 """
-    Pkg.instantiate(; verbose = false, workspace=false, io::IO=stderr)
+    Pkg.instantiate(; verbose = false, workspace=false, io::IO=stderr, julia_version_strict=false)
 
 If a `Manifest.toml` file exists in the active project, download all
 the packages declared in that manifest.
@@ -496,6 +496,7 @@ redirecting to the `build.log` file.
 `workspace=true` will also instantiate all projects in the workspace.
 If no `Project.toml` exist in the current active project, create one with all the
 dependencies in the manifest and instantiate the resulting project.
+`julia_version_strict=true` will turn manifest version check failures into errors instead of logging warnings.
 
 After packages have been installed the project will be precompiled.
 See more at [Environment Precompilation](@ref).

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -500,6 +500,9 @@ dependencies in the manifest and instantiate the resulting project.
 
 After packages have been installed the project will be precompiled.
 See more at [Environment Precompilation](@ref).
+
+!!! compat "Julia 1.12"
+    The `julia_version_strict` keyword argument requires at least Julia 1.12.
 """
 const instantiate = API.instantiate
 

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -47,16 +47,18 @@ PSA[:name => "instantiate",
         PSA[:name => "manifest", :short_name => "m", :api => :manifest => true],
         PSA[:name => "verbose", :short_name => "v", :api => :verbose => true],
         PSA[:name => "workspace", :api => :workspace => true],
+        PSA[:name => "julia_version_strict", :api => :julia_version_strict => false],
     ],
     :description => "downloads all the dependencies for the project",
     :help => md"""
-    instantiate [-v|--verbose] [--workspace]
-    instantiate [-v|--verbose] [--workspace] [-m|--manifest]
-    instantiate [-v|--verbose] [--workspace] [-p|--project]
+    instantiate [-v|--verbose] [--workspace] [--julia_version_strict]
+    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-m|--manifest]
+    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-p|--project]
 
 Download all the dependencies for the current project at the version given by the project's manifest.
 If no manifest exists or the `--project` option is given, resolve and download the dependencies compatible with the project.
 If `--workspace` is given, all dependencies in the workspace will be downloaded.
+If `--julia_version_strict` is given, manifest version check failures will error instead of log warnings.
 
 After packages have been installed the project will be precompiled. For more information see `pkg> ?precompile`.
 """,

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -347,21 +347,36 @@ end
 # METADATA #
 ############
 
-function check_warn_manifest_julia_version_compat(manifest::Manifest, manifest_file::String)
+function check_manifest_julia_version_compat(manifest::Manifest, manifest_file::String; julia_version_strict::Bool = false)
     isempty(manifest.deps) && return
     if manifest.manifest_format < v"2"
-        @warn """The active manifest file is an older format with no julia version entry. Dependencies may have \
-        been resolved with a different julia version.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
-        return
+        msg = """The active manifest file is an older format with no julia version entry. Dependencies may have \
+        been resolved with a different julia version."""
+        if julia_version_strict
+            pkgerror(msg)
+        else
+            @warn msg maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+            return
+        end
     end
     v = manifest.julia_version
     if v === nothing
-        @warn """The active manifest file is missing a julia version entry. Dependencies may have \
-        been resolved with a different julia version.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
-        return
+        msg = """The active manifest file is missing a julia version entry. Dependencies may have \
+        been resolved with a different julia version."""
+        if julia_version_strict
+            pkgerror(msg)
+        else
+            @warn msg maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+            return
+        end
     end
     if Base.thisminor(v) != Base.thisminor(VERSION)
-        @warn """The active manifest file has dependencies that were resolved with a different julia \
-        version ($(manifest.julia_version)). Unexpected behavior may occur.""" maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+        msg = """The active manifest file has dependencies that were resolved with a different julia \
+        version ($(manifest.julia_version)). Unexpected behavior may occur."""
+        if julia_version_strict
+            pkgerror(msg)
+        else
+            @warn msg maxlog = 1 _file = manifest_file _line = 0 _module = nothing
+        end
     end
 end

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -92,12 +92,12 @@ end
             m.julia_version = v"1.5.0"
             msg = r"The active manifest file has dependencies that were resolved with a different julia version"
             @test_logs (:warn, msg) Pkg.Types.check_manifest_julia_version_compat(m, env_manifest)
-            @test_throws PkgError Pkg.Types.check_manifest_julia_version_compat(m, env_manifest, julia_version_strict=true)
+            @test_throws Pkg.Types.PkgError Pkg.Types.check_manifest_julia_version_compat(m, env_manifest, julia_version_strict=true)
 
             m.julia_version = nothing
             msg = r"The active manifest file is missing a julia version entry"
             @test_logs (:warn, msg) Pkg.Types.check_manifest_julia_version_compat(m, env_manifest)
-            @test_throws PkgError Pkg.Types.check_manifest_julia_version_compat(m, env_manifest, julia_version_strict=true)
+            @test_throws Pkg.Types.PkgError Pkg.Types.check_manifest_julia_version_compat(m, env_manifest, julia_version_strict=true)
         end
     end
 

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -92,10 +92,12 @@ end
             m.julia_version = v"1.5.0"
             msg = r"The active manifest file has dependencies that were resolved with a different julia version"
             @test_logs (:warn, msg) Pkg.Types.check_manifest_julia_version_compat(m, env_manifest)
+            @test_throws PkgError Pkg.Types.check_manifest_julia_version_compat(m, env_manifest, julia_version_strict=true)
 
             m.julia_version = nothing
             msg = r"The active manifest file is missing a julia version entry"
             @test_logs (:warn, msg) Pkg.Types.check_manifest_julia_version_compat(m, env_manifest)
+            @test_throws PkgError Pkg.Types.check_manifest_julia_version_compat(m, env_manifest, julia_version_strict=true)
         end
     end
 

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -91,11 +91,11 @@ end
             m = Pkg.Types.read_manifest(env_manifest)
             m.julia_version = v"1.5.0"
             msg = r"The active manifest file has dependencies that were resolved with a different julia version"
-            @test_logs (:warn, msg) Pkg.Types.check_warn_manifest_julia_version_compat(m, env_manifest)
+            @test_logs (:warn, msg) Pkg.Types.check_manifest_julia_version_compat(m, env_manifest)
 
             m.julia_version = nothing
             msg = r"The active manifest file is missing a julia version entry"
-            @test_logs (:warn, msg) Pkg.Types.check_warn_manifest_julia_version_compat(m, env_manifest)
+            @test_logs (:warn, msg) Pkg.Types.check_manifest_julia_version_compat(m, env_manifest)
         end
     end
 


### PR DESCRIPTION
This PR adds a new kwarg to `instantiate`, `manifest_version_check_mode`, which can be used to turn the existing manifest version warnings into errors. We keep strict control over our Julia versions and dependencies, and never want to have a mismatch between the running Julia version and the manifest's Julia version. This kwarg would greatly simplify this behavior for that use case.

I'm not tied to this exact implementation; I could also implement the kwarg as a bool, or add a `:none` mode, etc.