### PR TITLE
Implement atomic TOML writes to prevent data corruption

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -14,7 +14,7 @@ import Base: StaleCacheKey
 
 import ..depots, ..depots1, ..logdir, ..devdir, ..printpkgstyle
 import ..Operations, ..GitTools, ..Pkg, ..Registry
-import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH
+import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH, ..atomic_toml_write
 using ..Types, ..TOML
 using ..Types: VersionTypes
 using Base.BinaryPlatforms
@@ -654,9 +654,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
             usage_path = joinpath(logdir(depot), fname)
             if !(isempty(usage)::Bool) || isfile(usage_path)
                 let usage=usage
-                    open(usage_path, "w") do io
-                        TOML.print(io, usage, sorted=true)
-                    end
+                    atomic_toml_write(usage_path, usage, sorted=true)
                 end
             end
         end
@@ -986,9 +984,7 @@ function gc(ctx::Context=Context(); collect_delay::Period=Day(7), verbose=false,
 
         # Write out the `new_orphanage` for this depot
         mkpath(dirname(orphanage_file))
-        open(orphanage_file, "w") do io
-            TOML.print(io, new_orphanage, sorted=true)
-        end
+        atomic_toml_write(orphanage_file, new_orphanage, sorted=true)
     end
 
     function recursive_dir_size(path)

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -1,6 +1,7 @@
 module Apps
 
 using Pkg
+using Pkg: atomic_toml_write
 using Pkg.Versions
 using Pkg.Types: AppInfo, PackageSpec, Context, EnvCache, PackageEntry, Manifest, handle_repo_add!, handle_repo_develop!, write_manifest, write_project,
                  pkgerror, projectfile_path, manifestfile_path
@@ -151,9 +152,7 @@ function _resolve(manifest::Manifest, pkgname=nothing)
             # TODO: What if project file has its own entryfile?
             project_data = TOML.parsefile(projectfile)
             project_data["entryfile"] = joinpath(sourcepath, "src", "$(pkg.name).jl")
-            open(projectfile, "w") do io
-                TOML.print(io, project_data)
-            end
+            atomic_toml_write(projectfile, project_data)
         else
             error("could not find project file for package $pkg")
         end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -6,7 +6,7 @@ using Tar: can_symlink
 using FileWatching: FileWatching
 
 import ..set_readonly, ..GitTools, ..TOML, ..pkg_server, ..can_fancyprint,
-       ..stderr_f, ..printpkgstyle, ..mv_temp_dir_retries
+       ..stderr_f, ..printpkgstyle, ..mv_temp_dir_retries, ..atomic_toml_write
 
 import Base: get, SHA1
 import Artifacts: artifact_names, ARTIFACTS_DIR_OVERRIDE, ARTIFACT_OVERRIDES, artifact_paths,
@@ -267,11 +267,7 @@ function bind_artifact!(artifacts_toml::String, name::String, hash::SHA1;
     # Spit it out onto disk
     let artifact_dict = artifact_dict
         parent_dir = dirname(artifacts_toml)
-        temp_artifacts_toml = isempty(parent_dir) ? tempname(pwd()) : tempname(parent_dir)
-        open(temp_artifacts_toml, "w") do io
-            TOML.print(io, artifact_dict, sorted=true)
-        end
-        mv(temp_artifacts_toml, artifacts_toml; force=true)
+        atomic_toml_write(artifacts_toml, artifact_dict, sorted=true)
     end
 
     # Mark that we have used this Artifact.toml
@@ -302,9 +298,7 @@ function unbind_artifact!(artifacts_toml::String, name::String;
         )
     end
 
-    open(artifacts_toml, "w") do io
-        TOML.print(io, artifact_dict, sorted=true)
-    end
+    atomic_toml_write(artifacts_toml, artifact_dict, sorted=true)
     return
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -5,7 +5,7 @@
 module PlatformEngines
 
 using SHA, Downloads, Tar
-import ...Pkg: Pkg, TOML, pkg_server, depots1, can_fancyprint, stderr_f
+import ...Pkg: Pkg, TOML, pkg_server, depots1, can_fancyprint, stderr_f, atomic_toml_write
 using ..MiniProgressBars
 using Base.BinaryPlatforms, p7zip_jll
 
@@ -188,12 +188,7 @@ function get_auth_header(url::AbstractString; verbose::Bool = false)
             auth_info["expires_at"] = expires_at
         end
     end
-    let auth_info = auth_info
-        open(tmp, write=true) do io
-            TOML.print(io, auth_info, sorted=true)
-        end
-    end
-    mv(tmp, auth_file, force=true)
+    atomic_toml_write(auth_file, auth_info, sorted=true)
     access_token = auth_info["access_token"]::String
     return "Authorization" => "Bearer $access_token"
 end

--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -2,7 +2,7 @@ module Registry
 
 import ..Pkg
 using ..Pkg: depots, depots1, printpkgstyle, stderr_f, isdir_nothrow, pathrepr, pkg_server,
-             GitTools
+    GitTools, atomic_toml_write
 using ..Pkg.PlatformEngines: download_verify_unpack, download, download_verify, exe7z, verify_archive_tree_hash
 using UUIDs, LibGit2, TOML, Dates
 import FileWatching
@@ -212,9 +212,7 @@ function download_registries(io::IO, regs::Vector{RegistrySpec}, depots::Union{S
                 end
                 mv(tmp, joinpath(regdir, reg.name * ".tar.gz"); force=true)
                 reg_info = Dict("uuid" => string(reg.uuid), "git-tree-sha1" => string(_hash), "path" => reg.name * ".tar.gz")
-                open(joinpath(regdir, reg.name * ".toml"), "w") do io
-                    TOML.print(io, reg_info)
-                end
+                atomic_toml_write(joinpath(regdir, reg.name * ".toml"), reg_info)
                 printpkgstyle(io, :Added, "`$(reg.name)` registry to $(Base.contractuser(regdir))")
             else
                 mktempdir() do tmp
@@ -368,9 +366,7 @@ function save_registry_update_log(d::Dict)
     pkg_scratch_space = joinpath(DEPOT_PATH[1], "scratchspaces", "44cfe95a-1eb2-52ea-b672-e2afdf69b78f")
     mkpath(pkg_scratch_space)
     pkg_reg_updated_file = joinpath(pkg_scratch_space, "registry_updates.toml")
-    open(pkg_reg_updated_file, "w") do io
-        TOML.print(io, d)
-    end
+    atomic_toml_write(pkg_reg_updated_file, d)
 end
 
 """
@@ -450,9 +446,7 @@ function update(regs::Vector{RegistrySpec}; io::IO=stderr_f(), force::Bool=true,
                                     registry_path = dirname(reg.path)
                                     mv(tmp, joinpath(registry_path, reg.name * ".tar.gz"); force=true)
                                     reg_info = Dict("uuid" => string(reg.uuid), "git-tree-sha1" => string(hash), "path" => reg.name * ".tar.gz")
-                                    open(joinpath(registry_path, reg.name * ".toml"), "w") do io
-                                        TOML.print(io, reg_info)
-                                    end
+                                    atomic_toml_write(joinpath(registry_path, reg.name * ".toml"), reg_info)
                                     registry_update_log[string(reg.uuid)] = now()
                                     @label done_tarball_read
                                 else

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -10,7 +10,7 @@ import Base.string
 
 using TOML
 import ..Pkg, ..Registry
-import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_dir, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS
+import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_dir, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS, atomic_toml_write
 import Base.BinaryPlatforms: Platform
 using ..Pkg.Versions
 import FileWatching
@@ -668,15 +668,10 @@ function write_env_usage(source_files, usage_filepath::AbstractString)
             usage[k] = [Dict("time" => maximum(times))]
         end
 
-        tempfile = tempname()
         try
-            open(tempfile, "w") do io
-                TOML.print(io, usage, sorted=true)
-            end
-            TOML.parsefile(tempfile) # compare to `usage` ?
-            mv(tempfile, usage_file; force=true) # only mv if parse succeeds
+            atomic_toml_write(usage_file, usage, sorted=true)
         catch err
-            @error "Failed to write valid usage file `$usage_file`" tempfile
+            @error "Failed to write valid usage file `$usage_file`" exception=err
         end
     end
     return
@@ -1250,7 +1245,7 @@ function write_env(env::EnvCache; update_undo=true,
     if env.project.readonly
         pkgerror("Cannot modify a readonly environment. The project at $(env.project_file) is marked as readonly.")
     end
-    
+
     if (env.project != env.original_project) && (!skip_writing_project)
         write_project(env)
     end


### PR DESCRIPTION
Replace direct TOML.print calls with atomic_toml_write wrapper that uses temporary files and atomic moves to prevent "teared" writes when processes are interrupted or multiple instances write to the same file.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/3698

🤖 Generated with [Claude Code](https://claude.ai/code)