### PR TITLE
Try running release-1.12 CI with `julia=1.12-nightly`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         pkg-server:
           - "pkg.julialang.org" # Default to this for all except specific cases
         julia-version:
-          - 'nightly'
+          - '1.12-nightly'
         exclude:
           - os: ubuntu-latest
             julia-arch: aarch64
@@ -50,11 +50,11 @@ jobs:
         include:
           - os: ubuntu-latest
             julia-arch: 'x64'
-            julia-version: 'nightly'
+            julia-version: '1.12-nightly'
             pkg-server: ""
           - os: ubuntu-latest
             julia-arch: 'x64'
-            julia-version: 'nightly'
+            julia-version: '1.12-nightly'
             pkg-server: "pkg.julialang.org"
     steps:
       - name: Set git to use LF and fix TEMP on windows
@@ -95,7 +95,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           # version: '1.6'
-          version: 'nightly'
+          version: '1.12-nightly'
       - name: Generate docs
         run: |
           julia --project --color=yes -e 'using Pkg; Pkg.activate("docs"); Pkg.instantiate();'


### PR DESCRIPTION
Running CI to check if the test failures seen in https://github.com/JuliaLang/Pkg.jl/pull/4513 are about the PR backports, or that I used `julia=1.12-nightly` for the julia version. 