### PR TITLE
Add support for reporting an upstream version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Pkg v1.13 Release Notes
 =======================
 
+- Added support for an optional `upstream_version` field in Project.toml and Manifest.toml files to track the version
+  of upstream software that a package wraps or is based on. This is particularly useful for wrapper packages like JLLs
+  where the package version might differ from the upstream software version. The upstream version is displayed in
+  `Pkg.status` output alongside the package version when present.
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -102,6 +102,24 @@ Note that Pkg.jl deviates from the SemVer specification when it comes to version
 the section on [pre-1.0 behavior](@ref compat-pre-1.0) for more details.
 
 
+### The `upstream_version` field
+
+`upstream_version` is an optional string field that can be used to track the version of the upstream software that a package wraps or is based on. This is particularly useful for wrapper packages (like JLLs) where the package version might differ from the upstream software version. For example:
+
+```toml
+version = "1.2.3"
+upstream_version = "4.5.6-beta2"
+```
+
+When present, the upstream version is displayed in `Pkg.status` output in the project header as:
+
+```text
+Project MyPackage v1.2.3 (upstream version: 4.5.6-beta2)
+```
+
+Unlike the `version` field, `upstream_version` is stored as a plain string and is not required to be parseable as a Julia `VersionNumber`. This allows for upstream version schemes that don't follow semantic versioning.
+
+
 ### The `readonly` field
 
 The `readonly` field is a boolean that, when set to `true`, marks the environment as read-only. This prevents any modifications to the environment, including adding, removing, or updating packages. For example:
@@ -241,6 +259,8 @@ dependency section includes a combination of the following entries:
 * `deps`: a vector listing the dependencies of the dependency, for example
   `deps = ["Example", "JSON"]`.
 * `version`: a version number, for example `version = "1.2.6"`.
+* `upstream_version`: an optional string field tracking the upstream software version,
+  for example `upstream_version = "4.5.6-beta2"`.
 * `path`: a file path to the source code, for example `path = /home/user/Example`.
 * `repo-url`: a URL to the repository where the source code was found,
   for example `repo-url = "https://github.com/JuliaLang/Example.jl.git"`.

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -96,6 +96,7 @@ mutable struct PackageSpec
     repo::GitRepo # private
     path::Union{Nothing, String}
     pinned::Bool
+    upstream_version::Union{Nothing, String}
     # used for input only
     url::Union{Nothing, String}
     rev::Union{Nothing, String}
@@ -110,12 +111,13 @@ function PackageSpec(;
         repo::GitRepo = GitRepo(),
         path::Union{Nothing, AbstractString} = nothing,
         pinned::Bool = false,
+        upstream_version::Union{Nothing, AbstractString} = nothing,
         url = nothing,
         rev = nothing,
         subdir = nothing
     )
     uuid = uuid === nothing ? nothing : UUID(uuid)
-    return PackageSpec(name, uuid, version, tree_hash, repo, path, pinned, url, rev, subdir)
+    return PackageSpec(name, uuid, version, tree_hash, repo, path, pinned, upstream_version, url, rev, subdir)
 end
 PackageSpec(name::AbstractString) = PackageSpec(; name = name)::PackageSpec
 PackageSpec(name::AbstractString, uuid::UUID) = PackageSpec(; name = name, uuid = uuid)::PackageSpec
@@ -256,6 +258,7 @@ Base.@kwdef mutable struct Project
     name::Union{String, Nothing} = nothing
     uuid::Union{UUID, Nothing} = nothing
     version::Union{VersionTypes, Nothing} = nothing
+    upstream_version::Union{String, Nothing} = nothing
     manifest::Union{String, Nothing} = nothing
     entryfile::Union{String, Nothing} = nothing
     # Sections
@@ -291,6 +294,7 @@ Base.@kwdef mutable struct PackageEntry
     exts::Dict{String, Union{Vector{String}, String}} = Dict{String, String}()
     uuid::Union{Nothing, UUID} = nothing
     apps::Dict{String, AppInfo} = Dict{String, AppInfo}() # used by AppManifest.toml
+    upstream_version::Union{String, Nothing} = nothing
     other::Union{Dict, Nothing} = nothing
 end
 Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
