### PR TITLE
Update LineEdit internal for hints

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -154,7 +154,7 @@ function create_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
                     end
                 else
                     LineEdit.edit_insert(s, ';')
-                    LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
+                    LineEdit.check_show_hint(s)
                 end
             end
         end
@@ -181,7 +181,7 @@ function repl_init(repl::REPL.LineEditREPL)
                 end
             else
                 LineEdit.edit_insert(s, ']')
-                LineEdit.check_for_hint(s) && LineEdit.refresh_line(s)
+                LineEdit.check_show_hint(s)
             end
         end
     )


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/57243

Missed this in https://github.com/JuliaLang/julia/pull/57192

```
julia> a[1]┌ Error: Error in the keymap
│   exception =
│    UndefVarError: `check_for_hint` not defined in `REPL.LineEdit`
│    Suggestion: check for spelling errors or missing imports.
│    Stacktrace:
│     [1] getproperty
│       @ ./Base_compiler.jl:47 [inlined]
│     [2] (::REPLExt.var"#repl_init##0#repl_init##1"{REPL.LineEdit.Prompt})(::REPL.LineEdit.MIState, ::REPL.LineEditREPL, ::Vararg{Any})
│       @ REPLExt ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/Pkg/ext/REPLExt/REPLExt.jl:184
│     [3] #invokelatest#1
│       @ ./essentials.jl:1057 [inlined]
│     [4] invokelatest
│       @ ./essentials.jl:1053 [inlined]
│     [5] (::REPL.LineEdit.var"#match_input##0#match_input##1"{REPLExt.var"#repl_init##0#repl_init##1"{REPL.LineEdit.Prompt}, String})(s::Any, p::Any)
│       @ REPL.LineEdit ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:1794
│     [6] macro expansion
│       @ ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2944 [inlined]
│     [7] macro expansion
│       @ ./lock.jl:376 [inlined]
│     [8] (::REPL.LineEdit.var"#prompt!##2#prompt!##3"{REPL.Terminals.TTYTerminal, REPL.LineEdit.ModalInterface, REPL.LineEdit.MIState, REPL.LineEdit.Prompt})()
│       @ REPL.LineEdit ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2933
└ @ REPL.LineEdit ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2946
```