### PR TITLE
fix resolve to not suceed when giving a non-existing version for a package

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -534,7 +534,7 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
         # We only fixup a JLL if the old major/minor/patch matches the new major/minor/patch
         if old_v !== nothing && Base.thispatch(old_v) == Base.thispatch(vers_fix[uuid])
             new_v = vers_fix[uuid]
-            if old_v != new_v
+            if old_v != new_v && haskey(compat_map[uuid], old_v)
                 compat_map[uuid][old_v] = compat_map[uuid][new_v]
                 # Note that we don't delete!(compat_map[uuid], old_v) because we want to keep the compat info around
                 # in case there's JLL version confusion between the sysimage pkgorigins version and manifest
@@ -569,6 +569,10 @@ function resolve_versions!(env::EnvCache, registries::Vector{Registry.RegistryIn
                 deps_fixed
             else
                 d = Dict{String, UUID}()
+                if !haskey(compat_map[pkg.uuid], pkg.version)
+                    available_versions = sort!(collect(keys(compat_map[pkg.uuid])))
+                    pkgerror("version $(pkg.version) of package $(pkg.name) is not available. Available versions: $(join(available_versions, ", "))")
+                end
                 for (uuid, _) in compat_map[pkg.uuid][pkg.version]
                     d[names[uuid]]  = uuid
                 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/4159

```
julia> Pkg.add(name="CMake_jll", version = v"3.24.3"; julia_version=nothing)
   Resolving package versions...
ERROR: version 3.24.3 of package CMake_jll is not available. Available versions: 3.17.1+0, 3.19.2+0, 3.22.2+0, 3.23.3+0, 3.24.3+0, 3.28.1+0, 3.29.3+0, 3.29.3+1, 3.30.2+0, 3.31.3+0, 3.31.5+0, 3.31.6+0
```