### PR TITLE
Add status messages for artifact installation

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -369,7 +369,7 @@ function download_artifact(
             end
         end
         # Move it to the location we expected
-        isnothing(progress) || progress(10000, 10000; status="installing")
+        isnothing(progress) || progress(10000, 10000; status="moving to artifact store")
         _mv_temp_artifact_dir(temp_dir, dst)
     catch err
         @debug "download_artifact error" tree_hash tarball_url tarball_hash err

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -330,6 +330,7 @@ function download_artifact(
     try
         download_verify_unpack(tarball_url, tarball_hash, temp_dir;
                                 ignore_existence=true, verbose, quiet_download, io, progress)
+        progress(10000, 10000; status="verifying")
         calc_hash = SHA1(GitTools.tree_hash(temp_dir))
 
         # Did we get what we expected?  If not, freak out.
@@ -368,6 +369,7 @@ function download_artifact(
             end
         end
         # Move it to the location we expected
+        progress(10000, 10000; status="installing")
         _mv_temp_artifact_dir(temp_dir, dst)
     catch err
         @debug "download_artifact error" tree_hash tarball_url tarball_hash err

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -330,7 +330,7 @@ function download_artifact(
     try
         download_verify_unpack(tarball_url, tarball_hash, temp_dir;
                                 ignore_existence=true, verbose, quiet_download, io, progress)
-        progress(10000, 10000; status="verifying")
+        isnothing(progress) || progress(10000, 10000; status="verifying")
         calc_hash = SHA1(GitTools.tree_hash(temp_dir))
 
         # Did we get what we expected?  If not, freak out.
@@ -369,7 +369,7 @@ function download_artifact(
             end
         end
         # Move it to the location we expected
-        progress(10000, 10000; status="installing")
+        isnothing(progress) || progress(10000, 10000; status="installing")
         _mv_temp_artifact_dir(temp_dir, dst)
     catch err
         @debug "download_artifact error" tree_hash tarball_url tarball_hash err

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -17,11 +17,12 @@ function pkg_format_bytes(bytes; binary=true, sigdigits::Integer=3)
 end
 
 Base.@kwdef mutable struct MiniProgressBar
-    max::Int = 1.0
+    max::Int = 1
     header::String = ""
     color::Symbol = :nothing
     width::Int = 40
     current::Int = 0
+    status::String = "" # If not empty this string replaces the bar
     prev::Int = 0
     has_shown::Bool = false
     time_shown::Float64 = 0.0
@@ -83,10 +84,14 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
             print(io, p.header)
         end
         print(io, " ")
-        printstyled(io, "━"^n_filled; color=p.color)
-        printstyled(io, perc >= 95 ? "━" : "╸"; color=p.color)
-        printstyled(io, "━"^n_left, " "; color=:light_black)
-        print(io, progress_text)
+        if !isempty(p.status)
+            print(io, p.status)
+        else
+            printstyled(io, "━"^n_filled; color=p.color)
+            printstyled(io, perc >= 95 ? "━" : "╸"; color=p.color)
+            printstyled(io, "━"^n_left, " "; color=:light_black)
+            print(io, progress_text)
+        end
         carriagereturn && print(io, "\r")
     end
     # Print everything in one call

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -908,7 +908,7 @@ function download_artifacts(ctx::Context;
                     first = true
                     timer = Timer(0, interval=1/10)
                     # TODO: Implement as a new MiniMultiProgressBar
-                    main_bar = MiniProgressBar(; indent=1, header = "Installing artifacts", color = :green, mode = :int, always_reprint=true)
+                    main_bar = MiniProgressBar(; indent=2, header = "Installing artifacts", color = :green, mode = :int, always_reprint=true)
                     main_bar.max = length(download_states)
                     while !is_done
                         main_bar.current = count(x -> x.state == :done, values(download_states))

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -540,6 +540,7 @@ function download_verify_unpack(
         if verbose
             @info("Unpacking $(tarball_path) into $(dest)...")
         end
+        progress(10000, 10000; status="unpacking")
         open(`$(exe7z()) x $tarball_path -so`) do io
             Tar.extract(io, dest, copy_symlinks = copy_symlinks())
         end

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -540,7 +540,7 @@ function download_verify_unpack(
         if verbose
             @info("Unpacking $(tarball_path) into $(dest)...")
         end
-        progress(10000, 10000; status="unpacking")
+        isnothing(progress) || progress(10000, 10000; status="unpacking")
         open(`$(exe7z()) x $tarball_path -so`) do io
             Tar.extract(io, dest, copy_symlinks = copy_symlinks())
         end


### PR DESCRIPTION
This PR replaces the artifact download progress bar with a status message if an installation step takes over half a second.

Here the unpacking step for Qt6Base takes over half a second.

This is required for #4001, where installing may take up to 60 seconds on some systems.

https://github.com/user-attachments/assets/5756c92f-0fca-40e2-9f4f-4e613647aa5b

