### PR TITLE
test fixes because Example v0.5.4 and v0.5.5 were registered

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -817,7 +817,7 @@ end
         @test Pkg.dependencies()[exuuid].version == v"0.3.0"
         @test Pkg.dependencies()[pngjll_uuid].version == v"1.6.37+4"
         Pkg.add(Pkg.PackageSpec(;name="JSON", version="0.18.0"); preserve=Pkg.PRESERVE_NONE)
-        @test Pkg.dependencies()[exuuid].version == v"0.5.3"
+        @test Pkg.dependencies()[exuuid].version > v"0.3.0"
         @test Pkg.dependencies()[json_uuid].version == v"0.18.0"
         @test Pkg.dependencies()[pngjll_uuid].version > v"1.6.37+4"
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -319,7 +319,8 @@ temp_pkg_dir() do project_path
                 @test isfile(joinpath(devdir, TEST_PKG.name, "deps", "deps.jl"))
                 Pkg.test(TEST_PKG.name)
                 Pkg.free(TEST_PKG.name)
-                @test Pkg.dependencies()[TEST_PKG.uuid].version == old_v
+                @test Pkg.dependencies()[TEST_PKG.uuid].version < v"100.0.0"
+                @test Pkg.dependencies()[TEST_PKG.uuid].version >= old_v
             end
         end
     end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -269,7 +269,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "develop / freeing" begin
-        Pkg.add(TEST_PKG.name)
+        Pkg.add(name=TEST_PKG.name, version=v"0.5.3")
         old_v = Pkg.dependencies()[TEST_PKG.uuid].version
         Pkg.rm(TEST_PKG.name)
         mktempdir() do devdir
@@ -277,10 +277,7 @@ temp_pkg_dir() do project_path
                 @test_throws PkgError Pkg.develop(Pkg.PackageSpec(url="bleh", rev="blurg"))
                 Pkg.develop(TEST_PKG.name)
                 @test isinstalled(TEST_PKG)
-                # This test is disabled because it relied on Example.jl having a version
-                # number in the Project.toml file on master that wasn't released, which
-                # is no longer true.
-                # @test Pkg.dependencies()[TEST_PKG.uuid].version > old_v
+                @test Pkg.dependencies()[TEST_PKG.uuid].version > old_v
                 test_pkg_main_file = joinpath(devdir, TEST_PKG.name, "src", TEST_PKG.name * ".jl")
                 @test isfile(test_pkg_main_file)
                 # Pkg #152

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -271,6 +271,7 @@ temp_pkg_dir() do project_path
     @testset "develop / freeing" begin
         Pkg.add(name=TEST_PKG.name, version=v"0.5.3")
         old_v = Pkg.dependencies()[TEST_PKG.uuid].version
+        @test old_v == v"0.5.3"
         Pkg.rm(TEST_PKG.name)
         mktempdir() do devdir
             withenv("JULIA_PKG_DEVDIR" => devdir) do
@@ -299,6 +300,21 @@ temp_pkg_dir() do project_path
                     touch("deps.jl")
                     """
                 )
+                exa_proj = joinpath(devdir, TEST_PKG.name, "Project.toml")
+                proj_str = read(exa_proj, String)
+                compat_onwards = split(proj_str, "[compat]")[2]
+                open(exa_proj, "w") do io
+                    println(io, """
+                    name = "Example"
+                    uuid = "$(TEST_PKG.uuid)"
+                    version = "100.0.0"
+
+                    [compat]
+                    $compat_onwards
+                    """)
+                end
+                Pkg.resolve()
+                @test Pkg.dependencies()[TEST_PKG.uuid].version == v"100.0.0"
                 Pkg.build(TEST_PKG.name)
                 @test isfile(joinpath(devdir, TEST_PKG.name, "deps", "deps.jl"))
                 Pkg.test(TEST_PKG.name)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -277,7 +277,10 @@ temp_pkg_dir() do project_path
                 @test_throws PkgError Pkg.develop(Pkg.PackageSpec(url="bleh", rev="blurg"))
                 Pkg.develop(TEST_PKG.name)
                 @test isinstalled(TEST_PKG)
-                @test Pkg.dependencies()[TEST_PKG.uuid].version > old_v
+                # This test is disabled because it relied on Example.jl having a version
+                # number in the Project.toml file on master that wasn't released, which
+                # is no longer true.
+                # @test Pkg.dependencies()[TEST_PKG.uuid].version > old_v
                 test_pkg_main_file = joinpath(devdir, TEST_PKG.name, "src", TEST_PKG.name * ".jl")
                 @test isfile(test_pkg_main_file)
                 # Pkg #152

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -57,9 +57,10 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
     tmp_pkg_path = mktempdir()
 
     pkg"activate ."
-    pkg"add Example@0.5"
+    pkg"add Example@0.5.3"
     @test isinstalled(TEST_PKG)
     v = Pkg.dependencies()[TEST_PKG.uuid].version
+    @test v == v"0.5.3"
     pkg"rm Example"
     pkg"add Example, Random"
     pkg"rm Example Random"
@@ -85,10 +86,7 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
 
     pkg"test Example"
     @test isinstalled(TEST_PKG)
-    # This test is disabled because it relied on Example.jl having a version
-    # number in the Project.toml file on master that wasn't released, which
-    # is no longer true.
-    # @test Pkg.dependencies()[TEST_PKG.uuid].version > v
+    @test Pkg.dependencies()[TEST_PKG.uuid].version > v
 
     pkg2 = "UnregisteredWithProject"
     pkg2_uuid = UUID("58262bb0-2073-11e8-3727-4fe182c12249")

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -85,7 +85,10 @@ temp_pkg_dir(;rm=false) do project_path; cd(project_path) do;
 
     pkg"test Example"
     @test isinstalled(TEST_PKG)
-    @test Pkg.dependencies()[TEST_PKG.uuid].version > v
+    # This test is disabled because it relied on Example.jl having a version
+    # number in the Project.toml file on master that wasn't released, which
+    # is no longer true.
+    # @test Pkg.dependencies()[TEST_PKG.uuid].version > v
 
     pkg2 = "UnregisteredWithProject"
     pkg2_uuid = UUID("58262bb0-2073-11e8-3727-4fe182c12249")


### PR DESCRIPTION
See https://buildkite.com/julialang/julia-master/builds/40302#01922f49-90f7-4410-9c2b-53fda2abb7a6/847-875

because https://github.com/JuliaLang/Example.jl/releases/tag/v0.5.5 and https://github.com/JuliaLang/Example.jl/releases/tag/v0.5.4

Our tests assumed that there was a version on the tip of Example master that was unregistered...