### PR TITLE
Export PkgArtifacts from itself under the name Artifacts for compat

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -14,8 +14,8 @@ import Artifacts: artifact_names, ARTIFACTS_DIR_OVERRIDE, ARTIFACT_OVERRIDES, ar
                   query_override, with_artifacts_directory, load_overrides
 import ..Types: write_env_usage, parse_toml
 
-
-export create_artifact, artifact_exists, artifact_path, remove_artifact, verify_artifact,
+const Artifacts = PkgArtifacts # This is to preserve compatability for folks who depend on the internals of this module
+export Artifacts, create_artifact, artifact_exists, artifact_path, remove_artifact, verify_artifact,
        artifact_meta, artifact_hash, bind_artifact!, unbind_artifact!, download_artifact,
        find_artifacts_toml, ensure_artifact_installed, @artifact_str, archive_artifact,
        select_downloadable_artifacts, ArtifactDownloadInfo
@@ -328,7 +328,7 @@ function download_artifact(
     io::IO=stderr_f(),
     progress::Union{Function, Nothing} = nothing,
 )
-    _artifact_paths = Artifacts.artifact_paths(tree_hash)
+    _artifact_paths = artifact_paths(tree_hash)
     pidfile = _artifact_paths[1] * ".pid"
     mkpath(dirname(pidfile))
     t_wait_msg = Timer(2) do t


### PR DESCRIPTION
To prevent breakage due to https://github.com/JuliaLang/Pkg.jl/pull/3750 for folks who choose to use `using Pkg.Artifacts; Artifacts.[...]` instead of `using Artifacts; Artifacts.[...]`. (e.g. https://github.com/JuliaSmoothOptimizers/SuiteSparseMatrixCollection.jl/pull/85)