### PR TITLE
🤖 Prototype: add overlay project support

### DIFF
--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -152,6 +152,27 @@ Shared environments can be activated with the `--shared` flag to `activate`:
 Shared environments have a `@` before their name in the Pkg REPL prompt.
 
 
+## Overlay Projects
+
+As an alternative to shared environments for development tools, you can use an
+[overlay project](@ref overlay-projects). An overlay project's dependencies are resolved
+together with whatever project you activate, sharing a single manifest. This avoids the version
+incompatibilities and redundant precompilation that can occur with stacked environments. See the
+[Overlay Projects](@ref overlay-projects) section in the `Project.toml` documentation for details.
+
+When using an overlay project, you typically want to disable the default stacked environment
+(`@v1.11`) since the overlay already provides your dev tools through the shared manifest.
+To do this, set `JULIA_LOAD_PATH` to only include the active project and stdlib:
+
+```sh
+# In your shell profile (e.g. .bashrc, .zshrc)
+export JULIA_LOAD_PATH="@:@stdlib"
+```
+
+The default value of `JULIA_LOAD_PATH` is `@:@v#.#:@stdlib`, where `@v#.#` is the versioned
+shared environment. Removing it prevents stacked environment packages from being loadable,
+which is what you want when the overlay project is the sole source of your extra dependencies.
+
 ## Environment Precompilation
 
 Before a package can be imported, Julia will "precompile" the source code into an intermediate more efficient cache on disc.

--- a/docs/src/managing-packages.md
+++ b/docs/src/managing-packages.md
@@ -553,6 +553,21 @@ To run a typical garbage collection with default arguments, simply use the `gc` 
 
 Note that only packages in `~/.julia/packages` are deleted.
 
