### PR TITLE
prevent error when updating sources with a non-existing manifest

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1231,13 +1231,15 @@ function write_env(env::EnvCache; update_undo=true,
                 @assert entry.repo.subdir == repo.subdir
             end
         end
-        if entry.path !== nothing
-            env.project.sources[pkg] = Dict("path" => entry.path)
-        elseif entry.repo != GitRepo()
-            d = Dict("url" => entry.repo.source)
-            entry.repo.rev !== nothing && (d["rev"] = entry.repo.rev)
-            entry.repo.subdir !== nothing && (d["subdir"] = entry.repo.subdir)
-            env.project.sources[pkg] = d
+        if entry !== nothing
+            if entry.path !== nothing
+                env.project.sources[pkg] = Dict("path" => entry.path)
+            elseif entry.repo != GitRepo()
+                d = Dict("url" => entry.repo.source)
+                entry.repo.rev !== nothing && (d["rev"] = entry.repo.rev)
+                entry.repo.subdir !== nothing && (d["subdir"] = entry.repo.subdir)
+                env.project.sources[pkg] = d
+            end
         end
     end
 


### PR DESCRIPTION
Just noticed this happening:

```
(Pkg) pkg> rm CMake_jll
ERROR: FieldError: type Nothing has no field `path`; Nothing has no fields at all.
Stacktrace:
  [1] getproperty
    @ ./Base_compiler.jl:57 [inlined]
  [2] write_env(env::Pkg.Types.EnvCache; update_undo::Bool, skip_writing_project::Bool)
    @ Pkg.Types ~/JuliaPkgs/pkg-4159/src/Types.jl:1234
  [3] write_env
    @ ~/JuliaPkgs/pkg-4159/src/Types.jl:1216 [inlined]
  [4] rm(ctx::Pkg.Types.Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
    @ Pkg.Operations ~/JuliaPkgs/pkg-4159/src/Operations.jl:1546
  [5] rm
```