### PR TITLE
Nicer no changes formatting

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2935,7 +2935,11 @@ function print_status(
     end
     no_changes = all(p -> p[2] == p[3], xs)
     if no_changes
-        printpkgstyle(io, Symbol("No packages added to or removed from"), "$(pathrepr(manifest ? env.manifest_file : env.project_file))", ignore_indent)
+        if manifest
+            printpkgstyle(io, :Manifest, "No packages added to or removed from $(pathrepr(env.manifest_file))", ignore_indent; color = Base.info_color())
+        else
+            printpkgstyle(io, :Project, "No packages added to or removed from $(pathrepr(env.project_file))", ignore_indent; color = Base.info_color())
+        end
     else
         xs = !filter ? xs : eltype(xs)[(id, old, new) for (id, old, new) in xs if (id in uuids || something(new, old).name in names)]
         if isempty(xs)


### PR DESCRIPTION
@ericphanson what do you think? The length of the current one is a bit against the Pkg (cargo) prefix styling

Shorter prefix and blue, as green = action, blue = info ?

Currently
<img width="988" height="116" alt="Screenshot 2025-08-04 at 4 11 32 PM" src="https://github.com/user-attachments/assets/5026b723-7fc8-41c2-a1a4-87811b05b93c" />

This PR
<img width="1083" height="124" alt="Screenshot 2025-08-04 at 4 11 28 PM" src="https://github.com/user-attachments/assets/280ca3c8-0368-418f-9e3d-fcd7a1ad4707" />

Re. 
https://github.com/JuliaLang/Pkg.jl/issues/3066
https://github.com/JuliaLang/Pkg.jl/pull/3806
