### PR TITLE
feat(errors): Improve error message for incorrect package UUID

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1594,7 +1594,15 @@ function check_registered(registries::Vector{Registry.RegistryInstance}, pkgs::V
     end
     pkg = is_all_registered(registries, pkgs)
     if pkg isa PackageSpec
-        pkgerror("expected package $(err_rep(pkg)) to be registered")
+        msg = "expected package $(err_rep(pkg)) to be registered"
+        # check if the name exists in the registry with a different uuid
+        if pkg.name !== nothing
+            uuids = Types.registered_uuids(registries, pkg.name)
+            if !isempty(uuids)
+                msg *= "\n You may have provided the wrong UUID for package $(pkg.name).\n Found the following UUIDs for that name: $(join(uuids, ", "))"
+            end
+        end
+        pkgerror(msg)
     end
     return nothing
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1597,9 +1597,18 @@ function check_registered(registries::Vector{Registry.RegistryInstance}, pkgs::V
         msg = "expected package $(err_rep(pkg)) to be registered"
         # check if the name exists in the registry with a different uuid
         if pkg.name !== nothing
-            uuids = Types.registered_uuids(registries, pkg.name)
-            if !isempty(uuids)
-                msg *= "\n You may have provided the wrong UUID for package $(pkg.name).\n Found the following UUIDs for that name: $(join(uuids, ", "))"
+            reg_uuid = Pair{String, Vector{UUID}}[]
+            for reg in registries
+                uuids = Registry.uuids_from_name(reg, pkg.name)
+                if !isempty(uuids)
+                    push!(reg_uuid, reg.name => uuids)
+                end
+            end
+            if !isempty(reg_uuid)
+                msg *= "\n You may have provided the wrong UUID for package $(pkg.name).\n Found the following UUIDs for that name:"
+                for (reg, uuids) in reg_uuid
+                    msg *= "\n  - $(join(uuids, ", ")) from registry: $reg"
+                end
             end
         end
         pkgerror(msg)

--- a/test/new.jl
+++ b/test/new.jl
@@ -538,7 +538,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         package_path = copy_test_package(tempdir, "UnregisteredUUID")
         Pkg.activate(package_path)
-        @test_throws PkgError("expected package `Example [142fd7e7]` to be registered") Pkg.add("JSON")
+        @test_throws PkgError Pkg.add("JSON")
     end end
     # empty git repo (no commits)
     isolate(loaded_depot=true) do; mktempdir() do tempdir
@@ -1536,7 +1536,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         package_path = copy_test_package(tempdir, "UnregisteredUUID")
         Pkg.activate(package_path)
-        @test_throws PkgError("expected package `Example [142fd7e7]` to be registered") Pkg.update()
+        @test_throws PkgError Pkg.update()
     end end
 end
 
@@ -1714,7 +1714,7 @@ end
     isolate(loaded_depot=true) do; mktempdir() do tempdir
         package_path = copy_test_package(tempdir, "UnregisteredUUID")
         Pkg.activate(package_path)
-        @test_throws PkgError("expected package `Example [142fd7e7]` to be registered") Pkg.update()
+        @test_throws PkgError Pkg.update()
     end end
     # package does not exist in the manifest
     isolate(loaded_depot=true) do

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -215,7 +215,8 @@ temp_pkg_dir() do project_path
                 errstr = sprint(showerror, e)
                 @test occursin("expected package `Example [00000000]` to be registered", errstr)
                 @test occursin("You may have provided the wrong UUID for package Example.", errstr)
-                @test occursin("Found the following UUIDs for that name: 7876af07-990d-54b4-ab0e-23690620f79a", errstr)
+                @test occursin("Found the following UUIDs for that name:", errstr)
+                @test occursin("- 7876af07-990d-54b4-ab0e-23690620f79a from registry: General", errstr)
             end
         end
         # Missing uuid

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -207,6 +207,17 @@ temp_pkg_dir() do project_path
 
     @testset "package with wrong UUID" begin
         @test_throws PkgError Pkg.add(PackageSpec(TEST_PKG.name, UUID(UInt128(1))))
+        @testset "package with wrong UUID but correct name" begin
+            try
+                Pkg.add(PackageSpec(name="Example", uuid=UUID(UInt128(2))))
+            catch e
+                @test e isa PkgError
+                errstr = sprint(showerror, e)
+                @test occursin("expected package `Example [00000000]` to be registered", errstr)
+                @test occursin("You may have provided the wrong UUID for package Example.", errstr)
+                @test occursin("Found the following UUIDs for that name: 7876af07-990d-54b4-ab0e-23690620f79a", errstr)
+            end
+        end
         # Missing uuid
         @test_throws PkgError Pkg.add(PackageSpec(uuid = uuid4()))
     end


### PR DESCRIPTION
When a user attempts to add a package with a correct name but an incorrect UUID, the error message was previously a generic "package not registered". This could leave the user unsure of the root cause.

This commit enhances the error handling to detect this specific scenario. If the provided package name exists in the registry but with a different UUID, the error message will now include the correct UUID(s) found for that package name, guiding the user toward the correct command.

A new test case is added to ensure the new error message is triggered correctly and displays the expected information.

Fixes #4267

This commit was written by an AI assistant.