@@ -304,9 +308,10 @@ Base.:(==)(t1::PackageEntry, t2::PackageEntry) = t1.name == t2.name &&
     t1.weakdeps == t2.weakdeps &&
     t1.exts == t2.exts &&
     t1.uuid == t2.uuid &&
+    t1.upstream_version == t2.upstream_version &&
     t1.apps == t2.apps
 # omits `other`
-Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.entryfile, x.pinned, x.repo, x.tree_hash, x.deps, x.weakdeps, x.exts, x.uuid], init = h)  # omits `other`
+Base.hash(x::PackageEntry, h::UInt) = foldr(hash, [x.name, x.version, x.path, x.entryfile, x.pinned, x.repo, x.tree_hash, x.deps, x.weakdeps, x.exts, x.uuid, x.upstream_version], init = h)  # omits `other`
 
 Base.@kwdef mutable struct Manifest
     julia_version::Union{Nothing, VersionNumber} = nothing # only set to VERSION when resolving

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -218,6 +218,7 @@ function Manifest(raw::Dict{String, Any}, f_or_io::Union{String, IO})::Manifest
                     entry.repo.rev = read_field("repo-rev", nothing, info, identity)
                     entry.repo.subdir = read_field("repo-subdir", nothing, info, identity)
                     entry.tree_hash = read_field("git-tree-sha1", nothing, info, safe_SHA1)
+                    entry.upstream_version = read_field("upstream_version", nothing, info, identity)
                     entry.uuid = uuid
                     deps = read_deps(get(info::Dict, "deps", nothing)::Union{Nothing, Dict{String, Any}, Vector{String}})
                     weakdeps = read_deps(get(info::Dict, "weakdeps", nothing)::Union{Nothing, Dict{String, Any}, Vector{String}})
@@ -321,6 +322,7 @@ function destructure(manifest::Manifest)::Dict
         entry!(new_entry, "version", entry.version)
         entry!(new_entry, "git-tree-sha1", entry.tree_hash)
         entry!(new_entry, "pinned", entry.pinned; default = false)
+        entry!(new_entry, "upstream_version", entry.upstream_version)
         path = entry.path
         if path !== nothing && Sys.iswindows() && !isabspath(path)
             path = join(splitpath(path), "/")

--- a/src/project.jl
+++ b/src/project.jl
@@ -214,6 +214,7 @@ function Project(raw::Dict; file = nothing)
     end
     project.uuid = read_project_uuid(get(raw, "uuid", nothing))
     project.version = read_project_version(get(raw, "version", nothing))
+    project.upstream_version = get(raw, "upstream_version", nothing)::Union{String, Nothing}
     project.deps = read_project_deps(get(raw, "deps", nothing), "deps")
     project.weakdeps = read_project_deps(get(raw, "weakdeps", nothing), "weakdeps")
     project.exts = get(Dict{String, String}, raw, "extensions")
@@ -272,6 +273,7 @@ function destructure(project::Project)::Dict
     entry!("name", project.name)
     entry!("uuid", project.uuid)
     entry!("version", project.version)
+    entry!("upstream_version", project.upstream_version)
     entry!("workspace", project.workspace)
     entry!("manifest", project.manifest)
     entry!("entryfile", project.entryfile)
@@ -292,7 +294,7 @@ function destructure(project::Project)::Dict
     return raw
 end
 
-const _project_key_order = ["name", "uuid", "keywords", "license", "desc", "version", "readonly", "workspace", "deps", "weakdeps", "sources", "extensions", "compat"]
+const _project_key_order = ["name", "uuid", "keywords", "license", "desc", "version", "upstream_version", "readonly", "workspace", "deps", "weakdeps", "sources", "extensions", "compat"]
 project_key_order(key::String) =
     something(findfirst(x -> x == key, _project_key_order), length(_project_key_order) + 1)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -48,4 +48,120 @@ end
     @test ps_versioned.version == "1.0.0"
 end
 
