### PR TITLE
allow `--quiet` or `;quiet=true` to Pkg.test to avoid printing status output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Pkg v1.13 Release Notes
 
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
+- `Pkg.test` now supports a `quiet` keyword argument and `--quiet` flag to suppress the dependency listing output before
+  running tests.
+  ([#3405])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve
   package versions, similar to the existing option for `Pkg.test`. ([#3329])
 - Packages are now automatically added to `[sources]` when they are added by url or devved. ([#4225])

--- a/src/API.jl
+++ b/src/API.jl
@@ -530,6 +530,7 @@ function test(
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
         allow_reresolve::Bool = true,
+        quiet::Bool = false,
         kwargs...
     )
     julia_args = Cmd(julia_args)
@@ -555,6 +556,7 @@ function test(
         force_latest_compatible_version,
         allow_earlier_backwards_compatible_versions,
         allow_reresolve,
+        quiet,
     )
     return
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2617,7 +2617,8 @@ function test(
         test_fn = nothing,
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
-        allow_reresolve::Bool = true
+        allow_reresolve::Bool = true,
+        quiet::Bool = false
     )
     Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
 
@@ -2663,7 +2664,9 @@ function test(
             env = EnvCache(proj)
             # Instantiate test env
             Pkg.instantiate(Context(env = env); allow_autoprecomp = false)
-            status(env, ctx.registries; mode = PKGMODE_COMBINED, io = ctx.io, ignore_indent = false, show_usagetips = false)
+            if !quiet
+                status(env, ctx.registries; mode = PKGMODE_COMBINED, io = ctx.io, ignore_indent = false, show_usagetips = false)
+            end
             flags = gen_subprocess_flags(source_path; coverage, julia_args)
 
             if should_autoprecompile()
@@ -2708,7 +2711,9 @@ function test(
         sandbox(ctx, pkg, testdir(source_path), test_project_override; preferences = test_project_preferences, force_latest_compatible_version, allow_earlier_backwards_compatible_versions, allow_reresolve) do
             test_fn !== nothing && test_fn()
             sandbox_ctx = Context(; io = ctx.io)
-            status(sandbox_ctx.env, sandbox_ctx.registries; mode = PKGMODE_COMBINED, io = sandbox_ctx.io, ignore_indent = false, show_usagetips = false)
+            if !quiet
+                status(sandbox_ctx.env, sandbox_ctx.registries; mode = PKGMODE_COMBINED, io = sandbox_ctx.io, ignore_indent = false, show_usagetips = false)
+            end
             flags = gen_subprocess_flags(source_path; coverage, julia_args)
 
             if should_autoprecompile()

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -364,12 +364,16 @@ const update = API.up
   - `allow_reresolve::Bool=true`: allow Pkg to reresolve the package versions in the test environment
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
+  - `quiet::Bool=false`: suppress the dependency listing output before running tests.
 
 !!! compat "Julia 1.9"
     `allow_reresolve` requires at least Julia 1.9.
 
 !!! compat "Julia 1.9"
     Passing a string to `coverage` requires at least Julia 1.9.
+
+!!! compat "Julia 1.13"
+    `quiet` requires at least Julia 1.13.
 
 Run the tests for the given package(s), or for the current project if no positional argument is given to `Pkg.test`
 (the current project would need to be a package). The package is tested by running its `test/runtests.jl` file.

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -10,16 +10,18 @@ compound_declarations = [
             :arg_parser => parse_package,
             :option_spec => [
                 PSA[:name => "coverage", :api => :coverage => true],
+                PSA[:name => "quiet", :api => :quiet => true],
             ],
             :completions => :complete_installed_packages,
             :description => "run tests for packages",
             :help => md"""
-                    test [--coverage] [pkg[=uuid]] ...
+                    test [--coverage] [--quiet] [pkg[=uuid]] ...
 
                 Run the tests for package `pkg`, or for the current project (which thus needs to be
                 a package) if `pkg` is omitted.  This is done by running the file `test/runtests.jl`
                 in the package directory. The option `--coverage` can be used to run the tests with
-                coverage enabled. The `startup.jl` file is disabled during testing unless
+                coverage enabled. The option `--quiet` can be used to suppress the dependency listing
+                output before running tests. The `startup.jl` file is disabled during testing unless
                 julia is started with `--startup-file=yes`.
                 """,
         ],


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/3405.

I wonder if the `quiet` name is perhaps a bit too broad. We only silence the status output but we will still print things like testsets etc (I think?). So maybe quiet should silence those as well?