### PR TITLE
fix building packages on app add

### DIFF
--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -216,6 +216,9 @@ function add(pkg::PackageSpec)
     manifest.deps[pkg.uuid] = entry
 
     _resolve(manifest, pkg.name)
+    if new === true || (new isa Set{UUID} && pkg.uuid in new)
+        Pkg.Operations.build_versions(ctx, Set([pkg.uuid]); verbose = true)
+    end
     precompile(pkg.name)
 
     @info "For package: $(pkg.name) installed apps $(join(keys(project.apps), ","))"


### PR DESCRIPTION
``` 
(Pkg) pkg> app add https://github.com/JuliaLang/IJulia.jl/pull/1211
     Cloning git-repo `https://github.com/JuliaLang/IJulia.jl`
    Updating git-repo `https://github.com/JuliaLang/IJulia.jl`
vvvvvvvvvvvvvvvvv
    Building IJulia → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/bea9c71417a55e82a31ea43cc0baabd6cf2ccf48/build.log` <---------------------------
^^^^^^^^^^^^
[ Info: Installing 'Julia 1.14' kernelspec in /home/kc/.local/share/jupyter/kernels/julia-1.14
[ Info: For package: IJulia installed apps ijulia

shell> ijulia 
install Jupyter via Conda, y/n? [y]: y
[ Info: Running `conda install -y jupyterlab` in root environment
Retrieving notices: ...working... done
```