### PR TITLE
Clear the registry cache on Pkg module end

### DIFF
--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -979,5 +979,6 @@ DEFAULT_IO[] = nothing
 Pkg.UPDATED_REGISTRY_THIS_SESSION[] = false
 PREV_ENV_PATH[] = ""
 Types.STDLIB[] = nothing
+empty!(Registry.REGISTRY_CACHE)
 
 end # module


### PR DESCRIPTION
Right now we have:

```
❯ julia +1.12-nightly -q
julia> using Pkg

julia> Pkg.Registry.REGISTRY_CACHE
Dict{String, Tuple{Base.SHA1, Bool, Pkg.Registry.RegistryInstance}} with 1 entry:
  "/tmp/jl_IUXDox/r… => (SHA1("11b5fad51c4f98cfe0c145ceab0b…
```