### PR TITLE
Add more tests for BinaryBuilder usage

### DIFF
--- a/test/historical_stdlib_version.jl
+++ b/test/historical_stdlib_version.jl
@@ -320,10 +320,12 @@ isolate(loaded_depot=true) do
                 # specific version vs. compat spec
                 @testset for version in (v"3.24.3+0", "3.24.3")
                     dependencies = [PackageSpec(; name="CMake_jll", version = version)]
-                    @testset "with context" begin
+                    @testset "with context (using private Pkg.add method)" begin
                         Pkg.activate(temp=true)
                         ctx = Pkg.Types.Context(; julia_version=nothing)
-                        Pkg.add(ctx, deepcopy(dependencies); platform)
+                        mydeps = deepcopy(dependencies)
+                        foreach(Pkg.API.handle_package_input!, mydeps)
+                        Pkg.add(ctx, mydeps; platform)
                     end
                     @testset "with julia_version" begin
                         Pkg.activate(temp=true)

--- a/test/historical_stdlib_version.jl
+++ b/test/historical_stdlib_version.jl
@@ -317,16 +317,18 @@ isolate(loaded_depot=true) do
             end
             @testset "non-stdlib JLL add" begin
                 platform = Platform("x86_64", "linux"; libc="musl")
-                @testset "with a specific version" begin
-                    dependencies = [PackageSpec(; name="CMake_jll", version = v"3.24.3+0")]
-                    Pkg.activate(temp=true)
-                    Pkg.add(deepcopy(dependencies); platform, julia_version=nothing)
-                end
-                @testset "with a compat spec" begin
-                    # note the string spec and lack of a `+0` here
-                    dependencies = [PackageSpec(; name="CMake_jll", version = "3.24.3")]
-                    Pkg.activate(temp=true)
-                    Pkg.add(deepcopy(dependencies); platform, julia_version=nothing)
+                # specific version vs. compat spec
+                @testset for version in (v"3.24.3+0", "3.24.3")
+                    dependencies = [PackageSpec(; name="CMake_jll", version = version)]
+                    @testset "with context" begin
+                        Pkg.activate(temp=true)
+                        ctx = Pkg.Types.Context(; julia_version=nothing)
+                        Pkg.add(ctx, deepcopy(dependencies); platform)
+                    end
+                    @testset "with julia_version" begin
+                        Pkg.activate(temp=true)
+                        Pkg.add(deepcopy(dependencies); platform, julia_version=nothing)
+                    end
                 end
             end
         end

--- a/test/historical_stdlib_version.jl
+++ b/test/historical_stdlib_version.jl
@@ -315,18 +315,18 @@ isolate(loaded_depot=true) do
                 @test v"0.3.14" > Pkg.dependencies()[OpenBLAS_jll_UUID].version >= v"0.3.13"
                 @test v"5.1.2" > Pkg.dependencies()[libblastrampoline_jll_UUID].version >= v"5.1.1"
             end
-            @testset "non-stdlib add" begin
-                dependencies = [PackageSpec(; name="CMake_jll", version = v"3.24.3")]
+            @testset "non-stdlib JLL add" begin
                 platform = Platform("x86_64", "linux"; libc="musl")
-
-                @testset "with julia_version directly" begin
+                @testset "with a specific version" begin
+                    dependencies = [PackageSpec(; name="CMake_jll", version = v"3.24.3+0")]
                     Pkg.activate(temp=true)
                     Pkg.add(deepcopy(dependencies); platform, julia_version=nothing)
                 end
-                @testset "with an already resolved context" begin
+                @testset "with a compat spec" begin
+                    # note the string spec and lack of a `+0` here
+                    dependencies = [PackageSpec(; name="CMake_jll", version = "3.24.3")]
                     Pkg.activate(temp=true)
-                    ctx = Pkg.Types.Context(;julia_version=nothing)
-                    Pkg.add(ctx, deepcopy(dependencies); platform)
+                    Pkg.add(deepcopy(dependencies); platform, julia_version=nothing)
                 end
             end
         end


### PR DESCRIPTION
Originally the tests added here were
```
dependencies = [PackageSpec(; name="CMake_jll", version = v"3.24.3")]
Pkg.add(deepcopy(dependencies); platform, julia_version=nothing)
```
which hit an error, but it turned out to be an incomplete `VersionNumber` that the Resolver wasn't making clear https://github.com/JuliaLang/Pkg.jl/issues/4159

Note `v"3.24.3+0"` exists, but `v"3.24.3"` doesn't.