### PR TITLE
Avoid false warning about apps in PATH on Windows

### DIFF
--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -82,7 +82,8 @@ end
 
 function check_apps_in_path(apps)
     for app_name in keys(apps)
-        which_result = Sys.which(app_name)
+        which_name = app_name * (Sys.iswindows() ? ".bat" : "")
+        which_result = Sys.which(which_name)
         if which_result === nothing
             @warn """
             App '$app_name' was installed but is not available in PATH.


### PR DESCRIPTION
In 1.12 and higher I keep getting this when adding Pkg apps.

> Warning: App 'runic' was installed but is not available in PATH.

However, `.julia\bin` is in my path, so the warning is wrong. The reason is that `Sys.which("runic") === nothing` (but in my terminal `which runic` does work).

```
julia> Sys.which("runic")

julia> Sys.which("runic.bat")
"C:\\ProgramData\\DevDrives\\.julia\\bin\\runic.bat"

(@v1.12) pkg> app rm Runic
[ Info: Deleting all apps for package Runic
[ Info: Deleted runic

(@v1.12) pkg> app add Runic
    Updating `C:\ProgramData\DevDrives\.julia\environments\apps\Runic\Project.toml`
⌅ [70703baa] + JuliaSyntax v0.4.10
  [21216c6a] + Preferences v1.5.0
    Updating `C:\ProgramData\DevDrives\.julia\environments\apps\Runic\Manifest.toml`
⌅ [70703baa] + JuliaSyntax v0.4.10
  [21216c6a] + Preferences v1.5.0
  [ade2ca70] + Dates v1.11.0
  [de0858da] + Printf v1.11.0
  [fa267f1f] + TOML v1.0.3
  [4ec0a83e] + Unicode v1.11.0
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading. To see why use `status --outdated -m`
[ Info: For package: Runic installed apps runic
┌ Warning: App 'runic' was installed but is not available in PATH.
│ Consider adding 'C:\ProgramData\DevDrives\.julia\bin' to your PATH environment variable.
└ @ Pkg.Apps C:\ProgramData\DevDrives\.julia\juliaup\julia-1.12-nightly\share\julia\stdlib\v1.12\Pkg\src\Apps\Apps.jl:91
```