### PR TITLE
advertise `undo` and `redo` when there are changes to an env

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2743,8 +2743,13 @@ function print_status(env::EnvCache, old_env::Union{Nothing,EnvCache}, registrie
         println(io)
     end
 
+    # figure out if we are at the end of status prints, given this is called twice for combined mode
+    last_status_report = mode != PKGMODE_COMBINED || mode == PKGMODE_COMBINED && manifest
+
     if !no_changes && !all_packages_downloaded
-        printpkgstyle(io, :Info, "Packages marked with $not_installed_indicator are not downloaded, use `instantiate` to download", color=Base.info_color(), ignore_indent)
+            printpkgstyle(io, :Info, "Packages marked with $not_installed_indicator are not downloaded, use `instantiate` to download. Use `undo/redo` to revert changes.", color=Base.info_color(), ignore_indent)
+    elseif last_status_report && old_env !== nothing && !no_changes
+        printpkgstyle(io, :Info, "Use `undo/redo` to revert changes.", color=Base.info_color(), ignore_indent)
     end
     if !outdated && (mode != PKGMODE_COMBINED || (manifest == true))
         tipend = manifest ? " -m" : ""


### PR DESCRIPTION
Seems a lot of people haven't discovered this functionality, so advertise it.
![Screenshot 2024-08-22 at 9 32 26 PM](https://github.com/user-attachments/assets/50325e24-9f78-41d6-8b4e-f7a0d0e7c4ef)
