### PR TITLE
Add `dependents` command to list reverse dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Pkg v1.14 Release Notes
 =======================
 
+- Added `Pkg.dependents` / `pkg> dependents` command to list the direct and indirect dependents of a package across
+  all reachable registries. Use `--all` to expand indirect dependents.
 - During package source installation, Pkg now reports when a package has an Artifacts.toml but no artifacts match the
   current platform. ([#4646])
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -42,6 +42,7 @@ Pkg.precompile
 Pkg.autoprecompilation_enabled
 Pkg.offline
 Pkg.why
+Pkg.dependents
 Pkg.dependencies
 Pkg.respect_sysimage_versions
 Pkg.project

--- a/ext/REPLExt/completions.jl
+++ b/ext/REPLExt/completions.jl
@@ -148,6 +148,18 @@ function complete_all_installed_packages(options, partial; hint::Bool, arguments
     return filter(pkg -> !(pkg in specified_names), packages)
 end
 
+function complete_registry_packages(options, partial; hint::Bool, arguments = [])
+    names = Set{String}()
+    for reg in Registry.reachable_registries()
+        for (_, entry) in reg
+            push!(names, entry.name)
+        end
+    end
+    result = sort!(collect(names))
+    specified_names = extract_specified_names(arguments)
+    return filter(pkg -> !(pkg in specified_names), result)
+end
+
 function complete_installed_packages_and_compat(options, partial; hint::Bool, arguments = [])
     env = try
         EnvCache()

--- a/src/API.jl
+++ b/src/API.jl
@@ -1696,6 +1696,133 @@ function why(ctx::Context, pkgs::Vector{PackageSpec}; io::IO, workspace::Bool = 
 end
 
 
+###############
+# Dependents  #
+###############
+
+dependents(pkg::Union{AbstractString, PackageSpec}; kwargs...) =
+    dependents([pkg isa AbstractString ? PackageSpec(; name = pkg) : pkg]; kwargs...)
+dependents(pkgs::Vector{<:AbstractString}; kwargs...) =
+    dependents([PackageSpec(; name = pkg) for pkg in pkgs]; kwargs...)
+
+function dependents(pkgs::Vector{PackageSpec}; io::IO = stderr_f(), all::Bool = false)
+    require_not_empty(pkgs, :dependents)
+    Registry.download_default_registries(io)
+    registries = Registry.reachable_registries()
+    if isempty(registries)
+        printpkgstyle(io, :Warning, "No registries found")
+        return
+    end
+    for (i, pkg) in enumerate(pkgs)
+        i > 1 && println(io)
+        _show_dependents(io, registries, pkg; show_indirect = all)
+    end
+    return
+end
+
+function _resolve_package_in_registries(registries, pkg::PackageSpec)
+    # found maps uuid => (name, [registry descriptions])
+    found = Dict{UUID, Tuple{String, Vector{String}}}()
+    for reg in registries
+        if pkg.uuid !== nothing
+            if haskey(reg, pkg.uuid)
+                name = reg[pkg.uuid].name
+                val = get!(() -> (name, String[]), found, pkg.uuid)
+                push!(val[2], "$(reg.name) ($(reg.path))")
+            end
+        elseif pkg.name !== nothing
+            uuids = Registry.uuids_from_name(reg, pkg.name)
+            for uuid in uuids
+                name = reg[uuid].name
+                val = get!(() -> (name, String[]), found, uuid)
+                push!(val[2], "$(reg.name) ($(reg.path))")
+            end
+        end
+    end
+    return found
+end
+
+function _show_dependents(io::IO, registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec; show_indirect::Bool = false)
+    found = _resolve_package_in_registries(registries, pkg)
+
+    if isempty(found)
+        pkgerror("Package $(something(pkg.name, string(pkg.uuid))) not found in any registry")
+    end
+
+    if length(found) > 1 && pkg.uuid === nothing
+        name = pkg.name
+        lines = String[]
+        for (uuid, (_, reg_paths)) in found
+            push!(lines, "  $name=$uuid (in $(join(reg_paths, ", ")))")
+        end
+        sort!(lines)
+        pkgerror(
+            "Package name \"$name\" is ambiguous. It matches $(length(found)) UUIDs:\n" *
+                join(lines, "\n") *
+                "\nDisambiguate with: dependents $name={uuid}"
+        )
+    end
+
+    for (target_uuid, (target_name, reg_paths)) in found
+        short_uuid = string(target_uuid)[1:8]
+        printpkgstyle(io, :Dependents, "$target_name [$short_uuid]")
+        println(io, "  Found in: ", join(reg_paths, ", "))
+
+        for reg in registries
+            # Build reverse dependency map for this registry
+            reverse_deps = Dict{UUID, Set{UUID}}()
+            for (uuid, entry) in reg
+                info = Registry.registry_info(reg, entry)
+                all_dep_uuids = Set{UUID}()
+                for (_, deps_set) in info.deps
+                    union!(all_dep_uuids, deps_set)
+                end
+                for (_, weak_set) in info.weak_deps
+                    union!(all_dep_uuids, weak_set)
+                end
+                for dep_uuid in all_dep_uuids
+                    push!(get!(Set{UUID}, reverse_deps, dep_uuid), uuid)
+                end
+            end
+
+            # Direct dependents of target
+            direct = get(Set{UUID}, reverse_deps, target_uuid)
+
+            # Indirect dependents via BFS through reverse dependency graph
+            indirect = Set{UUID}()
+            queue = collect(direct)
+            while !isempty(queue)
+                current = popfirst!(queue)
+                for next in get(Set{UUID}, reverse_deps, current)
+                    if next != target_uuid && next ∉ direct && next ∉ indirect
+                        push!(indirect, next)
+                        push!(queue, next)
+                    end
+                end
+            end
+
+            direct_names = sort!([reg[uuid].name for uuid in direct if haskey(reg, uuid)])
+            n_indirect = length(indirect)
+
+            if !isempty(direct_names) || n_indirect > 0
+                printstyled(io, "  $(reg.name)"; bold = true)
+                println(io, " registry")
+                println(io, "    $(length(direct_names)) direct: ", join(direct_names, ", "))
+                if n_indirect > 0
+                    if show_indirect
+                        indirect_names = sort!([reg[uuid].name for uuid in indirect if haskey(reg, uuid)])
+                        println(io, "    $n_indirect indirect: ", join(indirect_names, ", "))
+                    else
+                        println(io, "    $n_indirect indirect")
+                    end
+                end
+            end
+        end
+    end
+    return
+end
+
+
 ########
 # Undo #
 ########

--- a/src/API.jl
+++ b/src/API.jl
@@ -1726,16 +1726,18 @@ function _resolve_package_in_registries(registries, pkg::PackageSpec)
     for reg in registries
         if pkg.uuid !== nothing
             if haskey(reg, pkg.uuid)
-                name = reg[pkg.uuid].name
-                val = get!(() -> (name, String[]), found, pkg.uuid)
-                push!(val[2], "$(reg.name) ($(reg.path))")
+                id = pkg.uuid
+                if !haskey(found, id)
+                    found[id] = (reg[id].name, String[])
+                end
+                push!(found[id][2], "$(reg.name) ($(reg.path))")
             end
         elseif pkg.name !== nothing
-            uuids = Registry.uuids_from_name(reg, pkg.name)
-            for uuid in uuids
-                name = reg[uuid].name
-                val = get!(() -> (name, String[]), found, uuid)
-                push!(val[2], "$(reg.name) ($(reg.path))")
+            for uuid in Registry.uuids_from_name(reg, pkg.name)
+                if !haskey(found, uuid)
+                    found[uuid] = (reg[uuid].name, String[])
+                end
+                push!(found[uuid][2], "$(reg.name) ($(reg.path))")
             end
         end
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1825,14 +1825,49 @@ function dependents(pkgs::Vector{PackageSpec}; io::IO = stderr_f(), all::Bool = 
     Registry.download_default_registries(io)
     registries = Registry.reachable_registries()
     if isempty(registries)
-        printpkgstyle(io, :Warning, "No registries found")
-        return
+        pkgerror("No registries found")
     end
+    # Pre-compute the reverse-dependency maps for each registry once,
+    # so multiple `pkgs` don't each trigger a full registry scan.
+    rdeps_per_reg = [(reg, _build_reverse_deps(reg)...) for reg in registries]
     for (i, pkg) in enumerate(pkgs)
         i > 1 && println(io)
-        _show_dependents(io, registries, pkg; show_indirect = all)
+        _show_dependents(io, rdeps_per_reg, pkg; show_indirect = all)
     end
     return
+end
+
+# For each package in `reg`, take its latest non-yanked version and
+# record incoming edges (strong and weak separately) into the returned maps:
+#   strong[target_uuid] = Set of UUIDs that strong-depend on target at their latest version
+#   weak[target_uuid]   = Set of UUIDs that weak-depend on target at their latest version
+function _build_reverse_deps(reg::Registry.RegistryInstance)
+    strong = Dict{UUID, Set{UUID}}()
+    weak = Dict{UUID, Set{UUID}}()
+    for (uuid, entry) in reg
+        info = Registry.registry_info(reg, entry)
+        latest = nothing
+        for (v, vinfo) in info.version_info
+            vinfo.yanked && continue
+            if latest === nothing || v > latest
+                latest = v
+            end
+        end
+        latest === nothing && continue
+        for (vrange, deps_set) in info.deps
+            latest in vrange || continue
+            for dep_uuid in deps_set
+                push!(get!(Set{UUID}, strong, dep_uuid), uuid)
+            end
+        end
+        for (vrange, weak_set) in info.weak_deps
+            latest in vrange || continue
+            for dep_uuid in weak_set
+                push!(get!(Set{UUID}, weak, dep_uuid), uuid)
+            end
+        end
+    end
+    return strong, weak
 end
 
 function _resolve_package_in_registries(registries, pkg::PackageSpec)
@@ -1859,14 +1894,20 @@ function _resolve_package_in_registries(registries, pkg::PackageSpec)
     return found
 end
 
-function _show_dependents(io::IO, registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec; show_indirect::Bool = false)
+function _show_dependents(
+        io::IO,
+        rdeps_per_reg::Vector,
+        pkg::PackageSpec;
+        show_indirect::Bool = false,
+    )
+    registries = [t[1] for t in rdeps_per_reg]
     found = _resolve_package_in_registries(registries, pkg)
 
     if isempty(found)
         pkgerror("Package $(something(pkg.name, string(pkg.uuid))) not found in any registry")
     end
 
-    if length(found) > 1 && pkg.uuid === nothing
+    if length(found) > 1
         name = pkg.name
         lines = String[]
         for (uuid, (_, reg_paths)) in found
@@ -1885,33 +1926,22 @@ function _show_dependents(io::IO, registries::Vector{Registry.RegistryInstance},
         printpkgstyle(io, :Dependents, "$target_name [$short_uuid]")
         println(io, "  Found in: ", join(reg_paths, ", "))
 
-        for reg in registries
-            # Build reverse dependency map for this registry
-            reverse_deps = Dict{UUID, Set{UUID}}()
-            for (uuid, entry) in reg
-                info = Registry.registry_info(reg, entry)
-                all_dep_uuids = Set{UUID}()
-                for (_, deps_set) in info.deps
-                    union!(all_dep_uuids, deps_set)
-                end
-                for (_, weak_set) in info.weak_deps
-                    union!(all_dep_uuids, weak_set)
-                end
-                for dep_uuid in all_dep_uuids
-                    push!(get!(Set{UUID}, reverse_deps, dep_uuid), uuid)
-                end
-            end
+        for (reg, strong_rdeps, weak_rdeps) in rdeps_per_reg
+            direct = get(Set{UUID}, strong_rdeps, target_uuid)
+            weak_direct = setdiff(get(Set{UUID}, weak_rdeps, target_uuid), direct)
 
-            # Direct dependents of target
-            direct = get(Set{UUID}, reverse_deps, target_uuid)
-
-            # Indirect dependents via BFS through reverse dependency graph
+            # Indirect dependents via BFS following both strong and weak edges,
+            # excluding anything already counted as direct/weak-direct.
             indirect = Set{UUID}()
-            queue = collect(direct)
+            visited = union(direct, weak_direct)
+            queue = collect(visited)
             while !isempty(queue)
                 current = popfirst!(queue)
-                for next in get(Set{UUID}, reverse_deps, current)
-                    if next != target_uuid && next ∉ direct && next ∉ indirect
+                for rmap in (strong_rdeps, weak_rdeps)
+                    for next in get(Set{UUID}, rmap, current)
+                        next == target_uuid && continue
+                        next in visited && continue
+                        push!(visited, next)
                         push!(indirect, next)
                         push!(queue, next)
                     end
@@ -1919,12 +1949,16 @@ function _show_dependents(io::IO, registries::Vector{Registry.RegistryInstance},
             end
 
             direct_names = sort!([reg[uuid].name for uuid in direct if haskey(reg, uuid)])
+            weak_names = sort!([reg[uuid].name for uuid in weak_direct if haskey(reg, uuid)])
             n_indirect = length(indirect)
 
-            if !isempty(direct_names) || n_indirect > 0
+            if !isempty(direct_names) || !isempty(weak_names) || n_indirect > 0
                 printstyled(io, "  $(reg.name)"; bold = true)
                 println(io, " registry")
                 println(io, "    $(length(direct_names)) direct: ", join(direct_names, ", "))
+                if !isempty(weak_names)
+                    println(io, "    $(length(weak_names)) weak: ", join(weak_names, ", "))
+                end
                 if n_indirect > 0
                     if show_indirect
                         indirect_names = sort!([reg[uuid].name for uuid in indirect if haskey(reg, uuid)])

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -22,7 +22,7 @@ export UpgradeLevel, UPLEVEL_MAJOR, UPLEVEL_MINOR, UPLEVEL_PATCH
 export PreserveLevel, PRESERVE_TIERED_INSTALLED, PRESERVE_TIERED, PRESERVE_ALL_INSTALLED, PRESERVE_ALL, PRESERVE_DIRECT, PRESERVE_SEMVER, PRESERVE_NONE
 export Registry, RegistrySpec, Apps
 
-public activate, add, build, compat, develop, free, gc, generate, instantiate,
+public activate, add, build, compat, dependents, develop, free, gc, generate, instantiate,
     pin, precompile, readonly, redo, rm, resolve, status, test, undo, update, why
 
 depots() = Base.DEPOT_PATH
@@ -346,6 +346,16 @@ If `workspace` is true, this will consider all projects in the workspace and not
     This function requires at least Julia 1.9.
 """
 const why = API.why
+
+"""
+    Pkg.dependents(pkg::Union{String, PackageSpec})
+    Pkg.dependents(pkgs::Vector{PackageSpec}; all=false)
+
+List the direct dependents of `pkg` across all reachable registries.
+By default only the count of indirect dependents is shown; pass `all=true` to list them.
+If a package name is ambiguous (multiple UUIDs), use `PackageSpec(; name, uuid)` to disambiguate.
+"""
+const dependents = API.dependents
 
 """
     Pkg.update(; level::UpgradeLevel=UPLEVEL_MAJOR, mode::PackageMode = PKGMODE_PROJECT, preserve::PreserveLevel, workspace::Bool = false)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -352,8 +352,14 @@ const why = API.why
     Pkg.dependents(pkgs::Vector{PackageSpec}; all=false)
 
 List the direct dependents of `pkg` across all reachable registries.
-By default only the count of indirect dependents is shown; pass `all=true` to list them.
-If a package name is ambiguous (multiple UUIDs), use `PackageSpec(; name, uuid)` to disambiguate.
+
+Edges are computed from each candidate package's latest non-yanked registered
+version. Strong and weak dependencies are reported separately (`direct` vs
+`weak`). By default only the count of indirect dependents is shown; pass
+`all=true` to list them.
+
+If a package name is ambiguous (multiple UUIDs), use `PackageSpec(; name, uuid)`
+to disambiguate.
 """
 const dependents = API.dependents
 

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -262,6 +262,35 @@ compound_declarations = [
                 """,
         ],
         PSA[
+            :name => "dependents",
+            :api => API.dependents,
+            :should_splat => false,
+            :arg_count => 1 => Inf,
+            :arg_parser => parse_package,
+            :option_spec => [
+                PSA[:name => "all", :api => :all => true],
+            ],
+            :completions => :complete_registry_packages,
+            :description => "list packages that depend on the given package in reachable registries",
+            :help => md"""
+                    dependents [--all] pkg[=uuid] ...
+
+                List the direct dependents of `pkg` across all reachable registries.
+                By default only the count of indirect dependents is shown.
+                Use `--all` to also list all indirect dependents.
+
+                If a package name is ambiguous (multiple UUIDs), disambiguate with
+                `pkg=uuid` syntax.
+
+                **Examples**
+                ```
+                pkg> dependents JSON
+                pkg> dependents --all Example
+                pkg> dependents Example=7876af07-990d-54b4-ab0e-23690620f79a
+                ```
+                """,
+        ],
+        PSA[
             :name => "pin",
             :api => API.pin,
             :should_splat => false,

--- a/test/new.jl
+++ b/test/new.jl
@@ -2055,6 +2055,64 @@ end
 end
 
 #
+# # Dependents
+#
+@testset "dependents: REPL" begin
+    isolate() do
+        Pkg.REPLMode.TEST_MODE[] = true
+        api, opts = first(Pkg.pkg"dependents Foo")
+        @test api == Pkg.dependents
+        @test first(opts).name == "Foo"
+
+        api, args, opts = first(Pkg.pkg"dependents --all Foo")
+        @test api == Pkg.dependents
+        @test first(args).name == "Foo"
+        @test opts[:all] == true
+    end
+end
+
+@testset "dependents" begin
+    isolate() do
+        # Basic output structure: known package with dependents
+        io = IOBuffer()
+        Pkg.dependents("Parsers"; io)
+        str = String(take!(io))
+        @test occursin("Dependents", str)
+        @test occursin("Parsers", str)
+        @test occursin("direct:", str)
+        @test occursin("JSON", str)  # JSON depends on Parsers
+        @test occursin("indirect", str)
+
+        # --all flag shows indirect package names
+        io = IOBuffer()
+        Pkg.dependents("Parsers"; io, all = true)
+        str_all = String(take!(io))
+        @test occursin("indirect:", str_all)
+
+        # Without --all, indirect line has no colon (just count)
+        io = IOBuffer()
+        Pkg.dependents("Parsers"; io, all = false)
+        str_no_all = String(take!(io))
+        m = match(r"(\d+) indirect$"m, str_no_all)
+        @test m !== nothing
+        @test parse(Int, m[1]) > 0
+
+        # Package not in registry
+        @test_throws PkgError Pkg.dependents("ThisPackageDefinitelyDoesNotExist123456"; io)
+
+        # Lookup by UUID
+        io = IOBuffer()
+        Pkg.dependents(Pkg.PackageSpec(uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"); io)
+        str = String(take!(io))
+        @test occursin("Parsers", str)
+        @test occursin("direct:", str)
+
+        # Empty arguments
+        @test_throws PkgError Pkg.dependents(Pkg.PackageSpec[]; io)
+    end
+end
+
+#
 # # Update
 #
 @testset "update: input checking" begin

--- a/test/new.jl
+++ b/test/new.jl
@@ -2060,9 +2060,10 @@ end
 @testset "dependents: REPL" begin
     isolate() do
         Pkg.REPLMode.TEST_MODE[] = true
-        api, opts = first(Pkg.pkg"dependents Foo")
+        api, args, opts = first(Pkg.pkg"dependents Foo")
         @test api == Pkg.dependents
-        @test first(opts).name == "Foo"
+        @test first(args).name == "Foo"
+        @test isempty(opts)
 
         api, args, opts = first(Pkg.pkg"dependents --all Foo")
         @test api == Pkg.dependents
@@ -2083,11 +2084,13 @@ end
         @test occursin("JSON", str)  # JSON depends on Parsers
         @test occursin("indirect", str)
 
-        # --all flag shows indirect package names
+        # --all flag lists indirect package names; without it, only the count appears
         io = IOBuffer()
         Pkg.dependents("Parsers"; io, all = true)
         str_all = String(take!(io))
         @test occursin("indirect:", str_all)
+        # `all=true` output should be a strict superset (longer) than the summary form
+        @test length(str_all) > length(str)
 
         # Without --all, indirect line has no colon (just count)
         io = IOBuffer()
@@ -2096,6 +2099,15 @@ end
         m = match(r"(\d+) indirect$"m, str_no_all)
         @test m !== nothing
         @test parse(Int, m[1]) > 0
+
+        # Multi-package invocation: both targets appear, separated
+        io = IOBuffer()
+        Pkg.dependents([Pkg.PackageSpec(; name = "Parsers"), Pkg.PackageSpec(; name = "JSON")]; io)
+        str_multi = String(take!(io))
+        @test occursin("Parsers", str_multi)
+        @test occursin("JSON", str_multi)
+        # Two `Dependents` headers, one per package
+        @test count("Dependents", str_multi) == 2
 
         # Package not in registry
         @test_throws PkgError Pkg.dependents("ThisPackageDefinitelyDoesNotExist123456"; io)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/Pkg.jl/issues/871

Add `Pkg.dependents` / `pkg> dependents` to list packages that depend on a given package across all reachable registries. Shows direct dependents by name and indirect dependent count (use `--all` to expand).

```
(@v1.14) pkg> dependents FFMPEG
  Dependents FFMPEG [c87230d0]
  Found in: General (/Users/ian/.julia/registries/General.toml)
  PrivateRegistry registry
    2 direct: PrivatePackage1, PrivatePackage2
  General registry
    26 direct: AbstractPlotting, BaslerCamera, BeforeIT, ContactImplicitMPC, Dojo, DungAnalyse, EnsembleKalmanProcesses, GeophysicalModelGenerator, IMAS, Javis, Layered, Luxor, Makie, MakieGallery, MeshCat, MuJoCo, MultiGridBarrier, MultiGridBarrier3d, NMFk, Plots, RandomFeatures, Reel, RobotVisualizer, StableSpectralElements, TrajectoryOptimization, VideoIO
    7884 indirect
```

Developed with Claude