### PR TITLE
Rename depot tmp dir to temp

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -717,7 +717,7 @@ function install_archive(
     version_path::String;
     io::IO=stderr_f()
 )::Bool
-    depot_temp = mkpath(joinpath(dirname(dirname(dirname(version_path))), "tmp"))
+    depot_temp = mkpath(joinpath(dirname(dirname(dirname(version_path))), "temp"))
     tmp_objects = String[]
     url_success = false
     for (url, top) in urls


### PR DESCRIPTION
#4180 introduced using `.julia/tmp`

On reflection, `temp` would probably be more depot style.

![Screenshot 2025-03-02 at 9 52 11 AM](https://github.com/user-attachments/assets/fdc9d368-1f1f-4467-8997-f02fe3b70456)
