### PR TITLE
Increase version of `StaticArrays` in `why` tests

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -1585,7 +1585,7 @@ end
 
 @testset "why" begin
     isolate() do
-        Pkg.add(name = "StaticArrays", version = "1.5.0")
+        Pkg.add(name = "StaticArrays", version = "1.5.20")
 
         io = IOBuffer()
         Pkg.why("StaticArrays"; io)


### PR DESCRIPTION
 `StaticArrays@1.5.0` errors on `julia-1.11` and so does `StaticArrays@≤1.5.16` (https://github.com/JuliaRegistries/General/pull/86950#issuecomment-2403361516)
I tried to restrict `StaticArrays@≤1.5.16` to `julia-1.10` in the General Julia Registry in https://github.com/JuliaRegistries/General/pull/116935, but my PR was reverted in https://github.com/JuliaRegistries/General/pull/117626 due to the Pkg tests failing on `julia-1.11`, explicitly demanding to add `StaticArrays@1.5.0` to test the `why` functionality.

In order to restrict `StaticArrays@≤1.5.16` to `julia-1.10` and preventing the Pkg tests from erroring, we would need to adapt the `StaticArrays` version added in the `why` tests to be higher than `1.5.16` and below `1.6.0`, e.g. `1.5.20`.

Would it be possible to adjust this in the Pkg tests so that I can start another PR on the General Julia Registry?
