### PR TITLE
Bump version number for `release-1.12`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 keywords = ["package management"]
 license = "MIT"
 desc = "The next-generation Julia package manager."
-version = "1.12.0"
+version = "1.12.1"
 
 [workspace]
 projects = ["test", "docs"]


### PR DESCRIPTION
I was trying out `julia +1.12-nightly` and at first thought I didn't get the new Pkg version because it was showing `1.12.0`