### PR TITLE
Explain that no registry is installed when no registry is installed

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1586,6 +1586,12 @@ function is_all_registered(registries::Vector{Registry.RegistryInstance}, pkgs::
 end
 
 function check_registered(registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec})
+    if isempty(registries) && !isempty(pkgs)
+        registry_pkgs = filter(tracking_registered_version, pkgs)
+        if !isempty(registry_pkgs)
+            pkgerror("no registries have been installed. Cannot resolve the following packages:\n$(join(map(pkg -> "  " * err_rep(pkg), registry_pkgs), "\n"))")
+        end
+    end
     pkg = is_all_registered(registries, pkgs)
     if pkg isa PackageSpec
         pkgerror("expected package $(err_rep(pkg)) to be registered")


### PR DESCRIPTION
Currently you can get 
```
ERROR: LoadError: expected package `CSV [336ed68f]` to be registered
Stacktrace:
  [1] pkgerror(msg::String)
    @ Pkg.Types /opt/hostedtoolcache/julia/1.[11](https://github.com/JuliaManifolds/Manopt.jl/actions/runs/15639606087/job/44064155398#step:8:12).5/x64/share/julia/stdlib/v1.11/Pkg/src/Types.jl:68
  [2] check_registered
    @ /opt/hostedtoolcache/julia/1.11.5/x64/share/julia/stdlib/v1.11/Pkg/src/Operations.jl:[13](https://github.com/JuliaManifolds/Manopt.jl/actions/runs/15639606087/job/44064155398#step:8:14)29 [inlined]
...
```
Which can make the package listed seem special and send the user off on a wild goose chase about that package.

But the problem is that no registry is installed, so explain that.

I kept the list of packages in in case someone is intentionally trying to use julia without registries, so knowing the package list is helpful.

With this PR

<img width="663" alt="Screenshot 2025-06-13 at 8 51 03 PM" src="https://github.com/user-attachments/assets/461c254f-c381-40cd-8570-5cb1ea6c07a1" />
