### PR TITLE
Use same PrecompileTools.jl approach as REPL to precompile

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -165,7 +165,31 @@ let
         return nothing
     end
 
-    if Base.generating_output()
-        pkg_precompile()
+    # Copied from REPL (originally PrecompileTools.jl)
+    function check_edges(node)
+        parentmi = node.mi_info.mi
+        for child in node.children
+            childmi = child.mi_info.mi
+            if !(isdefined(childmi, :backedges) && parentmi ∈ childmi.backedges)
+                Base.precompile(childmi.specTypes)
+            end
+            check_edges(child)
+        end
+    end
+
+    if Base.generating_output() && Base.JLOptions().use_pkgimages != 0
+        Core.Compiler.Timings.reset_timings()
+        Core.Compiler.__set_measure_typeinf(true)
+        try
+            pkg_precompile()
+        finally
+            Core.Compiler.__set_measure_typeinf(false)
+            Core.Compiler.Timings.close_current_timer()
+        end
+        roots = Core.Compiler.Timings._timings[1].children
+        for child in roots
+            Base.precompile(child.mi_info.mi.specTypes)
+            check_edges(child)
+        end
     end
 end


### PR DESCRIPTION
Without this: (exposing `pkg_precompile` which it usually isn't)
```
julia> @time Pkg.pkg_precompile()
  1.796371 seconds (2.23 M allocations: 125.344 MiB, 4.53% gc time, 66.34% compilation time: 9% of which was recompilation)
```

With
```
julia> @time Pkg.pkg_precompile()
  0.929547 seconds (555.18 k allocations: 35.390 MiB, 2.02% gc time, 29.93% compilation time: 32% of which was recompilation)
```

The code is quite small. Do we want to make a utility in Base or just copy it here?