### PR TITLE
ensure REPLExt is precompiled before we disallow it

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ module PkgTestsInner
     original_wd = pwd()
 
     import Pkg
+    import REPL # should precompile REPLExt before we disallow it below
+    @assert Base.get_extension(Pkg, :REPLExt) !== nothing
     using Test, Logging
 
     if realpath(dirname(dirname(Base.pathof(Pkg)))) != realpath(dirname(@__DIR__))


### PR DESCRIPTION
Been seeing stuff like

```
     From worker 2:	│   exception =
      From worker 2:	│    1-element ExceptionStack:
      From worker 2:	│    LoadError: Precompililing Pkg extension REPLExt is disallowed. JULIA_PKG_DISALLOW_PKG_PRECOMPILATION=1
      From worker 2:	│    Stacktrace:
      From worker 2:	│      [1] error(s::String)
      From worker 2:	│        @ Base ./error.jl:44
      From worker 2:	│      [2] top-level scope
      From worker 2:	│        @ /cache/build/tester-amdci5-11/julialang/julia-release-1-dot-13/julia-89357f6466/share/julia/stdlib/v1.13/Pkg/ext/REPLExt/REPLExt.jl:4
      From worker 2:	│      [3] include(mod::Module, _path::String)
      From worker 2:	│        @ Base ./Base.jl:309
      From worker 2:	│      [4] __require_prelocked(pkg::Base.PkgId, env::Nothing)
      From worker 2:	│        @ Base ./loading.jl:2808
      From worker 2:	│      [5] _require_prelocked(uuidkey::Base.PkgId, env::Nothing)
      From worker 2:	│        @ Base ./loading.jl:2567
      From worker 2:	│      [6] _require_prelocked
      From worker 2:	│        @ ./loading.jl:2561 [inlined]
      From worker 2:	│      [7] run_extension_callbacks(extid::Base.ExtensionId)
      From worker 2:	│        @ Base ./loading.jl:1613
      From worker 2:	│      [8] run_extension_callbacks(pkgid::Base.PkgId)
```

on Base CI of Pkg. 