### PR TITLE
Add support for GitHub pull request URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Pkg v1.12 Release Notes
 - When adding or developing a package that exists in the `[weakdeps]` section, it is now automatically removed from
   weak dependencies and added as a regular dependency. ([#3865])
 - Enhanced fuzzy matching algorithm for package name suggestions.
+- The Pkg REPL now supports GitHub pull request URLs, allowing direct package installation from PRs via `pkg> add https://github.com/Org/Package.jl/pull/123` ([#4295])
 
 Pkg v1.11 Release Notes
 =======================

--- a/test/new.jl
+++ b/test/new.jl
@@ -432,6 +432,11 @@ end
         @test arg.url == "https://github.com/JuliaLang/Pkg.jl"
         @test arg.rev == "aa/gitlab"
 
+        api, args, opts = first(Pkg.pkg"add https://github.com/JuliaPy/PythonCall.jl/pull/529")
+        arg = args[1]
+        @test arg.url == "https://github.com/JuliaPy/PythonCall.jl"
+        @test arg.rev == "pull/529/head"
+
         api, args, opts = first(Pkg.pkg"add https://github.com/TimG1964/XLSX.jl#Bug-fixing-post-#289:subdir")
         arg = args[1]
         @test arg.url == "https://github.com/TimG1964/XLSX.jl"


### PR DESCRIPTION
Allow direct package installation from GitHub PR URLs such as: pkg> add https://github.com/Org/Package.jl/pull/123

This transforms PR URLs into the proper git reference format (pull/<number>/head) and ensures the correct refspecs are fetched to resolve the pull request.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/3975
Fixes https://github.com/JuliaLang/Pkg.jl/issues/740

🤖 Generated with [Claude Code](https://claude.ai/code)