### PR TITLE
Backports release 1.10

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -84,7 +84,14 @@ function _mv_temp_artifact_dir(temp_dir::String, new_path::String)::Nothing
         err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), temp_dir, new_path)
         if err ≥ 0
             # rename worked
-            chmod(new_path, filemode(dirname(new_path)))
+            new_path_mode = filemode(dirname(new_path))
+            if Sys.iswindows()
+                # If this is Windows, ensure the directory mode is executable,
+                # as `filemode()` is incomplete.  Some day, that may not be the
+                # case, there exists a test that will fail if this is changes.
+                new_path_mode |= 0o111
+            end
+            chmod(new_path, new_path_mode)
             set_readonly(new_path)
             return
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,9 +1,12 @@
+# "Precompiling" is the longest operation
+const pkgstyle_indent = textwidth(string(:Precompiling))
 
 function printpkgstyle(io::IO, cmd::Symbol, text::String, ignore_indent::Bool=false; color=:green)
-    indent = textwidth(string(:Precompiling)) # "Precompiling" is the longest operation
-    ignore_indent && (indent = 0)
-    printstyled(io, lpad(string(cmd), indent), color=color, bold=true)
-    println(io, " ", text)
+    indent = ignore_indent ? 0 : pkgstyle_indent
+    @lock io begin
+        printstyled(io, lpad(string(cmd), indent), color=color, bold=true)
+        println(io, " ", text)
+    end
 end
 
 function linewrap(str::String; io = stdout_f(), padding = 0, width = Base.displaysize(io)[2])

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -825,4 +825,16 @@ end
     end
 end
 
+if Sys.iswindows()
+    @testset "filemode(dir) non-executable on windows" begin
+        mktempdir() do dir
+            touch(joinpath(dir, "foo"))
+            @test !isempty(readdir(dir))
+            # This technically should be true, the fact that it's not is
+            # a wrinkle of libuv, it would be nice to fix it and so if we
+            # do, this test will let us know.
+            @test filemode(dir) & 0o001 == 0
+        end
+    end
+end
 end # module


### PR DESCRIPTION
Backported PRs:
- [x] #4128 <!-- Don't set up LibGit2 callbacks if using cli git -->
- [x] #4075 <!-- Fix artifact directories not having traversal permissions -->
- [x] #4202 <!-- Lock io within printpkgstyle to avoid print tearing -->

Need manual backport:
- [ ] #4136 <!-- Use copy_test_packages in some more places, and ensure that the copied test package is user writable. -->
- [ ] #4177 <!-- Update docs for versioned manifest -->

Contains multiple commits, manual intervention needed:
- [ ] #4151 <!-- Fixes for julia_version. Expand and consolidate julia_version tests. -->

Non-merged PRs with backport label:
- [ ] #4186 <!-- Update registries if necessary during `dev` -->