### PR TITLE
Add method for `dependencies(uuid)`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -85,12 +85,15 @@ function dependencies(env::EnvCache)
     pkgs = Operations.load_all_deps_loadable(env)
     return Dict(pkg.uuid::UUID => package_info(env, pkg) for pkg in pkgs)
 end
-function dependencies(fn::Function, uuid::UUID)
+function dependencies(uuid::UUID)
     dep = get(dependencies(), uuid, nothing)
     if dep === nothing
         pkgerror("dependency with UUID `$uuid` does not exist")
     end
-    fn(dep)
+    return dep
+end
+function dependencies(fn::Function, uuid::UUID)
+    return fn(dependencies(uuid))
 end
 
 


### PR DESCRIPTION
The function `dependencies` has two methods:

- First, with a `EnvCache`. When called with this, it returns the list of dependencies of the environment.

- Second, with a function and a UUID. When called with these arguments, it returns the list of dependencies of given UUID and applies the function.

This second method is not documented, but, when called with the identity function, provides a very simple way to answer the question "What are the direct dependencies of a given package?".

This is a valuable piece of information when developing tooling that assist people keeping the number dependencies minimal.

As things are, one has to call `Pkg.dependencies(identity, uuid)` to answer the abovementioned question. With this commit, a new method `Pkg.dependencies(uuid)` is added providing a natural way to obtain the list of direct dependencies of a package.