### PR TITLE
Fix 7z extraction when path has symlink/..

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -495,6 +495,9 @@ Get the decompression command for a tarball by detecting format via magic bytes.
 """
 function get_extract_cmd(tarball_path::AbstractString)
     format = detect_archive_format(tarball_path)
+    # 7z appears to normalize paths internally, which can cause mis-resolution
+    # if symbolic links are present
+    tarball_path = realpath(tarball_path)
     if format == "zstd"
         return `$(exezstd()) -d -c $tarball_path`
     else


### PR DESCRIPTION
7z appears to normalize internally causing it to fail to extract archives that have this pattern. One way to reproduce is to set DEPOT_PATH to a path that has a symlink/.. in the path. We get this wrong in Julia too, c.f. https://github.com/JuliaLang/julia/pull/60251