### PR TITLE
Stop discover_repo when reaching the depot

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -183,8 +183,10 @@ end
 function discover_repo(path::AbstractString)
     dir = abspath(path)
     stop_dir = homedir()
+    depot = Pkg.depots1()
 
     while true
+        dir == depot && return nothing
         gitdir = joinpath(dir, ".git")
         if isdir(gitdir) || isfile(gitdir)
             return dir


### PR DESCRIPTION
Fixes #4318 
(Though that will need to be proven on Base CI)


To not emit that warning, `discover_repo` must not be returning `nothing`.

I'm not sure why, but part of the problem is that the depot isn't in the user homedir on this CI machine.

```
Diff `/cache/build/tester-amdci5-15/julialang/julia-master/tmp/jl_OOzF78/environments/v1.13/Project.toml`
  [7876af07] + Example v0.5.5 [loaded: `/cache/build/tester-amdci5-15/julialang/julia-master/tmp/jl_80Rah8/packages/Example/SUIr0/src/Example.jl` (v0.5.5) expected `/cache/build/tester-amdci5-15/julialang/julia-master/tmp/jl_OOzF78/packages/Example/SUIr0/src/Example.jl` (v0.5.5)]
  [9a3f8284] + Random v1.11.0
```

So I think this might a logical thing to do that avoids the issue, but doesn't fix the core issue?

