### PR TITLE
Fix missed rename of Operations._compat. Add tests for interactive compat menu

### DIFF
--- a/ext/REPLExt/compat.jl
+++ b/ext/REPLExt/compat.jl
@@ -88,6 +88,6 @@ function _compat(ctx::Context; io = nothing)
         ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid}, Int32), stdin.handle, false)
     end
     new_entry = strip(resp)
-    compat(ctx, dep, string(new_entry))
+    API._compat(ctx, dep, string(new_entry))
     return
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/4343