### PR TITLE
Registry: Properly pass down `depot`

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -26,10 +26,14 @@ public activate, add, build, compat, develop, free, gc, generate, instantiate,
        pin, precompile, redo, rm, resolve, status, test, undo, update, why
 
 depots() = Base.DEPOT_PATH
-function depots1()
-    d = depots()
-    isempty(d) && Pkg.Types.pkgerror("no depots found in DEPOT_PATH")
-    return d[1]
+function depots1(depot_list::Union{String, Vector{String}}=depots())
+    # Get the first depot from a list, with proper error handling
+    if depot_list isa String
+        return depot_list
+    else
+        isempty(depot_list) && Pkg.Types.pkgerror("no depots provided")
+        return depot_list[1]
+    end
 end
 
 function pkg_server()

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -257,7 +257,7 @@ end
         @test isempty(Registry.reachable_registries(; depots=[depot_off_path]))
 
         # After this, we have depots only in the depot that's off the path
-        Registry.add("General"; depot=depot_off_path)
+        Registry.add("General"; depots=depot_off_path)
         @test isempty(Registry.reachable_registries())
         @test length(Registry.reachable_registries(; depots=[depot_off_path])) == 1
 


### PR DESCRIPTION
The `depot` kwarg was not being passed down to `reachable_registries`, causing installation of the default registry to fail in non-standard depots if the registry had been added to the default depot.