### PR TITLE
Error if the stdlib version requested mismatches current version

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1667,7 +1667,7 @@ end
 function _validate_stdlib_version!(pkg::PackageSpec, julia_version::Union{VersionNumber, Nothing})
     # Only validate if we have a specific Julia version and the package is a non-upgradable stdlib
     # FIXME: HistoricalStdlibVersions should also store UPGRADABLE_STDLIBS_UUIDS per version
-    return if julia_version !== nothing && is_stdlib(pkg.uuid, julia_version) && pkg.version !== nothing && !(pkg.uuid in Types.UPGRADABLE_STDLIBS_UUIDS)
+    return if julia_version !== nothing && pkg.uuid !== nothing && is_stdlib(pkg.uuid, julia_version) && pkg.version !== nothing && !(pkg.uuid in Types.UPGRADABLE_STDLIBS_UUIDS)
         current_stdlib_version = Types.stdlib_version(pkg.uuid, julia_version)
         if current_stdlib_version !== nothing
             # Check if the requested version conflicts with current stdlib version

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -549,7 +549,7 @@ function check_stdlib_version_compat!(pkg::PackageSpec, julia_version)
         throw(
             Resolve.ResolverError(
                 """Cannot add stdlib `$(pkg.name)` with version specification `$(pkg.version)`.
-                The current Julia version $(julia_version) uses `$(pkg.name)` v$(current_stdlib_version)."""
+                The current Julia version v$(julia_version) uses `$(pkg.name)` v$(current_stdlib_version)."""
             )
         )
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1697,9 +1697,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
     return show_update(ctx.env, ctx.registries; io = ctx.io)
 end
 
-function update_package_add(ctx::Context, pkg::PackageSpec, ::Nothing, is_dep::Bool)
-    return pkg
-end
+update_package_add(ctx::Context, pkg::PackageSpec, ::Nothing, is_dep::Bool) = pkg
 function update_package_add(ctx::Context, pkg::PackageSpec, entry::PackageEntry, is_dep::Bool)
     if entry.pinned
         if pkg.version == VersionSpec()

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1675,10 +1675,6 @@ function _validate_stdlib_version!(pkg::PackageSpec, julia_version::Union{Versio
                 pkg.version != current_stdlib_version
             elseif pkg.version isa VersionSpec
                 !(current_stdlib_version in pkg.version)
-            elseif pkg.version isa String
-                # Parse string version and check if it conflicts
-                version_spec = VersionSpec(pkg.version)
-                !(current_stdlib_version in version_spec)
             else
                 error("Unexpected version spec type for stdlib `$(pkg.name)`: $(typeof(pkg.version))")
             end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -549,7 +549,7 @@ function check_stdlib_version_compat!(pkg::PackageSpec, julia_version)
         throw(
             Resolve.ResolverError(
                 """Cannot add stdlib `$(pkg.name)` with version specification `$(pkg.version)`.
-                The current Julia version $(julia_version) uses stdlib `$(pkg.name)` version `$(current_stdlib_version)`."""
+                The current Julia version $(julia_version) uses `$(pkg.name)` v$(current_stdlib_version)."""
             )
         )
     end

--- a/test/api.jl
+++ b/test/api.jl
@@ -448,4 +448,67 @@ end
     end
 end
 
