### PR TITLE
Fix upgrade message (#4087)

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2122,7 +2122,7 @@ function up(
                     packages_holding_back, max_version, max_version_compat = cinfo
                     if current_version < max_version
                         printpkgstyle(
-                            ctx.io, :Info, "$(pkg.name) can be updated but at the cost of downgrading other packages. " *
+                            ctx.io, :Info, "$(pkg.name) can be updated but at the cost of upgrading/downgrading other packages. " *
                                 "To force upgrade to the latest version, try `add $(pkg.name)@$(max_version)`", color = Base.info_color()
                         )
                     end


### PR DESCRIPTION
When an upgrade is held back because it would require upgrading a dependency, the message in the current master is something like:
```julia-repl
        Info Revise can be updated but at the cost of downgrading other packages. To force upgrade to the latest version, try `add Revise@3.9.0`
```
this PR would change that text to:
```julia-repl
        Info Revise can be updated but at the cost of upgrading/downgrading other packages. To force upgrade to the latest version, try `add Revise@3.9.0`
```
Which is more correct and less confusing for the user.