### PR TITLE
CI: Add workflow to remove backport labels on merge into release branches

### DIFF
--- a/.github/workflows/backport-label-audit.yml
+++ b/.github/workflows/backport-label-audit.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: KristofferC/Backporter
-          ref: ib/label_audit  # TODO: remove after merge
+          ref: master
           path: backporter
 
       - name: Setup Julia

--- a/.github/workflows/backport-label-cleanup.yml
+++ b/.github/workflows/backport-label-cleanup.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: KristofferC/Backporter
-          ref: ib/label_audit  # TODO: remove after merge
+          ref: master
           path: backporter
 
       - name: Setup Julia


### PR DESCRIPTION
Adds two actions:

## Backport Label Cleanup (automatic)

When a backport PR is merged to a release branch, this workflow automatically removes the `backport-X.Y` label from the original PRs that were cherry-picked, and adds a comment linking to the backport PR and commit.

## Backport Label Audit (manual)

A `workflow_dispatch` action that can scan all PRs with a `backport-X.Y` label and check whether they have already been cherry-picked into the `release-X.Y` branch. Useful for catching any PRs that were missed. Defaults to dry run mode to allow review before making changes.

---

Both should make it easier to track what has been backported and in which backport PR.
