### PR TITLE
Add test for workspace sources pointing to parent package

### DIFF
--- a/test/test_packages/WorkspaceSourcesParent/Project.toml
+++ b/test/test_packages/WorkspaceSourcesParent/Project.toml
@@ -1,0 +1,6 @@
+name = "WorkspaceSourcesParent"
+uuid = "11111111-1111-1111-1111-111111111111"
+version = "0.1.0"
+
+[workspace]
+projects = ["docs"]

--- a/test/test_packages/WorkspaceSourcesParent/docs/Project.toml
+++ b/test/test_packages/WorkspaceSourcesParent/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+WorkspaceSourcesParent = "11111111-1111-1111-1111-111111111111"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+WorkspaceSourcesParent = {path = ".."}

--- a/test/test_packages/WorkspaceSourcesParent/src/WorkspaceSourcesParent.jl
+++ b/test/test_packages/WorkspaceSourcesParent/src/WorkspaceSourcesParent.jl
@@ -1,0 +1,3 @@
+module WorkspaceSourcesParent
+greet() = "Hello from WorkspaceSourcesParent!"
+end


### PR DESCRIPTION
Tests that workspace child projects with [sources] entries pointing to the parent package (e.g., path = "..") can be instantiated without errors.