### PR TITLE
handle_repo_add: unshallow repo when adding via commit hash

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1036,8 +1036,8 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
                     specific_refspec = ["+refs/heads/$(rev_or_hash):refs/cache/heads/$(rev_or_hash)"]
                     GitTools.fetch(ctx.io, repo, repo_source_typed; refspecs = specific_refspec, depth = 1)
                 else
-                    # For commit hashes, fetch all branches
-                    GitTools.fetch(ctx.io, repo, repo_source_typed; refspecs = refspecs)
+                    # For commit hashes, fetch all branches including the older commits
+                    GitTools.fetch(ctx.io, repo, repo_source_typed; refspecs = refspecs, depth = LibGit2.Consts.FETCH_DEPTH_UNSHALLOW)
                 end
                 obj_branch = get_object_or_branch(repo, rev_or_hash)
                 # If still not found, try with broader refspec as fallback


### PR DESCRIPTION
This might look similar to #4422 but it is a new issue, caused by #4487.

Pkg add fails to find the revision in the shallow clone. With the example repo from #4487, using the initial commit (which is not the tip commit) instead of a branch:
```julia
$ julia-nightly 
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.14.0-DEV.1310 (2025-11-27)
 _/ |\__'_|_|_|\__'_|  |  Commit cf40898d56a (1 day old master)
|__/                   |

(@v1.14) pkg> activate --temp
  Activating new project at `/tmp/jl_sJYBR2`

(jl_sJYBR2) pkg> add https://github.com/KristofferC/ForcePush.jl#437b5817cf774f9ce1d648dc5cbdd5a7238f2b14
    Updating git-repo `https://github.com/KristofferC/ForcePush.jl`
    Updating git-repo `https://github.com/KristofferC/ForcePush.jl`
ERROR: Did not find rev 437b5817cf774f9ce1d648dc5cbdd5a7238f2b14 in repository
```
(The same command works fine in julia 1.12.)

With my patch:
```julia
(jl_fbN4wb) pkg> add https://github.com/KristofferC/ForcePush.jl#437b5817cf774f9ce1d648dc5cbdd5a7238f2b14
    Updating git-repo `https://github.com/KristofferC/ForcePush.jl`
   Resolving package versions...
    Updating `/tmp/jl_fbN4wb/Project.toml`
  [bf084232] + ForcePush v0.1.0 `https://github.com/KristofferC/ForcePush.jl#437b581`
    Updating `/tmp/jl_fbN4wb/Manifest.toml`
  [bf084232] + ForcePush v0.1.0 `https://github.com/KristofferC/ForcePush.jl#437b581`
Precompiling ForcePush finished.
  1 dependency successfully precompiled in 1 seconds
```

One could move this into a further if block looking up the hash first and unshallowing it only when it is not found. But this would add even more branches there and I think it is reasonable to assume that when adding via commit hash that this will not be the tip of a branch.

PS: Once the repo is not shallow anymore it will also work without the patch until it is removed from the `.julia/clones` folder.