### PR TITLE
WIP: `Pkg.Registry.update()`: throw if an error is encountered

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -392,7 +392,7 @@ function update(; name=nothing, uuid=nothing, url=nothing, path=nothing, linked=
         update([RegistrySpec(; name, uuid, url, path, linked)]; kwargs...)
     end
 end
-function update(regs::Vector{RegistrySpec}; io::IO=stderr_f(), force::Bool=true, depots = [depots1()], update_cooldown = Second(1))
+function update(regs::Vector{RegistrySpec}; io::IO=stderr_f(), force::Bool=true, depots = [depots1()], update_cooldown = Second(1), throw_on_error = true)
     registry_update_log = get_registry_update_log()
     for depot in depots
         depot_regs = isempty(regs) ? reachable_registries(; depots=depot) : regs
@@ -430,6 +430,7 @@ function update(regs::Vector{RegistrySpec}; io::IO=stderr_f(), force::Bool=true,
                                     try
                                         download_verify(url, nothing, tmp)
                                     catch err
+                                        throw_on_error && rethrow()
                                         push!(errors, (reg.path, "failed to download from $(url). Exception: $(sprint(showerror, err))"))
                                         @goto done_tarball_read
                                     end


### PR DESCRIPTION
Fixes #4244 

With this PR, by default, if `Pkg.Registry.update()` encounters an exception, we will throw that exception.

However, the user can revert to the previous behavior (all exceptions are caught, none are rethrown) by specifying `throw_on_error = false`.

The name `throw_on_error` can be bikeshedded.