### PR TITLE
Allow use of a url and subdir in [sources]

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -195,6 +195,9 @@ function update_source_if_set(project, pkg)
     if pkg.path !== nothing
         source["path"] = pkg.path
     end
+    if pkg.subdir !== nothing
+        source["subdir"] = pkg.subdir
+    end
     path, repo = get_path_repo(project, pkg.name)
     if path !== nothing
         pkg.path = path
@@ -204,6 +207,9 @@ function update_source_if_set(project, pkg)
     end
     if repo.rev !== nothing
         pkg.repo.rev = repo.rev
+    end
+    if repo.subdir !== nothing
+        pkg.repo.subdir = repo.subdir
     end
 end
 

--- a/src/project.jl
+++ b/src/project.jl
@@ -92,7 +92,7 @@ read_project_compat(raw, project::Project) =
 
 read_project_sources(::Nothing, project::Project) = Dict{String,Any}()
 function read_project_sources(raw::Dict{String,Any}, project::Project)
-    valid_keys = ("path", "url", "rev")
+    valid_keys = ("path", "url", "rev", "subdir")
     sources = Dict{String,Any}()
     for (name, source) in raw
         if !(source isa AbstractDict)


### PR DESCRIPTION
Monorepos exist, so we shouldn't complain when somebody tries to combine the url and subdir parameters.

I think this is all that's needed to close #4026. These additions are just from looking through  #3783 for suspicious omissions. 