### PR TITLE
strip out tree_hash for stdlibs that have have been freed in newer julia versions

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -254,6 +254,7 @@ function load_tree_hash!(registries::Vector{Registry.RegistryInstance}, pkg::Pac
     if is_stdlib(pkg.uuid, julia_version) && pkg.tree_hash !== nothing
         # manifests from newer julia versions might have stdlibs that are upgradable (FORMER_STDLIBS)
         # that have tree_hash recorded, which we need to clear for this version where they are not upgradable
+        # given regular stdlibs don't have tree_hash recorded
         pkg.tree_hash = nothing
         return pkg
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -251,6 +251,12 @@ end
 ####################
 
 function load_tree_hash!(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec, julia_version)
+    if is_stdlib(pkg.uuid, julia_version) && pkg.tree_hash !== nothing
+        # manifests from newer julia versions might have stdlibs that are upgradable (FORMER_STDLIBS)
+        # that have tree_hash recorded, which we need to clear for this version where they are not upgradable
+        pkg.tree_hash = nothing
+        return pkg
+    end
     tracking_registered_version(pkg, julia_version) || return pkg
     hash = nothing
     for reg in registries


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/4058