### PR TITLE
[release-1.11] 1.11 Backports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         pkg-server:
           - "pkg.julialang.org" # Default to this for all except specific cases
         julia-version:
-          - 'nightly'
+          - '1.11'
         exclude:
           - os: ubuntu-latest
             julia-arch: aarch64
@@ -48,11 +48,11 @@ jobs:
         include:
           - os: ubuntu-latest
             julia-arch: 'x64'
-            julia-version: 'nightly'
+            julia-version: '1.11'
             pkg-server: ""
           - os: ubuntu-latest
             julia-arch: 'x64'
-            julia-version: 'nightly'
+            julia-version: '1.11'
             pkg-server: "pkg.julialang.org"
     steps:
       - name: Set git to use LF and fix TEMP on windows
@@ -93,7 +93,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           # version: '1.6'
-          version: 'nightly'
+          version: '1.11'
       - name: Generate docs
         run: |
           julia --project --color=yes -e 'using Pkg; Pkg.activate("docs"); Pkg.instantiate(); Pkg.develop(PackageSpec(path = pwd()))'

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -202,6 +202,13 @@ end
 ####################
 
 function load_tree_hash!(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec, julia_version)
+    if is_stdlib(pkg.uuid, julia_version) && pkg.tree_hash !== nothing
+        # manifests from newer julia versions might have stdlibs that are upgradable (FORMER_STDLIBS)
+        # that have tree_hash recorded, which we need to clear for this version where they are not upgradable
+        # given regular stdlibs don't have tree_hash recorded
+        pkg.tree_hash = nothing
+        return pkg
+    end
     tracking_registered_version(pkg, julia_version) || return pkg
     hash = nothing
     for reg in registries


### PR DESCRIPTION
Backported PRs:
- [x] #4062 <!-- strip out tree_hash for stdlibs that have have been freed in newer julia versions -->

Non-merged PRs with backport label:
- [ ] #4039 <!-- Allow use of a url and subdir in [sources] -->