### PR TITLE
release-1.13: normalize line endings for .bat files on Windows to use \r\n conistently (#4547)

### DIFF
--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -69,6 +69,11 @@ end
 
 
 function overwrite_file_if_different(file, content)
+    # Windows batch files require CRLF line endings for reliable label parsing
+    if endswith(file, ".bat")
+        content = replace(content, "\r\n" => "\n")  # normalize to LF first
+        content = replace(content, "\n" => "\r\n")  # then convert to CRLF
+    end
     return if !isfile(file) || read(file, String) != content
         mkpath(dirname(file))
         write(file, content)


### PR DESCRIPTION
(cherry picked from commit 89a1629d0b0555e9c218b4248e18436b7aca0e70)