### PR TITLE
Update naming conventions for packages

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -620,6 +620,11 @@ may fit your package better.
        library, even without explicit affiliation with the creators of the OpenSSL (provided
        there's no copyright or trademark infringement etc.)
 
+9. Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
+     * The package name begin with a capital letter and word separation is shown with upper camel case
+     * Packages that provide the functionality of a project from another language should use the Julia convention
+     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep orignal name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc.
+
 ## Registering packages
 
 Once a package is ready it can be registered with the [General Registry](https://github.com/JuliaRegistries/General#registering-a-package-in-general) (see also the [FAQ](https://github.com/JuliaRegistries/General#faq)).

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -623,7 +623,7 @@ may fit your package better.
 9. Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
      * The package name begin with a capital letter and word separation is shown with upper camel case
      * Packages that provide the functionality of a project from another language should use the Julia convention
-     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep orignal name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc.
+     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep orignal name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages are handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system. 
 
 ## Registering packages
 

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -623,7 +623,7 @@ may fit your package better.
 9. Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
      * The package name begin with a capital letter and word separation is shown with upper camel case
      * Packages that provide the functionality of a project from another language should use the Julia convention
-     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep orignal name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages are handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system. 
+     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep orignal name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages is handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system. 
 
 ## Registering packages
 


### PR DESCRIPTION
Based on a recent discussion on slack, this PR adds a guide to capitalisation. Since I saw the `_jll` idea is not mentioned, I added that as well.