### PR TITLE
Fix `compilecache` being called with too-permissive extension rights

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -868,7 +868,7 @@ function _precompilepkgs(pkgs::Vector{String},
                                     # for packages, we may load any extension (all possible triggers are accounted for above)
                                     loadable_exts = haskey(ext_to_parent, pkg) ? filter((dep)->haskey(ext_to_parent, dep), direct_deps[pkg]) : nothing
                                     Base.compilecache(pkg, sourcepath, std_pipe, std_pipe, keep_loaded_modules;
-                                                      #=flags, cacheflags, loadable_exts=#)
+                                                      #=flags, cacheflags,=# loadable_exts)
                                 end
                             end
                             if ret isa Base.PrecompilableError


### PR DESCRIPTION
This fixes our handling of `ext → ext` dependencies on 1.10, resolving https://github.com/EnzymeAD/Reactant.jl/issues/2764.

#### Why did our 1.10 tests not catch this?

Unfortunately I made two serious mistakes in the backport of https://github.com/JuliaLang/Pkg.jl/pull/4619 (and related Julia PR's):
  1. I did not notice this call to `compilecache` on the Pkg.jl side
  2. Tests were included in https://github.com/JuliaLang/julia/pull/60997 specifically to catch this, but the `Base.disable_parallel_precompile = true / false` mechanism does not exist on 1.10. Julia does not complain about creating the new global in Base, so the missing parallel coverage is silent. The tests landed match `1.11+`, but they end up only testing the (serial) `Base._require` pathway.