### PR TITLE
Support parsing version 0.0.0 internally for package versions

### DIFF
--- a/src/Versions.jl
+++ b/src/Versions.jl
@@ -331,9 +331,6 @@ function semver_interval(m::RegexMatch)
     major =                           parse(Int, _major)
     minor = (n_significant < 2) ? 0 : parse(Int, _minor)
     patch = (n_significant < 3) ? 0 : parse(Int, _patch)
-    if n_significant == 3 && major == 0 && minor == 0 && patch == 0
-        error("invalid version: \"0.0.0\"")
-    end
     # Default type is :caret
     vertyp = (typ == "" || typ == "^") ? :caret : :tilde
     v0 = VersionBound((major, minor, patch))
@@ -368,12 +365,10 @@ function inequality_interval(m::RegexMatch)
     major =                           parse(Int, _major)
     minor = (n_significant < 2) ? 0 : parse(Int, _minor)
     patch = (n_significant < 3) ? 0 : parse(Int, _patch)
-    if n_significant == 3 && major == 0 && minor == 0 && patch == 0
-        error("invalid version: 0.0.0")
-    end
     v = VersionBound(major, minor, patch)
     if occursin(r"^<\s*$", typ)
         nil = VersionBound(0, 0, 0)
+        v == v"0.0.0" && return VersionRange(nil, nil)
         if v[3] == 0
             if v[2] == 0
                 v1 = VersionBound(v[1]-1)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -90,6 +90,7 @@ import Pkg.Types: semver_spec, VersionSpec
     @test !(v"1.2.2" in semver_spec(">=1.2.3"))
 
     @test_throws ErrorException semver_spec("0.1.0-0.2.2")
+    @test semver_spec("0.0.0") == VersionSpec("0.0.0-0.0.0")
     @test semver_spec("0.1.0 - 0.2.2") == VersionSpec("0.1.0 - 0.2.2")
     @test semver_spec("1.2.3 - 4.5.6") == semver_spec("1.2.3  - 4.5.6") == semver_spec("1.2.3 -  4.5.6") == semver_spec("1.2.3  -  4.5.6")
     @test semver_spec("0.0.1 - 0.0.2") == VersionSpec("0.0.1 - 0.0.2")
@@ -144,7 +145,6 @@ import Pkg.Types: semver_spec, VersionSpec
 
     @test_throws ErrorException semver_spec("^^0.2.3")
     @test_throws ErrorException semver_spec("^^0.2.3.4")
-    @test_throws ErrorException semver_spec("0.0.0")
     @test_throws ErrorException semver_spec("0.7 1.0")
 
     @test Pkg.Types.isjoinable(Pkg.Types.VersionBound((1,5)), Pkg.Types.VersionBound((1,6)))


### PR DESCRIPTION
As was agreed in https://github.com/JuliaLang/julia/pull/57520, we decided to introduce a special `v"0.0.0"` version for Compiler as a fallback to `Base.Compiler`.

The issue is that Pkg internals [explicitly forbid](https://github.com/JuliaLang/Pkg.jl/blob/80d2e7505970b9f1a33b2a4e1c4c5bcea7a709b0/test/pkg.jl#L147) to use this version number, which shows up as

```julia
(Pkg) pkg> add Compiler@0.0.0
   Resolving package versions...
ERROR: invalid version: "0.0.0"
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:44
  [2] semver_interval(m::RegexMatch{String})
    @ Pkg.Versions ~/.julia/dev/Pkg/src/Versions.jl:335
  [3] semver_spec(s::String; throw::Bool)
    @ Pkg.Versions ~/.julia/dev/Pkg/src/Versions.jl:310
  [4] semver_spec
    @ ~/.julia/dev/Pkg/src/Versions.jl:303 [inlined]
  [5] set_compat
    @ ~/.julia/dev/Pkg/src/Operations.jl:303 [inlined]
  [6] add(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}, new_git::Set{Base.UUID}; allow_autoprecomp::Bool, preserve::PreserveLevel, platform::Base.BinaryPlatforms.Platform, target::Symbol)
    @ Pkg.Operations ~/.julia/dev/Pkg/src/Operations.jl:1725
  [...]
```

However, it seems that semantic versioning actually allows such a version number (see [this post](https://stackoverflow.com/a/66610835)). Furthermore, compat ranges generated by Pkg may in fact include `v"0.0.0"`, and are documented as such in https://pkgdocs.julialang.org/v1/compatibility/#Caret-specifiers. I also suspect that most things should "just work" with it.

For these reasons, it seems reasonable to me to add support for it. I would not be surprised however that it requires some discussion before a consensus is reached as to whether this is desirable or not.

Regarding the changes proposed in this PR, I would appreciate any pointers toward areas that require further modification or that are suspected to break.

(cc @aviatesk)