### PR TITLE
Mention that standard libraries have a version number since 1.11

### DIFF
--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -58,7 +58,7 @@ Status `~/.julia/environments/v1.10/Manifest.toml`
   [4ec0a83e] Unicode
 ```
 
-Since standard libraries (e.g. ` Dates`) are shipped with Julia, they do not have a version.
+Since julia 1.11 standard libraries (e.g. ` Dates`) have a version.
 
 To specify that you want a particular version (or set of versions) of a package, use the `compat` command. For example,
 to require any patch release of the v0.21 series of JSON after v0.21.4, call `compat JSON 0.21.4`:


### PR DESCRIPTION
Since julia 1.11 standard libraries have a version number and that should be reflected in the docs or this sentence should be removed. 
