### PR TITLE
Fix `get_object_or_branch` to recognize branches in bare clones used by `[sources]`

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1168,6 +1168,12 @@ function get_object_or_branch(repo, rev)
         err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
     end
     try
+        gitobject = LibGit2.GitObject(repo, "heads/" * rev)
+        return gitobject, true
+    catch err
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
+    end
+    try
         gitobject = LibGit2.GitObject(repo, rev)
         return gitobject, false
     catch err


### PR DESCRIPTION
I was using `[sources]` to point to a `main` branch of an unreleased package, but observed things not updating and the manifest using an old clone:

```
julia> Pkg.update()
    Updating registry at `~/.julia/registries/General.toml`
┌ Debug: get_object_or_branch result
│   pkg.name = "CompilerCaching"
│   rev_or_hash = "main"
│   obj_branch[2] = false
│   fetched = false
└ @ Pkg.Types ~/Julia/pkg/Pkg/src/Types.jl:970

    Updating `~/Julia/pkg/cuTile/Project.toml`
  [9db33cc3] ~ CompilerCaching v0.1.0 `https://github.com/maleadt/CompilerCaching.jl#main` ⇒ v0.1.0 `https://github.com/maleadt/CompilerCaching.jl#main`
    Updating `~/Julia/pkg/cuTile/Manifest-v1.12.toml`
  [9db33cc3] ~ CompilerCaching v0.1.0 `https://github.com/maleadt/CompilerCaching.jl#main` ⇒ v0.1.0 `https://github.com/maleadt/CompilerCaching.jl#main`
┌ Debug: precompile: instantiated
└ @ Pkg.API ~/Julia/pkg/Pkg/src/API.jl:1208
  ✗ cuTile
```

Not showing all details here, except for some debug info added by me, but the fact that things error on import indicates that there's a mismatch between the expected and actual version of CompilerCaching.jl.

Looking into this using Claude, it seems like Pkg doesn't recognize my `rev="main"` as a branch, so it doesn't consider updating the package. As far as I understand, this happens because (for some reason) the initial bare clone doesn't have the refs that `get_object_or_branch` expects:

```
❯ git -C .julia/clones/2983723077115117436 show-ref
83fc09154279be0c2dfbb19de944dc32bb2fbb4e refs/heads/main
```

Note that after an update, the expects refs do appear:

```
❯ git -C .julia/clones/2983723077115117436 show-ref
83fc09154279be0c2dfbb19de944dc32bb2fbb4e refs/heads/main
83fc09154279be0c2dfbb19de944dc32bb2fbb4e refs/remotes/cache/heads/main
```

In any case, to support the initial bare clone, this PR adds a check for `heads/` refs as well, in addition to `remotes/cache/heads/`. That fixes the issue for me:

```
julia> Pkg.update()
    Updating registry at `~/.julia/registries/General.toml`
┌ Debug: get_object_or_branch result
│   pkg.name = "CompilerCaching"
│   rev_or_hash = "main"
│   obj_branch[2] = true
│   fetched = false
└ @ Pkg.Types ~/Julia/pkg/Pkg/src/Types.jl:970
    Updating git-repo `https://github.com/maleadt/CompilerCaching.jl`
```