### PR TITLE
Fix greedy resolver failure (producing an invalid solution)

### DIFF
--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -362,6 +362,8 @@ function greedysolver(graph::Graph)
                     return (false, Int[])
                 elseif old_v1 == spp[p1]
                     sol[p1] = v1
+                    fill!(gconstr[p1], false)
+                    gconstr[p1][v1] = true
                     push!(staged_next, p1)
                 end
             end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -617,7 +617,6 @@ end
     )
     @test resolve_tst(deps_data, reqs_data, want_data)
 
-
     # require A, D, and lower version of Y
     reqs_data = Any[
         ["A", "*"],
@@ -635,6 +634,39 @@ end
         "G"=>v"2",
         "H"=>v"1",
         "I"=>v"1",
+    )
+    @test resolve_tst(deps_data, reqs_data, want_data)
+
+
+    VERBOSE && @info("SCHEME 15")
+    ## DEPENDENCY SCHEME 15: A GRAPH WITH A WEAK DEPENDENCE
+    ## (REDUCED VERSION OF A REALISTIC SCHEME, ref Pkg.jl issue #4030)
+    deps_data = Any[
+        ["A", v"1"],
+        ["A", v"2", "C", "*"],
+        ["B", v"1", "D", "1", :weak],
+        ["C", v"1", "E", "*"],
+        ["C", v"2", "E", "*"],
+        ["C", v"2", "B", "1"],
+        ["E", v"1", "D", "1"],
+        ["E", v"2", "F", "1"],
+        ["F", v"1", "D", "*"],
+        ["D", v"1"],
+        ["D", v"2"],
+    ]
+
+    @test sanity_tst(deps_data)
+
+    reqs_data = Any[
+        ["A", "*"],
+    ]
+    want_data = Dict(
+        "A" => v"2",
+        "B" => v"1",
+        "C" => v"2",
+        "D" => v"1",
+        "E" => v"2",
+        "F" => v"1",
     )
     @test resolve_tst(deps_data, reqs_data, want_data)
 


### PR DESCRIPTION
This fixes #4030. Also adds a reduced test case.
This was a rather simple bug in the greedy resolver that failed to actually account for all of the constraints. It's actually quite surprising how it went unnoticed for so long.