### PR TITLE
Fix lack of color in CI and don't warn about loaded packages in test Pkg.precompile. 

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1172,19 +1172,17 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     end
 
     io = ctx.io
-    if io isa IOContext{IO}
+    if io isa IOContext{IO} && !isa(io.io, Base.PipeEndpoint)
         # precompile does quite a bit of output and using the IOContext{IO} can cause
         # some slowdowns, the important part here is to not specialize the whole
-        # precompile function on the io
+        # precompile function on the io.
+        # But don't unwrap the IOContext if it is a PipeEndpoint, as that would
+        # cause the output to lose color.
         io = io.io
     end
 
     activate(dirname(ctx.env.project_file)) do
         pkgs_name = String[pkg.name for pkg in pkgs]
-        @show io typeof(io)
-        printstyled(io, "io with color\n", color=:green, bold=true)
-        @show ctx.io typeof(ctx.io)
-        printstyled(ctx.io, "ctx.io with color\n", color=:green, bold=true)
         return Base.Precompilation.precompilepkgs(pkgs_name; internal_call, strict, warn_loaded, timing, _from_loading, configs, manifest=workspace, io)
     end
 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1181,7 +1181,10 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
 
     activate(dirname(ctx.env.project_file)) do
         pkgs_name = String[pkg.name for pkg in pkgs]
-        @show io typeof(io) ctx.io typeof(ctx.io)
+        @show io typeof(io)
+        printstyled(io, "io with color\n", color=:green, bold=true)
+        @show ctx.io typeof(ctx.io)
+        printstyled(ctx.io, "ctx.io with color\n", color=:green, bold=true)
         return Base.Precompilation.precompilepkgs(pkgs_name; internal_call, strict, warn_loaded, timing, _from_loading, configs, manifest=workspace, io)
     end
 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1181,6 +1181,7 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
 
     activate(dirname(ctx.env.project_file)) do
         pkgs_name = String[pkg.name for pkg in pkgs]
+        @show io typeof(io) ctx.io typeof(ctx.io)
         return Base.Precompilation.precompilepkgs(pkgs_name; internal_call, strict, warn_loaded, timing, _from_loading, configs, manifest=workspace, io)
     end
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2476,7 +2476,9 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
 
             if should_autoprecompile()
                 cacheflags = Base.CacheFlags(parse(UInt8, read(`$(Base.julia_cmd()) $(flags) --eval 'show(ccall(:jl_cache_flags, UInt8, ()))'`, String)))
-                Pkg.precompile(; io=ctx.io, configs = flags => cacheflags)
+                # Don't warn about already loaded packages, since we are going to run tests in a new
+                # subprocess anyway.
+                Pkg.precompile(; io=ctx.io, warn_loaded = false, configs = flags => cacheflags)
             end
 
             printpkgstyle(ctx.io, :Testing, "Running tests...")


### PR DESCRIPTION
Fixes #4158
Fixes https://github.com/JuliaLang/Pkg.jl/issues/4196

I don't really understand the layers of indirection that the IO goes through to cause this, but this evidently fixes the color issue.