### PR TITLE
Add ASCII requirement for package naming

### DIFF
--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -625,6 +625,7 @@ may fit your package better.
 
 9. Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
      * The package name should begin with a capital letter and word separation is shown with upper camel case
+     * Only ASCII characters are allowed in a package name
      * Packages that provide the functionality of a project from another language should use the Julia convention
      * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep their original name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages is handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system.
 


### PR DESCRIPTION
Following https://discourse.julialang.org/t/can-package-names-contain-non-ascii-characters/132965