### PR TITLE
Add `--dry-run` for add/update etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Pkg v1.13 Release Notes
 =======================
 
+- Added `--dry-run` option to `add`, `develop`, `update`, and `resolve` commands to preview changes without applying
+  them. Use `pkg> add --dry-run Example`, `Pkg.add("Example"; dry_run=true)`, or similar for other commands. Changes
+  are displayed and then automatically reverted. ([#XXXX])
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve

--- a/src/API.jl
+++ b/src/API.jl
@@ -252,7 +252,7 @@ end
 
 function develop(
         ctx::Context, pkgs::Vector{PackageSpec}; shared::Bool = true,
-        preserve::PreserveLevel = Operations.default_preserve(), platform::AbstractPlatform = HostPlatform(), kwargs...
+        preserve::PreserveLevel = Operations.default_preserve(), platform::AbstractPlatform = HostPlatform(), dry_run::Bool = false, kwargs...
     )
     require_not_empty(pkgs, :develop)
     Context!(ctx; kwargs...)
@@ -299,12 +299,16 @@ function develop(
     end
 
     Operations.develop(ctx, pkgs, new_git; preserve = preserve, platform = platform)
+    if dry_run
+        undo(ctx; silent = true)
+        printpkgstyle(ctx.io, Symbol("Dry run"), "so changes have been reverted", color = Base.info_color())
+    end
     return
 end
 
 function add(
         ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel = Operations.default_preserve(),
-        platform::AbstractPlatform = HostPlatform(), target::Symbol = :deps, allow_autoprecomp::Bool = true, kwargs...
+        platform::AbstractPlatform = HostPlatform(), target::Symbol = :deps, allow_autoprecomp::Bool = true, dry_run::Bool = false, kwargs...
     )
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)
@@ -358,6 +362,10 @@ function add(
     end
 
     Operations.add(ctx, pkgs, new_git; allow_autoprecomp, preserve, platform, target)
+    if dry_run
+        undo(ctx; silent = true)
+        printpkgstyle(ctx.io, Symbol("Dry run"), "so changes have been reverted", color = Base.info_color())
+    end
     return
 end
 
@@ -416,6 +424,7 @@ function up(
         preserve::Union{Nothing, PreserveLevel} = isempty(pkgs) ? nothing : PRESERVE_ALL,
         update_registry::Bool = true,
         skip_writing_project::Bool = false,
+        dry_run::Bool = false,
         kwargs...
     )
     Context!(ctx; kwargs...)
@@ -442,12 +451,16 @@ function up(
         update_source_if_set(ctx.env, pkg)
     end
     Operations.up(ctx, pkgs, level; skip_writing_project, preserve)
+    if dry_run
+        undo(ctx; silent = true)
+        printpkgstyle(ctx.io, Symbol("Dry run"), "so changes have been reverted", color = Base.info_color())
+    end
     return
 end
 
 resolve(; io::IO = stderr_f(), kwargs...) = resolve(Context(; io); kwargs...)
-function resolve(ctx::Context; skip_writing_project::Bool = false, kwargs...)
-    up(ctx; level = UPLEVEL_FIXED, mode = PKGMODE_MANIFEST, update_registry = false, skip_writing_project, kwargs...)
+function resolve(ctx::Context; skip_writing_project::Bool = false, dry_run::Bool = false, kwargs...)
+    up(ctx; level = UPLEVEL_FIXED, mode = PKGMODE_MANIFEST, update_registry = false, skip_writing_project, dry_run, kwargs...)
     return nothing
 end
 
@@ -1623,9 +1636,9 @@ function add_snapshot_to_undo(env = nothing)
     return resize!(state.entries, min(length(state.entries), max_undo_limit))
 end
 
-undo(ctx = Context()) = redo_undo(ctx, :undo, 1)
-redo(ctx = Context()) = redo_undo(ctx, :redo, -1)
-function redo_undo(ctx, mode::Symbol, direction::Int)
+undo(ctx = Context(); kwargs...) = redo_undo(ctx, :undo, 1; kwargs...)
+redo(ctx = Context(); kwargs...) = redo_undo(ctx, :redo, -1; kwargs...)
+function redo_undo(ctx, mode::Symbol, direction::Int; silent::Bool = false)
     @assert direction == 1 || direction == -1
     state = get(undo_entries, ctx.env.project_file, nothing)
     state === nothing && pkgerror("no undo state for current project")
@@ -1635,7 +1648,9 @@ function redo_undo(ctx, mode::Symbol, direction::Int)
     snapshot = state.entries[state.idx]
     ctx.env.manifest, ctx.env.project = snapshot.manifest, snapshot.project
     write_env(ctx.env; update_undo = false)
-    return Operations.show_update(ctx.env, ctx.registries; io = ctx.io)
+    if !silent
+        return Operations.show_update(ctx.env, ctx.registries; io = ctx.io)
+    end
 end
 
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -151,8 +151,8 @@ const PreserveLevel = Types.PreserveLevel
 
 # Define new variables so tab comleting Pkg. works.
 """
-    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, target::Symbol=:deps)
-    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, target::Symbol=:deps)
+    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, dry_run::Bool=false)
+    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, dry_run::Bool=false)
 
 Add a package to the current project. This package will be available by using the
 `import` and `using` keywords in the Julia REPL, and if the current project is
@@ -163,6 +163,8 @@ added automatically with a lower bound of the added version.
 
 To add as a weak dependency (in the `[weakdeps]` field) set the kwarg `target=:weakdeps`.
 To add as an extra dep (in the `[extras]` field) set `target=:extras`.
+
+The `dry_run` option will preview the changes without actually applying them. Changes will be displayed and then automatically reverted.
 
 ## Resolution Tiers
 `Pkg` resolves the set of packages in your environment using a tiered algorithm.
@@ -324,7 +326,7 @@ If `workspace` is true, this will consider all projects in the workspace and not
 const why = API.why
 
 """
-    Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT, preserve::PreserveLevel)
+    Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT, preserve::PreserveLevel, dry_run::Bool=false)
     Pkg.update(pkg::Union{String, Vector{String}})
     Pkg.update(pkg::Union{PackageSpec, Vector{PackageSpec}})
 
@@ -335,6 +337,8 @@ If packages are given as positional arguments, the `preserve` argument can be us
 - `PRESERVE_ALL` (default): Only allow `pkg` to update.
 - `PRESERVE_DIRECT`: Only allow `pkg` and indirect dependencies that are not a direct dependency in the project to update.
 - `PRESERVE_NONE`: Allow `pkg` and all its indirect dependencies to update.
+
+The `dry_run` option will preview the changes without actually applying them. Changes will be displayed and then automatically reverted.
 
 After any package updates the project will be precompiled. See more at [Environment Precompilation](@ref).
 
@@ -500,8 +504,8 @@ const free = API.free
 
 
 """
-    Pkg.develop(pkg::Union{String, Vector{String}}; io::IO=stderr, preserve=PRESERVE_TIERED, installed=false)
-    Pkg.develop(pkgs::Union{PackageSpec, Vector{PackageSpec}}; io::IO=stderr, preserve=PRESERVE_TIERED, installed=false)
+    Pkg.develop(pkg::Union{String, Vector{String}}; io::IO=stderr, preserve=PRESERVE_TIERED, installed=false, dry_run::Bool=false)
+    Pkg.develop(pkgs::Union{PackageSpec, Vector{PackageSpec}}; io::IO=stderr, preserve=PRESERVE_TIERED, installed=false, dry_run::Bool=false)
 
 Make a package available for development by tracking it by path.
 If `pkg` is given with only a name or by a URL, the package will be downloaded
@@ -509,6 +513,8 @@ to the location specified by the environment variable `JULIA_PKG_DEVDIR`, with
 `joinpath(DEPOT_PATH[1],"dev")` being the default.
 
 If `pkg` is given as a local path, the package at that path will be tracked.
+
+The `dry_run` option will preview the changes without actually applying them. Changes will be displayed and then automatically reverted.
 
 The preserve strategies offered by `Pkg.add` are also available via the `preserve` kwarg.
 See [`Pkg.add`](@ref) for more information.
@@ -608,10 +614,12 @@ See more and how to disable auto-precompilation at [Environment Precompilation](
 const instantiate = API.instantiate
 
 """
-    Pkg.resolve(; io::IO=stderr)
+    Pkg.resolve(; io::IO=stderr, dry_run::Bool=false)
 
 Update the current manifest with potential changes to the dependency graph
 from packages that are tracking a path.
+
+The `dry_run` option will preview the changes without actually applying them. Changes will be displayed and then automatically reverted.
 """
 const resolve = API.resolve
 

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -113,11 +113,12 @@ compound_declarations = [
                 PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
                 PSA[:name => "weak", :short_name => "w", :api => :target => :weakdeps],
                 PSA[:name => "extra", :short_name => "e", :api => :target => :extras],
+                PSA[:name => "dry-run", :api => :dry_run => true],
             ],
             :completions => :complete_add_dev,
             :description => "add packages to project",
             :help => md"""
-                    add [--preserve=<opt>] [-w|--weak] [-e|--extra] pkg[=uuid] [@version] [#rev] ...
+                    add [--preserve=<opt>] [-w|--weak] [-e|--extra] [--dry-run] pkg[=uuid] [@version] [#rev] ...
 
                 Add package `pkg` to the current project file. If `pkg` could refer to
                 multiple different packages, specifying `uuid` allows you to disambiguate.
@@ -133,6 +134,9 @@ compound_declarations = [
                 The project will then track that git repository just like it would track a remote repository online.
                 If the package is not located at the top of the git repository, a subdirectory can be specified with
                 `path:subdir/path`.
+
+                The `--dry-run` option will preview the changes without actually applying them.
+                Changes will be displayed and then automatically reverted.
 
                 `Pkg` resolves the set of packages in your environment using a tiered approach.
                 The `--preserve` command line option allows you to key into a specific tier in the resolve algorithm.
@@ -188,12 +192,13 @@ compound_declarations = [
                 PSA[:name => "local", :api => :shared => false],
                 PSA[:name => "shared", :api => :shared => true],
                 PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
+                PSA[:name => "dry-run", :api => :dry_run => true],
             ],
             :completions => :complete_add_dev,
             :description => "clone the full package repo locally for development",
             :help => md"""
-                    [dev|develop] [--preserve=<opt>] [--shared|--local] pkg[=uuid] ...
-                    [dev|develop] [--preserve=<opt>] path
+                    [dev|develop] [--preserve=<opt>] [--shared|--local] [--dry-run] pkg[=uuid] ...
+                    [dev|develop] [--preserve=<opt>] [--dry-run] path
 
                 Make a package available for development. If `pkg` is an existing local path, that path will be recorded in
                 the manifest and used. Otherwise, a full git clone of `pkg` is made. The location of the clone is
@@ -202,6 +207,9 @@ compound_declarations = [
 
                 When `--local` is given, the clone is placed in a `dev` folder in the current project. This
                 is not supported for paths, only registered packages.
+
+                The `--dry-run` option will preview the changes without actually applying them.
+                Changes will be displayed and then automatically reverted.
 
                 This operation is undone by `free`.
 
@@ -309,12 +317,18 @@ compound_declarations = [
         PSA[
             :name => "resolve",
             :api => API.resolve,
+            :option_spec => [
+                PSA[:name => "dry-run", :api => :dry_run => true],
+            ],
             :description => "resolves to update the manifest from changes in dependencies of developed packages",
             :help => md"""
-                    resolve
+                    resolve [--dry-run]
 
                 Resolve the project i.e. run package resolution and update the Manifest. This is useful in case the dependencies of developed
                 packages have changed causing the current Manifest to be out of sync.
+
+                The `--dry-run` option will preview the changes without actually applying them.
+                Changes will be reverted after being displayed.
                 """,
         ],
         PSA[
@@ -362,6 +376,7 @@ compound_declarations = [
                 PSA[:name => "patch", :api => :level => UPLEVEL_PATCH],
                 PSA[:name => "fixed", :api => :level => UPLEVEL_FIXED],
                 PSA[:name => "preserve", :takes_arg => true, :api => :preserve => do_preserve],
+                PSA[:name => "dry-run", :api => :dry_run => true],
             ],
             :completions => :complete_installed_packages,
             :description => "update packages in manifest",
@@ -371,6 +386,7 @@ compound_declarations = [
 
                     opts: --major | --minor | --patch | --fixed
                           --preserve=<all/direct/none>
+                          --dry-run
 
                 Update `pkg` within the constraints of the indicated version
                 specifications. These specifications are of the form `@1`, `@1.2` or `@1.2.3`, allowing
@@ -380,6 +396,9 @@ compound_declarations = [
                 the following packages to be upgraded only within the current major, minor,
                 patch version; if the `--fixed` upgrade level is given, then the following
                 packages will not be upgraded at all.
+
+                The `--dry-run` option will preview the changes without actually applying them.
+                Changes will be reverted after being displayed.
 
                 After any package updates the project will be precompiled. For more information see `pkg> ?precompile`.
                 """,

--- a/test/dry_run_test.jl
+++ b/test/dry_run_test.jl
@@ -1,0 +1,40 @@
+using Test
+using Pkg
+
+@testset "dry-run" begin
+    mktempdir() do tmp_dir
+        cd(tmp_dir) do
+            Pkg.activate(".")
+
+            # Test add with dry-run
+            Pkg.add("Example"; dry_run = true)
+            @test !haskey(Pkg.project().dependencies, "Example")
+            @test !isfile("Manifest.toml")  # No manifest should exist
+
+            # Actually add Example 0.5.3 for subsequent tests
+            Pkg.add(name = "Example", version = "0.5.3")
+            @test haskey(Pkg.project().dependencies, "Example")
+            example_uuid = Pkg.project().dependencies["Example"]
+
+            # Test update with dry-run - should not upgrade from 0.5.3
+            initial_deps = copy(Pkg.dependencies())
+            manifest_before = read("Manifest.toml", String)
+            Pkg.update(; dry_run = true)
+            @test Pkg.dependencies() == initial_deps
+            @test read("Manifest.toml", String) == manifest_before
+
+            # Test resolve with dry-run
+            # TODO: This doesn't actually change anything currently, so it's a bit pointless
+            Pkg.resolve(; dry_run = true)
+            @test Pkg.dependencies() == initial_deps
+            @test read("Manifest.toml", String) == manifest_before
+
+            # Test develop with dry-run
+            Pkg.develop("JSON"; dry_run = true)
+            entry = get(Pkg.dependencies(), example_uuid, nothing)
+            @test entry !== nothing
+            @test !entry.is_tracking_path  # Should not be tracking path after dry-run
+            @test read("Manifest.toml", String) == manifest_before
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,7 @@ module PkgTestsInner
             "sources.jl",
             "workspaces.jl",
             "apps.jl",
+            "dry_run_test.jl",
         ]
 
         # Only test these if the test deps are available (they aren't typically via `Base.runtests`)


### PR DESCRIPTION
We previously had `preview` mode, which was [removed](https://github.com/JuliaLang/Pkg.jl/pull/1367) and replaced with a more robust `undo`/`redo`, but I think there's still benefit of having something like `preview` but instead utilize the improved `undo` mechanics automatically at the end of the operation.

i.e. if `undo` is robust, then this should be.

I also thought `--dry-run` was more typical, given that's what cargo has.