### PR TITLE
rename FORMER_STDLIBS -> UPGRADABLE_STDLIBS

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -460,8 +460,8 @@ is_project_uuid(env::EnvCache, uuid::UUID) = project_uuid(env) == uuid
 # Context #
 ###########
 
-const FORMER_STDLIBS = ["DelimitedFiles", "Statistics"]
-const FORMER_STDLIBS_UUIDS = Set{UUID}()
+const UPGRADABLE_STDLIBS = ["DelimitedFiles", "Statistics"]
+const UPGRADABLE_STDLIBS_UUIDS = Set{UUID}()
 const STDLIB = Ref{DictStdLibs}()
 function load_stdlib()
     stdlib = DictStdLibs()
@@ -473,8 +473,8 @@ function load_stdlib()
         v_str = get(project, "version", nothing)::Union{String, Nothing}
         version = isnothing(v_str) ? nothing : VersionNumber(v_str)
         nothing === uuid && continue
-        if name in FORMER_STDLIBS
-            push!(FORMER_STDLIBS_UUIDS, UUID(uuid))
+        if name in UPGRADABLE_STDLIBS
+            push!(UPGRADABLE_STDLIBS_UUIDS, UUID(uuid))
             continue
         end
         deps = UUID.(values(get(project, "deps", Dict{String,Any}())))
@@ -499,7 +499,7 @@ end
 is_stdlib(uuid::UUID) = uuid in keys(stdlib_infos())
 # Includes former stdlibs
 function is_or_was_stdlib(uuid::UUID, julia_version::Union{VersionNumber, Nothing})
-    return is_stdlib(uuid, julia_version) || uuid in FORMER_STDLIBS_UUIDS
+    return is_stdlib(uuid, julia_version) || uuid in UPGRADABLE_STDLIBS_UUIDS
 end
 
 


### PR DESCRIPTION
Calling these former stdlibs is confusing, I think.
My understanding:
- stdlib - package that ships with julia (no git-tree-sha1 in the manifest)
- upgradable stdlib - package that ships with julia, which can optionally be upgraded (gets a git-tree-sha1 if upgraded)
- former stdlibs - a package that used to be shipped with julia but isn't any longer (no packages yet, AFAIK)

If a julia 2.0 is cut, then upgradable stdlibs are primed to become former stdlibs, i.e. not shipped with julia, but before that it's confusing I think.

Also I don't believe we document that some stdlibs can be upgraded.