### PR TITLE
update package extension naming docs

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -416,7 +416,7 @@ Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 # name of extension to the left
 # extension dependencies required to load the extension to the right
 # use a list for multiple extension dependencies
-PlottingContourExt = "Contour"
+ContourExt = "Contour"
 
 [compat]
 Contour = "0.6.2"
@@ -433,9 +433,9 @@ end
 end # module
 ```
 
-`ext/PlottingContourExt.jl` (can also be in `ext/PlottingContourExt/PlottingContourExt.jl`):
+`ext/ContourExt.jl` (can also be in `ext/ContourExt/ContourExt.jl`):
 ```julia
-module PlottingContourExt # Should be same name as the file (just like a normal package)
+module ContourExt # Should be same name as the file (just like a normal package)
 
 using Plotting, Contour
 
@@ -446,8 +446,8 @@ end
 end # module
 ```
 
-Extensions can have any arbitrary name (here `PlottingContourExt`), but using something similar to the format of
-this example that makes the extended functionality and dependency of the extension clear is likely a good idea.
+Extensions can have arbitrary names (here `ContourExt`), following the format of this example is likely a good idea for extensions with a single dependency.
+In `Pkg` output, extension names are always shown together with their parent package name.
 
 !!! compat
     Often you will put the extension dependencies into the `test` target so they are loaded when running e.g. `Pkg.test()`. On earlier Julia versions
@@ -461,8 +461,8 @@ this example that makes the extended functionality and dependency of the extensi
 
 ### Behavior of extensions
 
-A user that depends only on `Plotting` will not pay the cost of the "extension" inside the `PlottingContourExt` module.
-It is only when the `Contour` package actually gets loaded that the `PlottingContourExt` extension is loaded too
+A user that depends only on `Plotting` will not pay the cost of the "extension" inside the `ContourExt` module.
+It is only when the `Contour` package actually gets loaded that the `ContourExt` extension is loaded too
 and provides the new functionality.
 
 In our example, the new functionality is an additional _method_, which we add to an existing _function_ from the parent package `Plotting`.
@@ -474,17 +474,17 @@ function plot end
 ```
 
 !!! note
-    If one considers `PlottingContourExt` as a completely separate package, it could be argued that defining `Plotting.plot(c::Contour.ContourCollection)` is
-    [type piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) since `PlottingContourExt` _owns_ neither the function `Plotting.plot` nor the type `Contour.ContourCollection`.
+    If one considers `ContourExt` as a completely separate package, it could be argued that defining `Plotting.plot(c::Contour.ContourCollection)` is
+    [type piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) since `ContourExt` _owns_ neither the function `Plotting.plot` nor the type `Contour.ContourCollection`.
     However, for extensions, it is ok to assume that the extension owns the functions in its parent package.
 
 In other situations, one may need to define new symbols in the extension (types, structs, functions, etc.) instead of reusing those from the parent package.
-Such symbols are created in a separate module corresponding to the extension, namely `PlottingContourExt`, and thus not in `Plotting` itself.
+Such symbols are created in a separate module corresponding to the extension, namely `ContourExt`, and thus not in `Plotting` itself.
 If extension symbols are needed in the parent package, one must call `Base.get_extension` to retrieve them.
-Here is an example showing how a custom type defined in `PlottingContourExt` can be accessed in `Plotting`:
+Here is an example showing how a custom type defined in `ContourExt` can be accessed in `Plotting`:
 
 ```julia
-ext = Base.get_extension(@__MODULE__, :PlottingContourExt)
+ext = Base.get_extension(@__MODULE__, :ContourExt)
 if !isnothing(ext)
     ContourPlotType = ext.ContourPlotType
 end
@@ -512,7 +512,7 @@ This is done by making the following changes (using the example above):
 
   @static if !isdefined(Base, :get_extension)
   function __init__()
-      @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")
+      @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/ContourExt.jl")
   end
   end
   ```
@@ -526,11 +526,11 @@ This is done by making the following changes (using the example above):
       # Other init functionality here
 
       @static if !isdefined(Base, :get_extension)
-          @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/PlottingContourExt.jl")
+          @require Contour = "d38c429a-6771-53c6-b99e-75d170b6e991" include("../ext/ContourExt.jl")
       end
   end
   ```
-- Make the following change in the conditionally-loaded code:
+- Make the following change in the conditionally-loaded code in `ContourExt.jl`:
   ```julia
   isdefined(Base, :get_extension) ? (using Contour) : (using ..Contour)
   ```
@@ -549,7 +549,7 @@ This is done by making the following changes (using the example above):
 - Add the following to your main package file (typically at the bottom):
   ```julia
   if !isdefined(Base, :get_extension)
-    include("../ext/PlottingContourExt.jl")
+    include("../ext/ContourExt.jl")
   end
   ```
 


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/Pkg.jl/pull/3600, Pkg output always displays the parent package name next to the extension name. The naming from the current pkg docs example (`PlottingContourExt`) makes Pkg output super verbose, like `Plotting -> PlottingContourExt`. Especially for longer package names, it can easily exceed typical line length.

Here, I update the docs to show shorter nonredundant naming, `ContourExt` (leading to `Plotting -> ContourExt` output). Many packages already follow this short naming, and presumably more will do if it becomes the official recommended way.