### PR TITLE
Make Pkg more robust to poor inference

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -281,7 +281,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel=Op
         end
     end
 
-    repo_pkgs = [pkg for pkg in pkgs if (pkg.repo.source !== nothing || pkg.repo.rev !== nothing)]
+    repo_pkgs = PackageSpec[pkg for pkg in pkgs if (pkg.repo.source !== nothing || pkg.repo.rev !== nothing)]
     new_git = handle_repos_add!(ctx, repo_pkgs)
     # repo + unpinned -> name, uuid, repo.rev, repo.source, tree_hash
     # repo + pinned -> name, uuid, tree_hash

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1319,7 +1319,7 @@ function build_versions(ctx::Context, uuids::Set{UUID}; verbose=false)
         ispath(buildfile(path)) && push!(builds, (uuid, name, path, version))
     end
     # toposort builds by dependencies
-    order = dependency_order_uuids(ctx.env, map(first, builds))
+    order = dependency_order_uuids(ctx.env, UUID[first(build) for build in builds])
     sort!(builds, by = build -> order[first(build)])
     max_name = maximum(build->textwidth(build[2]), builds; init=0)
 

--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -309,7 +309,7 @@ function greedysolver(graph::Graph)
     gconstr = graph.gconstr
 
     # initialize solution: all uninstalled
-    sol = [spp[p0] for p0 = 1:np]
+    sol = Int[spp[p0] for p0 = 1:np]
 
     # packages which are not allowed to be uninstalled
     # (NOTE: this is potentially a superset of graph.req_inds,


### PR DESCRIPTION
A few things in Pkg rely on inference to figure out (empty) collection types and error if inference can't figure it because the subsequent method signatures are narrow.
I wouldn't really care for any other package, but when working on inference it's not uncommon for it to temporarily be somewhat broken. It's useful to still have Pkg available so that the build finishes and that it is possible to install extra packages for debugging.