### PR TITLE
Lock io within printpkgstyle to avoid print tearing

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,8 @@
+# "Precompiling" is the longest operation
+const pkgstyle_indent = textwidth(string(:Precompiling))
 
 function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false; color=:green)
-    indent = textwidth(string(:Precompiling)) # "Precompiling" is the longest operation
-    ignore_indent && (indent = 0)
+    indent = ignore_indent ? 0 : pkgstyle_indent
     printstyled(io, lpad(string(cmd), indent), color=color, bold=true)
     println(io, " ", text)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,8 +3,10 @@ const pkgstyle_indent = textwidth(string(:Precompiling))
 
 function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false; color=:green)
     indent = ignore_indent ? 0 : pkgstyle_indent
-    printstyled(io, lpad(string(cmd), indent), color=color, bold=true)
-    println(io, " ", text)
+    @lock io begin
+        printstyled(io, lpad(string(cmd), indent), color=color, bold=true)
+        println(io, " ", text)
+    end
 end
 
 function linewrap(str::String; io = stdout_f(), padding = 0, width = Base.displaysize(io)[2])


### PR DESCRIPTION
This was sometimes breaking up printing so the test failed. i.e.
```
Installed 2025-03-29T21:02:12.769
artifact FFMPEG                10.6 MiB
```
