### PR TITLE
Tweak sentence syntax in getting-started.md

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -154,7 +154,7 @@ We can see that the `tutorial` environment now contains `Example` and `JSON`.
     If you have the same
     package (at the same version) installed in multiple environments, the package
     will only be downloaded and stored on the hard drive once. This makes environments
-    very lightweight and effectively free to create. Only using the default
+    very lightweight and effectively free to create. Using only the default
     environment with a huge number of packages in it is a common beginners mistake in
     Julia. Learning how to use environments effectively will improve your experience with
     Julia packages.


### PR DESCRIPTION
"Only using" tends to (incorrectly) emphasize the notion that the action of using is the only action being done.  Changing to "Using only" more correctly emphasizes the restriction to using only the one thing being mentioned (the global environment). Discussed at https://textranch.com/c/using-only-or-only-using/