### PR TITLE
Remove precompile statement using gensym-ed variable name

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -202,7 +202,6 @@ let
                 Base.precompile(Tuple{typeof(Base.:(==)), Base.Dict{String, Any}, Base.Dict{String, Any}})
                 Base.precompile(Tuple{typeof(Base.join), Base.GenericIOBuffer{Memory{UInt8}}, Tuple{String}, Char})
                 Base.precompile(Tuple{typeof(Base.values), Base.Dict{String, Array{Base.Dict{String, Any}, 1}}})
-                Base.precompile(Tuple{typeof(Base.all), Base.Generator{Base.ValueIterator{Base.Dict{String, Array{Base.Dict{String, Any}, 1}}}, TOML.Internals.Printer.var"#5#6"}})
                 Base.precompile(Tuple{typeof(TOML.Internals.Printer.is_array_of_tables), Array{Base.Dict{String, Any}, 1}})
                 Base.precompile(Tuple{Type{Array{Dates.DateTime, 1}}, UndefInitializer, Tuple{Int64}})
                 Base.precompile(Tuple{Type{Pair{A, B} where {B} where {A}}, String, Dates.DateTime})


### PR DESCRIPTION
This PR is mostly so we can get JuliaLowering compiling this package, but also made because using `TOML.Internals.Printer.var"#5#6"` won't be stable using normal lowering either.

If needed, that variable corresponds to the type of the lambda in `!all(is_tabular(v) for v in _values)` [here](https://github.com/JuliaLang/julia/blob/defde64779afcabad6d62c140fa2a06651e4ac8e/stdlib/TOML/src/print.jl#L192), which we could change so that the extra `Base.all` specialization isn't necessary.
