### PR TITLE
avoid writing and reparsing the artifact usage file once per artifact file in the project deps

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -982,9 +982,8 @@ function download_artifacts(ctx::Context;
         end
     end
 
-    for f in used_artifact_tomls
-        write_env_usage(f, "artifact_usage.toml")
-    end
+
+    write_env_usage(used_artifact_tomls, "artifact_usage.toml")
 end
 
 function check_artifacts_downloaded(pkg_root::String; platform::AbstractPlatform=HostPlatform())

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -613,7 +613,7 @@ write_env_usage(source_file::AbstractString, usage_filepath::AbstractString) =
 function write_env_usage(source_files, usage_filepath::AbstractString)
     # Don't record ghost usage
     source_files = filter(isfile, source_files)
-    !isempty(source_files) && return
+    isempty(source_files) && return
 
     # Ensure that log dir exists
     !ispath(logdir()) && mkpath(logdir())

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -606,9 +606,14 @@ function workspace_resolve_hash(env::EnvCache)
     return bytes2hex(sha1(str))
 end
 
-function write_env_usage(source_file::AbstractString, usage_filepath::AbstractString)
+
+write_env_usage(source_file::AbstractString, usage_filepath::AbstractString) =
+    write_env_usage([source_file], usage_filepath)
+
+function write_env_usage(source_files, usage_filepath::AbstractString)
     # Don't record ghost usage
-    !isfile(source_file) && return
+    source_files = filter(isfile, source_files)
+    !isempty(source_files) && return
 
     # Ensure that log dir exists
     !ispath(logdir()) && mkpath(logdir())
@@ -630,7 +635,9 @@ function write_env_usage(source_file::AbstractString, usage_filepath::AbstractSt
         end
 
         # record new usage
-        usage[source_file] = [Dict("time" => timestamp)]
+        for source_file in source_files
+            usage[source_file] = [Dict("time" => timestamp)]
+        end
 
         # keep only latest usage info
         for k in keys(usage)


### PR DESCRIPTION
> When in doubt, do things in bulk

The timings below will vary depending on the size of the artifact usage log file but I guess my computer is somewhat representative:

```
julia> ENV["JULIA_PKG_PRECOMPILE_AUTO"] = 0
0

julia> Pkg.activate(; temp=true)

julia> @btime Pkg.add("Plots")
# master
  618.572 ms (4700447 allocations: 339.36 MiB)

# PR
  428.434 ms (3376261 allocations: 268.50 MiB)
``` 

Looking at a TimerOutput profile we can see how the runtime for `download_artifacts` changes:

Master:

```
───────────────────────────────────────────────────────────────────────────────────────────────
                                                      Time                    Allocations      
                                             ───────────────────────   ────────────────────────
              Tot / % measured:                   829ms /  99.4%            340MiB /  99.3%    

Section                              ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────────
add                                       1    825ms  100.0%   825ms    338MiB  100.0%   338MiB
  add                                     1    825ms  100.0%   825ms    338MiB  100.0%   338MiB
...
    download_artifacts                    1    186ms   22.6%   186ms   75.8MiB   22.4%  75.8MiB
...
───────────────────────────────────────────────────────────────────────────────────────────────
```


PR:
```
───────────────────────────────────────────────────────────────────────────────────────────────
                                                      Time                    Allocations      
                                             ───────────────────────   ────────────────────────
              Tot / % measured:                   507ms /  99.6%            269MiB /  99.4%    

Section                              ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────────
add                                       1    505ms  100.0%   505ms    267MiB  100.0%   267MiB
  add                                     1    505ms  100.0%   505ms    267MiB  100.0%   267MiB
...
    download_artifacts                    1   7.46ms    1.3%  7.46ms   7.38MiB    2.7%  7.38MiB
...    
───────────────────────────────────────────────────────────────────────────────────────────────
```

186ms  -> 5.68 ms. 75 MB > 7.38 MB.