### PR TITLE
Fix typos and inconsistencies in documentation

### DIFF
--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -230,7 +230,7 @@ This is deduced automatically by the `artifacts""` string macro, however, if you
 !!! compat "Julia 1.7"
     Pkg's extended platform selection requires at least Julia 1.7, and is considered experimental.
 
-New in Julia 1.6, `Platform` objects can have extended attributes applied to them, allowing artifacts to be tagged with things such as CUDA driver version compatibility, microarchitectural compatibility, julia version compatibility and more!
+New in Julia 1.7, `Platform` objects can have extended attributes applied to them, allowing artifacts to be tagged with things such as CUDA driver version compatibility, microarchitectural compatibility, julia version compatibility and more!
 Note that this feature is considered experimental and may change in the future.
 If you as a package developer find yourself needing this feature, please get in contact with us so it can evolve for the benefit of the whole ecosystem.
 In order to support artifact selection at `Pkg.add()` time, `Pkg` will run the specially-named file `<project_root>/.pkg/select_artifacts.jl`, passing the current platform triplet as the first argument.

--- a/docs/src/basedocs.md
+++ b/docs/src/basedocs.md
@@ -4,7 +4,7 @@ EditURL = "https://github.com/JuliaLang/Pkg.jl/blob/master/docs/src/basedocs.md"
 
 # Pkg
 
-Pkg is Julia's builtin package manager, and handles operations
+Pkg is Julia's built-in package manager, and handles operations
 such as installing, updating and removing packages.
 
 !!! note

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -22,7 +22,7 @@ The format of the version specifier is described in detail below.
     The rules below apply to the `Project.toml` file; for registries, see [Registry Compat.toml](@ref).
 
 !!! info
-    Note that registration into Julia's General Registry requires each dependency to have a `[compat`] entry with an upper bound.
+    Note that registration into Julia's General Registry requires each dependency to have a `[compat]` entry with an upper bound.
 
 ## Version specifier format
 

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -127,7 +127,7 @@ just as public as those marked as public with the `export` keyword, but when fol
 `YourPackage.that_symbol`.
 
 Let's say we would like our `greet` function to be part of the public API, but not the
-`greet_alien` function. We could the write the following and release it as version `1.0.0`.
+`greet_alien` function. We could then write the following and release it as version `1.0.0`.
 
 ```julia
 module HelloWorld

--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -4,7 +4,7 @@ The following discusses Pkg's interaction with environments. For more on the rol
 
 ## Creating your own environments
 
-So far we have added packages to the default environment at `~/.julia/environments/v1.9`. It is however easy to create other, independent, projects.
+So far we have added packages to the default environment at `~/.julia/environments/v1.10`. It is however easy to create other, independent, projects.
 This approach has the benefit of allowing you to check in a `Project.toml`, and even a `Manifest.toml` if you wish, into version control (e.g. git) alongside your code.
 It should be pointed out that when two projects use the same package at the same version, the content of this package is not duplicated.
 In order to create a new project, create a directory for it and then activate that directory to make it the "active project", which package operations manipulate:
@@ -117,12 +117,12 @@ between several incompatible packages.
 
 ## Shared environments
 
-A "shared" environment is simply an environment that exists in `~/.julia/environments`. The default `v1.9` environment is
+A "shared" environment is simply an environment that exists in `~/.julia/environments`. The default `v1.10` environment is
 therefore a shared environment:
 
 ```julia-repl
 (@v1.10) pkg> st
-Status `~/.julia/environments/v1.9/Project.toml`
+Status `~/.julia/environments/v1.10/Project.toml`
 ```
 
 Shared environments can be activated with the `--shared` flag to `activate`:
@@ -167,9 +167,9 @@ with its dependencies.
 ```julia-repl
 (@v1.10) pkg> add Images
    Resolving package versions...
-    Updating `~/.julia/environments/v1.9/Project.toml`
+    Updating `~/.julia/environments/v1.10/Project.toml`
   [916415d5] + Images v0.25.2
-    Updating `~/.julia/environments/v1.9/Manifest.toml`
+    Updating `~/.julia/environments/v1.10/Manifest.toml`
     ...
 Precompiling environment...
   Progress [===================>                     ]  45/97

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -101,8 +101,8 @@ For more information about managing packages, see the [Managing Packages](@ref M
 
 Up to this point, we have covered basic package management: adding, updating, and removing packages.
 
-You may have noticed the `(@v1.9)` in the REPL prompt.
-This lets us know that `v1.9` is the **active environment**.
+You may have noticed the `(@v1.10)` in the REPL prompt.
+This lets us know that `v1.10` is the **active environment**.
 Different environments can have totally different packages and versions installed from another environment.
 The active environment is the environment that will be modified by Pkg commands such as `add`, `rm` and `update`.
 

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -14,8 +14,8 @@ may optionally have a manifest file:
 - **Manifest file:** a file in the root directory of a project, named
   `Manifest.toml` (or `JuliaManifest.toml`), describing a complete dependency graph
   and exact versions of each package and library used by a project. The file name may
-  also be suffixed by `-v{major}.{minor}.toml` which julia will prefer if the version
-  matches `VERSION`, allowing multiple environments to be maintained for different julia
+  also be suffixed by `-v{major}.{minor}.toml` which Julia will prefer if the version
+  matches `VERSION`, allowing multiple environments to be maintained for different Julia
   versions.
 
 **Package:** a project which provides reusable functionality that can be used by

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -28,7 +28,7 @@ Precompiling environment...
   2 dependencies successfully precompiled in 2 seconds
 ```
 
-Here we added the package `JSON` to the current environment (which is the default `@v1.8` environment).
+Here we added the package `JSON` to the current environment (which is the default `@v1.10` environment).
 In this example, we are using a fresh Julia installation,
 and this is our first time adding a package using Pkg. By default, Pkg installs the General registry
 and uses this registry to look up packages requested for inclusion in the current environment.

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -24,7 +24,7 @@ are described below.
 
 For a package, the optional `authors` field is a TOML array describing the package authors.
 Entries in the array can either be a string in the form `"NAME"` or `"NAME <EMAIL>"`, or a table keys following the [Citation File Format schema](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md) for either a
-[`person`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) or an[`entity`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsentity).
+[`person`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) or an [`entity`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsentity).
 
 For example:
 ```toml
@@ -130,7 +130,7 @@ handled by Pkg operations such as `add`.
 
 ### The `[sources]` section
 
-Specifiying a path or repo (+ branch) for a dependency is done in the `[sources]` section.
+Specifying a path or repo (+ branch) for a dependency is done in the `[sources]` section.
 These are especially useful for controlling unregistered dependencies without having to bundle a
 corresponding manifest file.
 


### PR DESCRIPTION
- Fix spelling errors: builtin → built-in, Specifiying → Specifying
- Fix grammar: "We could the write" → "We could then write"
- Fix version inconsistencies: update v1.8/v1.9 → v1.10 throughout examples
- Fix capitalization: julia → Julia where appropriate
- Fix formatting: missing space in markdown link, correct TOML section reference
- Align version numbers between compat notes and documentation text

🤖 Generated with [Claude Code](https://claude.ai/code)