### PR TITLE
Fix end of progress bar

### DIFF
--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -74,7 +74,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
     max_progress_width = max(0, min(termwidth - textwidth(p.header) - textwidth(progress_text) - 10 , p.width))
     n_filled = floor(Int, max_progress_width * perc / 100)
     partial_filled = (max_progress_width * perc / 100) - n_filled
-    n_left = max_progress_width - n_filled - 1
+    n_left = max_progress_width - n_filled
     headers = split(p.header)
     to_print = sprint(; context=io) do io
         print(io, " "^p.indent)
@@ -94,7 +94,7 @@ function show_progress(io::IO, p::MiniProgressBar; termwidth=nothing, carriagere
                 else
                     printstyled(io, "╺"; color=:light_black) # Less filled, use ╺
                 end
-                printstyled(io, "━"^n_left; color=:light_black)
+                printstyled(io, "━"^(n_left-1); color=:light_black)
             end
             printstyled(io, " "; color=:light_black)
             print(io, progress_text)


### PR DESCRIPTION
The progress bar would "bounce" by not printing any `:light_black` characters when `n_left == 0` but `n_filled != max_progress_width`.

```
#Before
julia> bar.current=980;show_progress(stdout,bar)
 Downloading packages ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺ 980/1000
#After
julia> bar.current=980;show_progress(stdout,bar)
 Downloading packages ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 980/1000
```