### PR TITLE
Backports release 1.12

### DIFF
--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -97,6 +97,15 @@ Specifiying a path or repo (+ branch) for a dependency is done in the `[sources]
 These are especially useful for controlling unregistered dependencies without having to bundle a
 corresponding manifest file.
 
+Each entry in the `[sources]` section supports the following keys:
+
+- **`url`**: The URL of the Git repository. Cannot be used with `path`.
+- **`rev`**: The Git revision (branch name, tag, or commit hash) to use. Only valid with `url`.
+- **`subdir`**: A subdirectory within the repository containing the package.
+- **`path`**: A local filesystem path to the package. Cannot be used with `url` or `rev`.
+
+This might in practice look something like:
+
 ```toml
 [sources]
 Example = {url = "https://github.com/JuliaLang/Example.jl", rev = "custom_branch"}

--- a/src/API.jl
+++ b/src/API.jl
@@ -1148,10 +1148,12 @@ function precompile(ctx::Context, pkgs::Vector{PackageSpec}; internal_call::Bool
     end
 
     io = ctx.io
-    if io isa IOContext{IO}
+    if io isa IOContext{IO} && !isa(io.io, Base.PipeEndpoint)
         # precompile does quite a bit of output and using the IOContext{IO} can cause
         # some slowdowns, the important part here is to not specialize the whole
-        # precompile function on the io
+        # precompile function on the io.
+        # But don't unwrap the IOContext if it is a PipeEndpoint, as that would
+        # cause the output to lose color.
         io = io.io
     end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2330,7 +2330,9 @@ function test(ctx::Context, pkgs::Vector{PackageSpec};
 
             if should_autoprecompile()
                 cacheflags = Base.CacheFlags(parse(UInt8, read(`$(Base.julia_cmd()) $(flags) --eval 'show(ccall(:jl_cache_flags, UInt8, ()))'`, String)))
-                Pkg.precompile(; io=ctx.io, configs = flags => cacheflags)
+                # Don't warn about already loaded packages, since we are going to run tests in a new
+                # subprocess anyway.
+                Pkg.precompile(; io=ctx.io, warn_loaded = false, configs = flags => cacheflags)
             end
 
             printpkgstyle(ctx.io, :Testing, "Running tests...")

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -350,7 +350,7 @@ function collect_project(pkg::Union{PackageSpec, Nothing}, path::String)
 end
 
 is_tracking_path(pkg) = pkg.path !== nothing
-is_tracking_repo(pkg) = pkg.repo.source !== nothing
+is_tracking_repo(pkg) = (pkg.repo.source !== nothing || pkg.repo.rev !== nothing)
 is_tracking_registry(pkg) = !is_tracking_path(pkg) && !is_tracking_repo(pkg)
 isfixed(pkg) = !is_tracking_registry(pkg) || pkg.pinned
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -14,7 +14,7 @@ using Base.BinaryPlatforms
 import ...Pkg
 import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
-import ...Pkg: usable_io
+import ...Pkg: usable_io, discover_repo
 
 #########
 # Utils #
@@ -2907,10 +2907,11 @@ function status(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pk
     old_env = nothing
     if git_diff
         project_dir = dirname(env.project_file)
-        if !ispath(joinpath(project_dir, ".git"))
+        git_repo_dir = discover_repo(project_dir)
+        if git_repo_dir == nothing
             @warn "diff option only available for environments in git repositories, ignoring."
         else
-            old_env = git_head_env(env, project_dir)
+            old_env = git_head_env(env, git_repo_dir)
             if old_env === nothing
                 @warn "could not read project from HEAD, displaying absolute status instead."
             end

--- a/src/REPLMode/REPLMode.jl
+++ b/src/REPLMode/REPLMode.jl
@@ -6,7 +6,7 @@ module REPLMode
 
 using Markdown, UUIDs, Dates
 
-import ..casesensitive_isdir, ..OFFLINE_MODE, ..linewrap, ..pathrepr
+import ..OFFLINE_MODE, ..linewrap, ..pathrepr
 using ..Types, ..Operations, ..API, ..Registry, ..Resolve, ..Apps
 import ..stdout_f, ..stderr_f
 

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -361,14 +361,16 @@ function parse_package_args(args::Vector{PackageToken}; add_or_dev=false)::Vecto
         parsed_rev = false
         while !isempty(args)
             modifier = popfirst!(args)
-            if modifier isa Subdir
+            if modifier isa PackageIdentifier
+                pushfirst!(args, modifier)
+                return
+            elseif modifier isa Subdir
                 if parsed_subdir
                     pkgerror("Multiple subdir specifiers `$args` found.")
                 end
                 pkg.subdir = modifier.dir
-                (isempty(args) || args[1] isa PackageIdentifier) && return
-                modifier = popfirst!(args)
                 parsed_subdir = true
+                (isempty(args) || args[1] isa PackageIdentifier) && return
             elseif modifier isa VersionToken
                 if parsed_version
                     pkgerror("Multiple version specifiers `$args` found.")

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -1,4 +1,5 @@
 import ..isdir_nothrow, ..Registry.RegistrySpec, ..isurl
+using UUIDs
 
 struct PackageIdentifier
     val::String
@@ -21,74 +22,335 @@ const PackageToken = Union{PackageIdentifier,
                            Rev,
                            Subdir}
 
-packagetoken(word::String)::PackageToken =
-    first(word) == '@' ? VersionToken(word[2:end]) :
-    first(word) == '#' ? Rev(word[2:end]) :
-    first(word) == ':' ? Subdir(word[2:end]) :
-    PackageIdentifier(word)
+# Check if a string is a valid UUID
+function is_valid_uuid(str::String)
+    try
+        UUID(str)
+        return true
+    catch
+        return false
+    end
+end
 
-###############
-# PackageSpec #
-###############
-"""
-Parser for PackageSpec objects.
-"""
-function parse_package(args::Vector{QString}, options; add_or_dev=false)::Vector{PackageSpec}
-    words′ = package_lex(args)
-    words = String[]
-    for word in words′
-        if (m = match(r"https://github.com/(.*?)/(.*?)/(?:tree|commit)/(.*?)$", word)) !== nothing
-            push!(words, "https://github.com/$(m.captures[1])/$(m.captures[2])")
-            push!(words, "#$(m.captures[3])")
-        else
-            push!(words, word)
+# Simple URL detection
+function looks_like_url(str::String)
+    return startswith(str, "http://") || startswith(str, "https://") ||
+           startswith(str, "git@") || startswith(str, "ssh://") ||
+           contains(str, ".git")
+end
+
+# Simple path detection
+function looks_like_path(str::String)
+    return contains(str, '/') || contains(str, '\\') || str == "." || str == ".." ||
+           (length(str) >= 2 && isletter(str[1]) && str[2] == ':')  # Windows drive letters
+end
+
+# Check if a string looks like a complete URL
+function looks_like_complete_url(str::String)
+    return (startswith(str, "http://") || startswith(str, "https://") ||
+            startswith(str, "git@") || startswith(str, "ssh://")) &&
+           (contains(str, '.') || contains(str, '/'))
+end
+
+# Check if a colon at given position is part of a Windows drive letter
+function is_windows_drive_colon(input::String, colon_pos::Int)
+    # Windows drive letters are single letters followed by colon at beginning
+    # Examples: "C:", "D:", etc.
+    if colon_pos == 2 && length(input) >= 2
+        first_char = input[1]
+        return isletter(first_char) && input[2] == ':'
+    end
+    return false
+end
+
+# Extract subdir specifier from the end of input (rightmost : that's not a Windows drive letter)
+function extract_subdir(input::String)
+    colon_pos = findlast(':', input)
+    if colon_pos === nothing
+        return input, nothing
+    end
+
+    # Skip Windows drive letters (e.g., C:, D:)
+    if is_windows_drive_colon(input, colon_pos)
+        return input, nothing
+    end
+
+    subdir_part = input[nextind(input, colon_pos):end]
+    remaining = input[1:prevind(input, colon_pos)]
+    return remaining, subdir_part
+end
+
+# Extract revision specifier from input (first # that separates base from revision)
+function extract_revision(input::String)
+    hash_pos = findfirst('#', input)
+    if hash_pos === nothing
+        return input, nothing
+    end
+
+    rev_part = input[nextind(input, hash_pos):end]
+    remaining = input[1:prevind(input, hash_pos)]
+    return remaining, rev_part
+end
+
+# Extract version specifier from the end of input (rightmost @)
+function extract_version(input::String)
+    at_pos = findlast('@', input)
+    if at_pos === nothing
+        return input, nothing
+    end
+
+    version_part = input[nextind(input, at_pos):end]
+    remaining = input[1:prevind(input, at_pos)]
+    return remaining, version_part
+end
+
+# Handle GitHub tree/commit URLs by converting them to standard URL + rev format
+function preprocess_github_tree_commit_url(input::String)
+    m = match(r"https://github.com/(.*?)/(.*?)/(?:tree|commit)/(.*?)$", input)
+    if m !== nothing
+        base_url = "https://github.com/$(m.captures[1])/$(m.captures[2])"
+        rev = m.captures[3]
+        return [PackageIdentifier(base_url), Rev(rev)]
+    end
+    return nothing
+end
+
+# Check if a colon in a URL string is part of URL structure (not a subdir separator)
+function is_url_structure_colon(input::String, colon_pos::Int)
+    after_colon = input[nextind(input, colon_pos):end]
+
+    # Check for git@host:path syntax
+    if startswith(input, "git@")
+        at_pos = findfirst('@', input)
+        if at_pos !== nothing
+            between_at_colon = input[nextind(input, at_pos):prevind(input, colon_pos)]
+            if !contains(between_at_colon, '/')
+                return true
+            end
         end
     end
-    args = PackageToken[packagetoken(pkgword) for pkgword in words]
 
-    return parse_package_args(args; add_or_dev=add_or_dev)
-end
-
-    # Match a git repository URL. This includes uses of `@` and `:` but
-    # requires that it has `.git` at the end.
-let url = raw"((git|ssh|http(s)?)|(git@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git$)(/)?",
-
-    # Match a `NAME=UUID` package specifier.
-    name_uuid = raw"[^@\#\s:]+\s*=\s*[^@\#\s:]+",
-
-    # Match a `#BRANCH` branch or tag specifier.
-    branch = raw"\#\s*[^@^:\s]+",
-
-    # Match an `@VERSION` version specifier.
-    version = raw"@\s*[^@\#\s]*",
-
-    # Match a `:SUBDIR` subdir specifier.
-    subdir = raw":[^@\#\s]+",
-
-    # Match any other way to specify a package. This includes package
-    # names, local paths, and URLs that don't match the `url` part. In
-    # order not to clash with the branch, version, and subdir
-    # specifiers, these cannot include `@` or `#`, and `:` is only
-    # allowed if followed by `/` or `\`. For URLs matching this part
-    # of the regex, that means that `@` (e.g. user names) and `:`
-    # (e.g. port) cannot be used but it doesn't have to end with
-    # `.git`.
-    other = raw"([^@\#\s:] | :(/|\\))+"
-
-    # Combine all of the above.
-    global const package_id_re = Regex(
-        "$url | $name_uuid | $branch | $version | $subdir | $other", "x")
-end
-
-function package_lex(qwords::Vector{QString})::Vector{String}
-    words = String[]
-    for qword in qwords
-        qword.isquoted ?
-            push!(words, qword.raw) :
-            append!(words, map(m->m.match, eachmatch(package_id_re, qword.raw)))
+    # Check for protocol:// syntax
+    if colon_pos <= lastindex(input) - 2
+        next_pos = nextind(input, colon_pos)
+        if next_pos <= lastindex(input) - 1 &&
+           input[colon_pos:nextind(input, nextind(input, colon_pos))] == "://"
+            return true
+        end
     end
-    return words
+
+    # Check for user:password@ syntax (: followed by text then @)
+    if contains(after_colon, '@')
+        at_in_after = findfirst('@', after_colon)
+        if at_in_after !== nothing
+            text_before_at = after_colon[1:prevind(after_colon, at_in_after)]
+            if !contains(text_before_at, '/')
+                return true
+            end
+        end
+    end
+
+    # Check for port numbers (: followed by digits then /)
+    if occursin(r"^\d+(/|$)", after_colon)
+        return true
+    end
+
+    return false
 end
+
+# Extract subdir from URL, being careful about URL structure
+function extract_url_subdir(input::String)
+    colon_pos = findlast(':', input)
+    if colon_pos === nothing
+        return input, nothing
+    end
+
+    # Check if this colon is part of URL structure
+    if is_url_structure_colon(input, colon_pos)
+        return input, nothing
+    end
+
+    after_colon = input[nextind(input, colon_pos):end]
+    before_colon = input[1:prevind(input, colon_pos)]
+
+    # Only treat as subdir if it looks like one and the part before looks like a URL
+    if (contains(after_colon, '/') || (!contains(after_colon, '@') && !contains(after_colon, '#'))) &&
+       (contains(before_colon, "://") || contains(before_colon, ".git") || contains(before_colon, '@'))
+        return before_colon, after_colon
+    end
+
+    return input, nothing
+end
+
+# Extract revision from URL, only after a complete URL
+function extract_url_revision(input::String)
+    hash_pos = findfirst('#', input)
+    if hash_pos === nothing
+        return input, nothing
+    end
+
+    before_hash = input[1:prevind(input, hash_pos)]
+    after_hash = input[nextind(input, hash_pos):end]
+
+    if looks_like_complete_url(before_hash)
+        return before_hash, after_hash
+    end
+
+    return input, nothing
+end
+
+# Parse URLs with specifiers
+# URLs can only have revisions (#) and subdirs (:), NOT versions (@)
+function parse_url_with_specifiers(input::String)
+    tokens = PackageToken[]
+    remaining = input
+
+    # Extract subdir if present (rightmost : that looks like a subdir)
+    remaining, subdir_part = extract_url_subdir(remaining)
+
+    # Extract revision (first # that comes after a complete URL)
+    remaining, rev_part = extract_url_revision(remaining)
+
+    # What's left is the base URL
+    push!(tokens, PackageIdentifier(remaining))
+
+    # Add the specifiers in the correct order
+    if rev_part !== nothing
+        push!(tokens, Rev(rev_part))
+    end
+    if subdir_part !== nothing
+        push!(tokens, Subdir(subdir_part))
+    end
+
+    return tokens
+end
+
+function parse_path_with_specifiers(input::String)
+    tokens = PackageToken[]
+    remaining = input
+
+    # Extract subdir if present (rightmost :)
+    remaining, subdir_part = extract_subdir(remaining)
+
+    # Extract revision if present (rightmost #)
+    remaining, rev_part = extract_revision(remaining)
+
+    # What's left is the base path
+    push!(tokens, PackageIdentifier(remaining))
+
+    # Add specifiers in correct order
+    if rev_part !== nothing
+        push!(tokens, Rev(rev_part))
+    end
+    if subdir_part !== nothing
+        push!(tokens, Subdir(subdir_part))
+    end
+
+    return tokens
+end
+
+# Parse package names with specifiers
+function parse_name_with_specifiers(input::String)
+    tokens = PackageToken[]
+    remaining = input
+
+    # Extract subdir if present (rightmost :)
+    remaining, subdir_part = extract_subdir(remaining)
+
+    # Extract version if present (rightmost @)
+    remaining, version_part = extract_version(remaining)
+
+    # Extract revision if present (rightmost #)
+    remaining, rev_part = extract_revision(remaining)
+
+    # What's left is the base name
+    push!(tokens, PackageIdentifier(remaining))
+
+    # Add specifiers in correct order
+    if rev_part !== nothing
+        push!(tokens, Rev(rev_part))
+    end
+    if version_part !== nothing
+        push!(tokens, VersionToken(version_part))
+    end
+    if subdir_part !== nothing
+        push!(tokens, Subdir(subdir_part))
+    end
+
+    return tokens
+end
+
+# Parse a single package specification
+function parse_package_spec_new(input::String)
+    # Handle quoted strings
+    if (startswith(input, '"') && endswith(input, '"')) ||
+       (startswith(input, '\'') && endswith(input, '\''))
+        input = input[2:end-1]
+    end
+
+    # Handle GitHub tree/commit URLs first (special case)
+    github_result = preprocess_github_tree_commit_url(input)
+    if github_result !== nothing
+        return github_result
+    end
+
+    # Handle name=uuid format
+    if contains(input, '=')
+        parts = split(input, '=', limit=2)
+        if length(parts) == 2
+            name = String(strip(parts[1]))
+            uuid_str = String(strip(parts[2]))
+            if is_valid_uuid(uuid_str)
+                return [PackageIdentifier("$name=$uuid_str")]
+            end
+        end
+    end
+
+    # Check what type of input this is and parse accordingly
+    if looks_like_url(input)
+        return parse_url_with_specifiers(input)
+    elseif looks_like_path(input)
+        return parse_path_with_specifiers(input)
+    else
+        return parse_name_with_specifiers(input)
+    end
+end
+
+function parse_package(args::Vector{QString}, options; add_or_dev=false)::Vector{PackageSpec}
+    tokens = PackageToken[]
+
+    i = 1
+    while i <= length(args)
+        arg = args[i]
+        input = arg.isquoted ? arg.raw : arg.raw
+
+        # Check if this argument is a standalone modifier (like #dev, @v1.0, :subdir)
+        if !arg.isquoted && (startswith(input, '#') || startswith(input, '@') || startswith(input, ':'))
+            # This is a standalone modifier - it should be treated as a token
+            if startswith(input, '#')
+                push!(tokens, Rev(input[2:end]))
+            elseif startswith(input, '@')
+                push!(tokens, VersionToken(input[2:end]))
+            elseif startswith(input, ':')
+                push!(tokens, Subdir(input[2:end]))
+            end
+        else
+            # Parse this argument normally
+            if arg.isquoted
+                # For quoted arguments, treat as literal without specifier extraction
+                arg_tokens = [PackageIdentifier(input)]
+            else
+                arg_tokens = parse_package_spec_new(input)
+            end
+            append!(tokens, arg_tokens)
+        end
+
+        i += 1
+    end
+
+    return parse_package_args(tokens; add_or_dev=add_or_dev)
+end
+
 
 function parse_package_args(args::Vector{PackageToken}; add_or_dev=false)::Vector{PackageSpec}
     # check for and apply PackageSpec modifier (e.g. `#foo` or `@v1.0.2`)
@@ -155,17 +417,13 @@ end
 function parse_package_identifier(pkg_id::PackageIdentifier; add_or_develop=false)::PackageSpec
     word = pkg_id.val
     if add_or_develop
+        if occursin(name_re, word) && isdir(expanduser(word))
+            @info "Use `./$word` to add or develop the local directory at `$(Base.contractuser(abspath(word)))`."
+        end
         if isurl(word)
             return PackageSpec(; url=word)
         elseif any(occursin.(['\\','/'], word)) || word == "." || word == ".."
-            if casesensitive_isdir(expanduser(word))
-                return PackageSpec(; path=normpath(expanduser(word)))
-            else
-                pkgerror("`$word` appears to be a local path, but directory does not exist")
-            end
-        end
-        if occursin(name_re, word) && casesensitive_isdir(expanduser(word))
-            @info "Use `./$word` to add or develop the local directory at `$(Base.contractuser(abspath(word)))`."
+            return PackageSpec(; path=normpath(expanduser(word)))
         end
     end
     if occursin(uuid_re, word)
@@ -195,7 +453,7 @@ end
 function parse_registry(word::AbstractString; add=false)::RegistrySpec
     word = expanduser(word)
     registry = RegistrySpec()
-    if add && isdir_nothrow(word) # TODO: Should be casesensitive_isdir
+    if add && isdir_nothrow(word)
         if isdir(joinpath(word, ".git")) # add path as url and clone it from there
             registry.url = abspath(word)
         else # put the path

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1224,7 +1224,7 @@ function write_env(env::EnvCache; update_undo=true,
         path, repo = get_path_repo(env.project, pkg)
         entry = manifest_info(env.manifest, uuid)
         if path !== nothing
-            @assert entry.path == path
+            @assert normpath(entry.path) == normpath(path)
         end
         if repo != GitRepo()
             @assert entry.repo.source == repo.source

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1227,7 +1227,6 @@ function write_env(env::EnvCache; update_undo=true,
             @assert normpath(entry.path) == normpath(path)
         end
         if repo != GitRepo()
-            @assert entry.repo.source == repo.source
             if repo.rev !== nothing
                 @assert entry.repo.rev == repo.rev
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,3 +99,19 @@ end
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value
 end
+
+function discover_repo(path::AbstractString)
+    dir = abspath(path)
+    stop_dir = homedir()
+
+    while true
+        gitdir = joinpath(dir, ".git")
+        if isdir(gitdir) || isfile(gitdir)
+            return dir
+        end
+        dir == stop_dir && return nothing
+        parent = dirname(dir)
+        parent == dir && return nothing
+        dir = parent
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,11 +94,6 @@ function isfile_nothrow(path::String)
     end
 end
 
-function casesensitive_isdir(dir::String)
-    dir = abspath(dir)
-    lastdir = splitpath(dir)[end]
-    isdir_nothrow(dir) && lastdir in readdir(joinpath(dir, ".."))
-end
 
 ## ordering of UUIDs ##
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -103,8 +103,10 @@ end
 function discover_repo(path::AbstractString)
     dir = abspath(path)
     stop_dir = homedir()
+    depot = Pkg.depots1()
 
     while true
+        dir == depot && return nothing
         gitdir = joinpath(dir, ".git")
         if isdir(gitdir) || isfile(gitdir)
             return dir

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -66,7 +66,6 @@ set_readonly(::Nothing) = nothing
 
 # try to call realpath on as much as possible
 function safe_realpath(path)
-    isempty(path) && return path
     if ispath(path)
         try
             return realpath(path)
@@ -75,6 +74,8 @@ function safe_realpath(path)
         end
     end
     a, b = splitdir(path)
+    # path cannot be reduced at the root or drive, avoid stack overflow
+    isempty(b) && return path
     return joinpath(safe_realpath(a), b)
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -19,8 +19,9 @@ end
 end
 
 @testset "safe_realpath" begin
+    realpath(Sys.BINDIR) == Pkg.safe_realpath(Sys.BINDIR)
     # issue #3085
-    for p in ("", "some-non-existing-path")
+    for p in ("", "some-non-existing-path", "some-non-existing-drive:")
         @test p == Pkg.safe_realpath(p)
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -3204,6 +3204,23 @@ end
     end
 end
 
+@testset "test instantiate with sources with only rev" begin
+    isolate() do
+        mktempdir() do dir
+            cp(joinpath(@__DIR__, "test_packages", "sources_only_rev", "Project.toml"), joinpath(dir, "Project.toml"))
+            cd(dir) do
+                with_current_env() do
+                    @test !isfile("Manifest.toml")
+                    Pkg.instantiate()
+                    uuid, info = only(Pkg.dependencies())
+                    @test info.git_revision == "ba3d6704f09330ae973773496a4212f85e0ffe45"
+                    @test info.git_source == "https://github.com/JuliaLang/Example.jl.git"
+                end
+            end
+        end
+    end
+end
+
 @testset "status showing incompatible loaded deps" begin
     cmd = addenv(`$(Base.julia_cmd()) --color=no --startup-file=no -e "
         using Pkg

--- a/test/new.jl
+++ b/test/new.jl
@@ -1063,6 +1063,226 @@ end
         @test api == Pkg.add
         @test args == [Pkg.PackageSpec(;url="https://github.com/00vareladavid/Unregistered.jl", rev="0.1.0")]
         @test isempty(opts)
+
+        api, args, opts = first(Pkg.pkg"add a/path/with/@/deal/with/it")
+        @test normpath(args[1].path) == normpath("a/path/with/@/deal/with/it")
+
+        # Test GitHub URLs with tree/commit paths
+        @testset "GitHub tree/commit URLs" begin
+            api, args, opts = first(Pkg.pkg"add https://github.com/user/repo/tree/feature-branch")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://github.com/user/repo"
+            @test args[1].rev == "feature-branch"
+
+            api, args, opts = first(Pkg.pkg"add https://github.com/user/repo/commit/abc123def")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://github.com/user/repo"
+            @test args[1].rev == "abc123def"
+        end
+
+        # Test Git URLs with branch specifiers
+        @testset "Git URLs with branch specifiers" begin
+            api, args, opts = first(Pkg.pkg"add https://github.com/user/repo.git#main")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://github.com/user/repo.git"
+            @test args[1].rev == "main"
+
+            api, args, opts = first(Pkg.pkg"add https://bitbucket.org/user/repo.git#develop")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://bitbucket.org/user/repo.git"
+            @test args[1].rev == "develop"
+
+            api, args, opts = first(Pkg.pkg"add git@github.com:user/repo.git#feature")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "git@github.com:user/repo.git"
+            @test args[1].rev == "feature"
+
+            api, args, opts = first(Pkg.pkg"add ssh://git@server.com/path/repo.git#branch-name")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "ssh://git@server.com/path/repo.git"
+            @test args[1].rev == "branch-name"
+        end
+
+
+        # Test Git URLs with subdir specifiers
+        @testset "Git URLs with subdir specifiers" begin
+            api, args, opts = first(Pkg.pkg"add https://github.com/user/monorepo.git:packages/MyPackage")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://github.com/user/monorepo.git"
+            @test args[1].subdir == "packages/MyPackage"
+
+            api, args, opts = first(Pkg.pkg"add ssh://git@server.com/repo.git:subdir/nested")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "ssh://git@server.com/repo.git"
+            @test args[1].subdir == "subdir/nested"
+        end
+
+        # Test complex URLs (with username in URL + branch/tag/subdir)
+        @testset "Complex Git URLs" begin
+            api, args, opts = first(Pkg.pkg"add https://username@bitbucket.org/org/repo.git#dev")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://username@bitbucket.org/org/repo.git"
+            @test args[1].rev == "dev"
+
+            api, args, opts = first(Pkg.pkg"add https://user:token@gitlab.company.com/group/project.git")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://user:token@gitlab.company.com/group/project.git"
+
+            api, args, opts = first(Pkg.pkg"add https://example.com:8080/git/repo.git:packages/core")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://example.com:8080/git/repo.git"
+            @test args[1].subdir == "packages/core"
+
+            # Test URLs with complex authentication and branch names containing #
+            api, args, opts = first(Pkg.pkg"add https://user:pass123@gitlab.example.com:8443/group/project.git#feature/fix-#42")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://user:pass123@gitlab.example.com:8443/group/project.git"
+            @test args[1].rev == "feature/fix-#42"
+
+            # Test URLs with complex authentication and subdirs
+            api, args, opts = first(Pkg.pkg"add https://api_key:secret@company.git.server.com/team/monorepo.git:libs/julia/pkg")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://api_key:secret@company.git.server.com/team/monorepo.git"
+            @test args[1].subdir == "libs/julia/pkg"
+
+            # Test URLs with authentication, branch with #, and subdir
+            api, args, opts = first(Pkg.pkg"add https://deploy:token123@internal.git.company.com/product/backend.git#hotfix/issue-#789:packages/core")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://deploy:token123@internal.git.company.com/product/backend.git"
+            @test args[1].rev == "hotfix/issue-#789"
+            @test args[1].subdir == "packages/core"
+
+            # Test SSH URLs with port numbers and subdirs
+            api, args, opts = first(Pkg.pkg"add ssh://git@custom.server.com:2222/path/to/repo.git:src/package")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "ssh://git@custom.server.com:2222/path/to/repo.git"
+            @test args[1].subdir == "src/package"
+
+            # Test URL with username in URL and multiple # in branch name
+            api, args, opts = first(Pkg.pkg"add https://ci_user@build.company.net/team/project.git#release/v2.0-#123-#456")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://ci_user@build.company.net/team/project.git"
+            @test args[1].rev == "release/v2.0-#123-#456"
+
+            # Test complex case: auth + port + branch with # + subdir
+            api, args, opts = first(Pkg.pkg"add https://robot:abc123@git.enterprise.com:9443/division/platform.git#bugfix/handle-#special-chars:modules/julia-pkg")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://robot:abc123@git.enterprise.com:9443/division/platform.git"
+            @test args[1].rev == "bugfix/handle-#special-chars"
+            @test args[1].subdir == "modules/julia-pkg"
+
+            # Test local paths with branch specifiers (paths can be repos)
+            api, args, opts = first(Pkg.pkg"add ./local/repo#feature-branch")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test normpath(args[1].path) == normpath("local/repo")  # normpath removes "./"
+            @test args[1].rev == "feature-branch"
+
+            # Test local paths with subdir specifiers
+            api, args, opts = first(Pkg.pkg"add ./monorepo:packages/subpkg")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].path == "monorepo"  # normpath removes "./"
+            @test args[1].subdir == "packages/subpkg"
+
+            # Test local paths with both branch and subdir
+            api, args, opts = first(Pkg.pkg"add ./project#develop:src/package")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].path == "project"  # normpath removes "./"
+            @test args[1].rev == "develop"
+            @test args[1].subdir == "src/package"
+
+            # Test local paths with branch containing # characters
+            api, args, opts = first(Pkg.pkg"add ../workspace/repo#bugfix/issue-#123")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test normpath(args[1].path) == normpath("../workspace/repo")
+            @test args[1].rev == "bugfix/issue-#123"
+
+            # Test complex local path case: relative path + branch with # + subdir
+            if !Sys.iswindows()
+                api, args, opts = first(Pkg.pkg"add ~/projects/myrepo#feature/fix-#456:libs/core")
+                @test api == Pkg.add
+                @test length(args) == 1
+                @test startswith(args[1].path, "/")  # ~ gets expanded to absolute path
+                @test endswith(normpath(args[1].path), normpath("/projects/myrepo"))
+                @test args[1].rev == "feature/fix-#456"
+                @test args[1].subdir == "libs/core"
+            end
+
+            # Test quoted URL with separate revision specifier (regression test)
+            api, args, opts = first(Pkg.pkg"add \"https://username@bitbucket.org/orgname/reponame.git\"#dev")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://username@bitbucket.org/orgname/reponame.git"
+            @test args[1].rev == "dev"
+
+            # Test quoted URL with separate version specifier
+            api, args, opts = first(Pkg.pkg"add \"https://company.git.server.com/project.git\"@v2.1.0")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://company.git.server.com/project.git"
+            @test args[1].version == "v2.1.0"
+
+            # Test quoted URL with separate subdir specifier
+            api, args, opts = first(Pkg.pkg"add \"https://gitlab.example.com/monorepo.git\":packages/core")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://gitlab.example.com/monorepo.git"
+            @test args[1].subdir == "packages/core"
+        end
+
+        # Test that regular URLs without .git still work
+        @testset "Non-.git URLs (unchanged behavior)" begin
+            api, args, opts = first(Pkg.pkg"add https://github.com/user/repo")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].url == "https://github.com/user/repo"
+            @test args[1].rev === nothing
+            @test args[1].subdir === nothing
+        end
+
+        @testset "Windows path handling" begin
+            # Test that Windows drive letters are not treated as subdir separators
+            api, args, opts = first(Pkg.pkg"add C:\\Users\\test\\project")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].path == normpath("C:\\\\Users\\\\test\\\\project")
+            @test args[1].subdir === nothing
+            
+            # Test with forward slashes too
+            api, args, opts = first(Pkg.pkg"add C:/Users/test/project")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].path == normpath("C:/Users/test/project")
+            @test args[1].subdir === nothing
+            
+            # Test that actual subdir syntax still works with Windows paths
+            api, args, opts = first(Pkg.pkg"add C:\\Users\\test\\project:subdir")
+            @test api == Pkg.add
+            @test length(args) == 1
+            @test args[1].path == normpath("C:\\\\Users\\\\test\\\\project")
+            @test args[1].subdir == "subdir"
+        end
+
         # Add using preserve option
         api, args, opts = first(Pkg.pkg"add --preserve=none Example")
         @test api == Pkg.add
@@ -1097,7 +1317,6 @@ end
         @test api == Pkg.add
         @test args == [Pkg.PackageSpec(;name="example")]
         @test isempty(opts)
-        @test_throws PkgError Pkg.pkg"add ./Example"
         api, args, opts = first(Pkg.pkg"add ./example")
         @test api == Pkg.add
         @test args == [Pkg.PackageSpec(;path="example")]
@@ -1110,7 +1329,7 @@ end
     end end
     isolate() do; cd_tempdir() do dir
         # adding a nonexistent directory
-        @test_throws PkgError("`some/really/random/Dir` appears to be a local path, but directory does not exist"
+        @test_throws PkgError("Path `$(normpath("some/really/random/Dir"))` does not exist."
                               ) Pkg.pkg"add some/really/random/Dir"
         # warn if not explicit about adding directory
         mkdir("Example")

--- a/test/new.jl
+++ b/test/new.jl
@@ -3423,6 +3423,21 @@ end
     end
 end
 
+@testset "status diff non-root" begin
+    isolate(loaded_depot=true) do
+        cd_tempdir() do dir
+            Pkg.generate("A")
+            git_init_and_commit(".")
+            Pkg.activate("A")
+            Pkg.add("Example")
+            io = IOBuffer()
+            Pkg.status(; io, diff=true)
+            str = String(take!(io))
+            @test occursin("+ Example", str)
+        end
+    end
+end
+
 @testset "test instantiate with sources with only rev" begin
     isolate() do
         mktempdir() do dir

--- a/test/new.jl
+++ b/test/new.jl
@@ -1048,6 +1048,14 @@ end
         @test api == Pkg.add
         @test args == [Pkg.PackageSpec(;name="Example", version="0.5.0")]
         @test isempty(opts)
+        # Add multiple packages with version specifier
+        api, args, opts = first(Pkg.pkg"add Example@0.5.5 Test")
+        @test api == Pkg.add
+        @test length(args) == 2
+        @test args[1].name == "Example"
+        @test args[1].version == "0.5.5"
+        @test args[2].name == "Test"
+        @test isempty(opts)
         # Add as a weakdep.
         api, args, opts = first(Pkg.pkg"add --weak Example")
         @test api == Pkg.add

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -590,13 +590,6 @@ end
     @test typeof(pkg_spec) == Pkg.Types.PackageSpec
 end
 
-@testset "parse git url (issue #1935) " begin
-    urls = ["https://github.com/abc/ABC.jl.git", "https://abc.github.io/ABC.jl"]
-    for url in urls
-        @test Pkg.REPLMode.package_lex([Pkg.REPLMode.QString((url), false)]) == [url]
-    end
-end
-
 @testset "unit test for REPLMode.promptf" begin
     function set_name(projfile_path, newname)
         sleep(1.1)

--- a/test/subdir.jl
+++ b/test/subdir.jl
@@ -258,13 +258,13 @@ end
         pkg"rm Dep"
 
         # Add from path at branch, REPL subdir syntax
-        pkgstr("add $(packages_dir):julia#master")
+        pkgstr("add $(packages_dir)#master:julia")
         @test isinstalled("Package")
         @test !isinstalled("Dep")
         @test isinstalled(dep)
         pkg"rm Package"
 
-        pkgstr("add $(packages_dir):dependencies/Dep#master")
+        pkgstr("add $(packages_dir)#master:dependencies/Dep")
         @test !isinstalled("Package")
         @test isinstalled("Dep")
         pkg"rm Dep"
@@ -331,13 +331,13 @@ end
         pkg"rm Dep"
 
         # Add from url at branch, REPL subdir syntax.
-        pkgstr("add $(packages_dir_url):julia#master")
+        pkgstr("add $(packages_dir_url)#master:julia")
         @test isinstalled("Package")
         @test !isinstalled("Dep")
         @test isinstalled(dep)
         pkg"rm Package"
 
-        pkgstr("add $(packages_dir_url):dependencies/Dep#master")
+        pkgstr("add $(packages_dir_url)#master:dependencies/Dep")
         @test !isinstalled("Package")
         @test isinstalled("Dep")
         pkg"rm Dep"

--- a/test/test_packages/sources_only_rev/Project.toml
+++ b/test/test_packages/sources_only_rev/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[sources]
+Example = {rev = "ba3d6704f09330ae973773496a4212f85e0ffe45"}


### PR DESCRIPTION
Backported PRs:
- [x] #4306 <!-- Fix reference_manifest_isolated_test to use temporary directory -->
- [x] #4308 <!-- fix resolve to not suceed when giving a non-existing version for a package -->
- [x] #4305 <!-- fix assert from triggering with different path separators -->
- [x] #4313 <!-- Fix stack overflow in `safe_realpath` -->
- [x] #4316 <!-- Fix lack of color in CI and don't warn about loaded packages in test Pkg.precompile.  -->

Need manual backport:
- [x] #4281 <!-- Document [sources] section keys -->
- [x] #4311 <!-- consider a package with a rev (but without a source) to not be "tracked" by a registry -->

Contains multiple commits, manual intervention needed:
- [x] #4299 <!-- Fix parsing to better handle branch/tag/subdir specifiers in complex URLs and paths -->
- [x] #4312 <!-- fix `status --diff` to work when package is in a non-root path -->

Non-merged PRs with backport label: