### PR TITLE
Fix startswith on SHA1 tree_hash in handle_repo_add! (#4561)

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1034,13 +1034,14 @@ function handle_repo_add!(ctx::Context, pkg::PackageSpec)
             fetched = false
             if obj_branch === nothing
                 fetched = true
+                rev_or_hash_str = string(rev_or_hash)
                 # For pull requests, fetch the specific PR ref
-                if startswith(rev_or_hash, "pull/") && endswith(rev_or_hash, "/head")
-                    pr_number = rev_or_hash[6:(end - 5)]  # Extract number from "pull/X/head"
+                if startswith(rev_or_hash_str, "pull/") && endswith(rev_or_hash_str, "/head")
+                    pr_number = rev_or_hash_str[6:(end - 5)]  # Extract number from "pull/X/head"
                     pr_refspecs = ["+refs/pull/$(pr_number)/head:refs/cache/pull/$(pr_number)/head"]
                     GitTools.fetch(ctx.io, repo, repo_source_typed; refspecs = pr_refspecs, depth = 1)
                     # For branch names, fetch only the specific branch
-                elseif !looks_like_commit_hash(string(rev_or_hash))
+                elseif !looks_like_commit_hash(rev_or_hash_str)
                     specific_refspec = ["+refs/heads/$(rev_or_hash):refs/cache/heads/$(rev_or_hash)"]
                     GitTools.fetch(ctx.io, repo, repo_source_typed; refspecs = specific_refspec, depth = 1)
                 else

--- a/test/new.jl
+++ b/test/new.jl
@@ -2450,6 +2450,20 @@ end
             @test !haskey(Pkg.dependencies(), test_stdlib_uuid)
         end
     end
+    # resolve with repo-tracked package that has tree_hash in manifest (issue #4561)
+    # This tests that startswith/endswith correctly handle SHA1 tree_hash types
+    isolate(loaded_depot = true) do
+        Pkg.add(url = "https://github.com/JuliaLang/Example.jl", rev = "v0.5.3")
+        # Remove both clones and packages so resolve needs to re-clone
+        rm(joinpath(DEPOT_PATH[1], "clones"); force = true, recursive = true)
+        rm(joinpath(DEPOT_PATH[1], "packages"); force = true, recursive = true)
+        # This should not throw "MethodError: no method matching startswith(::Base.SHA1, ::String)"
+        Pkg.resolve()
+        Pkg.dependencies(exuuid) do pkg
+            @test pkg.name == "Example"
+            @test isdir(pkg.source)
+        end
+    end
 end
 
 #


### PR DESCRIPTION
Convert rev_or_hash to string before calling startswith/endswith to handle the case where pkg.tree_hash is a Base.SHA1 type instead of a string.