### PR TITLE
fix unused imports reported by ExplicitImports.jl

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,3 +28,30 @@ jobs:
       - uses: fredrikekre/runic-action@v1
         with:
           version: "1.4" # Keep version in sync with .pre-commit-config.yaml
+
+  explicit-imports:
+    runs-on: ubuntu-latest
+    name: "ExplicitImports.jl"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 'nightly'
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Install dependencies
+        shell: julia {0}
+        run: |
+          # Add ExplicitImports.jl
+          using Pkg
+          Pkg.add([
+            PackageSpec(name = "ExplicitImports", version = "1.6"),
+          ])
+      - name: ExplicitImports.jl code checks
+        shell: julia --project {0}
+        run: |
+          using Pkg, ExplicitImports
+          check_no_implicit_imports(Pkg)
+          # check_no_stale_explicit_imports(Pkg) # artifact_names in PkgArtifacts
+          check_all_qualified_accesses_via_owners(Pkg)
+          check_no_self_qualified_accesses(Pkg)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
           # Add ExplicitImports.jl
           using Pkg
           Pkg.add([
-            PackageSpec(name = "ExplicitImports", version = "1.6"),
+            PackageSpec(name = "ExplicitImports", version = "1.12"),
           ])
       - name: ExplicitImports.jl code checks
         shell: julia --project {0}

--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -4,10 +4,12 @@ if Base.get_bool_env("JULIA_PKG_DISALLOW_PKG_PRECOMPILATION", false) == true
     error("Precompililing Pkg extension REPLExt is disallowed. JULIA_PKG_DISALLOW_PKG_PRECOMPILATION=$(ENV["JULIA_PKG_DISALLOW_PKG_PRECOMPILATION"])")
 end
 
-using Markdown, UUIDs, Dates
+using Dates: Dates
+using Markdown: Markdown
+using UUIDs: UUIDs, UUID
 
 import REPL
-import .REPL: LineEdit, REPLCompletions, TerminalMenus
+import .REPL: LineEdit, TerminalMenus
 
 import Pkg
 import .Pkg: linewrap, pathrepr, compat, can_fancyprint, printpkgstyle, PKGMODE_PROJECT

--- a/ext/REPLExt/precompile.jl
+++ b/ext/REPLExt/precompile.jl
@@ -29,10 +29,10 @@ let
         copy!(DEPOT_PATH, original_depot_path)
         copy!(LOAD_PATH, original_load_path)
 
-        Base.precompile(Tuple{typeof(REPL.LineEdit.complete_line), REPLExt.PkgCompletionProvider, REPL.LineEdit.PromptState})
+        Base.precompile(Tuple{typeof(REPL.LineEdit.complete_line), PkgCompletionProvider, REPL.LineEdit.PromptState})
         Base.precompile(Tuple{typeof(REPL.REPLCompletions.completion_text), REPL.REPLCompletions.PackageCompletion})
-        Base.precompile(Tuple{typeof(REPLExt.on_done), REPL.LineEdit.MIState, Base.GenericIOBuffer{Memory{UInt8}}, Bool, REPL.LineEditREPL})
-        Base.precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:hint,), Tuple{Bool}}, typeof(REPL.LineEdit.complete_line), REPLExt.PkgCompletionProvider, REPL.LineEdit.PromptState})
+        Base.precompile(Tuple{typeof(on_done), REPL.LineEdit.MIState, Base.GenericIOBuffer{Memory{UInt8}}, Bool, REPL.LineEditREPL})
+        Base.precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:hint,), Tuple{Bool}}, typeof(REPL.LineEdit.complete_line), PkgCompletionProvider, REPL.LineEdit.PromptState})
         return
     end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -2,21 +2,20 @@
 
 module API
 
-using UUIDs
-using Printf
+using UUIDs: UUIDs, UUID
+using Printf: Printf
 import Random
-using Dates
+using Dates: Dates, DateTime, Day, Period, now
 import LibGit2
 import Logging
 import FileWatching
 
-import Base: StaleCacheKey
 
-import ..depots, ..depots1, ..logdir, ..devdir, ..printpkgstyle
+import ..depots1, ..logdir, ..devdir, ..printpkgstyle
 import ..Operations, ..GitTools, ..Pkg, ..Registry
 import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH
