### PR TITLE
Use `Sys.STDLIB` instead of hardcoding path to Julia stdlib

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -528,7 +528,7 @@ const UPGRADABLE_STDLIBS_UUIDS = Set{UUID}()
 const STDLIB = Ref{Union{DictStdLibs, Nothing}}(nothing)
 function load_stdlib()
     stdlib = DictStdLibs()
-    for name in readdir(Sys.STDLIB::String)
+    for name in readdir(Sys.STDLIB)
         projfile = projectfile_path(stdlib_path(name); strict = true)
         nothing === projfile && continue
         project = parse_toml(projfile)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,11 +27,11 @@ end
 const URL_regex = r"((file|git|ssh|http(s)?)|([\w\-\.]+@[\w\-\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?"x
 isurl(r::String) = occursin(URL_regex, r)
 
-stdlib_path(stdlib::String) = joinpath(Sys.STDLIB::String, stdlib)
+stdlib_path(stdlib::String) = joinpath(Sys.STDLIB, stdlib)
 
 function pathrepr(path::String)
     # print stdlib paths as @stdlib/Name
-    if startswith(path, Sys.STDLIB::String)
+    if startswith(path, Sys.STDLIB)
         path = "@stdlib/" * basename(path)
     end
     return "`" * Base.contractuser(path) * "`"


### PR DESCRIPTION
This is cleaner and will allow changing this path at JuliaLang/julia#54353.