### PR TITLE
don't use tree hash from manifest if the path is set from sources

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -400,7 +400,9 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
         manifest_resolve!(ctx.env.manifest, pkgs)
         ensure_resolved(ctx, ctx.env.manifest, pkgs)
     end
-
+    for pkg in pkgs
+        update_source_if_set(ctx.env.project, pkg)
+    end
     Operations.up(ctx, pkgs, level; skip_writing_project, preserve)
     return
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1769,7 +1769,9 @@ function up_load_versions!(ctx::Context, pkg::PackageSpec, entry::PackageEntry, 
     entry.version !== nothing || return false # no version to set
     if entry.pinned || level == UPLEVEL_FIXED
         pkg.version = entry.version
-        pkg.tree_hash = entry.tree_hash
+        if pkg.path === nothing
+            pkg.tree_hash = entry.tree_hash
+        end
     elseif entry.repo.source !== nothing || source_repo.source !== nothing # repo packages have a version but are treated specially
         if source_repo.source !== nothing
             pkg.repo = source_repo

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -298,6 +298,9 @@ function destructure(manifest::Manifest)::Dict
     end
 
     for (uuid, entry) in manifest
+        # https://github.com/JuliaLang/Pkg.jl/issues/4086
+        @assert !(entry.tree_hash !== nothing && entry.path !== nothing)
+
         new_entry = something(entry.other, Dict{String,Any}())
         new_entry["uuid"] = string(uuid)
         entry!(new_entry, "version", entry.version)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/4086