### PR TITLE
More registry status

### DIFF
--- a/src/Registry/Registry.jl
+++ b/src/Registry/Registry.jl
@@ -603,7 +603,8 @@ function status(io::IO=stderr_f())
             end
             update_time = get(registry_update_log, string(reg.uuid), nothing)
             if !isnothing(update_time)
-                print(io, ", last updated $(update_time)")
+                time_string = Dates.format(update_time, dateformat"yyyy-mm-dd HH:MM:SS")
+                print(io, ", last updated $(time_string)")
             end
             println(io)
 

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -276,6 +276,20 @@ end
         @test isinstalled((name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")))
     end end
 
+    # Registry status. Mostly verify that it runs without errors but
+    # also make some sanity checks on the output. We can't really know
+    # whether it was installed as a git clone or a tarball, so that
+    # limits how much information we are guaranteed to get from
+    # status.
+    temp_pkg_dir() do depot
+        Registry.add("General")
+        buf = IOBuffer()
+        Pkg.Registry.status(buf)
+        status = String(take!(buf))
+        @test contains(status, "[23338594] General (https://github.com/JuliaRegistries/General.git)")
+        @test contains(status, "last updated")
+    end
+
     # only clone default registry if there are no registries installed at all
     temp_pkg_dir() do depot1; mktempdir() do depot2
         append!(empty!(DEPOT_PATH), [depot1, depot2])

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -5,6 +5,7 @@ using Pkg, UUIDs, LibGit2, Test
 using Pkg: depots1
 using Pkg.REPLMode: pkgstr
 using Pkg.Types: PkgError, manifest_info, PackageSpec, EnvCache
+using Dates: Second
 
 using ..Utils
 
@@ -263,7 +264,7 @@ end
 
         # Test that `update()` with `depots` runs
         io = Base.BufferStream()
-        Registry.update(; depots=[depot_off_path], io)
+        Registry.update(; depots=[depot_off_path], io, update_cooldown = Second(0))
         closewrite(io)
         output = read(io, String)
         @test occursin("registry at `$(depot_off_path)", output)


### PR DESCRIPTION
Extend the registry status command to show more information that can be useful for troubleshooting.

Example:
```
Registry Status 
 [xxxxxxxx] REDACTED (git@xxx)
    git registry, last updated 2025-07-03 14:11:13
 [23338594] General (https://github.com/JuliaRegistries/General.git)
    packed registry with hash d46462924dc723db4433cdc5cbc163529d12eba0, last updated 2025-07-03 14:11:13
    served by https://pkg.julialang.org (eager flavor) - update available
```

Feel free to bikeshed the layout and suggest more information that is useful and can easily be added.

The first commit updates the update log when a registry is first added. Without this the "last updated" information can be wildly wrong if a registry is removed at some point and much later added again.

~~I haven't looked into how this can be tested yet.~~ It has some rudimentary testing now at least.