### PR TITLE
[release-1.10] Backports for 1.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - 'master'
       - 'release-*'
+      - 'backports-release-*'
   push:
     branches:
       - 'master'
       - 'release-*'
+      - 'backports-release-*'
     tags: '*'
 defaults:
   run:

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -13,7 +13,10 @@ may optionally have a manifest file:
 
 - **Manifest file:** a file in the root directory of a project, named
   `Manifest.toml` (or `JuliaManifest.toml`), describing a complete dependency graph
-  and exact versions of each package and library used by a project.
+  and exact versions of each package and library used by a project. The file name may
+  also be suffixed by `-v{major}.{minor}.toml` which julia will prefer if the version
+  matches `VERSION`, allowing multiple environments to be maintained for different julia
+  versions.
 
 **Package:** a project which provides reusable functionality that can be used by
 other Julia projects via `import X` or `using X`. A package should have a

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -11,6 +11,7 @@ import LibGit2
 using Printf
 
 use_cli_git() = Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
+const RESOLVING_DELTAS_HEADER = "Resolving Deltas:"
 
 function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     progress = unsafe_load(progress)
@@ -18,7 +19,10 @@ function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     bar = p[:transfer_progress]
     @assert typeof(bar) == MiniProgressBar
     if progress.total_deltas != 0
-        bar.header = "Resolving Deltas:"
+        if bar.header != RESOLVING_DELTAS_HEADER
+            bar.header = RESOLVING_DELTAS_HEADER
+            bar.prev = 0
+        end
         bar.max = progress.total_deltas
         bar.current = progress.indexed_deltas
     else

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -192,23 +192,20 @@ function projectfile_path(env_path::String; strict=false)
 end
 
 function manifestfile_path(env_path::String; strict=false)
-    man_names = @static Base.manifest_names isa Tuple ? Base.manifest_names : Base.manifest_names()
-    for name in man_names
+    for name in Base.manifest_names
         maybe_file = joinpath(env_path, name)
         isfile(maybe_file) && return maybe_file
     end
     if strict
         return nothing
     else
-        n_names = length(man_names)
-        if n_names == 1
-            return joinpath(env_path, only(man_name))
+        # given no matching manifest exists, if JuliaProject.toml is used,
+        # prefer to create JuliaManifest.toml, otherwise Manifest.toml
+        project, _ = splitext(basename(projectfile_path(env_path)::String))
+        if project == "JuliaProject"
+            return joinpath(env_path, "JuliaManifest.toml")
         else
-            project = basename(projectfile_path(env_path)::String)
-            idx = findfirst(x -> x == project, Base.project_names)
-            @assert idx !== nothing
-            idx = idx + (n_names - length(Base.project_names)) # ignore custom name if present
-            return joinpath(env_path, man_names[idx])
+            return joinpath(env_path, "Manifest.toml")
         end
     end
 end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -217,7 +217,11 @@ function read_manifest(f_or_io::Union{String, IO})
         rethrow()
     end
     if Base.is_v1_format_manifest(raw)
-        raw = convert_v1_format_manifest(raw)
+        if isempty(raw) # treat an empty Manifest file as v2 format for convenience
+            raw["manifest_format"] = "2.0.0"
+        else
+            raw = convert_v1_format_manifest(raw)
+        end
     end
     return Manifest(raw, f_or_io)
 end

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -44,6 +44,35 @@ end
         end
     end
 
+    @testset "Empty manifest file is automatically upgraded to v2" begin
+        isolate(loaded_depot=true) do
+            io = IOBuffer()
+            d = mktempdir()
+            manifest = joinpath(d, "Manifest.toml")
+            touch(manifest)
+            Pkg.activate(d; io=io)
+            output = String(take!(io))
+            @test occursin(r"Activating.*project at.*", output)
+            env_manifest = Pkg.Types.Context().env.manifest_file
+            @test samefile(env_manifest, manifest)
+            # an empty manifest is still technically considered to be v1 manifest
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+            @test Pkg.Types.Context().env.manifest.manifest_format == v"2.0.0"
+
+            Pkg.add("Profile"; io=io)
+            env_manifest = Pkg.Types.Context().env.manifest_file
+            @test samefile(env_manifest, manifest)
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+            @test Pkg.Types.Context().env.manifest.manifest_format == v"2.0.0"
+
+            # check that having a Project with deps, and an empty manifest file doesn't error
+            rm(manifest)
+            touch(manifest)
+            Pkg.activate(d; io=io)
+            Pkg.add("Example"; io=io)
+        end
+    end
+
     @testset "v1.0: activate, change, maintain manifest format" begin
         reference_manifest_isolated_test("v1.0", v1 = true) do env_dir, env_manifest
             io = IOBuffer()


### PR DESCRIPTION
Backported PRs:
- [x] #3731 <!-- fix preferential Manifest.toml naming --> for https://github.com/JuliaLang/julia/pull/56600
- [x] #4080 <!-- Actually switch to "Resolving Deltas" -->
- [x] #4091 <!-- Automatically upgrade empty manifest files to v2 format -->
- [x] https://github.com/JuliaLang/julia/pull/56624
- [x] https://github.com/JuliaLang/julia/pull/56621

Need manual backport:
- [ ] #4000 <!-- update package extension naming docs -->

Contains multiple commits, manual intervention needed:
- [ ] #3852 <!-- collect e.g. weak deps from project even if it is not a package -->
- [ ] #3865 <!-- make `add` and `dev` on a package remove it from the set of weak dependencies -->

Non-merged PRs with backport label:
- [ ] #4075 <!-- Fix artifact directories not having traversal permissions -->

