### PR TITLE
Fix eagerly stopping hint completions

### DIFF
--- a/ext/REPLExt/completions.jl
+++ b/ext/REPLExt/completions.jl
@@ -54,9 +54,9 @@ end
 
 
 const JULIA_UUID = UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
-function complete_remote_package(partial; hint::Bool)
-    found_match = false
-    isempty(partial) && return String[]
+function complete_remote_package!(comps, partial; hint::Bool)
+    isempty(partial) && return true # true means returned early
+    found_match = !isempty(comps)
     cmp = Set{String}()
     for reg in Registry.reachable_registries()
         for (uuid, regpkg) in reg
@@ -80,9 +80,9 @@ function complete_remote_package(partial; hint::Bool)
                     if is_julia_compat === nothing || is_julia_compat
                         push!(cmp, name)
                         # In hint mode the result is only used if there is a single matching entry
-                        # so we abort the search
+                        # so we can return no matches in case of more than one match
                         if hint && found_match
-                            return sort!(collect(cmp))
+                            return true # true means returned early
                         end
                         found_match = true
                         break
@@ -91,7 +91,8 @@ function complete_remote_package(partial; hint::Bool)
             end
         end
     end
-    return sort!(collect(cmp))
+    append!(comps, sort!(collect(cmp)))
+    return false # false means performed full search
 end
 
 function complete_help(options, partial; hint::Bool)
@@ -149,8 +150,9 @@ function complete_add_dev(options, partial, i1, i2; hint::Bool)
     if occursin(Base.Filesystem.path_separator_re, partial)
         return comps, idx, !isempty(comps)
     end
-    comps = vcat(comps, sort(complete_remote_package(partial; hint)))
-    if !isempty(partial)
+    returned_early = complete_remote_package!(comps, partial; hint)
+    # returning early means that no further search should be done here
+    if !returned_early
         append!(comps, filter!(startswith(partial), [info.name for info in values(Types.stdlib_infos())]))
     end
     return comps, idx, !isempty(comps)


### PR DESCRIPTION
Fixes #4200 

https://github.com/JuliaLang/Pkg.jl/pull/3917 wasn't quite the right fix. I think key thing is knowing whether the were path completions before completing packages, and we also need to know whether to skip the stdlib section.

<img width="274" alt="Screenshot 2025-03-29 at 2 34 04 PM" src="https://github.com/user-attachments/assets/909642fa-7a50-4d69-8e45-a1d1cc9383fd" />

and 
<img width="303" alt="Screenshot 2025-03-29 at 2 34 13 PM" src="https://github.com/user-attachments/assets/760f3c57-ab83-4ed7-9f92-371998b1754e" />

