### PR TITLE
make more descriptive errors if `first` fails on empty urls when installing a git repo or finding installed registries

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -788,6 +788,17 @@ function install_git(
     urls::Set{String},
     version_path::String
 )::Nothing
+    if isempty(urls)
+        pkgerror(
+            "Package $name [$uuid] has no repository URL available. This could happen if:\n" *
+                "  - The package is not registered in any configured registry\n" *
+                "  - The package exists in a registry but lacks repository information\n" *
+                "  - Registry files are corrupted or incomplete\n" *
+                "  - Network issues prevented registry updates\n" *
+                "Please check that the package name is correct and that your registries are up to date."
+        )
+    end
+
     repo = nothing
     tree = nothing
     # TODO: Consolidate this with some of the repo handling in Types.jl
@@ -795,8 +806,9 @@ function install_git(
         clones_dir = joinpath(depots1(), "clones")
         ispath(clones_dir) || mkpath(clones_dir)
         repo_path = joinpath(clones_dir, string(uuid))
-        repo = GitTools.ensure_clone(io, repo_path, first(urls); isbare=true,
-                                     header = "[$uuid] $name from $(first(urls))")
+        first_url = first(urls)
+        repo = GitTools.ensure_clone(io, repo_path, first_url; isbare=true,
+                                     header = "[$uuid] $name from $first_url")
         git_hash = LibGit2.GitHash(hash.bytes)
         for url in urls
             try LibGit2.with(LibGit2.GitObject, repo, git_hash) do g

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -138,7 +138,9 @@ function populate_known_registries_with_urls!(registries::Vector{RegistrySpec})
         elseif reg.name !== nothing
             if reg.name == known.name
                 named_regs = filter(r -> r.name == reg.name, known_registries)
-                if !all(r -> r.uuid == first(named_regs).uuid, named_regs)
+                if isempty(named_regs)
+                    Pkg.Types.pkgerror("registry with name `$(reg.name)` not found in known registries.")
+                elseif !all(r -> r.uuid == first(named_regs).uuid, named_regs)
                     Pkg.Types.pkgerror("multiple registries with name `$(reg.name)`, please specify with uuid.")
                 end
                 reg.uuid = known.uuid
@@ -340,7 +342,9 @@ function find_installed_registries(io::IO,
             elseif needle.name !== nothing
                 if needle.name == candidate.name
                     named_regs = filter(r -> r.name == needle.name, haystack)
-                    if !all(r -> r.uuid == first(named_regs).uuid, named_regs)
+                    if isempty(named_regs)
+                        Pkg.Types.pkgerror("registry with name `$(needle.name)` not found in reachable registries.")
+                    elseif !all(r -> r.uuid == first(named_regs).uuid, named_regs)
                         Pkg.Types.pkgerror("multiple registries with name `$(needle.name)`, please specify with uuid.")
                     end
                     push!(output, candidate)


### PR DESCRIPTION
Fixes #3879