### PR TITLE
improve error message info for bad compat entries

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -150,7 +150,7 @@ let
             end
 
             Base.precompile(Tuple{typeof(Pkg.API.status)})
-            Base.precompile(Tuple{typeof(Pkg.Types.read_project_compat),Base.Dict{String,Any},Pkg.Types.Project,},)
+            Base.precompile(Tuple{typeof(Pkg.Types.read_project_compat),Base.Dict{String,Any},Pkg.Types.Project},)
             Base.precompile(Tuple{typeof(Pkg.Versions.semver_interval),Base.RegexMatch})
 
             Base.precompile(Tuple{typeof(Pkg.REPLMode.do_cmds), Array{Pkg.REPLMode.Command, 1}, Base.TTY})

--- a/src/project.jl
+++ b/src/project.jl
@@ -99,7 +99,7 @@ function read_project_compat(raw::Dict{String,Any}, project::Project; file=nothi
         try
             compat[name] = Compat(semver_spec(version), version)
         catch err
-            pkgerror("Could not parse compatibility version spec $(repr(version)) for dependency `$name`" * location_string)
+            pkgerror("Could not parse compatibility version spec $(repr(version)) for dependency `$name`$location_string")
         end
     end
     return compat

--- a/src/project.jl
+++ b/src/project.jl
@@ -90,21 +90,22 @@ function read_project_apps(raw::Dict{String,Any}, project::Project)
     return appinfos
 end
 
-read_project_compat(::Nothing, project::Project) = Dict{String,Compat}()
-function read_project_compat(raw::Dict{String,Any}, project::Project)
+read_project_compat(::Nothing, project::Project; file=nothing) = Dict{String,Compat}()
+function read_project_compat(raw::Dict{String,Any}, project::Project; file=nothing)
     compat = Dict{String,Compat}()
+    location_string = file === nothing ? "" : " in $(repr(file))"
     for (name, version) in raw
         version = version::String
         try
             compat[name] = Compat(semver_spec(version), version)
         catch err
-            pkgerror("Could not parse compatibility version for dependency `$name`")
+            pkgerror("Could not parse compatibility version spec $(repr(version)) for dependency `$name`" * location_string)
         end
     end
     return compat
 end
-read_project_compat(raw, project::Project) =
-    pkgerror("Expected `compat` section to be a key-value list")
+read_project_compat(raw, project::Project; file=nothing) =
+    pkgerror("Expected `compat` section to be a key-value list" * (file === nothing ? "" : " in $(repr(file))"))
 
 read_project_sources(::Nothing, project::Project) = Dict{String,Dict{String,String}}()
 function read_project_sources(raw::Dict{String,Any}, project::Project)
@@ -209,7 +210,7 @@ function Project(raw::Dict; file=nothing)
     project.exts     = get(Dict{String, String}, raw, "extensions")
     project.sources  = read_project_sources(get(raw, "sources", nothing), project)
     project.extras   = read_project_deps(get(raw, "extras", nothing), "extras")
-    project.compat   = read_project_compat(get(raw, "compat", nothing), project)
+    project.compat   = read_project_compat(get(raw, "compat", nothing), project; file)
     project.targets  = read_project_targets(get(raw, "targets", nothing), project)
     project.workspace = read_project_workspace(get(raw, "workspace", nothing), project)
     project.apps     = read_project_apps(get(raw, "apps", nothing), project)
@@ -271,14 +272,14 @@ function destructure(project::Project)::Dict
     entry!("extras",   project.extras)
     entry!("compat",   Dict(name => x.str for (name, x) in project.compat))
     entry!("targets",  project.targets)
-    
+
     # Only write readonly if it's true (not the default false)
     if project.readonly
         raw["readonly"] = true
     else
         delete!(raw, "readonly")
     end
-    
+
     return raw
 end
 


### PR DESCRIPTION
Fixes http://github.com/JuliaLang/Pkg.jl/issues/1853

With this:
```
Could not parse compatibility version spec "invalid_version_spec" for dependency `julia` in "/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/jl_urojiY/Project.toml"
```