### PR TITLE
Bump version from 1.13.0 to 1.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."
-version = "1.13.0"
+version = "1.14.0"
 
 [workspace]
 projects = ["test", "docs"]


### PR DESCRIPTION
Spotted in https://github.com/JuliaLang/julia/pull/60020

> Julia version: 1.14.0-DEV
> Pkg version: 1.13.0(Does not match)