### PR TITLE
fix `status --diff` to work when package is in a non-root path

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -15,7 +15,7 @@ using Base.BinaryPlatforms
 import ...Pkg
 import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
-import ...Pkg: usable_io
+import ...Pkg: usable_io, discover_repo
 
 #########
 # Utils #
@@ -2988,10 +2988,11 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
     old_env = nothing
     if git_diff
         project_dir = dirname(env.project_file)
-        if !ispath(joinpath(project_dir, ".git"))
+        git_repo_dir = discover_repo(project_dir)
+        if git_repo_dir == nothing
             @warn "diff option only available for environments in git repositories, ignoring."
         else
-            old_env = git_head_env(env, project_dir)
+            old_env = git_head_env(env, git_repo_dir)
             if old_env === nothing
                 @warn "could not read project from HEAD, displaying absolute status instead."
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -175,3 +175,19 @@ end
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value
 end
+
+function discover_repo(path::AbstractString)
+    dir = abspath(path)
+    stop_dir = homedir()
+
+    while true
+        gitdir = joinpath(dir, ".git")
+        if isdir(gitdir) || isfile(gitdir)
+            return dir
+        end
+        dir == stop_dir && return nothing
+        parent = dirname(dir)
+        parent == dir && return nothing
+        dir = parent
+    end
+end

--- a/test/new.jl
+++ b/test/new.jl
@@ -1358,14 +1358,14 @@ end
             @test length(args) == 1
             @test args[1].path == normpath("C:\\\\Users\\\\test\\\\project")
             @test args[1].subdir === nothing
-            
+
             # Test with forward slashes too
             api, args, opts = first(Pkg.pkg"add C:/Users/test/project")
             @test api == Pkg.add
             @test length(args) == 1
             @test args[1].path == normpath("C:/Users/test/project")
             @test args[1].subdir === nothing
-            
+
             # Test that actual subdir syntax still works with Windows paths
             api, args, opts = first(Pkg.pkg"add C:\\Users\\test\\project:subdir")
             @test api == Pkg.add
@@ -3512,6 +3512,21 @@ end
                     Pkg.resolve()
                 end
             end
+        end
+    end
+end
+
+@testset "status diff non-root" begin
+    isolate(loaded_depot=true) do
+        cd_tempdir() do dir
+            Pkg.generate("A")
+            git_init_and_commit(".")
+            Pkg.activate("A")
+            Pkg.add("Example")
+            io = IOBuffer()
+            Pkg.status(; io, diff=true)
+            str = String(take!(io))
+            @test occursin("+ Example", str)
         end
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/1738