### PR TITLE
Re-remove double space before progress bar

### DIFF
--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -84,7 +84,6 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
         else
             print(io, p.header, " ")
         end
-        print(io, " ")
         if !isempty(p.status)
             print(io, p.status)
         else


### PR DESCRIPTION
Fixed in #4008, then reintroduced in #4005 from what I assume is unfortunate timing.

@IanButterworth 