### PR TITLE
reset caching of STDLIBs reading after precompilation is done

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -869,5 +869,6 @@ include("precompile.jl")
 DEFAULT_IO[] = nothing
 Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
 PREV_ENV_PATH[] = ""
+Types.STDLIB[] = nothing
 
 end # module

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -471,7 +471,7 @@ is_project_uuid(env::EnvCache, uuid::UUID) = project_uuid(env) == uuid
 
 const UPGRADABLE_STDLIBS = ["DelimitedFiles", "Statistics"]
 const UPGRADABLE_STDLIBS_UUIDS = Set{UUID}()
-const STDLIB = Ref{DictStdLibs}()
+const STDLIB = Ref{Union{DictStdLibs, Nothing}}(nothing)
 function load_stdlib()
     stdlib = DictStdLibs()
     for name in readdir(stdlib_dir())
@@ -500,7 +500,7 @@ function stdlibs()
     return Dict(uuid => (info.name, info.version) for (uuid, info) in stdlib_infos())
 end
 function stdlib_infos()
-    if !isassigned(STDLIB)
+    if STDLIB[] === nothing
         STDLIB[] = load_stdlib()
     end
     return STDLIB[]


### PR DESCRIPTION
There is a use case where one wants to provide extra "fake" stdlibs after Pkg has been precompiled. Right now, Pkg stores the set of stdlibs during precompile time breaking that use case. This resets it. 