### PR TITLE
Fix race condition potentially overwriting user configuration

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -369,8 +369,15 @@ function __init__()
     else
         atreplinit() do repl
             if isinteractive() && repl isa REPL.LineEditREPL
-                isdefined(repl, :interface) || (repl.interface = REPL.setup_interface(repl))
-                repl_init(repl)
+                # Do not call `REPL.setup_interface` here — it will be called
+                # by `run_frontend`, which respects user options set in other
+                # `atreplinit` hooks (e.g. `auto_insert_closing_bracket`).
+                @async begin
+                    while !isdefined(repl, :interface)
+                        sleep(0.1)
+                    end
+                    repl_init(repl)
+                end
             end
         end
     end

--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -369,15 +369,15 @@ function __init__()
     else
         atreplinit() do repl
             if isinteractive() && repl isa REPL.LineEditREPL
-                # Do not call `REPL.setup_interface` here — it will be called
-                # by `run_frontend`, which respects user options set in other
-                # `atreplinit` hooks (e.g. `auto_insert_closing_bracket`).
-                @async begin
-                    while !isdefined(repl, :interface)
-                        sleep(0.1)
+                # Let run_frontend build keymaps after all atreplinit hooks run.
+                errormonitor(
+                    @async begin
+                        while !isdefined(repl, :interface)
+                            sleep(0.01)
+                        end
+                        repl_init(repl)
                     end
-                    repl_init(repl)
-                end
+                )
             end
         end
     end


### PR DESCRIPTION
If the user set, e.g.,
```julia
atreplinit() do repl
    # Robust against older julia versions
    if hasfield(typeof(repl.options), :auto_insert_closing_bracket)
        repl.options.auto_insert_closing_bracket = false
    end
end
```
in their `startup.jl` it has no effect in VS Code's REPL due to VS Code's plugin loading `Pkg.jl` which is calling `REPL.setup_interface(repl)` inside an `atreplinit` hook, which bakes keymaps before user options are applied. The proper approach is to let `run_frontend` handle interface creation and defer mode initialization until the interface exists.

Note, that this fix is necessary, but not sufficient to make it work, because the same race condition needs to be fixed at least in [TerminalPager.jl](https://github.com/ronisbr/TerminalPager.jl/pull/83) and in [julia-vscode](https://github.com/julia-vscode/julia-vscode/pull/4063).

I used Claude Opus 4.6 while developing this fix.