### PR TITLE
[release-1.10] 1.10 Backports

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -189,6 +189,13 @@ end
 ####################
 
 function load_tree_hash!(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec, julia_version)
+    if is_stdlib(pkg.uuid, julia_version) && pkg.tree_hash !== nothing
+        # manifests from newer julia versions might have stdlibs that are upgradable (FORMER_STDLIBS)
+        # that have tree_hash recorded, which we need to clear for this version where they are not upgradable
+        # given regular stdlibs don't have tree_hash recorded
+        pkg.tree_hash = nothing
+        return pkg
+    end
     tracking_registered_version(pkg, julia_version) || return pkg
     hash = nothing
     for reg in registries

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1385,6 +1385,7 @@ function add(ctx::Context, pkgs::Vector{PackageSpec}, new_git=Set{UUID}();
     assert_can_add(ctx, pkgs)
     # load manifest data
     for (i, pkg) in pairs(pkgs)
+        delete!(ctx.env.project.weakdeps, pkg.name)
         entry = manifest_info(ctx.env.manifest, pkg.uuid)
         is_dep = any(uuid -> uuid == pkg.uuid, [uuid for (name, uuid) in ctx.env.project.deps])
         pkgs[i] = update_package_add(ctx, pkg, entry, is_dep)
@@ -1411,6 +1412,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}, new_git::Set{UUID};
     assert_can_add(ctx, pkgs)
     # no need to look at manifest.. dev will just nuke whatever is there before
     for pkg in pkgs
+        delete!(ctx.env.project.weakdeps, pkg.name)
         ctx.env.project.deps[pkg.name] = pkg.uuid
     end
     # resolve & apply package versions
@@ -2207,6 +2209,7 @@ function status_ext_info(pkg::PackageSpec, env::EnvCache)
     manifest = env.manifest
     manifest_info = get(manifest, pkg.uuid, nothing)
     manifest_info === nothing && return nothing
+    depses = manifest_info.deps
     weakdepses = manifest_info.weakdeps
     exts = manifest_info.exts
     if !isempty(weakdepses) && !isempty(exts)
@@ -2217,10 +2220,14 @@ function status_ext_info(pkg::PackageSpec, env::EnvCache)
             # Check if deps are loaded
             extdeps_info= Tuple{String, Bool}[]
             for extdep in extdeps
-                haskey(weakdepses, extdep) ||
-                    pkgerror(isnothing(pkg.name) ? "M" : "$(pkg.name) has a m",
-                             "alformed Project.toml, the extension package $extdep is not listed in [weakdeps]")
-                uuid = weakdepses[extdep]
+                if !(haskey(weakdepses, extdep) || haskey(depses, extdep))
+                    pkgerror(isnothing(pkg.name) ? "M" : "$(pkg.name) has a malformed Project.toml, ",
+                             "the extension package $extdep is not listed in [weakdeps] or [deps]")
+                end
+                uuid = get(weakdepses, extdep, nothing)
+                if uuid === nothing
+                    uuid = depses[extdep]
+                end
                 loaded = haskey(Base.loaded_modules, Base.PkgId(uuid, extdep))
                 push!(extdeps_info, (extdep, loaded))
             end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -423,7 +423,7 @@ Base.@kwdef mutable struct Context
     julia_version::Union{VersionNumber,Nothing} = VERSION
 end
 
-project_uuid(env::EnvCache) = env.pkg === nothing ? nothing : env.pkg.uuid
+project_uuid(env::EnvCache) = env.pkg === nothing ? Base.dummy_uuid(env.project_file) : env.pkg.uuid
 collides_with_project(env::EnvCache, pkg::PackageSpec) =
     is_project_name(env, pkg.name) || is_project_uuid(env, pkg.uuid)
 is_project(env::EnvCache, pkg::PackageSpec) = is_project_uuid(env, pkg.uuid)

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -1,5 +1,6 @@
 using  .Utils
 using Test
+using UUIDs
 
 @testset "weak deps" begin
     he_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl")
@@ -77,5 +78,16 @@ using Test
         @test occursin("OffsetArraysExt", out)
         @test occursin("HasExtensions", out)
         @test occursin("HasDepWithExtensions", out)
+    end
+
+    isolate(loaded_depot=false) do
+        mktempdir() do dir
+            Pkg.Registry.add("General")
+            path = joinpath(@__DIR__, "test_packages", "TestWeakDepProject")
+            cp(path, joinpath(dir, "TestWeakDepProject"))
+            Pkg.activate(joinpath(dir, "TestWeakDepProject"))
+            Pkg.resolve()
+            @test Pkg.dependencies()[UUID("2ab3a3ac-af41-5b50-aa03-7779005ae688")].version == v"0.3.26"
+        end
     end
 end

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -88,6 +88,15 @@ using UUIDs
             Pkg.activate(joinpath(dir, "TestWeakDepProject"))
             Pkg.resolve()
             @test Pkg.dependencies()[UUID("2ab3a3ac-af41-5b50-aa03-7779005ae688")].version == v"0.3.26"
+
+            # Check that explicitly adding a package that is a weak dep removes it from the set of weak deps
+            ctx = Pkg.Types.Context()
+            @test "LogExpFunctions" in keys(ctx.env.project.weakdeps)
+            @test !("LogExpFunctions" in keys(ctx.env.project.deps))
+            Pkg.add("LogExpFunctions")
+            ctx = Pkg.Types.Context()
+            @test "LogExpFunctions" in keys(ctx.env.project.deps)
+            @test !("LogExpFunctions" in keys(ctx.env.project.weakdeps))
         end
     end
 end

--- a/test/test_packages/TestWeakDepProject/Project.toml
+++ b/test/test_packages/TestWeakDepProject/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
+[weakdeps]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+
+[compat]
+ForwardDiff = "=0.10.36"
+LogExpFunctions = "=0.3.26"


### PR DESCRIPTION
Backported PRs:
- [x] #4062 <!-- strip out tree_hash for stdlibs that have have been freed in newer julia versions -->
- [x] #3852 <!-- collect e.g. weak deps from project even if it is not a package -->
- [x] #3865 <!-- make `add` and `dev` on a package remove it from the set of weak dependencies -->

Need manual backport:
- [ ] #4000 <!-- update package extension naming docs -->

