### PR TITLE
fix Base.unreference_module call

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -731,8 +731,7 @@ end
 
         # Force Julia to re-load ArtifactOverrideLoading from scratch
         pkgid = Base.PkgId(aol_uuid, "ArtifactOverrideLoading")
-        delete!(Base.module_keys, Base.loaded_modules[pkgid])
-        delete!(Base.loaded_modules, pkgid)
+        Base.unreference_module(pkgid)
         touch(joinpath(depot_container, "ArtifactOverrideLoading", "src", "ArtifactOverrideLoading.jl"))
 
         # Verify that the hash-based overrides (and clears) worked


### PR DESCRIPTION
No need to commit privacy violations here, when we have a API method for doing this for this purpose 