### PR TITLE
Fix historical stdlib fixup if `Pkg` is in the Manifest

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -235,7 +235,7 @@ function fixups_from_projectfile!(ctx::Context)
             # pkg.exts = p.exts # TODO: STDLIBS_BY_VERSION doesn't record this
             # pkg.entryfile = p.entryfile # TODO: STDLIBS_BY_VERSION doesn't record this
             for (name, _) in pkg.weakdeps
-                if !haskey(p.deps, name)
+                if !(name in p.deps)
                     delete!(pkg.deps, name)
                 end
             end

--- a/test/historical_stdlib_version.jl
+++ b/test/historical_stdlib_version.jl
@@ -255,6 +255,11 @@ isolate(loaded_depot=true) do
             end
         end
 
+        @testset "Old Pkg add regression" begin
+            Pkg.activate(temp=true)
+            Pkg.add(; name="Pkg", julia_version=v"1.11")
+        end
+
         @testset "Stdlib add" begin
             Pkg.activate(temp=true)
             # Stdlib add (current julia version)


### PR DESCRIPTION
The code here appeared to be untested and broke whenever something actually used it. Example backtrace:

```
julia> JLLPrefixes.collect_artifact_paths(["ripgrep_jll"])
ERROR: MethodError: no method matching haskey(::Vector{Base.UUID}, ::String)
The function `haskey` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  haskey(::Pkg.Types.Manifest, ::Any)
   @ Pkg ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/Pkg/src/Types.jl:323
  haskey(::REPL.Terminals.TTYTerminal, ::Any)
   @ REPL ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/REPL/src/Terminals.jl:155
  haskey(::LibGit2.CachedCredentials, ::Any)
   @ LibGit2 ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/LibGit2/src/types.jl:1357
  ...

Stacktrace:
  [1] fixups_from_projectfile!(ctx::Pkg.Types.Context)
    @ Pkg.Operations ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/Pkg/src/Operations.jl:238
  [2] add(ctx::Pkg.Types.Context, pkgs::Vector{…}, new_git::Set{…}; allow_autoprecomp::Bool, preserve::Pkg.Types.PreserveLevel, platform::Base.BinaryPlatforms.Platform, target::Symbol)
    @ Pkg.Operations ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/Pkg/src/Operations.jl:1710
  [3] add
    @ ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/Pkg/src/Operations.jl:1680 [inlined]
  [4] add(ctx::Pkg.Types.Context, pkgs::Vector{…}; preserve::Pkg.Types.PreserveLevel, platform::Base.BinaryPlatforms.Platform, target::Symbol, allow_autoprecomp::Bool, kwargs::@Kwargs{…})
    @ Pkg.API ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/Pkg/src/API.jl:328
```