### PR TITLE
Fix JLL version fix fix

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -510,11 +510,11 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
             new_v = vers_fix[uuid]
             if old_v != new_v
                 compat_map[uuid][old_v] = compat_map[uuid][new_v]
+                # Note that we don't delete!(compat_map[uuid], old_v) because we want to keep the compat info around
+                # in case there's JLL version confusion between the sysimage pkgorigins version and manifest
+                # but that issue hasn't been fully specified, so keep it to be cautious
             end
             vers_fix[uuid] = old_v
-            # Note that we don't delete!(compat_map[uuid], old_v) because we want to keep the compat info around
-            # in case there's JLL version confusion between the sysimage pkgorigins version and manifest
-            # but that issue hasn't been fully specified, so keep it to be cautious
         end
     end
     vers = vers_fix

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -508,9 +508,9 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
         # We only fixup a JLL if the old major/minor/patch matches the new major/minor/patch
         if old_v !== nothing && Base.thispatch(old_v) == Base.thispatch(vers_fix[uuid])
             new_v = vers_fix[uuid]
-            compat_map[pkg.uuid][old_v] = compat_map[pkg.uuid][new_v]
+            compat_map[uuid][old_v] = compat_map[uuid][new_v]
             vers_fix[uuid] = old_v
-            delete!(compat_map[pkg.uuid], new_v)
+            delete!(compat_map[uuid], new_v)
         end
     end
     vers = vers_fix

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -510,7 +510,7 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
             new_v = vers_fix[uuid]
             compat_map[uuid][old_v] = compat_map[uuid][new_v]
             vers_fix[uuid] = old_v
-            delete!(compat_map[uuid], new_v)
+            new_v != old_v && delete!(compat_map[uuid], new_v)
         end
     end
     vers = vers_fix

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -508,7 +508,9 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
         # We only fixup a JLL if the old major/minor/patch matches the new major/minor/patch
         if old_v !== nothing && Base.thispatch(old_v) == Base.thispatch(vers_fix[uuid])
             new_v = vers_fix[uuid]
-            compat_map[uuid][old_v] = compat_map[uuid][new_v]
+            if old_v != new_v
+                compat_map[uuid][old_v] = compat_map[uuid][new_v]
+            end
             vers_fix[uuid] = old_v
             # Note that we don't delete!(compat_map[uuid], old_v) because we want to keep the compat info around
             # in case there's JLL version confusion between the sysimage pkgorigins version and manifest

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -510,7 +510,9 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
             new_v = vers_fix[uuid]
             compat_map[uuid][old_v] = compat_map[uuid][new_v]
             vers_fix[uuid] = old_v
-            new_v != old_v && delete!(compat_map[uuid], new_v)
+            # Note that we don't delete!(compat_map[uuid], old_v) because we want to keep the compat info around
+            # in case there's JLL version confusion between the sysimage pkgorigins version and manifest
+            # but that issue hasn't been fully specified, so keep it to be cautious
         end
     end
     vers = vers_fix

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -507,7 +507,10 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
         old_v = get(jll_fix, uuid, nothing)
         # We only fixup a JLL if the old major/minor/patch matches the new major/minor/patch
         if old_v !== nothing && Base.thispatch(old_v) == Base.thispatch(vers_fix[uuid])
+            new_v = vers_fix[uuid]
+            compat_map[pkg.uuid][old_v] = compat_map[pkg.uuid][new_v]
             vers_fix[uuid] = old_v
+            delete!(compat_map[pkg.uuid], new_v)
         end
     end
     vers = vers_fix


### PR DESCRIPTION
Reported here https://github.com/JuliaRegistries/General/pull/122129#issuecomment-2572659866

```
ERROR: KeyError: key v"1.0.11+3" not found
Stacktrace:
  [1] getindex
    @ ./dict.jl:498 [inlined]
  [2] resolve_versions!(env::Pkg.Types.EnvCache, registries::Vector{Pkg.Registry.RegistryInstance}, pkgs::Vector{Pkg.Types.PackageSpec}, julia_version::VersionNumber, installed_only::Bool)
    @ Pkg.Operations ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/Operations.jl:452
  [3] up(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}, level::Pkg.Types.UpgradeLevel; skip_writing_project::Bool, preserve::Nothing)
    @ Pkg.Operations ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/Operations.jl:1546
  [4] up
    @ ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/Operations.jl:1528 [inlined]
  [5] up(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}; level::Pkg.Types.UpgradeLevel, mode::Pkg.Types.PackageMode, preserve::Nothing, update_registry::Bool, skip_writing_project::Bool, kwargs::@Kwargs{})
    @ Pkg.API ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/API.jl:351
  [6] up
    @ ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/API.jl:326 [inlined]
  [7] up
    @ ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/API.jl:164 [inlined]
  [8] #resolve#143
    @ ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/API.jl:357 [inlined]
  [9] resolve
    @ ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/API.jl:356 [inlined]
 [10] resolve(; io::Base.TTY, kwargs::@Kwargs{})
    @ Pkg.API ~/.asdf/installs/julia/1.10.7/share/julia/stdlib/v1.10/Pkg/src/API.jl:355
 [11] top-level scope
    @ none:1
```