### PR TITLE
Prefer adding already loaded dep versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Pkg v1.13 Release Notes
 
 - `Pkg.test` now respects the `--check-bounds` setting from the parent Julia session instead of forcing `--check-bounds=yes`.
 
+- `Pkg.add` now prefers versions of packages that are already loaded in the current Julia session when resolving
+  dependencies. This helps maintain compatibility with code already running in your session. The behavior can be
+  disabled using `Pkg.add(pkg; prefer_loaded_versions=false)`. ([#4507])
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Pkg v1.13 Release Notes
   silently in the background while returning to the REPL), `c` to cancel, `i` for a profile peek, `v` to toggle
   verbose mode, `?`/`h` for help, and `Ctrl-C` to interrupt. After detaching, use `pkg> precompile --monitor` to
   reattach, `--stop` to stop gracefully, or `--cancel` to cancel immediately. ([#4602])
+- `Pkg.add` now prefers versions of packages that are already loaded in the current Julia session when resolving
+  dependencies. This helps maintain compatibility with code already running in your session. The behavior can be
+  disabled using `Pkg.add(pkg; prefer_loaded_versions=false)`. ([#4507])
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ Pkg v1.13 Release Notes
   silently in the background while returning to the REPL), `c` to cancel, `i` for a profile peek, `v` to toggle
   verbose mode, `?`/`h` for help, and `Ctrl-C` to interrupt. After detaching, use `pkg> precompile --monitor` to
   reattach, `--stop` to stop gracefully, or `--cancel` to cancel immediately. ([#4602])
-- `Pkg.add` now prefers versions of packages that are already loaded in the current Julia session when resolving
-  dependencies. This helps maintain compatibility with code already running in your session. The behavior can be
-  disabled using `Pkg.add(pkg; prefer_loaded_versions=false)`. ([#4507])
+- The Pkg REPL `add` command now prefers versions of packages that are already loaded in the current Julia
+  session when resolving dependencies. This helps maintain compatibility with code already running in your
+  session. The functional `Pkg.add` API keeps the previous (loading-independent) behavior by default for
+  reproducibility; pass `Pkg.add(pkg; prefer_loaded_versions=true)` to opt in. ([#4507])
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Pkg v1.13 Release Notes
   reattach, `--stop` to stop gracefully, or `--cancel` to cancel immediately. ([#4602])
 - The Pkg REPL `add` command now prefers versions of packages that are already loaded in the current Julia
   session when resolving dependencies. This helps maintain compatibility with code already running in your
-  session. The functional `Pkg.add` API keeps the previous (loading-independent) behavior by default for
-  reproducibility; pass `Pkg.add(pkg; prefer_loaded_versions=true)` to opt in. ([#4507])
+  session; run `pkg> up` afterwards to update to the latest compatible versions. The functional `Pkg.add`
+  API keeps the previous (loading-independent) behavior by default for reproducibility; pass
+  `Pkg.add(pkg; prefer_loaded_versions=true)` to opt in. ([#4507])
 - Project.toml environments now support a `readonly` field to mark environments as read-only, preventing modifications.
   ([#4284])
 - `Pkg.build` now supports an `allow_reresolve` keyword argument to control whether the build process can re-resolve

--- a/src/API.jl
+++ b/src/API.jl
@@ -320,7 +320,8 @@ end
 
 function add(
         ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel = Operations.default_preserve(),
-        platform::AbstractPlatform = HostPlatform(), target::Symbol = :deps, allow_autoprecomp::Bool = true, kwargs...
+        platform::AbstractPlatform = HostPlatform(), target::Symbol = :deps, allow_autoprecomp::Bool = true,
+        prefer_loaded_versions::Bool = true, kwargs...
     )
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)
@@ -376,7 +377,7 @@ function add(
         update_source_if_set(ctx.env, pkg)
     end
 
-    Operations.add(ctx, pkgs, new_git; allow_autoprecomp, preserve, platform, target)
+    Operations.add(ctx, pkgs, new_git; allow_autoprecomp, preserve, platform, target, prefer_loaded_versions)
     return
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -321,7 +321,7 @@ end
 function add(
         ctx::Context, pkgs::Vector{PackageSpec}; preserve::PreserveLevel = Operations.default_preserve(),
         platform::AbstractPlatform = HostPlatform(), target::Symbol = :deps, allow_autoprecomp::Bool = true,
-        prefer_loaded_versions::Bool = true, kwargs...
+        prefer_loaded_versions::Bool = Pkg.in_repl_mode(), kwargs...
     )
     require_not_empty(pkgs, :add)
     Context!(ctx; kwargs...)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -755,7 +755,7 @@ end
 # all versioned packages should have a `tree_hash`
 function resolve_versions!(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
-        installed_only::Bool
+        installed_only::Bool, preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
     installed_only = installed_only || OFFLINE_MODE[]
 
@@ -824,7 +824,10 @@ function resolve_versions!(
     unbind_stdlibs = julia_version === VERSION
     reqs = Resolve.Requires(pkg.uuid => is_stdlib(pkg.uuid, julia_version) && unbind_stdlibs ? VersionSpec("*") : VersionSpec(pkg.version) for pkg in pkgs)
     deps_map_compressed, compat_map_compressed, weak_deps_map_compressed, weak_compat_map_compressed, pkg_versions_map, pkg_versions_per_registry, uuid_to_name, reqs, fixed = deps_graph(env, registries, names, reqs, fixed, julia_version, installed_only)
-    graph = Resolve.Graph(deps_map_compressed, compat_map_compressed, weak_deps_map_compressed, weak_compat_map_compressed, pkg_versions_map, pkg_versions_per_registry, uuid_to_name, reqs, fixed, false, julia_version)
+    graph = Resolve.Graph(
+        deps_map_compressed, compat_map_compressed, weak_deps_map_compressed, weak_compat_map_compressed,
+        pkg_versions_map, pkg_versions_per_registry, uuid_to_name, reqs, fixed, false, julia_version, preferred_versions
+    )
     Resolve.simplify_graph!(graph)
     vers = Resolve.resolve(graph)
 
@@ -897,6 +900,84 @@ function resolve_versions!(
         final_deps_map[pkg.uuid] = deps
     end
     return final_deps_map
+end
+
+function collect_preferred_loaded_versions(env::EnvCache)
+    preferred = Dict{UUID, VersionNumber}()
+    for (pkgid, mod) in Base.loaded_modules
+        pkgid isa Base.PkgId || continue
+        pkg_uuid = pkgid.uuid
+        pkg_uuid isa UUID || continue
+        Types.is_stdlib(pkg_uuid) && continue
+        haskey(env.manifest, pkg_uuid) && continue
+        env.pkg !== nothing && pkg_uuid == env.pkg.uuid && continue
+        version = Base.pkgversion(mod)
+        version isa VersionNumber || continue
+        preferred[pkg_uuid] = version
+    end
+    return preferred
+end
+
+function preferred_loaded_packages_usage(
+        pkgs::Vector{PackageSpec}, preferred_versions::Dict{UUID, VersionNumber}, manifest_uuids::Set{UUID},
+        direct_requested_uuids::Set{UUID}
+    )
+    (isempty(preferred_versions) || isempty(pkgs)) && return String[], 0
+    direct_names = String[]
+    indirect_count = 0
+    for pkg in pkgs
+        uuid = pkg.uuid
+        uuid isa UUID || continue
+        uuid in manifest_uuids && continue
+        preferred_version = get(preferred_versions, uuid, nothing)
+        preferred_version === nothing && continue
+        pkg_version = pkg.version
+        pkg_version isa VersionNumber || continue
+        pkg_version == preferred_version || continue
+        pkg.name === nothing && continue
+        if uuid in direct_requested_uuids
+            push!(direct_names, pkg.name)
+        else
+            indirect_count += 1
+        end
+    end
+    sort!(direct_names)
+    unique!(direct_names)
+    return direct_names, indirect_count
+end
+
+function maybe_print_preferred_loaded_note(io::IO, direct_names::Vector{String}, indirect_count::Int)
+    isempty(direct_names) && indirect_count == 0 && return
+    parts = String[]
+    if !isempty(direct_names)
+        push!(parts, join(direct_names, ", "))
+    end
+    if indirect_count > 0
+        dep_word = indirect_count == 1 ? "dependency" : "dependencies"
+        push!(parts, "$(indirect_count) $(dep_word)")
+    end
+    joined = length(parts) == 2 ? string(parts[1], " and ", parts[2]) : parts[1]
+    msg = if length(direct_names) + indirect_count > 1
+        "Preferring versions of $(joined) that are already loaded"
+    else
+        "Preferring the version of $(joined) that is already loaded"
+    end
+    printpkgstyle(io, :Resolve, msg; color = Base.info_color())
+    return
+end
+
+function apply_preferred_versions_to_direct!(pkgs::Vector{PackageSpec}, preferred_versions::Dict{UUID, VersionNumber})
+    isempty(preferred_versions) && return
+    empty_spec = VersionSpec()
+    for pkg in pkgs
+        pkg.version == empty_spec || continue
+        uuid = pkg.uuid
+        uuid isa UUID || continue
+        pref_version = get(preferred_versions, uuid, nothing)
+        pref_version === nothing && continue
+        pkg.version = VersionSpec(pref_version)
+    end
+    return
 end
 
 get_or_make!(d::Dict{K, V}, k::K) where {K, V} = get!(d, k) do;
@@ -2154,39 +2235,42 @@ end
 
 function tiered_resolve(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
-        try_all_installed::Bool
+        try_all_installed::Bool; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
     if try_all_installed
         try # do not modify existing subgraph and only add installed versions of the new packages
             @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version; preferred_versions)
         catch err
             err isa Resolve.ResolverError || rethrow()
         end
     end
     try # do not modify existing subgraph
         @debug "tiered_resolve: trying PRESERVE_ALL"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
         @debug "tiered_resolve: trying PRESERVE_DIRECT"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
         @debug "tiered_resolve: trying PRESERVE_SEMVER"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     @debug "tiered_resolve: trying PRESERVE_NONE"
-    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
+    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version; preferred_versions)
 end
 
-function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
+function targeted_resolve(
+        env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel,
+        julia_version; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
+    )
     if preserve == PRESERVE_ALL || preserve == PRESERVE_ALL_INSTALLED
         pkgs = load_all_deps(env, pkgs; preserve)
     else
@@ -2194,23 +2278,24 @@ function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryIns
     end
     check_registered(registries, pkgs)
 
-    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED, preferred_versions)
     return pkgs, deps_map
 end
 
 function _resolve(
         io::IO, env::EnvCache, registries::Vector{Registry.RegistryInstance},
-        pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version
+        pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version;
+        preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
     usingstrategy = preserve != PRESERVE_TIERED ? " using $preserve" : ""
     printpkgstyle(io, :Resolving, "package versions$(usingstrategy)...")
     return try
         if preserve == PRESERVE_TIERED_INSTALLED
-            tiered_resolve(env, registries, pkgs, julia_version, true)
+            tiered_resolve(env, registries, pkgs, julia_version, true; preferred_versions)
         elseif preserve == PRESERVE_TIERED
-            tiered_resolve(env, registries, pkgs, julia_version, false)
+            tiered_resolve(env, registries, pkgs, julia_version, false; preferred_versions)
         else
-            targeted_resolve(env, registries, pkgs, preserve, julia_version)
+            targeted_resolve(env, registries, pkgs, preserve, julia_version; preferred_versions)
         end
     catch err
 
@@ -2273,7 +2358,7 @@ end
 function add(
         ctx::Context, pkgs::Vector{PackageSpec}, new_git = Set{UUID}();
         allow_autoprecomp::Bool = true, preserve::PreserveLevel = default_preserve(), platform::AbstractPlatform = HostPlatform(),
-        target::Symbol = :deps
+        target::Symbol = :deps, prefer_loaded_versions::Bool = true
     )
     assert_can_add(ctx, pkgs)
     # load manifest data
@@ -2317,11 +2402,34 @@ function add(
         return
     end
 
+    preferred_loaded_versions = Dict{UUID, VersionNumber}()
+    existing_manifest_uuids = Set{UUID}()
+    preferred_direct_note_names = String[]
+    preferred_indirect_note_count = 0
+    direct_requested_uuids = Set{UUID}()
     foreach(pkg -> target_field[pkg.name] = pkg.uuid, pkgs) # update set of deps/weakdeps/extras
+    for pkg in pkgs
+        uuid = pkg.uuid
+        uuid isa UUID || continue
+        push!(direct_requested_uuids, uuid)
+    end
+
+    if target == :deps && prefer_loaded_versions
+        preferred_loaded_versions = collect_preferred_loaded_versions(ctx.env)
+        existing_manifest_uuids = Set(keys(ctx.env.manifest))
+    end
 
     if target == :deps # nothing to resolve/install if it's weak or extras
         # resolve
-        man_pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
+        apply_preferred_versions_to_direct!(pkgs, preferred_loaded_versions)
+        man_pkgs, deps_map = _resolve(
+            ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version;
+            preferred_versions = preferred_loaded_versions
+        )
+        preferred_direct_note_names, preferred_indirect_note_count = preferred_loaded_packages_usage(
+            man_pkgs, preferred_loaded_versions, existing_manifest_uuids, direct_requested_uuids
+        )
+        maybe_print_preferred_loaded_note(ctx.io, preferred_direct_note_names, preferred_indirect_note_count)
         update_manifest!(ctx.env, man_pkgs, deps_map, ctx.julia_version, ctx.registries)
         new_apply = download_source(ctx)
         fixups_from_projectfile!(ctx)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2388,33 +2388,25 @@ function add(
         return
     end
 
-    preferred_loaded_versions = Dict{UUID, VersionNumber}()
-    existing_manifest_uuids = Set{UUID}()
-    preferred_direct_note_names = String[]
-    preferred_indirect_note_count = 0
-    direct_requested_uuids = Set{UUID}()
     foreach(pkg -> target_field[pkg.name] = pkg.uuid, pkgs) # update set of deps/weakdeps/extras
-    for pkg in pkgs
-        uuid = pkg.uuid
-        uuid isa UUID || continue
-        push!(direct_requested_uuids, uuid)
-    end
-
-    if target == :deps && prefer_loaded_versions
-        preferred_loaded_versions = collect_preferred_loaded_versions(ctx.env)
-        existing_manifest_uuids = Set(keys(ctx.env.manifest))
-    end
 
     if target == :deps # nothing to resolve/install if it's weak or extras
         # resolve
+        preferred_loaded_versions = Dict{UUID, VersionNumber}()
+        existing_manifest_uuids = Set{UUID}()
+        direct_requested_uuids = Set{UUID}(pkg.uuid for pkg in pkgs if pkg.uuid isa UUID)
+        if prefer_loaded_versions
+            preferred_loaded_versions = collect_preferred_loaded_versions(ctx.env)
+            existing_manifest_uuids = Set(keys(ctx.env.manifest))
+        end
         man_pkgs, deps_map = _resolve(
             ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version;
             preferred_versions = preferred_loaded_versions
         )
-        preferred_direct_note_names, preferred_indirect_note_count = preferred_loaded_packages_usage(
+        direct_names, indirect_count = preferred_loaded_packages_usage(
             man_pkgs, preferred_loaded_versions, existing_manifest_uuids, direct_requested_uuids
         )
-        maybe_print_preferred_loaded_note(ctx.io, preferred_direct_note_names, preferred_indirect_note_count)
+        maybe_print_preferred_loaded_note(ctx.io, direct_names, indirect_count)
         update_manifest!(ctx.env, man_pkgs, deps_map, ctx.julia_version, ctx.registries)
         new_apply = download_source(ctx)
         fixups_from_projectfile!(ctx)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -966,20 +966,6 @@ function maybe_print_preferred_loaded_note(io::IO, direct_names::Vector{String},
     return
 end
 
-function apply_preferred_versions_to_direct!(pkgs::Vector{PackageSpec}, preferred_versions::Dict{UUID, VersionNumber})
-    isempty(preferred_versions) && return
-    empty_spec = VersionSpec()
-    for pkg in pkgs
-        pkg.version == empty_spec || continue
-        uuid = pkg.uuid
-        uuid isa UUID || continue
-        pref_version = get(preferred_versions, uuid, nothing)
-        pref_version === nothing && continue
-        pkg.version = VersionSpec(pref_version)
-    end
-    return
-end
-
 get_or_make!(d::Dict{K, V}, k::K) where {K, V} = get!(d, k) do;
     V()
 end
@@ -2237,43 +2223,34 @@ function tiered_resolve(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
         try_all_installed::Bool; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
-    if !isempty(preferred_versions)
-        # first try maintaining any loaded versions of the new packages
-        try # do not modify existing subgraph
-            @debug "tiered_resolve: trying PRESERVE_ALL with any loaded versions of new packages"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
-        catch err
-            err isa Resolve.ResolverError || rethrow()
-        end
-    end
     if try_all_installed
         try # do not modify existing subgraph and only add installed versions of the new packages
             @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version; preferred_versions)
         catch err
             err isa Resolve.ResolverError || rethrow()
         end
     end
     try # do not modify existing subgraph
         @debug "tiered_resolve: trying PRESERVE_ALL"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
         @debug "tiered_resolve: trying PRESERVE_DIRECT"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
         @debug "tiered_resolve: trying PRESERVE_SEMVER"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     @debug "tiered_resolve: trying PRESERVE_NONE"
-    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
+    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version; preferred_versions)
 end
 
 function targeted_resolve(
@@ -2430,7 +2407,6 @@ function add(
 
     if target == :deps # nothing to resolve/install if it's weak or extras
         # resolve
-        apply_preferred_versions_to_direct!(pkgs, preferred_loaded_versions)
         man_pkgs, deps_map = _resolve(
             ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version;
             preferred_versions = preferred_loaded_versions

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -958,9 +958,9 @@ function maybe_print_preferred_loaded_note(io::IO, direct_names::Vector{String},
     end
     joined = length(parts) == 2 ? string(parts[1], " and ", parts[2]) : parts[1]
     msg = if length(direct_names) + indirect_count > 1
-        "Preferring versions of $(joined) that are already loaded"
+        "was able to add the versions of $(joined) that are already loaded"
     else
-        "Preferring the version of $(joined) that is already loaded"
+        "was able to add the version of $(joined) that is already loaded"
     end
     printpkgstyle(io, :Resolve, msg; color = Base.info_color())
     return
@@ -2237,34 +2237,43 @@ function tiered_resolve(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
         try_all_installed::Bool; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
+    if !isempty(preferred_versions)
+        # first try maintaining any loaded versions of the new packages
+        try # do not modify existing subgraph
+            @debug "tiered_resolve: trying PRESERVE_ALL with any loaded versions of new packages"
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
+        catch err
+            err isa Resolve.ResolverError || rethrow()
+        end
+    end
     if try_all_installed
         try # do not modify existing subgraph and only add installed versions of the new packages
             @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version; preferred_versions)
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
         catch err
             err isa Resolve.ResolverError || rethrow()
         end
     end
     try # do not modify existing subgraph
         @debug "tiered_resolve: trying PRESERVE_ALL"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
         @debug "tiered_resolve: trying PRESERVE_DIRECT"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version; preferred_versions)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
         @debug "tiered_resolve: trying PRESERVE_SEMVER"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version; preferred_versions)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     @debug "tiered_resolve: trying PRESERVE_NONE"
-    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version; preferred_versions)
+    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
 end
 
 function targeted_resolve(

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -755,7 +755,7 @@ end
 # all versioned packages should have a `tree_hash`
 function resolve_versions!(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
-        installed_only::Bool
+        installed_only::Bool, preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
     installed_only = installed_only || OFFLINE_MODE[]
 
@@ -824,7 +824,10 @@ function resolve_versions!(
     unbind_stdlibs = julia_version === VERSION
     reqs = Resolve.Requires(pkg.uuid => is_stdlib(pkg.uuid, julia_version) && unbind_stdlibs ? VersionSpec("*") : VersionSpec(pkg.version) for pkg in pkgs)
     deps_map_compressed, compat_map_compressed, weak_deps_map_compressed, weak_compat_map_compressed, pkg_versions_map, pkg_versions_per_registry, uuid_to_name, reqs, fixed = deps_graph(env, registries, names, reqs, fixed, julia_version, installed_only)
-    graph = Resolve.Graph(deps_map_compressed, compat_map_compressed, weak_deps_map_compressed, weak_compat_map_compressed, pkg_versions_map, pkg_versions_per_registry, uuid_to_name, reqs, fixed, false, julia_version)
+    graph = Resolve.Graph(
+        deps_map_compressed, compat_map_compressed, weak_deps_map_compressed, weak_compat_map_compressed,
+        pkg_versions_map, pkg_versions_per_registry, uuid_to_name, reqs, fixed, false, julia_version, preferred_versions
+    )
     Resolve.simplify_graph!(graph)
     vers = Resolve.resolve(graph)
 
@@ -897,6 +900,84 @@ function resolve_versions!(
         final_deps_map[pkg.uuid] = deps
     end
     return final_deps_map
+end
+
+function collect_preferred_loaded_versions(env::EnvCache)
+    preferred = Dict{UUID, VersionNumber}()
+    for (pkgid, mod) in Base.loaded_modules
+        pkgid isa Base.PkgId || continue
+        pkg_uuid = pkgid.uuid
+        pkg_uuid isa UUID || continue
+        Types.is_stdlib(pkg_uuid) && continue
+        haskey(env.manifest, pkg_uuid) && continue
+        env.pkg !== nothing && pkg_uuid == env.pkg.uuid && continue
+        version = Base.pkgversion(mod)
+        version isa VersionNumber || continue
+        preferred[pkg_uuid] = version
+    end
+    return preferred
+end
+
+function preferred_loaded_packages_usage(
+        pkgs::Vector{PackageSpec}, preferred_versions::Dict{UUID, VersionNumber}, manifest_uuids::Set{UUID},
+        direct_requested_uuids::Set{UUID}
+    )
+    (isempty(preferred_versions) || isempty(pkgs)) && return String[], 0
+    direct_names = String[]
+    indirect_count = 0
+    for pkg in pkgs
+        uuid = pkg.uuid
+        uuid isa UUID || continue
+        uuid in manifest_uuids && continue
+        preferred_version = get(preferred_versions, uuid, nothing)
+        preferred_version === nothing && continue
+        pkg_version = pkg.version
+        pkg_version isa VersionNumber || continue
+        pkg_version == preferred_version || continue
+        pkg.name === nothing && continue
+        if uuid in direct_requested_uuids
+            push!(direct_names, pkg.name)
+        else
+            indirect_count += 1
+        end
+    end
+    sort!(direct_names)
+    unique!(direct_names)
+    return direct_names, indirect_count
+end
+
+function maybe_print_preferred_loaded_note(io::IO, direct_names::Vector{String}, indirect_count::Int)
+    isempty(direct_names) && indirect_count == 0 && return
+    parts = String[]
+    if !isempty(direct_names)
+        push!(parts, join(direct_names, ", "))
+    end
+    if indirect_count > 0
+        dep_word = indirect_count == 1 ? "dependency" : "dependencies"
+        push!(parts, "$(indirect_count) $(dep_word)")
+    end
+    joined = length(parts) == 2 ? string(parts[1], " and ", parts[2]) : parts[1]
+    msg = if length(direct_names) + indirect_count > 1
+        "Preferring versions of $(joined) that are already loaded"
+    else
+        "Preferring the version of $(joined) that is already loaded"
+    end
+    printpkgstyle(io, :Resolve, msg; color = Base.info_color())
+    return
+end
+
+function apply_preferred_versions_to_direct!(pkgs::Vector{PackageSpec}, preferred_versions::Dict{UUID, VersionNumber})
+    isempty(preferred_versions) && return
+    empty_spec = VersionSpec()
+    for pkg in pkgs
+        pkg.version == empty_spec || continue
+        uuid = pkg.uuid
+        uuid isa UUID || continue
+        pref_version = get(preferred_versions, uuid, nothing)
+        pref_version === nothing && continue
+        pkg.version = VersionSpec(pref_version)
+    end
+    return
 end
 
 get_or_make!(d::Dict{K, V}, k::K) where {K, V} = get!(d, k) do;
@@ -2176,39 +2257,42 @@ end
 
 function tiered_resolve(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
-        try_all_installed::Bool
+        try_all_installed::Bool; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
     if try_all_installed
         try # do not modify existing subgraph and only add installed versions of the new packages
             @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version; preferred_versions)
         catch err
             err isa Resolve.ResolverError || rethrow()
         end
     end
     try # do not modify existing subgraph
         @debug "tiered_resolve: trying PRESERVE_ALL"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
         @debug "tiered_resolve: trying PRESERVE_DIRECT"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
         @debug "tiered_resolve: trying PRESERVE_SEMVER"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     @debug "tiered_resolve: trying PRESERVE_NONE"
-    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
+    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version; preferred_versions)
 end
 
-function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version)
+function targeted_resolve(
+        env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, preserve::PreserveLevel,
+        julia_version; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
+    )
     if preserve == PRESERVE_ALL || preserve == PRESERVE_ALL_INSTALLED
         pkgs = load_all_deps(env, pkgs; preserve)
     else
@@ -2216,23 +2300,24 @@ function targeted_resolve(env::EnvCache, registries::Vector{Registry.RegistryIns
     end
     check_registered(registries, pkgs)
 
-    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED)
+    deps_map = resolve_versions!(env, registries, pkgs, julia_version, preserve == PRESERVE_ALL_INSTALLED, preferred_versions)
     return pkgs, deps_map
 end
 
 function _resolve(
         io::IO, env::EnvCache, registries::Vector{Registry.RegistryInstance},
-        pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version
+        pkgs::Vector{PackageSpec}, preserve::PreserveLevel, julia_version;
+        preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
     usingstrategy = preserve != PRESERVE_TIERED ? " using $preserve" : ""
     printpkgstyle(io, :Resolving, "package versions$(usingstrategy)...")
     return try
         if preserve == PRESERVE_TIERED_INSTALLED
-            tiered_resolve(env, registries, pkgs, julia_version, true)
+            tiered_resolve(env, registries, pkgs, julia_version, true; preferred_versions)
         elseif preserve == PRESERVE_TIERED
-            tiered_resolve(env, registries, pkgs, julia_version, false)
+            tiered_resolve(env, registries, pkgs, julia_version, false; preferred_versions)
         else
-            targeted_resolve(env, registries, pkgs, preserve, julia_version)
+            targeted_resolve(env, registries, pkgs, preserve, julia_version; preferred_versions)
         end
     catch err
 
@@ -2295,7 +2380,7 @@ end
 function add(
         ctx::Context, pkgs::Vector{PackageSpec}, new_git = Set{UUID}();
         allow_autoprecomp::Bool = true, preserve::PreserveLevel = default_preserve(), platform::AbstractPlatform = HostPlatform(),
-        target::Symbol = :deps
+        target::Symbol = :deps, prefer_loaded_versions::Bool = true
     )
     assert_can_add(ctx, pkgs)
     # load manifest data
@@ -2339,11 +2424,34 @@ function add(
         return
     end
 
+    preferred_loaded_versions = Dict{UUID, VersionNumber}()
+    existing_manifest_uuids = Set{UUID}()
+    preferred_direct_note_names = String[]
+    preferred_indirect_note_count = 0
+    direct_requested_uuids = Set{UUID}()
     foreach(pkg -> target_field[pkg.name] = pkg.uuid, pkgs) # update set of deps/weakdeps/extras
+    for pkg in pkgs
+        uuid = pkg.uuid
+        uuid isa UUID || continue
+        push!(direct_requested_uuids, uuid)
+    end
+
+    if target == :deps && prefer_loaded_versions
+        preferred_loaded_versions = collect_preferred_loaded_versions(ctx.env)
+        existing_manifest_uuids = Set(keys(ctx.env.manifest))
+    end
 
     if target == :deps # nothing to resolve/install if it's weak or extras
         # resolve
-        man_pkgs, deps_map = _resolve(ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version)
+        apply_preferred_versions_to_direct!(pkgs, preferred_loaded_versions)
+        man_pkgs, deps_map = _resolve(
+            ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version;
+            preferred_versions = preferred_loaded_versions
+        )
+        preferred_direct_note_names, preferred_indirect_note_count = preferred_loaded_packages_usage(
+            man_pkgs, preferred_loaded_versions, existing_manifest_uuids, direct_requested_uuids
+        )
+        maybe_print_preferred_loaded_note(ctx.io, preferred_direct_note_names, preferred_indirect_note_count)
         update_manifest!(ctx.env, man_pkgs, deps_map, ctx.julia_version, ctx.registries)
         new_apply = download_source(ctx)
         fixups_from_projectfile!(ctx)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2410,33 +2410,25 @@ function add(
         return
     end
 
-    preferred_loaded_versions = Dict{UUID, VersionNumber}()
-    existing_manifest_uuids = Set{UUID}()
-    preferred_direct_note_names = String[]
-    preferred_indirect_note_count = 0
-    direct_requested_uuids = Set{UUID}()
     foreach(pkg -> target_field[pkg.name] = pkg.uuid, pkgs) # update set of deps/weakdeps/extras
-    for pkg in pkgs
-        uuid = pkg.uuid
-        uuid isa UUID || continue
-        push!(direct_requested_uuids, uuid)
-    end
-
-    if target == :deps && prefer_loaded_versions
-        preferred_loaded_versions = collect_preferred_loaded_versions(ctx.env)
-        existing_manifest_uuids = Set(keys(ctx.env.manifest))
-    end
 
     if target == :deps # nothing to resolve/install if it's weak or extras
         # resolve
+        preferred_loaded_versions = Dict{UUID, VersionNumber}()
+        existing_manifest_uuids = Set{UUID}()
+        direct_requested_uuids = Set{UUID}(pkg.uuid for pkg in pkgs if pkg.uuid isa UUID)
+        if prefer_loaded_versions
+            preferred_loaded_versions = collect_preferred_loaded_versions(ctx.env)
+            existing_manifest_uuids = Set(keys(ctx.env.manifest))
+        end
         man_pkgs, deps_map = _resolve(
             ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version;
             preferred_versions = preferred_loaded_versions
         )
-        preferred_direct_note_names, preferred_indirect_note_count = preferred_loaded_packages_usage(
+        direct_names, indirect_count = preferred_loaded_packages_usage(
             man_pkgs, preferred_loaded_versions, existing_manifest_uuids, direct_requested_uuids
         )
-        maybe_print_preferred_loaded_note(ctx.io, preferred_direct_note_names, preferred_indirect_note_count)
+        maybe_print_preferred_loaded_note(ctx.io, direct_names, indirect_count)
         update_manifest!(ctx.env, man_pkgs, deps_map, ctx.julia_version, ctx.registries)
         new_apply = download_source(ctx)
         fixups_from_projectfile!(ctx)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -966,20 +966,6 @@ function maybe_print_preferred_loaded_note(io::IO, direct_names::Vector{String},
     return
 end
 
-function apply_preferred_versions_to_direct!(pkgs::Vector{PackageSpec}, preferred_versions::Dict{UUID, VersionNumber})
-    isempty(preferred_versions) && return
-    empty_spec = VersionSpec()
-    for pkg in pkgs
-        pkg.version == empty_spec || continue
-        uuid = pkg.uuid
-        uuid isa UUID || continue
-        pref_version = get(preferred_versions, uuid, nothing)
-        pref_version === nothing && continue
-        pkg.version = VersionSpec(pref_version)
-    end
-    return
-end
-
 get_or_make!(d::Dict{K, V}, k::K) where {K, V} = get!(d, k) do;
     V()
 end
@@ -2259,43 +2245,34 @@ function tiered_resolve(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
         try_all_installed::Bool; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
-    if !isempty(preferred_versions)
-        # first try maintaining any loaded versions of the new packages
-        try # do not modify existing subgraph
-            @debug "tiered_resolve: trying PRESERVE_ALL with any loaded versions of new packages"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
-        catch err
-            err isa Resolve.ResolverError || rethrow()
-        end
-    end
     if try_all_installed
         try # do not modify existing subgraph and only add installed versions of the new packages
             @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version; preferred_versions)
         catch err
             err isa Resolve.ResolverError || rethrow()
         end
     end
     try # do not modify existing subgraph
         @debug "tiered_resolve: trying PRESERVE_ALL"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
         @debug "tiered_resolve: trying PRESERVE_DIRECT"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
         @debug "tiered_resolve: trying PRESERVE_SEMVER"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version; preferred_versions)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     @debug "tiered_resolve: trying PRESERVE_NONE"
-    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
+    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version; preferred_versions)
 end
 
 function targeted_resolve(
@@ -2452,7 +2429,6 @@ function add(
 
     if target == :deps # nothing to resolve/install if it's weak or extras
         # resolve
-        apply_preferred_versions_to_direct!(pkgs, preferred_loaded_versions)
         man_pkgs, deps_map = _resolve(
             ctx.io, ctx.env, ctx.registries, pkgs, preserve, ctx.julia_version;
             preferred_versions = preferred_loaded_versions

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2366,7 +2366,7 @@ end
 function add(
         ctx::Context, pkgs::Vector{PackageSpec}, new_git = Set{UUID}();
         allow_autoprecomp::Bool = true, preserve::PreserveLevel = default_preserve(), platform::AbstractPlatform = HostPlatform(),
-        target::Symbol = :deps, prefer_loaded_versions::Bool = true
+        target::Symbol = :deps, prefer_loaded_versions::Bool = false
     )
     assert_can_add(ctx, pkgs)
     # load manifest data

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -958,9 +958,9 @@ function maybe_print_preferred_loaded_note(io::IO, direct_names::Vector{String},
     end
     joined = length(parts) == 2 ? string(parts[1], " and ", parts[2]) : parts[1]
     msg = if length(direct_names) + indirect_count > 1
-        "Preferring versions of $(joined) that are already loaded"
+        "was able to add the versions of $(joined) that are already loaded"
     else
-        "Preferring the version of $(joined) that is already loaded"
+        "was able to add the version of $(joined) that is already loaded"
     end
     printpkgstyle(io, :Resolve, msg; color = Base.info_color())
     return
@@ -2259,34 +2259,43 @@ function tiered_resolve(
         env::EnvCache, registries::Vector{Registry.RegistryInstance}, pkgs::Vector{PackageSpec}, julia_version,
         try_all_installed::Bool; preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
     )
+    if !isempty(preferred_versions)
+        # first try maintaining any loaded versions of the new packages
+        try # do not modify existing subgraph
+            @debug "tiered_resolve: trying PRESERVE_ALL with any loaded versions of new packages"
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
+        catch err
+            err isa Resolve.ResolverError || rethrow()
+        end
+    end
     if try_all_installed
         try # do not modify existing subgraph and only add installed versions of the new packages
             @debug "tiered_resolve: trying PRESERVE_ALL_INSTALLED"
-            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version; preferred_versions)
+            return targeted_resolve(env, registries, pkgs, PRESERVE_ALL_INSTALLED, julia_version)
         catch err
             err isa Resolve.ResolverError || rethrow()
         end
     end
     try # do not modify existing subgraph
         @debug "tiered_resolve: trying PRESERVE_ALL"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version; preferred_versions)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_ALL, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try # do not modify existing direct deps
         @debug "tiered_resolve: trying PRESERVE_DIRECT"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version; preferred_versions)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_DIRECT, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     try
         @debug "tiered_resolve: trying PRESERVE_SEMVER"
-        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version; preferred_versions)
+        return targeted_resolve(env, registries, pkgs, PRESERVE_SEMVER, julia_version)
     catch err
         err isa Resolve.ResolverError || rethrow()
     end
     @debug "tiered_resolve: trying PRESERVE_NONE"
-    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version; preferred_versions)
+    return targeted_resolve(env, registries, pkgs, PRESERVE_NONE, julia_version)
 end
 
 function targeted_resolve(

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -162,8 +162,8 @@ const PreserveLevel = Types.PreserveLevel
 
 # Define new variables so tab comleting Pkg. works.
 """
-    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, target::Symbol=:deps)
-    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, target::Symbol=:deps)
+    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, prefer_loaded_versions::Bool=true)
+    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, prefer_loaded_versions::Bool=true)
 
 Add a package to the current project. This package will be available by using the
 `import` and `using` keywords in the Julia REPL, and if the current project is
@@ -174,6 +174,16 @@ added automatically with a lower bound of the added version.
 
 To add as a weak dependency (in the `[weakdeps]` field) set the kwarg `target=:weakdeps`.
 To add as an extra dep (in the `[extras]` field) set `target=:extras`.
+
+## Loaded Version Preference
+
+By default, when adding packages, Pkg will prefer versions of packages (and their dependencies) that are
+already loaded in the current Julia session. This helps maintain compatibility with code already running
+in your session. To disable this behavior and resolve versions independently of what's currently loaded,
+set `prefer_loaded_versions=false`.
+
+!!! compat "Julia 1.13"
+    The `prefer_loaded_versions` kwarg requires at least Julia 1.13.
 
 ## Resolution Tiers
 `Pkg` resolves the set of packages in your environment using a tiered algorithm.
@@ -213,6 +223,7 @@ precompiled before, or the precompile cache has been deleted by the LRU cache st
 Pkg.add("Example") # Add a package from registry
 Pkg.add("Example", target=:weakdeps) # Add a package as a weak dependency
 Pkg.add("Example", target=:extras) # Add a package to the `[extras]` list
+Pkg.add("Example"; prefer_loaded_versions=false) # Add a package, ignoring versions already loaded in this session
 Pkg.add("Example"; preserve=Pkg.PRESERVE_ALL) # Add the `Example` package and strictly preserve existing dependencies
 Pkg.add(name="Example", version="0.3") # Specify version; latest release in the 0.3 series
 Pkg.add(name="Example", version="0.3.1") # Specify version; exact release

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -162,8 +162,8 @@ const PreserveLevel = Types.PreserveLevel
 
 # Define new variables so tab comleting Pkg. works.
 """
-    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, prefer_loaded_versions::Bool=true)
-    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, prefer_loaded_versions::Bool=true)
+    Pkg.add(pkg::Union{String, Vector{String}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, prefer_loaded_versions::Bool=Pkg.in_repl_mode())
+    Pkg.add(pkg::Union{PackageSpec, Vector{PackageSpec}}; preserve=PRESERVE_TIERED, target::Symbol=:deps, prefer_loaded_versions::Bool=Pkg.in_repl_mode())
 
 Add a package to the current project. This package will be available by using the
 `import` and `using` keywords in the Julia REPL, and if the current project is
@@ -177,10 +177,11 @@ To add as an extra dep (in the `[extras]` field) set `target=:extras`.
 
 ## Loaded Version Preference
 
-By default, when adding packages, Pkg will prefer versions of packages (and their dependencies) that are
-already loaded in the current Julia session. This helps maintain compatibility with code already running
-in your session. To disable this behavior and resolve versions independently of what's currently loaded,
-set `prefer_loaded_versions=false`.
+When adding packages from the Pkg REPL mode (`pkg> add`), Pkg will by default prefer versions of packages
+(and their dependencies) that are already loaded in the current Julia session. This helps maintain
+compatibility with code already running in your session. When calling `Pkg.add` programmatically the
+default is the opposite: versions are resolved independently of what's currently loaded, for more
+reproducible behavior. Pass `prefer_loaded_versions=true`/`false` to override the default.
 
 !!! compat "Julia 1.13"
     The `prefer_loaded_versions` kwarg requires at least Julia 1.13.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -225,7 +225,7 @@ precompiled before, or the precompile cache has been deleted by the LRU cache st
 Pkg.add("Example") # Add a package from registry
 Pkg.add("Example", target=:weakdeps) # Add a package as a weak dependency
 Pkg.add("Example", target=:extras) # Add a package to the `[extras]` list
-Pkg.add("Example"; prefer_loaded_versions=false) # Add a package, ignoring versions already loaded in this session
+Pkg.add("Example"; prefer_loaded_versions=true) # Prefer the version of Example already loaded in this session, if any
 Pkg.add("Example"; preserve=Pkg.PRESERVE_ALL) # Add the `Example` package and strictly preserve existing dependencies
 Pkg.add(name="Example", version="0.3") # Specify version; latest release in the 0.3 series
 Pkg.add(name="Example", version="0.3.1") # Specify version; exact release

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -179,9 +179,10 @@ To add as an extra dep (in the `[extras]` field) set `target=:extras`.
 
 When adding packages from the Pkg REPL mode (`pkg> add`), Pkg will by default prefer versions of packages
 (and their dependencies) that are already loaded in the current Julia session. This helps maintain
-compatibility with code already running in your session. When calling `Pkg.add` programmatically the
-default is the opposite: versions are resolved independently of what's currently loaded, for more
-reproducible behavior. Pass `prefer_loaded_versions=true`/`false` to override the default.
+compatibility with code already running in your session. Run `pkg> up` afterwards to update to the latest
+compatible versions. When calling `Pkg.add` programmatically the default is the opposite: versions are
+resolved independently of what's currently loaded, for more reproducible behavior. Pass
+`prefer_loaded_versions=true`/`false` to override the default.
 
 !!! compat "Julia 1.13"
     The `prefer_loaded_versions` kwarg requires at least Julia 1.13.

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -234,6 +234,7 @@ mutable struct Graph
     newmsg::Vector{FieldValue}
     diff::Vector{FieldValue}
     cavfld::Vector{FieldValue}
+    preferred_versions::Dict{UUID, VersionNumber}
 
     function Graph(
             deps_compressed::Dict{UUID, Vector{Dict{VersionRange, Set{UUID}}}},
@@ -246,7 +247,8 @@ mutable struct Graph
             reqs::Requires,
             fixed::Dict{UUID, Fixed},
             verbose::Bool = false,
-            julia_version::Union{VersionNumber, Nothing} = VERSION
+            julia_version::Union{VersionNumber, Nothing} = VERSION,
+            preferred_versions::Dict{UUID, VersionNumber} = Dict{UUID, VersionNumber}()
         )
 
         # Tell the resolver about julia itself
@@ -391,7 +393,7 @@ mutable struct Graph
 
         graph = new(
             data, gadj, gmsk, gconstr, adjdict, req_inds, fix_inds, ignored, solve_stack, spp, np,
-            FieldValue[], FieldValue[], FieldValue[]
+            FieldValue[], FieldValue[], FieldValue[], Dict{UUID, VersionNumber}(preferred_versions)
         )
 
         _add_fixed!(graph, fixed)
@@ -416,7 +418,8 @@ mutable struct Graph
         ignored = copy(graph.ignored)
         solve_stack = [([copy(gc0) for gc0 in sav_gconstr], copy(sav_ignored)) for (sav_gconstr, sav_ignored) in graph.solve_stack]
 
-        return new(data, gadj, gmsk, gconstr, adjdict, req_inds, fix_inds, ignored, solve_stack, spp, np)
+        preferred_versions = copy(graph.preferred_versions)
+        return new(data, gadj, gmsk, gconstr, adjdict, req_inds, fix_inds, ignored, solve_stack, spp, np, FieldValue[], FieldValue[], FieldValue[], preferred_versions)
     end
 end
 

--- a/src/Resolve/graphtype.jl
+++ b/src/Resolve/graphtype.jl
@@ -1421,8 +1421,14 @@ function build_eq_classes1!(graph::Graph, p0::Int, cmat_workspace::BitMatrix, cv
     eq_sets = [Set{Int}(v0 for v0 in 1:spp[p0] if cvecs[v0] == rvec) for rvec in repr_vecs]
     sort!(eq_sets, by = maximum)
 
-    # each set is represented by its highest-valued member
-    repr_vers = map(maximum, eq_sets)
+    # each set is represented by its highest-valued member,
+    # unless it contains a preferred (already-loaded) version
+    pref_version = get(graph.preferred_versions, pkgs[p0], nothing)
+    pref_idx = pref_version !== nothing ? get(vdict[p0], pref_version, nothing) : nothing
+    repr_vers = map(eq_sets) do eq_set
+        pref_idx !== nothing && pref_idx ∈ eq_set && return pref_idx
+        return maximum(eq_set)
+    end
     # the last representative must always be the uninstalled state
     @assert repr_vers[end] == spp[p0]
 

--- a/src/Resolve/maxsum.jl
+++ b/src/Resolve/maxsum.jl
@@ -1,7 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 const DEFAULT_MAX_TIME = "300"
-const PREFERRED_VERSION_WEIGHT_BONUS = VersionWeight(typemax(Int32))
+# Prefer loaded versions, but not so strongly that it overrides compatibility constraints.
+# This bonus is added to the version weight of already-loaded packages, making them more
+# favorable than other versions but not creating hard requirements.
+const PREFERRED_VERSION_WEIGHT_BONUS = VersionWeight(100, 0, 0)
 
 # Some parameters to drive the decimation process
 mutable struct MaxSumParams

--- a/test/new.jl
+++ b/test/new.jl
@@ -3955,7 +3955,7 @@ end
         Pkg.activate(; temp = true)
         Pkg.add("Example", io = io) # v0.5.5 exists, but v0.5.4 is loaded
         add_output = String(take!(io))
-        @test occursin("Preferring the version of Example that is already loaded", add_output)
+        @test occursin("was able to add the version of Example that is already loaded", add_output)
         @test occursin("[7876af07] + Example v0.5.4", add_output)
         """
         cmd = addenv(

--- a/test/new.jl
+++ b/test/new.jl
@@ -3942,4 +3942,28 @@ end
     end
 end
 
+@testset "Pkg.add prefers loaded dependency versions" begin
+    isolate(loaded_depot = true) do
+        script = """
+        using Pkg, Test
+        Pkg.activate(; temp = true)
+        io = IOBuffer()
+        Pkg.add(name = "Example", version = v"0.5.4", io = io)
+        add_output = String(take!(io))
+        @test occursin("[7876af07] + Example v0.5.4", add_output)
+        using Example
+        Pkg.activate(; temp = true)
+        Pkg.add("Example", io = io) # v0.5.5 exists, but v0.5.4 is loaded
+        add_output = String(take!(io))
+        @test occursin("Preferring the version of Example that is already loaded", add_output)
+        @test occursin("[7876af07] + Example v0.5.4", add_output)
+        """
+        cmd = addenv(
+            `$(Base.julia_cmd()) --startup-file=no --project=$(dirname(@__DIR__)) -e $script`,
+            "JULIA_DEPOT_PATH" => join(DEPOT_PATH, Sys.iswindows() ? ";" : ":")
+        )
+        @test Utils.show_output_if_command_errors(cmd)
+    end
+end
+
 end #module

--- a/test/new.jl
+++ b/test/new.jl
@@ -3955,6 +3955,10 @@ end
         Pkg.activate(; temp = true)
         Pkg.add("Example", io = io) # v0.5.5 exists, but v0.5.4 is loaded
         add_output = String(take!(io))
+        @test occursin("[7876af07] + Example v0.5.5", add_output)
+        Pkg.activate(; temp = true)
+        Pkg.add("Example", io = io, prefer_loaded_versions = true) # v0.5.5 exists, but v0.5.4 is loaded
+        add_output = String(take!(io))
         @test occursin("was able to add the version of Example that is already loaded", add_output)
         @test occursin("[7876af07] + Example v0.5.4", add_output)
         """

--- a/test/new.jl
+++ b/test/new.jl
@@ -3961,6 +3961,14 @@ end
         add_output = String(take!(io))
         @test occursin("was able to add the version of Example that is already loaded", add_output)
         @test occursin("[7876af07] + Example v0.5.4", add_output)
+        Pkg.activate(; temp = true)
+        # REPL mode default: should prefer loaded version without explicit kwarg
+        Base.ScopedValues.@with Pkg.IN_REPL_MODE => true begin
+            Pkg.add("Example", io = io)
+        end
+        add_output = String(take!(io))
+        @test occursin("was able to add the version of Example that is already loaded", add_output)
+        @test occursin("[7876af07] + Example v0.5.4", add_output)
         """
         cmd = addenv(
             `$(Base.julia_cmd()) --startup-file=no --project=$(dirname(@__DIR__)) -e $script`,

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -431,13 +431,13 @@ end
         # Tests that Example@0.5.1 does not get installed
         temp_pkg_dir() do env
             Pkg.Registry.add(url = "https://github.com/JuliaRegistries/Test")
-            Pkg.add("Example"; prefer_loaded_versions = false)
+            Pkg.add("Example")
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             Pkg.update() # should not update Example
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             @test_throws Pkg.Resolve.ResolverError Pkg.add(PackageSpec(name = "Example", version = v"0.5.1"))
             Pkg.rm("Example")
-            Pkg.add("JSON"; prefer_loaded_versions = false) # depends on Example
+            Pkg.add("JSON") # depends on Example
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             Pkg.update()
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -431,13 +431,13 @@ end
         # Tests that Example@0.5.1 does not get installed
         temp_pkg_dir() do env
             Pkg.Registry.add(url = "https://github.com/JuliaRegistries/Test")
-            Pkg.add("Example")
+            Pkg.add("Example"; prefer_loaded_versions = false)
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             Pkg.update() # should not update Example
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             @test_throws Pkg.Resolve.ResolverError Pkg.add(PackageSpec(name = "Example", version = v"0.5.1"))
             Pkg.rm("Example")
-            Pkg.add("JSON") # depends on Example
+            Pkg.add("JSON"; prefer_loaded_versions = false) # depends on Example
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"
             Pkg.update()
             @test manifest_info(EnvCache().manifest, uuid).version == v"0.5.0"


### PR DESCRIPTION
Here JSON v1.3.0 exists. In the 2nd env Pkg.add prefers adding the versions that are already loaded so the env graph can be used in the current session without more precompilation.

Note that it's a preference via a high weighting in the resolver, not a hard rule.. so it shouldn't introduce resolver errors.

<img width="841" height="743" alt="Screenshot 2025-11-16 at 11 08 25 AM" src="https://github.com/user-attachments/assets/839d9a48-432a-41fc-8b19-e09b26c740e3" />

Developed with Codex and Claude

