### PR TITLE
Fix reference_manifest_isolated_test to use temporary directory

### DIFF
--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -12,24 +12,25 @@ function reference_manifest_isolated_test(f, dir::String; v1::Bool=false)
     source_env_project = joinpath(source_env_dir, "Project.toml")
     
     # Create a temporary directory for the test files
-    temp_dir = mktempdir()
+    temp_base_dir = mktempdir()
     try
-        # Copy files to temporary directory
-        env_manifest = joinpath(temp_dir, "Manifest.toml")
-        env_project = joinpath(temp_dir, "Project.toml")
-        cp(source_env_manifest, env_manifest)
-        cp(source_env_project, env_project)
+        # Copy entire directory structure to preserve paths that tests expect
+        env_dir = joinpath(temp_base_dir, dir)
+        cp(source_env_dir, env_dir)
+        
+        env_manifest = joinpath(env_dir, "Manifest.toml")
+        env_project = joinpath(env_dir, "Project.toml")
         
         isfile(env_manifest) || error("Reference manifest is missing")
         if Base.is_v1_format_manifest(Base.parsed_toml(env_manifest)) == !v1
             error("Reference manifest file at $(env_manifest) is invalid")
         end
         isolate(loaded_depot=true) do
-            f(temp_dir, env_manifest)
+            f(env_dir, env_manifest)
         end
     finally
         # Clean up temporary directory
-        rm(temp_dir, recursive=true)
+        rm(temp_base_dir, recursive=true)
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/2969

Use a separate temporary directory instead of creating backup files
in the source directory to avoid read-only filesystem errors.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
