### PR TITLE
Allow configuring can_fancyprint(io::IO) using IOContext

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -57,7 +57,7 @@ stdout_f() = something(DEFAULT_IO[], unstableio(stdout))
 const PREV_ENV_PATH = Ref{String}("")
 
 usable_io(io) = (io isa Base.TTY) || (io isa IOContext{IO} && io.io isa Base.TTY)
-can_fancyprint(io::IO) = (usable_io(io)) && (get(ENV, "CI", nothing) != "true")
+can_fancyprint(io::IO) = @something get(io, :Pkg_force_fancyprint, nothing) (usable_io(io)) && (get(ENV, "CI", nothing) != "true")
 should_autoprecompile() = Base.JLOptions().use_compiled_modules == 1 && Base.get_bool_env("JULIA_PKG_PRECOMPILE_AUTO", true)
 
 include("utils.jl")


### PR DESCRIPTION
Hi!

This PR adds the ability to override `can_fancyprint(io::IO)` for a self-provided IO by setting an IOContext flag:  `:Pkg_force_fancyprint` can be set to true or false.

# Why
My use case is Pluto, where we call Pkg functions like `Pkg.precompile()` with a **buffer as `io`**. Our display (in the browser) supports fancy-printing, but because the buffer is not a `<: Base.TTY`, Pkg will not fancy-print.

The current workaround in Pluto is to add type piracy to the `Pkg.can_fancyprint` function, defining a new, more specific method for `can_fancyprint(io::IOContext{BufferStream})` where we set it to `true`, but I want to avoid this solution.

What do you think?