+## Overlay Project
+
+The `JULIA_PKG_OVERLAY` environment variable specifies a path to an [overlay project](@ref overlay-projects) —
+a `Project.toml` whose dependencies are merged into every active environment's resolution. This
+is useful for globally available dev tools that should be resolved together with your project.
+The same can be set programmatically via `Pkg.OVERLAY_PROJECT[]`, which takes precedence over
+the environment variable.
+
+```julia
+ENV["JULIA_PKG_OVERLAY"] = expanduser("~/.julia/overlay")
+
+# Or use @ to reference a named environment in your depots
+ENV["JULIA_PKG_OVERLAY"] = "@devtools"  # expands to ~/.julia/environments/devtools
+```
+
 ## Offline Mode
 
 In offline mode, Pkg tries to do as much as possible without connecting

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -287,6 +287,62 @@ This structure is particularly beneficial for developers using a monorepo approa
 Workspaces can be nested: a project that itself defines a workspace can also be part of another workspace.
 In this case, the workspaces are "merged" with a single manifest being stored alongside the "root project" (the project that doesn't have another workspace including it).
 
+### [Overlay Projects](@id overlay-projects)
+
+An overlay project is a globally-configured `Project.toml` whose dependencies get merged into
+every active environment as if it were an additional workspace member. This is useful for
+development tools (e.g. `Debugger`, `JET`, `Cthulhu`) that you want available everywhere
+without polluting individual project dependencies.
+
+Unlike stacked environments (`LOAD_PATH` / `@v1.11`), which use separate manifests and can
+load incompatible versions, an overlay project shares the active environment's manifest. This
+means overlay dependencies are resolved together with your project's dependencies, respecting
+`[compat]` constraints and avoiding redundant precompilation.
+
+An overlay project is a plain `Project.toml` with `[deps]` and optionally `[compat]` and
+`[sources]` sections. It should **not** have `name`, `uuid`, or `version` fields — it is not
+a package, just a dependency list.
+
+```toml
+# ~/.julia/overlay/Project.toml
+[deps]
+Debugger = "31a5f54b-26ea-5571-9fe8-bf658c09c6c1"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+
+[compat]
+Debugger = "0.7"
+JET = "0.9"
+```
+
+To enable the overlay, either set the environment variable `JULIA_PKG_OVERLAY` or the Julia
+global `Pkg.OVERLAY_PROJECT[]`:
+
+```julia
+# Via environment variable (e.g. in startup.jl or shell profile)
+ENV["JULIA_PKG_OVERLAY"] = expanduser("~/.julia/overlay")
+
+# Or via Julia global (takes precedence over the env var)
+Pkg.OVERLAY_PROJECT[] = expanduser("~/.julia/overlay")
+```
+
+The path can point to a directory (containing a `Project.toml`) or directly to a `Project.toml`
+file. Paths starting with `@` are expanded using the same logic as `JULIA_LOAD_PATH` entries —
+they resolve to named environments in your depots. For example:
+
+```julia
+ENV["JULIA_PKG_OVERLAY"] = "@devtools"  # expands to ~/.julia/environments/devtools
+```
+
+Once configured, the overlay's dependencies will appear in resolution and in the manifest of
+whatever project you activate. If an overlay dependency conflicts with a project's `[compat]`,
+resolution will fail with a normal compat error — adjust the overlay's `[compat]` or remove the
+conflicting dependency.
+
+!!! note
+    The overlay project is **never written to** by Pkg operations. It does not appear in any
+    `[workspace]` section — it is injected at runtime only. Changing the overlay's contents
+    will trigger re-resolution on the next `Pkg.instantiate` or `Pkg.resolve`.
+
 ### The `[extras]` section (legacy)
 
 !!! warning

--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -114,6 +114,9 @@ function promptf()
     if Pkg.OFFLINE_MODE[]
         prefix = "$(prefix)[offline] "
     end
+    if project_file !== nothing && Types.is_overlay_active(project_file)
+        prefix = "$(prefix)[overlay] "
+    end
     return "$(prefix)pkg> "
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -153,6 +153,14 @@ function check_readonly(ctx::Context)
     return ctx.env.project.readonly && pkgerror("Cannot modify a readonly environment. The project at $(ctx.env.project_file) is marked as readonly.")
 end
 
+function check_overlay(ctx::Context)
+    Types.is_overlay_active(ctx.env) && pkgerror(
+        "The active project is the overlay project at $(ctx.env.project_file). " *
+        "This operation is not supported for overlay projects. " *
+        "Only `add` and `rm` are supported to manage the overlay's dependency list."
+    )
+end
+
 # Provide some convenience calls
 for f in (:develop, :add, :rm, :up, :pin, :free, :test, :build, :status, :why, :precompile)
     @eval begin
@@ -271,6 +279,7 @@ function develop(
     Context!(ctx; kwargs...)
     Operations.ensure_manifest_registries!(ctx)
     check_readonly(ctx)
+    check_overlay(ctx)
 
     for pkg in pkgs
         check_package_name(pkg.name, "develop")
@@ -376,6 +385,25 @@ function add(
         update_source_if_set(ctx.env, pkg)
     end
 
+    # Overlay project: just write deps to Project.toml, skip resolution/manifest
+    if Types.is_overlay_active(ctx.env)
+        target_field = if target == :deps
+            ctx.env.project.deps
+        elseif target == :weakdeps
+            ctx.env.project.weakdeps
+        elseif target == :extras
+            ctx.env.project.extras
+        else
+            pkgerror("Unrecognized target $(target)")
+        end
+        for pkg in pkgs
+            target_field[pkg.name] = pkg.uuid
+        end
+        Types.write_project(ctx.env)
+        Operations.show_update(ctx.env, ctx.registries; io = ctx.io)
+        return
+    end
+
     Operations.add(ctx, pkgs, new_git; allow_autoprecomp, preserve, platform, target)
     return
 end
@@ -407,6 +435,21 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode = PKGMODE_PROJECT, all
     mode == PKGMODE_PROJECT && project_deps_resolve!(ctx.env, pkgs)
     mode == PKGMODE_MANIFEST && manifest_resolve!(ctx.env.manifest, pkgs)
     ensure_resolved(ctx, ctx.env.manifest, pkgs)
+
+    # Overlay project: just remove deps from Project.toml, skip resolution/manifest
+    if Types.is_overlay_active(ctx.env)
+        for pkg in pkgs
+            if haskey(ctx.env.project.deps, pkg.name)
+                delete!(ctx.env.project.deps, pkg.name)
+            elseif haskey(ctx.env.project.weakdeps, pkg.name)
+                delete!(ctx.env.project.weakdeps, pkg.name)
+            end
+            haskey(ctx.env.project.compat, pkg.name) && delete!(ctx.env.project.compat, pkg.name)
+        end
+        Types.write_project(ctx.env)
+        Operations.show_update(ctx.env, ctx.registries; io = ctx.io)
+        return
+    end
 
     Operations.rm(ctx, pkgs; mode)
 
@@ -455,6 +498,7 @@ function up(
     Context!(ctx; kwargs...)
     Operations.ensure_manifest_registries!(ctx)
     check_readonly(ctx)
+    check_overlay(ctx)
     if Operations.is_fully_pinned(ctx)
         printpkgstyle(ctx.io, :Update, "All dependencies are pinned - nothing to update.", color = Base.info_color())
         return
@@ -490,6 +534,7 @@ function pin(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool = false, wo
     Context!(ctx; kwargs...)
     Operations.ensure_manifest_registries!(ctx)
     check_readonly(ctx)
+    check_overlay(ctx)
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, PKGMODE_MANIFEST; workspace)
@@ -532,6 +577,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; all_pkgs::Bool = false, w
     Context!(ctx; kwargs...)
     Operations.ensure_manifest_registries!(ctx)
     check_readonly(ctx)
+    check_overlay(ctx)
     if all_pkgs
         !isempty(pkgs) && pkgerror("cannot specify packages when operating on all packages")
         append_all_pkgs!(pkgs, ctx, PKGMODE_MANIFEST; workspace)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3196,6 +3196,10 @@ is_instantiated(x::PackageSpec) = x.version != VersionSpec() || is_stdlib(x.uuid
 function print_diff(io::IO, old::Union{Nothing, PackageSpec}, new::Union{Nothing, PackageSpec})
     return if !is_instantiated(old) && is_instantiated(new)
         printstyled(io, "+ $(stat_rep(new))"; color = :light_green)
+    elseif !is_instantiated(old) && !is_instantiated(new)
+        pkg = something(new, old)
+        pkg === nothing && return
+        printstyled(io, "+ $(stat_rep(pkg))"; color = :light_green)
     elseif !is_instantiated(new)
         printstyled(io, "- $(stat_rep(old))"; color = :light_red)
     elseif is_tracking_registry(old) && is_tracking_registry(new) &&
@@ -3437,7 +3441,8 @@ function print_status(
         if workspace && !manifest
             for (path, _) in env.workspace
                 relative_path = Types.relative_project_path(env.project_file, path)
-                printpkgstyle(io, :Status, relative_path, true)
+                display_path = startswith(relative_path, "..") ? path : relative_path
+                printpkgstyle(io, :Status, display_path, true)
             end
         end
         # Sort stdlibs and _jlls towards the end in status output

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -60,6 +60,7 @@ end
 const UPDATED_REGISTRY_THIS_SESSION = Ref(false)
 const OFFLINE_MODE = Ref(false)
 const RESPECT_SYSIMAGE_VERSIONS = Ref(true)
+const OVERLAY_PROJECT = Ref{Union{Nothing, String}}(nothing)
 # For globally overriding in e.g. tests
 const DEFAULT_IO = Base.ScopedValues.ScopedValue{IO}()
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -383,6 +383,27 @@ function find_root_base_project(start_project::String)
     return
 end
 
+function find_overlay_project()::Union{Nothing, String}
+    path = Pkg.OVERLAY_PROJECT[]
+    if path === nothing
+        path = get(ENV, "JULIA_PKG_OVERLAY", nothing)
+    end
+    path === nothing && return nothing
+    if startswith(path, "@")
+        project_file = Base.load_path_expand(path)
+        project_file isa String || return nothing
+        return project_file
+    end
+    project_file = Base.locate_project_file(abspath(path))
+    project_file isa String || return nothing
+    return project_file
+end
+
+function is_overlay_active(project_file::String)
+    overlay = find_overlay_project()
+    overlay === nothing && return false
+    return Pkg.safe_realpath(project_file) == Pkg.safe_realpath(overlay)
+end
 function collect_workspace(base_project_file::String, d::Dict{String, Project} = Dict{String, Project}())
     base_project = read_project(base_project_file)
     d[base_project_file] = base_project
@@ -447,6 +468,12 @@ function EnvCache(env::Union{Nothing, String} = nothing)
         delete!(workspace, abspath(project_file))
     end
 
+    overlay_project_file = find_overlay_project()
+    if overlay_project_file !== nothing
+        overlay = read_project(overlay_project_file)
+        workspace[abspath(overlay_project_file)] = overlay
+    end
+
     dir = abspath(project_dir)
     manifest_file = manifest_file !== nothing ?
         (isabspath(manifest_file) ? manifest_file : abspath(dir, manifest_file)) :
@@ -468,6 +495,8 @@ function EnvCache(env::Union{Nothing, String} = nothing)
 
     return env′
 end
+
+is_overlay_active(env::EnvCache) = is_overlay_active(env.project_file)
 
 # Convert a path from project-relative to manifest-relative
 # If path is absolute, returns it as-is


### PR DESCRIPTION
Prototyped the overlay project feature I mentioned in https://github.com/JuliaLang/Pkg.jl/issues/4637#issuecomment-4070173063 with Claude.
This still needs code loading support to merge in the overlay project into the workspace.
The goal here is to avoid using the environment stack for dev tools (which has a seprate manifest) and instead always resolve the dev tools together with your active project.
This does not help "torn environments" if you load packages, do package operations and then load more packages. 
Also, it is a bit ugly that if you share a manifest with someone they get all these devtool packages in there, maybe there should be two manifests, one that is everything reachable from the actual active project and one that is the "orphan" dpeendencies assuming the overlay environment would be removed...

TODO:

- Code loading support
- Precompilation support

Usage:

```
julia> ENV["JULIA_PKG_OVERLAY"]
"@devtools"

(@devtools) [overlay] pkg> activate @devtools
  Activating project at `~/.julia/environments/devtools`

(@devtools) [overlay] pkg> st
Status `~/.julia/environments/devtools/Project.toml` (empty project)

(@devtools) [overlay] pkg> add BenchmarkTools, Revise
    Updating `~/.julia/environments/devtools/Project.toml`
  [6e4b80f9] + BenchmarkTools
  [295af30f] + Revise
    Updating `~/.julia/environments/devtools/Manifest.toml`
  [6e4b80f9] + BenchmarkTools
  [295af30f] + Revise

(@devtools) [overlay] pkg> activate --temp
  Activating new project at `/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_sjMOea`

(jl_sjMOea) pkg> st --workspace
Status `/private/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_sjMOea/Project.toml`
Status /Users/kc/.julia/environments/devtools/Project.toml
  [6e4b80f9] BenchmarkTools
  [295af30f] Revise

(jl_sjMOea) pkg> add Example
   Resolving package versions...
   Installed JuliaInterpreter ─ v0.10.11
   Installed Revise ─────────── v3.14.0
    Updating `/private/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_sjMOea/Project.toml`
  [7876af07] + Example v0.5.5
    Updating `/private/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_sjMOea/Manifest.toml`
  [7876af07] + Example v0.5.5

(jl_sjMOea) pkg> st -m
Status `/private/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_sjMOea/Manifest.toml`
  [7876af07] Example v0.5.5

(jl_sjMOea) pkg> st -m --workspace
Status `/private/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_sjMOea/Manifest.toml`
  [6e4b80f9] BenchmarkTools v1.6.3
  [da1fd8a2] CodeTracking v3.0.0
  [34da2185] Compat v4.18.1
  [807dbc54] Compiler v0.1.1
  [7876af07] Example v0.5.5
  [682c06a0] JSON v1.4.0
```


🤖 description:

-----------
Julia's stacked environments (LOAD_PATH / `@v#.#`) allow loading dev tools alongside project deps, but they use separate manifests. This can lead to incompatible versions being loaded, wasted precompilation, and [compat] violations. Workspaces solve this with a shared manifest, but require explicit [workspace] entries in every project.

An overlay project bridges this gap: a globally-configured Project.toml whose deps get merged into every active environment as if it were a workspace member. Dev tools like Debugger, JET, and Cthulhu can be listed once in the overlay and resolved together with whatever project you're working on — sharing a single manifest and respecting [compat].

Configuration (checked in order, first wins):
  - Pkg.OVERLAY_PROJECT[] = "~/.julia/overlay"
  - ENV["JULIA_PKG_OVERLAY"] = "@devtools"

Paths starting with @ are expanded via Base.load_path_expand, so "@devtools" resolves to ~/.julia/environments/devtools/Project.toml.

The implementation injects the overlay into env.workspace in the EnvCache constructor (~5 lines), which means all downstream code — dep loading, compat intersection, resolve hashing, precompilation — works automatically since it already iterates over workspace members.

When the overlay project itself is active (pkg> activate @devtools), only `add` and `rm` are supported — they write directly to the overlay's Project.toml without resolution or manifest updates. Other operations (develop, update, pin, free) error with a clear message. The REPL prompt shows [overlay] when the overlay project is active.

------------