### PR TITLE
Report when no artifacts match this platform during source install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Pkg v1.14 Release Notes
+=======================
+
+- During package source installation, Pkg now reports when a package has an Artifacts.toml but no artifacts match the
+  current platform. ([#4646])
+
 Pkg v1.13 Release Notes
 =======================
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1520,6 +1520,25 @@ end
 
 download_source(ctx::Context; readonly::Bool = true) = download_source(ctx, collect(values(ctx.env.manifest)); readonly)
 
+function count_artifacts(pkg_root::String; platform::AbstractPlatform = HostPlatform())
+    for f in artifact_names
+        artifacts_toml = joinpath(pkg_root, f)
+        if isfile(artifacts_toml)
+            eager = select_downloadable_artifacts(artifacts_toml; platform, include_lazy = false)
+            all_matching = select_downloadable_artifacts(artifacts_toml; platform, include_lazy = true)
+            return (length(eager), length(all_matching) - length(eager))
+        end
+    end
+    return nothing
+end
+
+function artifact_suffix(artifact_counts)
+    artifact_counts === nothing && return ""
+    n_eager, n_lazy = artifact_counts
+    n_eager + n_lazy == 0 && return " (no artifacts on this platform)"
+    return ""
+end
+
 function download_source(ctx::Context, pkgs; readonly::Bool = true)
     pidfile_stale_age = 10 # recommended value is about 3-5x an estimated normal download time (i.e. 2-3s)
     pkgs_to_install = NamedTuple{(:pkg, :urls, :path), Tuple{eltype(pkgs), Set{String}, String}}[]
@@ -1644,7 +1663,8 @@ function download_source(ctx::Context, pkgs; readonly::Bool = true)
                             short_treehash = string(pkg.tree_hash)[1:16]
                             "[$short_treehash]"
                         end
-                        printpkgstyle(io, :Installed, string(rpad(pkg.name * " ", max_name + 2, "─"), " ", vstr))
+                        artifact_str = artifact_suffix(count_artifacts(path))
+                        printpkgstyle(io, :Installed, string(rpad(pkg.name * " ", max_name + 2, "─"), " ", vstr, artifact_str))
                         fancyprint && show_progress(io, bar)
                     end
                 end
@@ -1670,7 +1690,8 @@ function download_source(ctx::Context, pkgs; readonly::Bool = true)
                 short_treehash = string(pkg.tree_hash)[1:16]
                 "[$short_treehash]"
             end
-            printpkgstyle(ctx.io, :Installed, string(rpad(pkg.name * " ", max_name + 2, "─"), " ", vstr))
+            artifact_str = artifact_suffix(count_artifacts(path))
+            printpkgstyle(ctx.io, :Installed, string(rpad(pkg.name * " ", max_name + 2, "─"), " ", vstr, artifact_str))
         end
     end
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -842,9 +842,25 @@ end
     end
 
     # Platform with no matching artifacts → (0, 0), warning suffix
-    result = count_artifacts(artifacts_toml_dir; platform = bogus_platform)
-    @test result === (0, 0)
-    @test artifact_suffix(result) == " (no artifacts on this platform)"
+    # Use a temp dir with a platform-specific-only Artifacts.toml (no platform-independent entries)
+    # so that the bogus platform genuinely matches nothing.
+    mktempdir() do platform_specific_dir
+        write(
+            joinpath(platform_specific_dir, "Artifacts.toml"), """
+            [[HelloWorldC]]
+            arch = "x86_64"
+            os = "linux"
+            git-tree-sha1 = "0000000000000000000000000000000000000000"
+
+                [[HelloWorldC.download]]
+                sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+                url = "https://example.com/HelloWorldC.tar.gz"
+            """
+        )
+        result = count_artifacts(platform_specific_dir; platform = bogus_platform)
+        @test result === (0, 0)
+        @test artifact_suffix(result) == " (no artifacts on this platform)"
+    end
 
     # HostPlatform → at least one eager match (HelloWorldC) and one lazy (socrates)
     host_result = count_artifacts(artifacts_toml_dir; platform = HostPlatform())

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -3,6 +3,7 @@ import ..Pkg # ensure we are using the correct Pkg
 
 using Test, Random, Pkg.Artifacts, Base.BinaryPlatforms, Pkg.PlatformEngines
 import Pkg.Artifacts: pack_platform!, unpack_platform, with_artifacts_directory, ensure_all_artifacts_installed, extract_all_hashes
+import Pkg.Operations: count_artifacts, artifact_suffix
 using TOML, Dates
 import Base: SHA1
 
@@ -829,6 +830,31 @@ end
         end
     end
 end
+
+@testset "count_artifacts and artifact_suffix" begin
+    artifacts_toml_dir = joinpath(@__DIR__, "test_packages", "ArtifactInstallation")
+    bogus_platform = Platform("bogus", "linux")
+
+    # No Artifacts.toml → nothing, no suffix
+    mktempdir() do empty_dir
+        @test count_artifacts(empty_dir) === nothing
+        @test artifact_suffix(nothing) == ""
+    end
+
+    # Platform with no matching artifacts → (0, 0), warning suffix
+    result = count_artifacts(artifacts_toml_dir; platform = bogus_platform)
+    @test result === (0, 0)
+    @test artifact_suffix(result) == " (no artifacts on this platform)"
+
+    # HostPlatform → at least one eager match (HelloWorldC) and one lazy (socrates)
+    host_result = count_artifacts(artifacts_toml_dir; platform = HostPlatform())
+    @test host_result !== nothing
+    n_eager, n_lazy = host_result
+    @test n_eager >= 1
+    @test n_lazy >= 1   # socrates is lazy = true
+    @test artifact_suffix(host_result) == ""
+end
+
 
 if Sys.iswindows()
     @testset "filemode(dir) non-executable on windows" begin


### PR DESCRIPTION
An idea to help confusion around platform-irrelevant JLLs etc.

```
(jl_ZUyfPF) pkg> add VideoIO
  Installing known registries into `/tmp/123jf`
       Added `General` registry to /tmp/123jf/registries
   Resolving package versions...
   Installed Glob ────────────────── v1.4.0
   Installed Libuuid_jll ─────────── v2.41.3+0 (no artifacts on this platform)
   Installed HarfBuzz_jll ────────── v8.5.1+0
   Installed Bzip2_jll ───────────── v1.0.9+0
   Installed libaom_jll ──────────── v3.13.1+0
   Installed libass_jll ──────────── v0.17.4+0
   Installed MosaicViews ─────────── v0.3.4
   Installed PaddedViews ─────────── v0.5.12
   Installed StackViews ──────────── v0.1.2
   Installed Libmount_jll ────────── v2.41.3+0 (no artifacts on this platform)
   Installed x264_jll ────────────── v10164.0.1+0
   Installed Cairo_jll ───────────── v1.18.5+1
   Installed Xorg_libXau_jll ─────── v1.0.13+0 (no artifacts on this platform)
   Installed TensorCore ──────────── v0.1.1
   Installed Xorg_libX11_jll ─────── v1.8.13+0 (no artifacts on this platform)
   Installed Graphite2_jll ───────── v1.3.15+0
   Installed Statistics ──────────── v1.11.1
   Installed Xorg_libpciaccess_jll ─ v0.18.1+0 (no artifacts on this platform)
   Installed Xorg_libXfixes_jll ──── v6.0.2+0 (no artifacts on this platform)
   Installed Pixman_jll ──────────── v0.44.2+0
   Installed Libffi_jll ──────────── v3.4.7+0
   Installed OffsetArrays ────────── v1.17.0
   Installed Colors ──────────────── v0.13.1
   Installed Fontconfig_jll ──────── v2.17.1+0
   Installed FileIO ──────────────── v1.18.0
   Installed PrecompileTools ─────── v1.3.3
   Installed Expat_jll ───────────── v2.7.3+0
   Installed Glib_jll ────────────── v2.86.3+0
   Installed GettextRuntime_jll ──── v0.22.4+0
   Installed ColorVectorSpace ────── v0.11.0
   Installed Requires ────────────── v1.3.1
   Installed FriBidi_jll ─────────── v1.0.17+0
   Installed libpng_jll ──────────── v1.6.56+0
   Installed LAME_jll ────────────── v3.100.3+0
   Installed libvorbis_jll ───────── v1.3.8+0
   Installed Xorg_libXrender_jll ─── v0.9.12+0 (no artifacts on this platform)
   Installed Opus_jll ────────────── v1.6.1+0
   Installed ColorTypes ──────────── v0.12.1
   Installed libfdk_aac_jll ──────── v2.0.4+0
   Installed Ogg_jll ─────────────── v1.3.6+0
   Installed Xorg_libxcb_jll ─────── v1.17.1+0 (no artifacts on this platform)
   Installed Scratch ─────────────── v1.3.0
   Installed Xorg_libXdmcp_jll ───── v1.1.6+0 (no artifacts on this platform)
   Installed LZO_jll ─────────────── v2.10.3+0
   Installed Reexport ────────────── v1.2.2
   Installed libva_jll ───────────── v2.23.0+0 (no artifacts on this platform)
   Installed FFMPEG_jll ──────────── v8.0.1+1
   Installed Libiconv_jll ────────── v1.18.0+0
   Installed FFMPEG ──────────────── v0.4.5
   Installed JLLWrappers ─────────── v1.7.1
   Installed FixedPointNumbers ───── v0.8.5
   Installed LLVMOpenMP_jll ──────── v18.1.8+0
   Installed x265_jll ────────────── v4.1.0+0
   Installed MappedArrays ────────── v0.4.3
   Installed ImageCore ───────────── v0.10.5
   Installed Preferences ─────────── v1.5.2
   Installed libdrm_jll ──────────── v2.4.125+1 (no artifacts on this platform)
   Installed FreeType2_jll ───────── v2.14.3+1
   Installed VideoIO ─────────────── v1.6.1
   Installed Xorg_xtrans_jll ─────── v1.6.0+0 (no artifacts on this platform)
   Installed Xorg_libXext_jll ────── v1.3.8+0 (no artifacts on this platform)
  Installing artifacts ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 26/26
...
```