### PR TITLE
Add a pkg message if julia_version is being specified

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -597,7 +597,7 @@ function Context!(ctx::Context; kwargs...)
     if haskey(kwargs, :julia_version) && ctx.julia_version !== nothing && ctx.julia_version != VERSION
         Pkg.printpkgstyle(
             ctx.io, :Context,
-            "Pkg is being asked to operate using julia_version `$(ctx.julia_version)`",
+            "Pkg is operating with julia_version set to `$(ctx.julia_version)`",
             color = Base.warn_color()
         )
     end


### PR DESCRIPTION
Probably useful for BinaryBuilder logs generally, but also debugging