+@testset "upstream_version tests" begin
+    mktempdir() do tmpdir
+        # Create a project with upstream_version
+        project_file = joinpath(tmpdir, "Project.toml")
+        open(project_file, "w") do io
+            write(
+                io, """
+                name = "TestPkg"
+                uuid = "12345678-1234-1234-1234-123456789abc"
+                version = "0.1.0"
+                upstream_version = "2.4.1-beta"
+
+                [deps]
+                TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+                """
+            )
+        end
+
+        # Test reading
+        project = Pkg.Types.read_project(project_file)
+        @test project.upstream_version == "2.4.1-beta"
+        @test project.name == "TestPkg"
+        @test project.version == v"0.1.0"
+
+        # Test writing
+        destructured = Pkg.Types.destructure(project)
+        @test destructured["upstream_version"] == "2.4.1-beta"
+
+        # Write back and read again
+        output_file = joinpath(tmpdir, "Project_output.toml")
+        Pkg.Types.write_project(destructured, output_file)
+
+        project2 = Pkg.Types.read_project(output_file)
+        @test project2.upstream_version == "2.4.1-beta"
+
+        # Test that it's preserved in the written file
+        content = read(output_file, String)
+        @test occursin("upstream_version = \"2.4.1-beta\"", content)
+
+        # Test nil case
+        project_file2 = joinpath(tmpdir, "Project2.toml")
+        open(project_file2, "w") do io
+            write(
+                io, """
+                name = "TestPkg2"
+                uuid = "87654321-4321-4321-4321-210987654321"
+                version = "0.1.0"
+
+                [deps]
+                TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+                """
+            )
+        end
+
+        project_no_upstream = Pkg.Types.read_project(project_file2)
+        @test project_no_upstream.upstream_version === nothing
+
+        # Test that it doesn't appear in written file when not set
+        destructured_no_upstream = Pkg.Types.destructure(project_no_upstream)
+        @test !haskey(destructured_no_upstream, "upstream_version")
+    end
+
+    # Test PackageSpec upstream_version field
+    @testset "PackageSpec upstream_version" begin
+        ps = PackageSpec(name = "Example", upstream_version = "1.2.3-alpha")
+        @test ps.upstream_version == "1.2.3-alpha"
+
+        ps_nil = PackageSpec(name = "Example")
+        @test ps_nil.upstream_version === nothing
+    end
+
+    # Test manifest upstream_version functionality
+    @testset "Manifest upstream_version" begin
+        mktempdir() do tmpdir
+            # Create a manifest with upstream_version in an entry
+            manifest_file = joinpath(tmpdir, "Manifest.toml")
+            open(manifest_file, "w") do io
+                write(
+                    io, """
+                    julia_version = "1.13.0"
+                    manifest_format = "2.0"
+
+                    [[deps.Example]]
+                    uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+                    version = "1.0.0"
+                    upstream_version = "2.3.4-rc1"
+                    """
+                )
+            end
+
+            # Test reading manifest
+            manifest = Pkg.Types.read_manifest(manifest_file)
+            example_uuid = Base.UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+            @test haskey(manifest, example_uuid)
+
+            entry = manifest[example_uuid]
+            @test entry.upstream_version == "2.3.4-rc1"
+            @test entry.version == v"1.0.0"
+
+            # Test writing manifest
+            destructured = Pkg.Types.destructure(manifest)
+            output_file = joinpath(tmpdir, "Manifest_output.toml")
+            Pkg.Types.write_manifest(destructured, output_file)
+
+            # Verify the upstream_version is written
+            content = read(output_file, String)
+            @test occursin("upstream_version = \"2.3.4-rc1\"", content)
+
+            # Test reading it back
+            manifest2 = Pkg.Types.read_manifest(output_file)
+            entry2 = manifest2[example_uuid]
+            @test entry2.upstream_version == "2.3.4-rc1"
+        end
+    end
+end
+
 end # module


### PR DESCRIPTION
i.e. for JLLs whose package version is most likely not the same as the upstream version.

Currently we don't record the upstream version reliably from BB, but it's proving painful for advisory tracking (cc. @mbauman)

Here ImageMagick_jll has been modified to have a made up `upstream_version` field in its Project.toml here


<img width="631" height="600" alt="Screenshot 2025-08-27 at 1 22 02 PM" src="https://github.com/user-attachments/assets/e137f104-d029-4349-8dd3-fa0fda845b4f" />
