### PR TITLE
Fix a JET warning in `tree_hash`

### DIFF
--- a/src/GitTools.jl
+++ b/src/GitTools.jl
@@ -379,7 +379,7 @@ function tree_hash(::Type{HashType}, root::AbstractString; debug_out::Union{IO, 
             if debug_out !== nothing
                 indent_str = "| "^indent
                 println(debug_out, "$(indent_str)+ [D] $(basename(filepath)) - $(bytes2hex(hash))")
-                print(debug_out, String(take!(child_stream)))
+                print(debug_out, String(take!(child_stream::IOBuffer)))
                 println(debug_out, indent_str)
             end
         else


### PR DESCRIPTION
This fixes the following JET warning:
```julia
┌ tree_hash(::Type{HashType}, root::AbstractString; debug_out::Union{Nothing, IO}, indent::Int64) where HashType @ Pkg.GitTools /home/lgoe/code/julia/Pkg.jl/src/GitTools.jl:382
│ no matching method found `take!(::Nothing)` (1/2 union split): Pkg.GitTools.take!(child_stream::Union{Nothing, IOBuffer})
```