### PR TITLE
Update registries if necessary during `dev`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -249,6 +249,7 @@ function develop(ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool=true,
 
     new_git = handle_repos_develop!(ctx, pkgs, shared)
 
+    Operations.update_registries(ctx; force=false, update_cooldown=Day(1))
 
     for pkg in pkgs
         if Types.collides_with_project(ctx.env, pkg)


### PR DESCRIPTION
Fixes #4185 

Otherwise resolve can fail if the manifest that the package is being dev-ed into is in a newer state than the local machine's registry.