### PR TITLE
Fix julia#55850 by using safe_realpath instead of abspath in projname

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -7,7 +7,7 @@ import .REPL: LineEdit, REPLCompletions, TerminalMenus
 
 import Pkg
 import .Pkg: linewrap, pathrepr, compat, can_fancyprint, printpkgstyle, PKGMODE_PROJECT
-using .Pkg: Types, Operations, API, Registry, Resolve, REPLMode
+using .Pkg: Types, Operations, API, Registry, Resolve, REPLMode, safe_realpath
 
 using .REPLMode: Statement, CommandSpec, Command, prepare_cmd, tokenize, core_parse, SPECS, api_options, parse_option, api_options, is_opt, wrap_option
 
@@ -47,7 +47,7 @@ function projname(project_file::String)
     end
     for depot in Base.DEPOT_PATH
         envdir = joinpath(depot, "environments")
-        if startswith(abspath(project_file), abspath(envdir))
+        if startswith(safe_realpath(project_file), safe_realpath(envdir))
             return "@" * name
         end
     end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -733,4 +733,14 @@ end
     end
 end
 
+@testset "JuliaLang/julia #55850" begin
+    tmp_55850 = mktempdir()
+    tmp_sym_link = joinpath(tmp_55850, "sym")
+    symlink(tmp_55850, tmp_sym_link; dir_target=true)
+    withenv("JULIA_DEPOT_PATH" => tmp_sym_link, "JULIA_LOAD_PATH" => nothing) do
+        prompt = readchomp(`$(Base.julia_cmd()[1]) --startup-file=no -e "using Pkg: Pkg, Types; import REPL; const REPLExt = Base.get_extension(Pkg, :REPLExt); print(REPLExt.projname(Types.find_project_file()))"`)
+        @test prompt == "@v$(VERSION.major).$(VERSION.minor)"
+    end
+end
+
 end # module

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -737,7 +737,7 @@ end
     tmp_55850 = mktempdir()
     tmp_sym_link = joinpath(tmp_55850, "sym")
     symlink(tmp_55850, tmp_sym_link; dir_target=true)
-    withenv("JULIA_DEPOT_PATH" => tmp_sym_link * ":", "JULIA_LOAD_PATH" => nothing) do
+    withenv("JULIA_DEPOT_PATH" => tmp_sym_link * (Sys.iswindows() ? ";" : ":"), "JULIA_LOAD_PATH" => nothing) do
         prompt = readchomp(`$(Base.julia_cmd()[1]) --project=$(dirname(@__DIR__)) --startup-file=no -e "using Pkg, REPL; Pkg.activate(io=devnull); REPLExt = Base.get_extension(Pkg, :REPLExt); print(REPLExt.promptf())"`)
         @test prompt == "(@v$(VERSION.major).$(VERSION.minor)) pkg> "
     end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -738,8 +738,8 @@ end
     tmp_sym_link = joinpath(tmp_55850, "sym")
     symlink(tmp_55850, tmp_sym_link; dir_target=true)
     withenv("JULIA_DEPOT_PATH" => tmp_sym_link * ":", "JULIA_LOAD_PATH" => nothing) do
-        prompt = readchomp(`$(Base.julia_cmd()[1]) --startup-file=no -e "using Pkg: Pkg, Types; import REPL; const REPLExt = Base.get_extension(Pkg, :REPLExt); print(REPLExt.projname(Types.find_project_file()))"`)
-        @test prompt == "@v$(VERSION.major).$(VERSION.minor)"
+        prompt = readchomp(`$(Base.julia_cmd()[1]) --project=$(dirname(@__DIR__)) --startup-file=no -e "using Pkg, REPL; Pkg.activate(io=devnull); REPLExt = Base.get_extension(Pkg, :REPLExt); print(REPLExt.promptf())"`)
+        @test prompt == "(@v$(VERSION.major).$(VERSION.minor)) pkg> "
     end
 end
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -737,7 +737,7 @@ end
     tmp_55850 = mktempdir()
     tmp_sym_link = joinpath(tmp_55850, "sym")
     symlink(tmp_55850, tmp_sym_link; dir_target=true)
-    withenv("JULIA_DEPOT_PATH" => tmp_sym_link, "JULIA_LOAD_PATH" => nothing) do
+    withenv("JULIA_DEPOT_PATH" => tmp_sym_link * ":", "JULIA_LOAD_PATH" => nothing) do
         prompt = readchomp(`$(Base.julia_cmd()[1]) --startup-file=no -e "using Pkg: Pkg, Types; import REPL; const REPLExt = Base.get_extension(Pkg, :REPLExt); print(REPLExt.projname(Types.find_project_file()))"`)
         @test prompt == "@v$(VERSION.major).$(VERSION.minor)"
     end


### PR DESCRIPTION
Replaces `REPLExt.projname` with `REPL.projname` since they are identical.

Will solve https://github.com/JuliaLang/julia/issues/55850 for situations where Pkg is loaded once https://github.com/JuliaLang/julia/pull/55851 is merged.

Test will be covered by https://github.com/JuliaLang/julia/pull/55851.