### PR TITLE
Use `git -C` instead of `cd`

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -169,13 +169,11 @@ function fetch(io::IO, repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing,
     try
         if use_cli_git()
             let remoteurl=remoteurl
-                cd(LibGit2.path(repo)) do
-                    cmd = `git fetch -q $remoteurl $(only(refspecs))`
-                    try
-                        run(pipeline(cmd; stdout=devnull))
-                    catch err
-                        Pkg.Types.pkgerror("The command $(cmd) failed, error: $err")
-                    end
+                cmd = `git -C $(LibGit2.path(repo)) fetch -q $remoteurl $(only(refspecs))`
+                try
+                    run(pipeline(cmd; stdout=devnull))
+                catch err
+                    Pkg.Types.pkgerror("The command $(cmd) failed, error: $err")
                 end
             end
         else


### PR DESCRIPTION
It is simpler to not let the current Julia process change its working
directory and just tell `git` where to work. (Noticed this when
launching a new tmux tab which opened up with a `.julia/clones/` working
diretory, for example.)
