### PR TITLE
Add test for project sources path preservation

### DIFF
--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -203,6 +203,10 @@ end
                 manifest = TOML.parsefile("Manifest.toml")
                 parent_entry = only(manifest["deps"]["WorkspaceSourcesParent"])
                 @test parent_entry["path"] == "."
+                # Verify the Project.toml sources path was NOT corrupted (issue #4575)
+                # The path should remain ".." (project-relative), not "." (manifest-relative)
+                project = TOML.parsefile("docs/Project.toml")
+                @test project["sources"]["WorkspaceSourcesParent"]["path"] == ".."
             end
         end
     end


### PR DESCRIPTION
Expand the workspace sources test to verify that Project.toml sources paths are not corrupted from project-relative to manifest-relative during instantiate.

Taken from #4575 