-using ..Types, ..TOML
-using ..Types: VersionTypes
+using ..Types
+using TOML: TOML
 using Base.BinaryPlatforms
 import ..stderr_f, ..stdout_f
 using ..Artifacts: artifact_paths
@@ -583,7 +582,7 @@ function gc(ctx::Context = Context(); collect_delay::Period = Day(7), verbose = 
     env = ctx.env
 
     # Only look at user-depot unless force=true
-    gc_depots = force ? depots() : [depots1()]
+    gc_depots = force ? Base.DEPOT_PATH : [depots1()]
 
     # First, we load in our `manifest_usage.toml` files which will tell us when our
     # "index files" (`Manifest.toml`, `Artifacts.toml`) were last used.  We will combine
@@ -1430,10 +1429,10 @@ function activate(path::AbstractString; shared::Bool = false, temp::Bool = false
             end
         end
     else
-        # initialize `fullpath` in case of empty `Pkg.depots()`
+        # initialize `fullpath` in case of empty `Base.DEPOT_PATH`
         fullpath = ""
         # loop over all depots to check if the shared environment already exists
-        for depot in Pkg.depots()
+        for depot in Base.DEPOT_PATH
             fullpath = joinpath(Pkg.envdir(depot), path)
             isdir(fullpath) && break
         end

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -2,11 +2,12 @@ module Apps
 
 using Pkg
 using Pkg.Versions
-using Pkg.Types: AppInfo, PackageSpec, Context, EnvCache, PackageEntry, Manifest, handle_repo_add!, handle_repo_develop!, write_manifest, write_project,
+using Pkg.Types: AppInfo, PackageSpec, Context, EnvCache, PackageEntry, Manifest, handle_repo_add!, handle_repo_develop!, write_manifest,
     pkgerror, projectfile_path, manifestfile_path
 using Pkg.Operations: print_single, source_path, update_package_add
 using Pkg.API: handle_package_input!
-using TOML, UUIDs
+using TOML: TOML
+using UUIDs: UUIDs, UUID
 import Pkg.Registry
 
 app_env_folder() = joinpath(first(DEPOT_PATH), "environments", "apps")

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -1,6 +1,12 @@
 module PkgArtifacts
 
-using Artifacts, Base.BinaryPlatforms, SHA
+using Artifacts: artifact_names, @artifact_str, artifact_exists, artifact_hash, artifact_meta,
+    artifact_path, find_artifacts_toml,
+    select_downloadable_artifacts, artifact_paths,
+    artifacts_dirs, pack_platform!, unpack_platform, load_artifacts_toml,
+    query_override
+using Base.BinaryPlatforms
+using SHA: SHA, SHA256_CTX, sha256
 using ..MiniProgressBars, ..PlatformEngines
 using Tar: can_symlink
 using FileWatching: FileWatching
@@ -9,9 +15,6 @@ import ..set_readonly, ..GitTools, ..TOML, ..pkg_server, ..can_fancyprint,
     ..stderr_f, ..printpkgstyle, ..mv_temp_dir_retries
 
 import Base: get, SHA1
-import Artifacts: artifact_names, ARTIFACTS_DIR_OVERRIDE, ARTIFACT_OVERRIDES, artifact_paths,
-    artifacts_dirs, pack_platform!, unpack_platform, load_artifacts_toml,
-    query_override, with_artifacts_directory, load_overrides
 import ..Types: write_env_usage, parse_toml
 
 const Artifacts = PkgArtifacts # This is to preserve compatability for folks who depend on the internals of this module

--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -5,10 +5,9 @@ module GitTools
 using ..Pkg
 using ..MiniProgressBars
 import ..can_fancyprint, ..printpkgstyle, ..stdout_f
-using SHA
-import Base: SHA1
+using SHA: SHA, update!
 import LibGit2
-using Printf
+using Printf: Printf
 
 use_cli_git() = Base.get_bool_env("JULIA_PKG_USE_CLI_GIT", false)
 const RESOLVING_DELTAS_HEADER = "Resolving Deltas:"
@@ -75,7 +74,7 @@ function ensure_clone(io::IO, target_path, url; kwargs...)
     if ispath(target_path)
         return LibGit2.GitRepo(target_path)
     else
-        return GitTools.clone(io, url, target_path; kwargs...)
+        return clone(io, url, target_path; kwargs...)
     end
 end
 

--- a/src/MiniProgressBars.jl
+++ b/src/MiniProgressBars.jl
@@ -2,7 +2,7 @@ module MiniProgressBars
 
 export MiniProgressBar, start_progress, end_progress, show_progress, print_progress_bottom
 
-using Printf
+using Printf: Printf, @sprintf
 
 # Until Base.format_bytes supports sigdigits
 function pkg_format_bytes(bytes; binary = true, sigdigits::Integer = 3)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3,17 +3,17 @@
 module Operations
 
 using FileWatching: FileWatching
-using UUIDs
+using UUIDs: UUIDs, UUID
 using Random: randstring
 import LibGit2, Dates, TOML
 
 using ..Types, ..Resolve, ..PlatformEngines, ..GitTools, ..MiniProgressBars
-import ..depots, ..depots1, ..devdir, ..set_readonly, ..Types.PackageEntry
-import ..Artifacts: ensure_artifact_installed, artifact_names, extract_all_hashes,
+import ..depots1, ..devdir, ..set_readonly, ..Types.PackageEntry
+import ..Artifacts: ensure_artifact_installed, artifact_names,
     artifact_exists, select_downloadable_artifacts, mv_temp_dir_retries
 using Base.BinaryPlatforms
 import ...Pkg
-import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
+import ...Pkg: Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
 import ...Pkg: usable_io
 
@@ -33,7 +33,7 @@ function find_installed(name::String, uuid::UUID, sha1::SHA1)
     slug_default = Base.version_slug(uuid, sha1)
     # 4 used to be the default so look there first
     for slug in (slug_default, Base.version_slug(uuid, sha1, 4))
-        for depot in depots()
+        for depot in Base.DEPOT_PATH
             path = abspath(depot, "packages", name, slug)
             ispath(path) && return path
         end
@@ -194,9 +194,9 @@ end
 function is_instantiated(env::EnvCache, workspace::Bool = false; platform = HostPlatform())::Bool
     # Load everything
     if workspace
-        pkgs = Operations.load_all_deps(env)
+        pkgs = load_all_deps(env)
     else
-        pkgs = Operations.load_all_deps_loadable(env)
+        pkgs = load_all_deps_loadable(env)
     end
     # If the top-level project is a package, ensure it is instantiated as well
     if env.pkg !== nothing
@@ -855,8 +855,8 @@ function install_git(
         GitTools.checkout_tree_to_path(repo, tree, version_path)
         return
     finally
-        repo !== nothing && LibGit2.close(repo)
-        tree !== nothing && LibGit2.close(tree)
+        repo !== nothing && close(repo)
+        tree !== nothing && close(tree)
     end
 end
 
@@ -2592,8 +2592,8 @@ function stat_rep(x::PackageSpec; name = true)
         rev = occursin(r"\b([a-f0-9]{40})\b", x.repo.rev) ? x.repo.rev[1:7] : x.repo.rev
     end
     subdir_str = x.repo.subdir === nothing ? "" : ":$(x.repo.subdir)"
-    repo = Operations.is_tracking_repo(x) ? "`$(x.repo.source)$(subdir_str)#$(rev)`" : ""
-    path = Operations.is_tracking_path(x) ? "$(pathrepr(x.path))" : ""
+    repo = is_tracking_repo(x) ? "`$(x.repo.source)$(subdir_str)#$(rev)`" : ""
+    path = is_tracking_path(x) ? "$(pathrepr(x.path))" : ""
     pinned = x.pinned ? "⚲" : ""
     return join(filter(!isempty, [name, version, repo, path, pinned]), " ")
 end
@@ -2878,7 +2878,7 @@ function print_status(
 
         pkg_downloaded = !is_instantiated(new) || is_package_downloaded(env.manifest_file, new)
 
-        new_ver_avail = !latest_version && !Operations.is_tracking_repo(new) && !Operations.is_tracking_path(new)
+        new_ver_avail = !latest_version && !is_tracking_repo(new) && !is_tracking_path(new)
         pkg_upgradable = new_ver_avail && isempty(cinfo[1])
         pkg_heldback = new_ver_avail && !isempty(cinfo[1])
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -13,7 +13,7 @@ end
 
 import Random
 import TOML
-using Dates
+using Dates: Day, Period, Second
 
 export @pkg_str
 export PackageSpec
@@ -25,13 +25,12 @@ export Registry, RegistrySpec
 public activate, add, build, compat, develop, free, gc, generate, instantiate,
     pin, precompile, redo, rm, resolve, status, test, undo, update, why
 
-depots() = Base.DEPOT_PATH
-function depots1(depot_list::Union{String, Vector{String}} = depots())
+function depots1(depot_list::Union{String, Vector{String}} = Base.DEPOT_PATH)
     # Get the first depot from a list, with proper error handling
     if depot_list isa String
         return depot_list
     else
-        isempty(depot_list) && Pkg.Types.pkgerror("no depots provided")
+        isempty(depot_list) && Types.pkgerror("no depots provided")
         return depot_list[1]
     end
 end
@@ -87,7 +86,7 @@ include("Apps/Apps.jl")
 include("REPLMode/REPLMode.jl")
 
 import .REPLMode: @pkg_str
-import .Types: UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH, UPLEVEL_FIXED
+import .Types: UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
 import .Types: PKGMODE_MANIFEST, PKGMODE_PROJECT
 import .Types: PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 
@@ -879,7 +878,7 @@ function _auto_gc(ctx::Types.Context; collect_delay::Period = Day(7))
     return if curr_time - DEPOT_ORPHANAGE_TIMESTAMPS[depots1()] > delay_secs
         printpkgstyle(ctx.io, :Info, "We haven't cleaned this depot up for a bit, running Pkg.gc()...", color = Base.info_color())
         try
-            Pkg.gc(ctx; collect_delay)
+            gc(ctx; collect_delay)
             DEPOT_ORPHANAGE_TIMESTAMPS[depots1()] = curr_time
         catch ex
             @error("GC failed", exception = ex)
@@ -894,7 +893,7 @@ end
 
 function _auto_precompile(ctx::Types.Context, pkgs::Vector{PackageSpec} = PackageSpec[]; warn_loaded = true, already_instantiated = false)
     if should_autoprecompile()
-        Pkg.precompile(ctx, pkgs; internal_call = true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
+        precompile(ctx, pkgs; internal_call = true, warn_loaded = warn_loaded, already_instantiated = already_instantiated)
     end
     return
 end
@@ -903,7 +902,7 @@ include("precompile.jl")
 
 # Reset globals that might have been mutated during precompilation.
 DEFAULT_IO[] = nothing
-Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
+UPDATED_REGISTRY_THIS_SESSION[] = false
 PREV_ENV_PATH[] = ""
 Types.STDLIB[] = nothing
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -4,10 +4,13 @@
 
 module PlatformEngines
 
-using SHA, Downloads, Tar
+using SHA: SHA, sha256
+using Downloads: Downloads
+using Tar: Tar
 import ...Pkg: Pkg, TOML, pkg_server, depots1, can_fancyprint, stderr_f
 using ..MiniProgressBars
-using Base.BinaryPlatforms, p7zip_jll
+using Base.BinaryPlatforms
+using p7zip_jll: p7zip_jll
 
 export verify, unpack, package, download_verify_unpack
 

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -4,7 +4,9 @@ module REPLMode
 
 @eval Base.Experimental.@compiler_options optimize = 1
 
-using Markdown, UUIDs, Dates
+using Dates: Dates, Hour
+using Markdown: Markdown, @md_str
+using UUIDs: UUIDs, UUID
 
 import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap, ..pathrepr
 using ..Types, ..Operations, ..API, ..Registry, ..Resolve, ..Apps

--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -5,9 +5,9 @@ module Resolve
 using ..Versions
 import ..stdout_f, ..stderr_f
 
-using Printf
-using Random
-using UUIDs
+using Printf: @sprintf
+using Random: Random, shuffle!
+using UUIDs: UUID
 
 export resolve, sanity_check, Graph, pkgID
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -2,21 +2,20 @@
 
 module Types
 
-using UUIDs
-using Random
-using Dates
+using UUIDs: UUIDs
+using Random: Random
+using Dates: Dates, now
 import LibGit2
 import Base.string
 
-using TOML
+using TOML: TOML
 import ..Pkg, ..Registry
-import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_dir, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS
-import Base.BinaryPlatforms: Platform
+import ..Pkg: GitTools, depots1, logdir, set_readonly, safe_realpath, stdlib_dir, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS
 using ..Pkg.Versions
 import FileWatching
 
 import Base: SHA1
-using SHA
+using SHA: SHA, sha1
 
 export UUID, SHA1, VersionRange, VersionSpec,
     PackageSpec, PackageEntry, EnvCache, Context, GitRepo, Context!, Manifest, Project, err_rep,
@@ -787,7 +786,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
     cloned = false
     package_path = pkg.repo.subdir === nothing ? repo_path : joinpath(repo_path, pkg.repo.subdir)
     if !has_name(pkg)
-        LibGit2.close(GitTools.ensure_clone(ctx.io, repo_path, pkg.repo.source))
+        close(GitTools.ensure_clone(ctx.io, repo_path, pkg.repo.source))
         cloned = true
         resolve_projectfile!(pkg, package_path)
     end
@@ -810,7 +809,7 @@ function handle_repo_develop!(ctx::Context, pkg::PackageSpec, shared::Bool)
     else
         mkpath(dirname(dev_path))
         if !cloned
-            LibGit2.close(GitTools.ensure_clone(ctx.io, dev_path, pkg.repo.source))
+            close(GitTools.ensure_clone(ctx.io, dev_path, pkg.repo.source))
         else
             mv(repo_path, dev_path)
         end
@@ -1038,10 +1037,10 @@ end
 
 function project_resolve!(env::EnvCache, pkgs::AbstractVector{PackageSpec})
     for pkg in pkgs
-        if has_uuid(pkg) && !has_name(pkg) && Types.is_project_uuid(env, pkg.uuid)
+        if has_uuid(pkg) && !has_name(pkg) && is_project_uuid(env, pkg.uuid)
             pkg.name = env.pkg.name
         end
-        if has_name(pkg) && !has_uuid(pkg) && Types.is_project_name(env, pkg.name)
+        if has_name(pkg) && !has_uuid(pkg) && is_project_name(env, pkg.name)
             pkg.uuid = env.pkg.uuid
         end
     end

--- a/src/fuzzysorting.jl
+++ b/src/fuzzysorting.jl
@@ -92,7 +92,7 @@ function fuzzyscore(needle::AbstractString, haystack::AbstractString)
 end
 
 function fuzzysort(search::String, candidates::Vector{String})
-    scores = map(cand -> (FuzzySorting.fuzzyscore(search, cand), -Float64(FuzzySorting.levenshtein(search, cand))), candidates)
+    scores = map(cand -> (fuzzyscore(search, cand), -Float64(levenshtein(search, cand))), candidates)
     return candidates[sortperm(scores)] |> reverse, any(s -> s[1] >= print_score_threshold, scores)
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -614,7 +614,7 @@ temp_pkg_dir() do project_path
                 empty!(DEPOT_PATH)
                 pushfirst!(DEPOT_PATH, depo1)
                 Base.append_bundled_depot_path!(DEPOT_PATH)
-                LibGit2.close(LibGit2.clone(TEST_PKG.url, "Example.jl"))
+                close(LibGit2.clone(TEST_PKG.url, "Example.jl"))
                 mkdir("machine1")
                 cd("machine1")
                 Pkg.activate(".")
@@ -1032,7 +1032,7 @@ end
     @testset "Pkg.add" begin
         Pkg.activate(temp = true)
         mktempdir() do tmp_dir
-            LibGit2.close(LibGit2.clone(TEST_PKG.url, tmp_dir))
+            close(LibGit2.clone(TEST_PKG.url, tmp_dir))
             Pkg.develop(path = tmp_dir)
             Pkg.pin("Example")
             Pkg.add("Example")
@@ -1063,7 +1063,7 @@ end
             tag = LibGit2.GitObject(repo, "v$ver")
             hash = string(LibGit2.target(tag))
             LibGit2.checkout!(repo, hash)
-            LibGit2.close(repo)
+            close(repo)
             Pkg.develop(path = tmp_dir)
             Pkg.pin("Example")
             Pkg.update("Example")  # pkg should remain pinned

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -28,7 +28,7 @@ end
 temp_pkg_dir() do project_path
     with_pkg_env(project_path; change_dir = true) do;
         pkg"generate HelloWorld"
-        LibGit2.close((LibGit2.init(".")))
+        close((LibGit2.init(".")))
         cd("HelloWorld")
 
         @test_throws PkgError pkg"dev Example#blergh"


### PR DESCRIPTION
There are more `imports` we can move to `using :` but this cleans up quite a bit for now. Also adds some CI to catch future things.