### PR TITLE
Backports release 1.11

### DIFF
--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -100,6 +100,7 @@ corresponding manifest file.
 ```toml
 [sources]
 Example = {url = "https://github.com/JuliaLang/Example.jl", rev = "custom_branch"}
+WithinMonorepo = {url = "https://github.org/author/BigProject", subdir = "SubPackage"}
 SomeDependency = {path = "deps/SomeDependency.jl"}
 ```
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -195,6 +195,9 @@ function update_source_if_set(project, pkg)
     if pkg.path !== nothing
         source["path"] = pkg.path
     end
+    if pkg.subdir !== nothing
+        source["subdir"] = pkg.subdir
+    end
     path, repo = get_path_repo(project, pkg.name)
     if path !== nothing
         pkg.path = path
@@ -204,6 +207,9 @@ function update_source_if_set(project, pkg)
     end
     if repo.rev !== nothing
         pkg.repo.rev = repo.rev
+    end
+    if repo.subdir !== nothing
+        pkg.repo.subdir = repo.subdir
     end
 end
 

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -11,6 +11,7 @@ import LibGit2
 using Printf
 
 use_cli_git() = Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
+const RESOLVING_DELTAS_HEADER = "Resolving Deltas:"
 
 function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     progress = unsafe_load(progress)
@@ -18,7 +19,10 @@ function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
     bar = p[:transfer_progress]
     @assert typeof(bar) == MiniProgressBar
     if progress.total_deltas != 0
-        bar.header = "Resolving Deltas:"
+        if bar.header != RESOLVING_DELTAS_HEADER
+            bar.header = RESOLVING_DELTAS_HEADER
+            bar.prev = 0
+        end
         bar.max = progress.total_deltas
         bar.current = progress.indexed_deltas
     else

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -217,7 +217,11 @@ function read_manifest(f_or_io::Union{String, IO})
         rethrow()
     end
     if Base.is_v1_format_manifest(raw)
-        raw = convert_v1_format_manifest(raw)
+        if isempty(raw) # treat an empty Manifest file as v2 format for convenience
+            raw["manifest_format"] = "2.0.0"
+        else
+            raw = convert_v1_format_manifest(raw)
+        end
     end
     return Manifest(raw, f_or_io)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -92,7 +92,7 @@ read_project_compat(raw, project::Project) =
 
 read_project_sources(::Nothing, project::Project) = Dict{String,Any}()
 function read_project_sources(raw::Dict{String,Any}, project::Project)
-    valid_keys = ("path", "url", "rev")
+    valid_keys = ("path", "url", "rev", "subdir")
     sources = Dict{String,Any}()
     for (name, source) in raw
         if !(source isa AbstractDict)

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -44,6 +44,35 @@ end
         end
     end
 
+    @testset "Empty manifest file is automatically upgraded to v2" begin
+        isolate(loaded_depot=true) do
+            io = IOBuffer()
+            d = mktempdir()
+            manifest = joinpath(d, "Manifest.toml")
+            touch(manifest)
+            Pkg.activate(d; io=io)
+            output = String(take!(io))
+            @test occursin(r"Activating.*project at.*", output)
+            env_manifest = Pkg.Types.Context().env.manifest_file
+            @test samefile(env_manifest, manifest)
+            # an empty manifest is still technically considered to be v1 manifest
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest))
+            @test Pkg.Types.Context().env.manifest.manifest_format == v"2.0.0"
+
+            Pkg.add("Profile"; io=io)
+            env_manifest = Pkg.Types.Context().env.manifest_file
+            @test samefile(env_manifest, manifest)
+            @test Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == false
+            @test Pkg.Types.Context().env.manifest.manifest_format == v"2.0.0"
+
+            # check that having a Project with deps, and an empty manifest file doesn't error
+            rm(manifest)
+            touch(manifest)
+            Pkg.activate(d; io=io)
+            Pkg.add("Example"; io=io)
+        end
+    end
+
     @testset "v1.0: activate, change, maintain manifest format" begin
         reference_manifest_isolated_test("v1.0", v1 = true) do env_dir, env_manifest
             io = IOBuffer()

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -33,6 +33,12 @@ temp_pkg_dir() do project_path
                 end
             end
 
+            cd(joinpath(dir, "WithSources", "TestMonorepo")) do
+                with_current_env() do
+                    Pkg.test()
+                end
+            end
+
             cd(joinpath(dir, "WithSources", "TestProject")) do
                 with_current_env() do
                     Pkg.test()

--- a/test/test_packages/WithSources/TestMonorepo/Project.toml
+++ b/test/test_packages/WithSources/TestMonorepo/Project.toml
@@ -1,0 +1,13 @@
+name = "TestMonorepo"
+uuid = "864d8eef-2526-4817-933e-34008eadd182"
+authors = ["KristofferC <kristoffer.carlsson@juliacomputing.com>"]
+version = "0.1.0"
+
+[extras]
+Example = "d359f271-ef68-451f-b4fc-6b43e571086c"
+
+[sources]
+Example = {url = "https://github.com/JuliaLang/Pkg.jl", subdir = "test/test_packages/Example"}
+
+[targets]
+test = ["Example"]

--- a/test/test_packages/WithSources/TestMonorepo/src/TestMonorepo.jl
+++ b/test/test_packages/WithSources/TestMonorepo/src/TestMonorepo.jl
@@ -1,0 +1,5 @@
+module TestMonorepo
+
+greet() = print("Hello World!")
+
+end

--- a/test/test_packages/WithSources/TestMonorepo/test/runtests.jl
+++ b/test/test_packages/WithSources/TestMonorepo/test/runtests.jl
@@ -1,0 +1,1 @@
+using Example


### PR DESCRIPTION
Backported PRs:
- [x] #4080 <!-- Actually switch to "Resolving Deltas" -->
- [x] #4091 <!-- Automatically upgrade empty manifest files to v2 format -->
- [x] #4039 <!-- Allow use of a url and subdir in [sources] -->



Non-merged PRs with backport label:
- [ ] #4075 <!-- Fix artifact directories not having traversal permissions -->