### PR TITLE
[release-1.10] fix swallowing internal errors in Pkg.precompile

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1563,6 +1563,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
                 length(tasks) == 1 && notify(interrupted_or_done)
             end
         end
+        Base.errormonitor(task) # interrupts are handled separately so ok to watch for other errors like this
         push!(tasks, task)
     end
     isempty(tasks) && notify(interrupted_or_done)


### PR DESCRIPTION
1.10 version of https://github.com/JuliaLang/julia/pull/55432

```
(@v1.10) pkg> precompile
Precompiling project...
  ✗ SimpleLooper
  0 dependencies successfully precompiled in 1 seconds. 7 already precompiled.

ERROR: The following 1 direct dependency failed to precompile:

SimpleLooper [ff33fe5b-d8e3-4cbd-8bd9-3d2408ff8cab]

Failed to precompile SimpleLooper [ff33fe5b-d8e3-4cbd-8bd9-3d2408ff8cab] to "/Users/ian/.julia/compiled/v1.10/SimpleLooper/jl_y7CN8M".
ERROR: LoadError: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:44
 [2] top-level scope
   @ ~/Documents/GitHub/SimpleLooper.jl/src/SimpleLooper.jl:3
```

```
(@v1.10) pkg> precompile
Precompiling project...
^C Interrupted: Exiting precompilation...            ]  0/1
  ◑ SimpleLooper
  1 dependency had output during precompilation:
┌ SimpleLooper
│  [1413] signal (2): Interrupt: 2
│  in expression starting at /Users/ian/Documents/GitHub/SimpleLooper.jl/src/SimpleLooper.jl:3
└  
```
