### PR TITLE
1.11 backports

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -147,6 +147,7 @@ function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
                     end
                 else
                     LineEdit.edit_insert(s, ';')
+                    LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
                 end
             end
         end
@@ -173,6 +174,7 @@ function repl_init(repl::REPL.AbstractREPL)
                 end
             else
                 LineEdit.edit_insert(s, ']')
+                LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
             end
         end
     )

--- a/ext/REPLExt/completions.jl
+++ b/ext/REPLExt/completions.jl
@@ -5,7 +5,7 @@ function _shared_envs()
     possible = String[]
     for depot in Base.DEPOT_PATH
         envdir = joinpath(depot, "environments")
-        isdir(envdir) || continue
+        Base.isaccessibledir(envdir) || continue
         append!(possible, readdir(envdir))
     end
     return possible
@@ -38,15 +38,7 @@ function complete_expanded_local_dir(s, i1, i2, expanded_user, oldi2)
     cmp2 = cmp[2]
     completions = [REPL.REPLCompletions.completion_text(p) for p in cmp[1]]
     completions = filter!(completions) do x
-        try
-            isdir(s[1:prevind(s, first(cmp2)-i1+1)]*x)
-        catch e
-            if e isa Base.IOError && e.code == Base.UV_EACCES
-                return false
-            else
-                rethrow()
-            end
-        end
+        Base.isaccessibledir(s[1:prevind(s, first(cmp2)-i1+1)]*x)
     end
     if expanded_user
         if length(completions) == 1 && endswith(joinpath(homedir(), ""), first(completions))


### PR DESCRIPTION
Backported PRs:
- [x] #4054 <!-- REPLExt: run repl hint generation for modeswitch chars when not switching -->
- [x] #4053 <!-- REPLExt: use Base.isaccessibledir rather than isdir in completions -->

Non-merged PRs with backport label:
- [ ] #4039 <!-- Allow use of a url and subdir in [sources] -->