### PR TITLE
show the original libgit2 error message which includes the `insteadOf` url

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -255,7 +255,7 @@ function fetch(io::IO, repo::LibGit2.GitRepo, remoteurl = nothing; header = noth
         if (err.class == LibGit2.Error.Repository && err.code == LibGit2.Error.ERROR)
             Pkg.Types.pkgerror("Git repository not found at '$(remoteurl)': ($(err.msg))")
         else
-            Pkg.Types.pkgerror("failed to fetch from $(remoteurl): ($err.msg)")
+            Pkg.Types.pkgerror("failed to fetch from $(remoteurl): ($(err.msg))")
         end
     finally
         Base.shred!(credentials)


### PR DESCRIPTION
fixes #1706

The LibGit2 error message seems to show this URL.
