### PR TITLE
[release-1.11] 1.11 backports

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -436,6 +436,13 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
         old_v = get(jll_fix, uuid, nothing)
         # We only fixup a JLL if the old major/minor/patch matches the new major/minor/patch
         if old_v !== nothing && Base.thispatch(old_v) == Base.thispatch(vers_fix[uuid])
+            new_v = vers_fix[uuid]
+            if old_v != new_v
+                compat_map[uuid][old_v] = compat_map[uuid][new_v]
+                # Note that we don't delete!(compat_map[uuid], old_v) because we want to keep the compat info around
+                # in case there's JLL version confusion between the sysimage pkgorigins version and manifest
+                # but that issue hasn't been fully specified, so keep it to be cautious
+            end
             vers_fix[uuid] = old_v
         end
     end


### PR DESCRIPTION
Backported PRs:
- [x] #4130 <!-- Fix JLL version fix fix -->

Non-merged PRs with backport label:
- [ ] #4128 <!-- Don't set up LibGit2 callbacks if using cli git -->
- [ ] #4075 <!-- Fix artifact directories not having traversal permissions -->