### PR TITLE
Use copy_test_packages in some more places, and ensure that the copied test package is user writable.

### DIFF
--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -98,9 +98,8 @@ using UUIDs
     isolate(loaded_depot=false) do
         mktempdir() do dir
             Pkg.Registry.add("General")
-            path = joinpath(@__DIR__, "test_packages", "TestWeakDepProject")
-            cp(path, joinpath(dir, "TestWeakDepProject"))
-            Pkg.activate(joinpath(dir, "TestWeakDepProject"))
+            path = copy_test_package(dir, "TestWeakDepProject")
+            Pkg.activate(path)
             Pkg.resolve()
             @test Pkg.dependencies()[UUID("2ab3a3ac-af41-5b50-aa03-7779005ae688")].version == v"0.3.26"
 

--- a/test/new.jl
+++ b/test/new.jl
@@ -3224,9 +3224,8 @@ end
 temp_pkg_dir() do project_path
     @testset "test entryfile entries" begin
         mktempdir() do dir
-            path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "ProjectPath"))
-            cp(path, joinpath(dir, "ProjectPath"))
-            cd(joinpath(dir, "ProjectPath")) do
+            path = copy_test_package(dir, "ProjectPath")
+            cd(path) do
                 with_current_env() do
                     Pkg.resolve()
                     @test success(run(`$(Base.julia_cmd()) --startup-file=no --project -e 'using ProjectPath'`))
@@ -3238,9 +3237,8 @@ temp_pkg_dir() do project_path
 end
 @testset "test resolve with tree hash" begin
     mktempdir() do dir
-        path = abspath(joinpath(@__DIR__, "../test", "test_packages", "ResolveWithRev"))
-        cp(path, joinpath(dir, "ResolveWithRev"))
-        cd(joinpath(dir, "ResolveWithRev")) do
+        path = copy_test_package(dir, "ResolveWithRev")
+        cd(path) do
             with_current_env() do
                 @test !isfile("Manifest.toml")
                 @test !isdir(joinpath(DEPOT_PATH[1], "packages", "Example"))

--- a/test/project_manifest.jl
+++ b/test/project_manifest.jl
@@ -7,9 +7,8 @@ using ..Utils
 temp_pkg_dir() do project_path
     @testset "test Project.toml manifest" begin
         mktempdir() do dir
-            path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "monorepo"))
-            cp(path, joinpath(dir, "monorepo"))
-            cd(joinpath(dir, "monorepo")) do
+            path = copy_test_package(dir, "monorepo")
+            cd(path) do
                 with_current_env() do
                     Pkg.develop(path="packages/B")
                 end

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -7,9 +7,8 @@ using ..Utils
 temp_pkg_dir() do project_path
     @testset "test Project.toml [sources]" begin
         mktempdir() do dir
-            path = abspath(joinpath(dirname(pathof(Pkg)), "../test", "test_packages", "WithSources"))
-            cp(path, joinpath(dir, "WithSources"))
-            cd(joinpath(dir, "WithSources")) do
+            path = copy_test_package(dir, "WithSources")
+            cd(path) do
                 with_current_env() do
                     Pkg.resolve()
                     @test !isempty(Pkg.project().sources["Example"])

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -270,9 +270,21 @@ function git_init_package(tmp, path)
     return pkgpath
 end
 
+function ensure_test_package_user_writable(dir)
+    for (root, _, files) in walkdir(dir)
+        chmod(root, filemode(root) | 0o200 | 0o100)
+
+        for file in files
+            filepath = joinpath(root, file)
+            chmod(filepath, filemode(filepath) | 0o200)
+        end
+    end
+end
+
 function copy_test_package(tmpdir::String, name::String; use_pkg=true)
     target = joinpath(tmpdir, name)
     cp(joinpath(@__DIR__, "test_packages", name), target)
+    ensure_test_package_user_writable(target)
     use_pkg || return target
 
     # The known Pkg UUID, and whatever UUID we're currently using for testing

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -148,9 +148,8 @@ end
 
 @testset "test resolve with tree hash" begin
     mktempdir() do dir
-        path = abspath(joinpath(@__DIR__, "../test", "test_packages", "WorkspaceTestInstantiate"))
-        cp(path, joinpath(dir, "WorkspaceTestInstantiate"))
-        cd(joinpath(dir, "WorkspaceTestInstantiate")) do
+        path = copy_test_package(dir, "WorkspaceTestInstantiate")
+        cd(path) do
             with_current_env() do
                 @test !isfile("Manifest.toml")
                 @test !isfile("test/Manifest.toml")


### PR DESCRIPTION
The tests assume the copied files are writable, so this makes this assumption explicit and enforces it. This allows running the Pkg tests as part of Base.runtests of an installed Julia installation, where sources might be readonly. 