### PR TITLE
Fix workspace test path: use test env Context for instantiate and precompile

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3072,8 +3072,10 @@ function test(
         if testdir(source_path) in dirname.(keys(ctx.env.workspace))
             proj = Base.locate_project_file(abspath(testdir(source_path)))
             env = EnvCache(proj)
-            # Instantiate test env
-            Pkg.instantiate(Context(env = env); allow_autoprecomp = false)
+            # Use a Context pointing at the test env so that instantiate and
+            # precompile operate on the test project rather than the parent.
+            test_ctx = Context(env = env; io = ctx.io)
+            Pkg.instantiate(test_ctx; allow_autoprecomp = false)
             status(env, ctx.registries; mode = PKGMODE_COMBINED, io = ctx.io, ignore_indent = false, show_usagetips = false)
             flags = gen_subprocess_flags(source_path; coverage, julia_args)
 
@@ -3081,7 +3083,7 @@ function test(
                 cacheflags = parse(CacheFlags, read(`$(Base.julia_cmd()) $(flags) --eval 'show(Base.CacheFlags())'`, String))
                 # Don't warn about already loaded packages, since we are going to run tests in a new
                 # subprocess anyway.
-                Pkg.precompile(; io = ctx.io, warn_loaded = false, configs = flags => cacheflags)
+                Pkg.precompile(test_ctx; io = ctx.io, warn_loaded = false, configs = flags => cacheflags)
             end
 
             printpkgstyle(ctx.io, :Testing, "Running tests...")

--- a/test/test_packages/WorkspaceTestInstantiate/test/Project.toml
+++ b/test/test_packages/WorkspaceTestInstantiate/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_packages/WorkspaceTestInstantiate/test/runtests.jl
+++ b/test/test_packages/WorkspaceTestInstantiate/test/runtests.jl
@@ -1,1 +1,5 @@
+using Test
+# Example is a test-only dep (not in root Project.toml).
+# Verify it was precompiled against the test project, not the parent.
+@test Base.isprecompiled(Base.identify_package("Example"))
 using Example

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -175,13 +175,15 @@ end
             path = copy_test_package(dir, "WorkspaceTestInstantiate")
             cd(path) do
                 with_current_env() do
-                    @test !isfile("Manifest.toml")
-                    @test !isfile("test/Manifest.toml")
-                    Pkg.test()
-                    @test isfile("Manifest.toml")
-                    @test !isfile("test/Manifest.toml")
-                    rm(joinpath(DEPOT_PATH[1], "packages", "Example"); recursive = true)
-                    Pkg.test()
+                    withenv("JULIA_PKG_PRECOMPILE_AUTO" => "1") do
+                        @test !isfile("Manifest.toml")
+                        @test !isfile("test/Manifest.toml")
+                        Pkg.test()
+                        @test isfile("Manifest.toml")
+                        @test !isfile("test/Manifest.toml")
+                        rm(joinpath(DEPOT_PATH[1], "packages", "Example"); recursive = true)
+                        Pkg.test()
+                    end
                 end
             end
         end


### PR DESCRIPTION
Previously, `Pkg.precompile()` was called without a Context, so it used the currently active (parent) project instead of the test project. The `instantiate` call also created a throwaway Context each time.

Create a shared `test_ctx` pointing at the test env and pass it to both `instantiate` and `precompile` so they operate on the correct project.