### PR TITLE
REPLMode.jl: set compiler_options optimize = 1

### DIFF
--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -2,11 +2,7 @@
 
 module REPLMode
 
-if isdefined(Base, :Experimental) &&
-   isdefined(Base.Experimental, Symbol("@compiler_options"))
-    # Note: compile=min makes --code-coverage not work
-    @eval Base.Experimental.@compiler_options optimize = 1 infer = false  # compile=min
-end
+@eval Base.Experimental.@compiler_options optimize = 1
 
 using Markdown, UUIDs, Dates
 

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -2,6 +2,14 @@
 
 module REPLMode
 
+if isdefined(Base, :Experimental) &&
+   isdefined(Base.Experimental, Symbol("@compiler_options"))
+    # Without this, resolve() takes a couple of seconds, with, it takes 0.1 seconds.
+    # Maybe with better structured code or precompilation it's not necessary.
+    # Note: compile=min makes --code-coverage not work
+    @eval Base.Experimental.@compiler_options optimize = 0 infer = false compile=min
+end
+
 using Markdown, UUIDs, Dates
 
 import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap, ..pathrepr

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -4,10 +4,8 @@ module REPLMode
 
 if isdefined(Base, :Experimental) &&
    isdefined(Base.Experimental, Symbol("@compiler_options"))
-    # Without this, resolve() takes a couple of seconds, with, it takes 0.1 seconds.
-    # Maybe with better structured code or precompilation it's not necessary.
     # Note: compile=min makes --code-coverage not work
-    @eval Base.Experimental.@compiler_options optimize = 0 infer = false compile=min
+    @eval Base.Experimental.@compiler_options optimize = 1 infer = false  # compile=min
 end
 
 using Markdown, UUIDs, Dates


### PR DESCRIPTION
Fixes 3x PythonCall startup regression because of: https://github.com/JuliaPy/CondaPkg.jl/issues/145 (at least least if backported to 1.11).

```
$ julia +1.11 --compile=min

julia> @time Pkg.REPLMode.gen_help()
  0.180643 seconds (91.88 k allocations: 2.218 MiB, 17.97% compilation time)

vs.
julia> @time Pkg.REPLMode.gen_help()
  2.129547 seconds (871.64 k allocations: 44.875 MiB, 5.32% gc time, 99.94% compilation time)
```

That one function slows down CondaPkg, and therefore also PythoCall, by that amount on 1.11