### PR TITLE
fix: work around string indexing issues in windows drive letter detection

### DIFF
--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -80,8 +80,7 @@ end
 
 # Simple path detection
 function looks_like_path(str::String)
-    return contains(str, '/') || contains(str, '\\') || str == "." || str == ".." ||
-        (length(str) >= 2 && isletter(str[1]) && str[2] == ':')  # Windows drive letters
+    return contains(str, '/') || contains(str, '\\') || str == "." || str == ".." || is_windows_drive_colon(str)
 end
 
 # Check if a string looks like a complete URL
@@ -93,13 +92,14 @@ function looks_like_complete_url(str::String)
         (contains(str, '.') || contains(str, '/'))
 end
 
+is_windows_drive_colon(str::String) = occursin(r"^[a-zA-Z]:", str)
+
 # Check if a colon at given position is part of a Windows drive letter
 function is_windows_drive_colon(input::String, colon_pos::Int)
     # Windows drive letters are single letters followed by colon at beginning
     # Examples: "C:", "D:", etc.
     if colon_pos == 2 && length(input) >= 2
-        first_char = input[1]
-        return isletter(first_char) && input[2] == ':'
+        return is_windows_drive_colon(input)
     end
     return false
 end

--- a/src/fuzzysorting.jl
+++ b/src/fuzzysorting.jl
@@ -197,8 +197,8 @@ function case_preservation_score(needle::AbstractString, haystack::AbstractStrin
     matches = 0
     min_len = min(length(needle), length(haystack))
 
-    for i in 1:min_len
-        if needle[i] == haystack[i]
+    for (n, h) in zip(needle, haystack)
+        if n == h
             matches += 1
         end
     end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -43,6 +43,8 @@ temp_pkg_dir() do project_path
 
         @test_throws PkgError pkg"dev Example#blergh"
 
+        @test_throws PkgError pkg"add ÖÖÖ"
+
         @test_throws PkgError pkg"generate 2019Julia"
         pkg"generate Foo"
         pkg"dev ./Foo"


### PR DESCRIPTION
Fixes
```
(@v1.12) pkg> add ÖÖÖ
ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'Ö', [3]=>'Ö'
Stacktrace:
  [1] string_index_err(s::AbstractString, i::Int64)
    @ Base ./strings/string.jl:12
  [2] getindex_continued(s::String, i::Int64, u::UInt32)
    @ Base ./strings/string.jl:473
  [3] getindex
    @ ./strings/string.jl:465 [inlined]
  [4] looks_like_path(str::String)
    @ Pkg.REPLMode ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/argument_parsers.jl:44
  [5] parse_package_spec_new(input::String)
    @ Pkg.REPLMode ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/argument_parsers.jl:312
  [6] parse_package(args::Vector{Pkg.REPLMode.QString}, options::Dict{Symbol, Any}; add_or_dev::Bool)
    @ Pkg.REPLMode ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/argument_parsers.jl:343
  [7] parse_package
    @ ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/argument_parsers.jl:319 [inlined]
  [8] (::Pkg.REPLMode.var"#31#32")(x::Vector{Pkg.REPLMode.QString}, y::Dict{Symbol, Any})
    @ Pkg.REPLMode ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/command_declarations.jl:106
  [9] Pkg.REPLMode.Command(statement::Pkg.REPLMode.Statement)
    @ Pkg.REPLMode ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/REPLMode.jl:369
 [10] iterate
    @ ./generator.jl:48 [inlined]
 [11] _collect(c::Vector{Pkg.REPLMode.Statement}, itr::Base.Generator{Vector{Pkg.REPLMode.Statement}, Type{Pkg.REPLMode.Command}}, ::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:810
 [12] collect_similar
    @ ./array.jl:732 [inlined]
 [13] map
    @ ./abstractarray.jl:3372 [inlined]
 [14] prepare_cmd(input::String)
    @ Pkg.REPLMode ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/REPLMode/REPLMode.jl:381
 [15] do_cmds(repl::REPL.LineEditREPL, commands::String)
    @ REPLExt ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/ext/REPLExt/REPLExt.jl:97
 [16] on_done(s::REPL.LineEdit.MIState, buf::IOBuffer, ok::Bool, repl::REPL.LineEditREPL)
    @ REPLExt ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/ext/REPLExt/REPLExt.jl:113
 [17] #invokelatest_gr#232
    @ ./reflection.jl:1280 [inlined]
 [18] invokelatest_gr
    @ ./reflection.jl:1274 [inlined]
 [19] (::REPLExt.var"#create_mode##0#create_mode##1"{REPL.LineEditREPL})(s::REPL.LineEdit.MIState, buf::IOBuffer, ok::Bool)
    @ REPLExt ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/ext/REPLExt/REPLExt.jl:135
 [20] run_interface(terminal::Base.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2854
 [21] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/REPL/src/REPL.jl:1663
 [22] (::REPL.var"#61#62"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/.julia/juliaup/julia-1.12.1+0.x64.linux.gnu/share/julia/stdlib/v1.12/REPL/src/REPL.jl:650
```