### PR TITLE
Backport also collect packages tracking a repo when "traversing" developed packages (#4198)

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -292,16 +292,20 @@ function collect_developed!(env::EnvCache, pkg::PackageSpec, developed::Vector{P
     source = project_rel_path(env, source_path(env.manifest_file, pkg))
     source_env = EnvCache(projectfile_path(source))
     pkgs = load_all_deps(source_env)
-    for pkg in filter(is_tracking_path, pkgs)
+    for pkg in pkgs
         if any(x -> x.uuid == pkg.uuid, developed)
             continue
         end
-        # normalize path
-        pkg.path = Types.relative_project_path(env.manifest_file,
-                   project_rel_path(source_env,
-                   source_path(source_env.manifest_file, pkg)))
-        push!(developed, pkg)
-        collect_developed!(env, pkg, developed)
+        if is_tracking_path(pkg)
+            # normalize path
+            pkg.path = Types.relative_project_path(env.manifest_file,
+                    project_rel_path(source_env,
+                    source_path(source_env.manifest_file, pkg)))
+            push!(developed, pkg)
+            collect_developed!(env, pkg, developed)
+        elseif is_tracking_repo(pkg)
+            push!(developed, pkg)
+        end
     end
 end
 

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -44,6 +44,12 @@ temp_pkg_dir() do project_path
                     Pkg.test()
                 end
             end
+
+            cd(joinpath(dir, "WithSources", "URLSourceInDevvedPackage")) do
+                with_current_env() do
+                    Pkg.test()
+                end
+            end
         end
     end
 end

--- a/test/test_packages/WithSources/TestMonorepo/Project.toml
+++ b/test/test_packages/WithSources/TestMonorepo/Project.toml
@@ -3,11 +3,15 @@ uuid = "864d8eef-2526-4817-933e-34008eadd182"
 authors = ["KristofferC <kristoffer.carlsson@juliacomputing.com>"]
 version = "0.1.0"
 
+[deps]
+Unregistered = "dcb67f36-efa0-11e8-0cef-2fc465ed98ae"
+
 [extras]
 Example = "d359f271-ef68-451f-b4fc-6b43e571086c"
 
 [sources]
 Example = {url = "https://github.com/JuliaLang/Pkg.jl", subdir = "test/test_packages/Example"}
+Unregistered = {url = "https://github.com/00vareladavid/Unregistered.jl", rev = "1b7a462"}
 
 [targets]
 test = ["Example"]

--- a/test/test_packages/WithSources/TestMonorepo/src/TestMonorepo.jl
+++ b/test/test_packages/WithSources/TestMonorepo/src/TestMonorepo.jl
@@ -1,4 +1,5 @@
 module TestMonorepo
+using Unregistered
 
 greet() = print("Hello World!")
 

--- a/test/test_packages/WithSources/TestMonorepo/test/runtests.jl
+++ b/test/test_packages/WithSources/TestMonorepo/test/runtests.jl
@@ -1,1 +1,2 @@
 using Example
+using Unregistered

--- a/test/test_packages/WithSources/URLSourceInDevvedPackage/Project.toml
+++ b/test/test_packages/WithSources/URLSourceInDevvedPackage/Project.toml
@@ -1,0 +1,10 @@
+name = "URLSourceInDevvedPackage"
+uuid = "78d3b172-12ec-4a7f-9187-8bf78594552a"
+version = "0.1.0"
+authors = ["Kristoffer <kcarlsson89@gmail.com>"]
+
+[deps]
+TestMonorepo = "864d8eef-2526-4817-933e-34008eadd182"
+
+[sources]
+TestMonorepo = {path = "../TestMonorepo"}

--- a/test/test_packages/WithSources/URLSourceInDevvedPackage/src/URLSourceInDevvedPackage.jl
+++ b/test/test_packages/WithSources/URLSourceInDevvedPackage/src/URLSourceInDevvedPackage.jl
@@ -1,0 +1,5 @@
+module URLSourceInDevvedPackage
+
+greet() = print("Hello World!")
+
+end # module URLSourceInDevvedPackage

--- a/test/test_packages/WithSources/URLSourceInDevvedPackage/test/runtests.jl
+++ b/test/test_packages/WithSources/URLSourceInDevvedPackage/test/runtests.jl
@@ -1,0 +1,2 @@
+using URLSourceInDevvedPackage
+using TestMonorepo


### PR DESCRIPTION

(cherry picked from commit bde7ce0392712e4cc16464fe1ee50cedbc43a6d4)