### PR TITLE
[release-1.12] Add test for workspace sources pointing to parent package 

### DIFF
--- a/test/test_packages/WorkspaceSourcesParent/Project.toml
+++ b/test/test_packages/WorkspaceSourcesParent/Project.toml
@@ -1,0 +1,6 @@
+name = "WorkspaceSourcesParent"
+uuid = "11111111-1111-1111-1111-111111111111"
+version = "0.1.0"
+
+[workspace]
+projects = ["docs"]

--- a/test/test_packages/WorkspaceSourcesParent/docs/Project.toml
+++ b/test/test_packages/WorkspaceSourcesParent/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+WorkspaceSourcesParent = "11111111-1111-1111-1111-111111111111"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+WorkspaceSourcesParent = {path = ".."}

--- a/test/test_packages/WorkspaceSourcesParent/src/WorkspaceSourcesParent.jl
+++ b/test/test_packages/WorkspaceSourcesParent/src/WorkspaceSourcesParent.jl
@@ -1,0 +1,3 @@
+module WorkspaceSourcesParent
+greet() = "Hello from WorkspaceSourcesParent!"
+end


### PR DESCRIPTION
Testing the test in #4568 without the fix

Confirmed:
```
workspace sources pointing to parent package: Error During Test at /Users/runner/work/Pkg.jl/Pkg.jl/test/workspaces.jl:191
  Got exception outside of a @test
  AssertionError: normpath(entry.path) == normpath(path)
  Stacktrace:
    [1] write_env(env::Pkg.Types.EnvCache; update_undo::Bool, skip_writing_project::Bool)
      @ Pkg.Types ~/work/Pkg.jl/Pkg.jl/src/Types.jl:1292
    [2] write_env
      @ ~/work/Pkg.jl/Pkg.jl/src/Types.jl:1283 [inlined]
    [3] up(ctx::Pkg.Types.Context, pkgs::Vector{Pkg.Types.PackageSpec}, level::Pkg.Types.UpgradeLevel; skip_writing_project::Bool, preserve::Nothing)
      @ Pkg.Operations ~/work/Pkg.jl/Pkg.jl/src/Operations.jl:1986
    [4] up
      @ ~/work/Pkg.jl/Pkg.jl/src/Operations.jl:1957 [inlined]
```