### PR TITLE
Only check for left over registry installs outside of buildkite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,11 @@ module PkgTestsInner
         end
 
         # Make sure that none of our tests have left temporary registries lying around
-        @test isdir(joinpath(Base.DEPOT_PATH[1], "registries")) == original_depot_had_registries
+        # Skip this check when running in Julia base CI where other tests (e.g. stdlib_dependencies)
+        # may install registries in the shared DEPOT_PATH before this check runs
+        if !Base.get_bool_env("BUILDKITE", false)
+            @test isdir(joinpath(Base.DEPOT_PATH[1], "registries")) == original_depot_had_registries
+        end
     end
 
     if haskey(ENV, "CI")


### PR DESCRIPTION
It makes sense to run this test locally and on this repos github actions, but not on base tests where parallel tests are using the depot.

@Keno I couldn't identify a better identifier for that situation than `!Base.get_bool_env("BUILDKITE", false)`. I thought `Base.runtests` set some `JULIA_BASE_TESTS` env var, but I can't find such a thing..