### PR TITLE
Backports for Julia 1.11

### DIFF
--- a/test/new.jl
+++ b/test/new.jl
@@ -1585,7 +1585,7 @@ end
 
 @testset "why" begin
     isolate() do
-        Pkg.add(name = "StaticArrays", version = "1.5.0")
+        Pkg.add(name = "StaticArrays", version = "1.5.20")
 
         io = IOBuffer()
         Pkg.why("StaticArrays"; io)


### PR DESCRIPTION
Backported PRs:
- [x] #4077 (cherry picked from commit 814949ed2334afcaf51e437a5fa4002d1ae7eaaa)

This is necessary to fix CI on the `release-1.11` branch of Julia.