### PR TITLE
Add a helper script for making missing Pkg tags

### DIFF
--- a/contrib/list_missing_pkg_tags.jl
+++ b/contrib/list_missing_pkg_tags.jl
@@ -43,9 +43,9 @@ function get_commit_hash_for_pkg_version(repo, tag)
             println("Warning: Pkg.version file missing for tag $tag")
             return nothing
         end
-    catch e
-        println("Error processing tag $tag: ", e)
-        return nothing
+    catch
+        println("Error processing tag $tag")
+        rethrow()
     end
 end
 

--- a/contrib/list_missing_pkg_tags.jl
+++ b/contrib/list_missing_pkg_tags.jl
@@ -1,0 +1,89 @@
+using LibGit2
+
+const JULIA_REPO_URL = "https://github.com/JuliaLang/julia.git"
+const JULIA_REPO_DIR = "julia"
+const PKG_VERSION_PATH = "stdlib/Pkg.version"
+const PKG_REPO_URL = "https://github.com/JuliaLang/Pkg.jl.git"
+const PKG_REPO_DIR = "Pkg.jl"
+
+function checkout_or_update_repo(url, dir)
+    if isdir(dir)
+        println("Updating existing repository: $dir")
+        repo = LibGit2.GitRepo(dir)
+        LibGit2.fetch(repo)
+    else
+        println("Cloning repository: $url")
+        LibGit2.clone(url, dir)
+    end
+end
+
+function get_tags(repo)
+    refs = LibGit2.ref_list(repo)
+    tags = filter(ref -> startswith(ref, "refs/tags/"), refs)
+    return sort!(replace.(tags, "refs/tags/" => ""))
+end
+
+function is_stable_v1_release(tag)
+    return occursin(r"^v\d+\.\d+\.\d+$", tag) && VersionNumber(tag) >= v"1.0.0"
+end
+
+function extract_pkg_sha1(text::AbstractString)
+    m = match(r"PKG_SHA1\s*=\s*([a-f0-9]{40})", text)
+    return m !== nothing ? m[1] : nothing
+end
+
+function get_commit_hash_for_pkg_version(repo, tag)
+    try
+        tag_ref = LibGit2.GitReference(repo, "refs/tags/" * tag)
+        LibGit2.checkout!(repo, string(LibGit2.GitHash(LibGit2.peel(tag_ref))))
+        version_file = joinpath(JULIA_REPO_DIR, PKG_VERSION_PATH)
+        if isfile(version_file)
+            return extract_pkg_sha1(readchomp(version_file))
+        else
+            println("Warning: Pkg.version file missing for tag $tag")
+            return nothing
+        end
+    catch e
+        println("Error processing tag $tag: ", e)
+        return nothing
+    end
+end
+
+tempdir = mktempdir()
+cd(tempdir) do
+    # Update Julia repo
+    checkout_or_update_repo(JULIA_REPO_URL, JULIA_REPO_DIR)
+    julia_repo = LibGit2.GitRepo(JULIA_REPO_DIR)
+
+    # Get Julia tags, filtering only stable releases
+    julia_tags = filter(is_stable_v1_release, get_tags(julia_repo))
+    version_commit_map = Dict{String, String}()
+
+    for tag in julia_tags
+        println("Processing Julia tag: $tag")
+        commit_hash = get_commit_hash_for_pkg_version(julia_repo, tag)
+        if commit_hash !== nothing
+            version_commit_map[tag] = commit_hash
+        end
+    end
+
+    # Update Pkg.jl repo
+    checkout_or_update_repo(PKG_REPO_URL, PKG_REPO_DIR)
+    pkg_repo = LibGit2.GitRepo(PKG_REPO_DIR)
+
+    # Get existing tags in Pkg.jl
+    pkg_tags = Set(get_tags(pkg_repo))
+
+    # Filter out versions that already exist
+    missing_versions = filter(v -> v ∉ pkg_tags, collect(keys(version_commit_map)))
+
+    # Sort versions numerically
+    sort!(missing_versions, by=VersionNumber)
+
+    # Generate `git tag` commands
+    println("\nGit tag commands for missing Pkg.jl versions:")
+    for version in missing_versions
+        commit = version_commit_map[version]
+        println("git tag $version $commit")
+    end
+end


### PR DESCRIPTION
Output as of now:
```
Git tag commands for missing Pkg.jl versions:
git tag v1.0.5 1609a05aee5d5960670738d8d834d91235bd6b1e
git tag v1.3.1 f71e2c5a119b9c850f9b357fc8c56068f5b51cc0
git tag v1.4.1 9419c70af69153cd5c4276bff90fbb135e0aa3f1
git tag v1.5.4 0c3ccb119efd8b3182c114599abe78bc4f89dd4c
git tag v1.6.2 ab8f6c8e7fbfc86023e45d937b3298c7afdc872b
git tag v1.6.3 12d944551784d6f84446768738d4e917cd857764
git tag v1.6.5 3d41ca188d72e1dc1862e780f31153d629d6a3dd
git tag v1.6.6 30a31381d06d845999314d39005ee8457bd08924
git tag v1.6.7 292c1e637a0a8e15b8b5fa8e6fe14dcc0b0cd6e5
git tag v1.8.3 354530e4c8c3215d92ae15672e7a2bab1db62f76
git tag v1.8.4 b09e05add2442b2ffae9d7bdd7976a7d36949433
git tag v1.8.5 b09e05add2442b2ffae9d7bdd7976a7d36949433
git tag v1.9.1 3fa06b9f96fc8a180f9285447584c84e4d8d8278
git tag v1.10.5 edfa2ed0ea117d61d33405d4214edb6513b3f236
git tag v1.10.6 d4a39f00d50d1fed30dcebb3af97801a8ac2d66a
git tag v1.10.7 06f7a7e5bb0fedc20455060d6778f5a66851c026
git tag v1.10.8 6390ea92bf585e182c96cb5db7529c067874e5f5
git tag v1.10.9 0b3af4592d7158d4cba1132a9cc9df15e8e51706
git tag v1.11.1 aba90d22b42a993b118276caa8df5146776d3844
git tag v1.11.2 64bf95a4847898cf70de54d0c861c877ed5c1595
git tag v1.11.3 2eb8ae5b8f421fc77295f9cf382132d39e14d16f
git tag v1.11.4 2eb8ae5b8f421fc77295f9cf382132d39e14d16f
```