### PR TITLE
Fix stack overflow in `safe_realpath`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,7 +119,6 @@ end
 
 # try to call realpath on as much as possible
 function safe_realpath(path)
-    isempty(path) && return path
     if ispath(path)
         try
             return realpath(path)
@@ -128,6 +127,8 @@ function safe_realpath(path)
         end
     end
     a, b = splitdir(path)
+    # path cannot be reduced at the root or drive, avoid stack overflow
+    isempty(b) && return path
     return joinpath(safe_realpath(a), b)
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -19,8 +19,9 @@ end
 end
 
 @testset "safe_realpath" begin
+    realpath(Sys.BINDIR) == Pkg.safe_realpath(Sys.BINDIR)
     # issue #3085
-    for p in ("", "some-non-existing-path")
+    for p in ("", "some-non-existing-path", "some-non-existing-drive:")
         @test p == Pkg.safe_realpath(p)
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3085

That issue was already closed by https://github.com/JuliaLang/Pkg.jl/pull/3087 but I still ran into the same issue, it seems the fix was wrong.

The stack overflow can still be triggered on Windows by

```jl
using Pkg: safe_realpath
safe_realpath("some-non-existing-drive:")
```

It keeps on recursing trying to make it smaller with `splitdir`, but it can't. We know we cannot make it smaller if the returned "filename" is empty.

On Linux we have:
```jl
julia> splitdir("/")
("/", "")
```

On Windows:
```jl
julia> splitdir("C://")
("C:/", "")
```