### PR TITLE
slightly improve memory in resolver code

### DIFF
--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -268,12 +268,17 @@ mutable struct Graph
                 p1 == p0 && error("Package $(pkgID(pkgs[p0], uuid_to_name)) version $vn has a dependency with itself")
                 # check conflicts instead of intersecting?
                 # (intersecting is used by fixed packages though...)
-                req_p1 = get!(VersionSpec, req, p1)
-                req[p1] = req_p1 ∩ vs
+                req_p1 = get(req, p1, nothing)
+                if req_p1 == nothing
+                    req[p1] = vs
+                else
+                    req[p1] = req_p1 ∩ vs
+                end
             end
             # Translate the requirements into bit masks
             # Hot code, measure performance before changing
             req_msk = Dict{Int,BitVector}()
+            sizehint!(req_msk, length(req))
             maybe_weak = haskey(compat_weak, uuid0) && haskey(compat_weak[uuid0], vn)
             for (p1, vs) in req
                 pv = pvers[p1]


### PR DESCRIPTION
Nothing dramatic but trying to grab some low hanging fruits.

```
Resolve.Graph               1    125ms   24.9%   125ms    136MiB   50.8%   136MiB
``` 

vs
```                       
Resolve.Graph               1    102ms   21.0%   102ms    104MiB   44.1%   104MiB
``` 