+@testset "Stdlib version validation" begin
+    isolate() do
+        Pkg.activate(temp = true)
+
+        # Test that adding a stdlib with wrong version fails
+        pkg_uuid = Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f") # Pkg stdlib UUID
+        current_pkg_version = Pkg.Types.stdlib_version(pkg_uuid, VERSION)
+
+        # Create a fake wrong version that's different from current
+        wrong_version = VersionNumber(current_pkg_version.major, current_pkg_version.minor + 1, 0)
+
+        # Test that adding Pkg with wrong version throws an error
+        @test_throws r"Cannot add stdlib `Pkg` with version " Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = wrong_version))
+
+        # Test that adding Pkg with correct version works (should be a no-op)
+        @test_nowarn Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = current_pkg_version))
+
+        Pkg.activate(temp = true)
+        # Test that upgradable stdlibs (downgradable too) are not affected by version validation
+        # DelimitedFiles is an upgradable stdlib
+        delim_files_uuid = Base.UUID("8bb1440f-4735-579b-a4ab-409b98df4dab")
+        # Should be able to add DelimitedFiles with any version without error
+        old_version = v"1.9.0" # julia 1.13.0 is on v1.9.1
+        @test Pkg.Types.stdlib_version(delim_files_uuid, VERSION) != old_version
+        # We expect this might fail for resolver reasons, but NOT for stdlib version validation
+        Pkg.add(Pkg.PackageSpec(name = "DelimitedFiles", uuid = delim_files_uuid, version = old_version))
+        @test Pkg.dependencies("DelimitedFiles").version == old_version
+
+        Pkg.activate(temp = true)
+        # Test VersionSpec validation (like REPL "Package@version" syntax)
+        # Test that adding Pkg with wrong version via VersionSpec throws an error
+        wrong_version_spec = Pkg.Versions.VersionSpec(wrong_version)
+        @test_throws r"Cannot add stdlib `Pkg` with version " Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = wrong_version_spec))
+
+        Pkg.activate(temp = true)
+        # Test that adding Pkg with correct version via VersionSpec works
+        correct_version_spec = Pkg.Versions.VersionSpec(current_pkg_version)
+        @test_nowarn Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = correct_version_spec))
+
+        Pkg.activate(temp = true)
+        # Test that VersionSpec with ranges that include current version work
+        # This should work as the current version is within the range
+        version_range_spec = Pkg.Versions.VersionSpec("*")  # Allow any version
+        @test_nowarn Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = version_range_spec))
+
+        Pkg.activate(temp = true)
+        # Test String version validation (like REPL "Package@version" syntax)
+        # Test that adding Pkg with wrong version via String throws an error
+        wrong_version_string = string(wrong_version)
+        @test_throws r"Cannot add stdlib `Pkg` with version " Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = wrong_version_string))
+
+        Pkg.activate(temp = true)
+        # Test that adding Pkg with correct version via String works
+        correct_version_string = string(current_pkg_version)
+        @test_nowarn Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = correct_version_string))
+
+        Pkg.activate(temp = true)
+        # Test stdlib not in manifest scenario (fresh environment)
+        # This tests the first update_package_add method with ::Nothing entry
+        @test_throws r"Cannot add stdlib `Pkg` with version " Pkg.add(Pkg.PackageSpec(name = "Pkg", uuid = pkg_uuid, version = wrong_version))
+    end
+end
+
 end # module APITests

--- a/test/api.jl
+++ b/test/api.jl
@@ -474,7 +474,7 @@ end
         @test Pkg.Types.stdlib_version(delim_files_uuid, VERSION) != old_version
         # We expect this might fail for resolver reasons, but NOT for stdlib version validation
         Pkg.add(Pkg.PackageSpec(name = "DelimitedFiles", uuid = delim_files_uuid, version = old_version))
-        @test Pkg.dependencies("DelimitedFiles").version == old_version
+        @test Pkg.dependencies()[delim_files_uuid].version == old_version
 
         Pkg.activate(temp = true)
         # Test VersionSpec validation (like REPL "Package@version" syntax)

--- a/test/historical_stdlib_version.jl
+++ b/test/historical_stdlib_version.jl
@@ -303,7 +303,7 @@ isolate(loaded_depot = true) do
             Pkg.add(; name = "GMP_jll", julia_version = v"1.7")
 
             # This is expected to fail, that version can't live with `julia_version = v"1.7"`
-            @test_throws Pkg.Resolve.ResolverError Pkg.add(; name = "GMP_jll", version = v"6.2.0+5", julia_version = v"1.7")
+            @test_throws Pkg.Types.PkgError Pkg.add(; name = "GMP_jll", version = v"6.2.0+5", julia_version = v"1.7")
 
             Pkg.activate(temp = true)
             # Stdlib add (julia_version == nothing)

--- a/test/historical_stdlib_version.jl
+++ b/test/historical_stdlib_version.jl
@@ -303,7 +303,7 @@ isolate(loaded_depot = true) do
             Pkg.add(; name = "GMP_jll", julia_version = v"1.7")
 
             # This is expected to fail, that version can't live with `julia_version = v"1.7"`
-            @test_throws Pkg.Types.PkgError Pkg.add(; name = "GMP_jll", version = v"6.2.0+5", julia_version = v"1.7")
+            @test_throws Pkg.Resolve.ResolverError Pkg.add(; name = "GMP_jll", version = v"6.2.0+5", julia_version = v"1.7")
 
             Pkg.activate(temp = true)
             # Stdlib add (julia_version == nothing)


### PR DESCRIPTION
Fixes #4334 

```
(jl_TIjQ4O) pkg> add Pkg@1.14
ERROR: Cannot add stdlib `Pkg` with version specification `1.14`.
The current Julia version 1.13.0-DEV.897 uses `Pkg` v1.13.0.

(jl_TIjQ4O) pkg> add Pkg@1.12
ERROR: Cannot add stdlib `Pkg` with version specification `1.12`.
The current Julia version 1.13.0-DEV.897 uses `Pkg` v1.13.0.
```

I think this is also the only time we actually test that upgradable stdlibs are upgradable (downgradable)?