### PR TITLE
fix: fixup historical stdlibs in manifest

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -425,8 +425,8 @@ function fixups_from_projectfile!(ctx::Context)
             pkg.weakdeps = Dict{String, Base.UUID}(stdlibs[uuid].name => uuid for uuid in p.weakdeps)
             # pkg.exts = p.exts # TODO: STDLIBS_BY_VERSION doesn't record this
             # pkg.entryfile = p.entryfile # TODO: STDLIBS_BY_VERSION doesn't record this
-            for (name, _) in pkg.weakdeps
-                if !(name in p.deps)
+            for (name, uuid) in pkg.weakdeps
+                if !(uuid in p.deps)
                     delete!(pkg.deps, name)
                 end
             end


### PR DESCRIPTION
`p.deps` in this branch is a `Vector{Base.UUID}` so `name in p.deps` will always be false (but it doesn't error like before https://github.com/JuliaLang/Pkg.jl/pull/4264).
The type is from [`StdlibInfo`](https://github.com/JuliaPackaging/HistoricalStdlibVersions.jl/blob/main/src/StdlibInfo.jl#L15) in HistoricalStdlibVersions.

I don't really know how to test that this works correctly.

cc: @Keno @giordano 

It would also be great if this could make it's way into 1.12 since we are running into the original issue with `MethodError: no method matching haskey(::Vector{Base.UUID}, ::String)`.