### PR TITLE
See if tests would pass with larger timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 70
+    timeout-minutes: 110
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Tests are timing out on master, but as far as I can tell, they're not actually stuck - something has just gotten massively slower after a julia upgrade. See if tests would pass with a larger timeout.