### PR TITLE
Add `maxfailures` option to `Pkg.test`

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -567,10 +567,10 @@ function test(
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
         allow_reresolve::Bool = true,
-        maxfailures::Int = 0,
+        maxfailures::Union{Nothing,Int} = nothing,
         kwargs...
     )
-    maxfailures >= 0 || pkgerror("`maxfailures` must be a non-negative integer, got $maxfailures")
+    maxfailures !== nothing && maxfailures < 0 && pkgerror("`maxfailures` must be a non-negative integer, got $maxfailures")
     julia_args = Cmd(julia_args)
     test_args = Cmd(test_args)
     Context!(ctx; kwargs...)

--- a/src/API.jl
+++ b/src/API.jl
@@ -567,8 +567,10 @@ function test(
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
         allow_reresolve::Bool = true,
+        maxfailures::Int = 0,
         kwargs...
     )
+    maxfailures >= 0 || pkgerror("`maxfailures` must be a non-negative integer, got $maxfailures")
     julia_args = Cmd(julia_args)
     test_args = Cmd(test_args)
     Context!(ctx; kwargs...)
@@ -593,6 +595,7 @@ function test(
         force_latest_compatible_version,
         allow_earlier_backwards_compatible_versions,
         allow_reresolve,
+        maxfailures,
     )
     return
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2675,21 +2675,10 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free = true)
     end
 end
 
-function gen_test_code(source_path::String; test_args::Cmd, maxfailures::Int = 0)
+function gen_test_code(source_path::String; test_args::Cmd)
     test_file = testfile(source_path)
-    maxfailures_setup = if maxfailures > 0
-        """
-        let _Test = Base.require(Base.PkgId(Base.UUID("8dfed614-e22c-358e-b65c-d98082ae9e1e"), "Test"))
-            _Test.global_failure_count[] = 0
-            _Test.global_failure_limit = $maxfailures
-        end
-        """
-    else
-        ""
-    end
     return """
     $(Base.load_path_setup_code(false))
-    $maxfailures_setup
     cd($(repr(dirname(test_file))))
     append!(empty!(ARGS), $(repr(test_args.exec)))
     include($(repr(test_file)))
@@ -2987,25 +2976,24 @@ end
 testdir(source_path::String) = joinpath(source_path, "test")
 testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 
-function run_test_subprocess(io::IO, flags::Cmd, source_path::String, test_args::Cmd; with_threads::Bool, maxfailures::Int = 0)
-    code = gen_test_code(source_path; test_args, maxfailures)
+function run_test_subprocess(io::IO, flags::Cmd, source_path::String, test_args::Cmd; with_threads::Bool)
+    code = gen_test_code(source_path; test_args)
     threads_arg = with_threads ? `--threads=$(get_threads_spec())` : ``
     cmd = `$(Base.julia_cmd()) $threads_arg $(flags) --eval $code`
     return subprocess_handler(cmd, io, "Tests interrupted. Exiting the test process")
 end
 
-function run_test_subprocess_in_env(io::IO, flags::Cmd, source_path::String, test_args::Cmd; maxfailures::Int = 0)
+function run_test_subprocess_in_env(io::IO, flags::Cmd, source_path::String, test_args::Cmd)
     path_sep = Sys.iswindows() ? ';' : ':'
     return withenv("JULIA_LOAD_PATH" => "@$(path_sep)$(testdir(source_path))", "JULIA_PROJECT" => nothing) do
-        run_test_subprocess(io, flags, source_path, test_args; with_threads = false, maxfailures)
+        run_test_subprocess(io, flags, source_path, test_args; with_threads = false)
     end
 end
 
 function run_sandboxed_tests!(
         ctx::Context, pkg::PackageSpec, source_path::String, test_args::Cmd,
         coverage::Union{Bool, AbstractString}, julia_args::Cmd, test_fn,
-        pkgs_errored::Vector{Tuple{String, Base.Process}};
-        maxfailures::Int = 0
+        pkgs_errored::Vector{Tuple{String, Base.Process}}
     )
     test_fn !== nothing && test_fn()
     sandbox_ctx = Context(; io = ctx.io)
@@ -3025,7 +3013,7 @@ function run_sandboxed_tests!(
 
     printpkgstyle(ctx.io, :Testing, "Running tests...")
     flush(ctx.io)
-    p, interrupted = run_test_subprocess(ctx.io, flags, source_path, test_args; with_threads = true, maxfailures)
+    p, interrupted = run_test_subprocess(ctx.io, flags, source_path, test_args; with_threads = true)
     if success(p)
         printpkgstyle(ctx.io, :Testing, pkg.name * " tests passed ")
     elseif !interrupted
@@ -3041,7 +3029,7 @@ function test(
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
         allow_reresolve::Bool = true,
-        maxfailures::Int = 0
+        maxfailures::Union{Nothing,Int} = nothing
     )
     Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
 
@@ -3079,6 +3067,7 @@ function test(
 
     # sandbox
     pkgs_errored = Tuple{String, Base.Process}[]
+    maxfailures_env = maxfailures !== nothing ? ("JULIA_TEST_MAXFAILURES" => string(maxfailures),) : ()
     for (pkg, source_path) in zip(pkgs, source_paths)
         # TODO: DRY with code below.
         # If the test is in the our "workspace", no need to create a temp env etc, just activate and run thests
@@ -3101,7 +3090,9 @@ function test(
 
             printpkgstyle(ctx.io, :Testing, "Running tests...")
             flush(ctx.io)
-            p, interrupted = run_test_subprocess_in_env(ctx.io, flags, source_path, test_args; maxfailures)
+            p, interrupted = withenv(maxfailures_env...) do
+                run_test_subprocess_in_env(ctx.io, flags, source_path, test_args)
+            end
             if success(p)
                 printpkgstyle(ctx.io, :Testing, pkg.name * " tests passed ")
             elseif !interrupted
@@ -3125,18 +3116,19 @@ function test(
         end
         # now we sandbox
         printpkgstyle(ctx.io, :Testing, pkg.name)
-        sandbox(
-            ctx, pkg, testdir(source_path), test_project_override;
-            preferences = test_project_preferences,
-            force_latest_compatible_version,
-            allow_earlier_backwards_compatible_versions,
-            allow_reresolve,
-        ) do
-            run_sandboxed_tests!(
-                ctx, pkg, source_path, test_args,
-                coverage, julia_args, test_fn, pkgs_errored;
-                maxfailures,
-            )
+        withenv(maxfailures_env...) do
+            sandbox(
+                ctx, pkg, testdir(source_path), test_project_override;
+                preferences = test_project_preferences,
+                force_latest_compatible_version,
+                allow_earlier_backwards_compatible_versions,
+                allow_reresolve,
+            ) do
+                run_sandboxed_tests!(
+                    ctx, pkg, source_path, test_args,
+                    coverage, julia_args, test_fn, pkgs_errored,
+                )
+            end
         end
     end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2675,10 +2675,21 @@ function free(ctx::Context, pkgs::Vector{PackageSpec}; err_if_free = true)
     end
 end
 
-function gen_test_code(source_path::String; test_args::Cmd)
+function gen_test_code(source_path::String; test_args::Cmd, maxfailures::Int = 0)
     test_file = testfile(source_path)
+    maxfailures_setup = if maxfailures > 0
+        """
+        let _Test = Base.require(Base.PkgId(Base.UUID("8dfed614-e22c-358e-b65c-d98082ae9e1e"), "Test"))
+            _Test.global_failure_count[] = 0
+            _Test.global_failure_limit = $maxfailures
+        end
+        """
+    else
+        ""
+    end
     return """
     $(Base.load_path_setup_code(false))
+    $maxfailures_setup
     cd($(repr(dirname(test_file))))
     append!(empty!(ARGS), $(repr(test_args.exec)))
     include($(repr(test_file)))
@@ -2976,24 +2987,25 @@ end
 testdir(source_path::String) = joinpath(source_path, "test")
 testfile(source_path::String) = joinpath(testdir(source_path), "runtests.jl")
 
-function run_test_subprocess(io::IO, flags::Cmd, source_path::String, test_args::Cmd; with_threads::Bool)
-    code = gen_test_code(source_path; test_args)
+function run_test_subprocess(io::IO, flags::Cmd, source_path::String, test_args::Cmd; with_threads::Bool, maxfailures::Int = 0)
+    code = gen_test_code(source_path; test_args, maxfailures)
     threads_arg = with_threads ? `--threads=$(get_threads_spec())` : ``
     cmd = `$(Base.julia_cmd()) $threads_arg $(flags) --eval $code`
     return subprocess_handler(cmd, io, "Tests interrupted. Exiting the test process")
 end
 
-function run_test_subprocess_in_env(io::IO, flags::Cmd, source_path::String, test_args::Cmd)
+function run_test_subprocess_in_env(io::IO, flags::Cmd, source_path::String, test_args::Cmd; maxfailures::Int = 0)
     path_sep = Sys.iswindows() ? ';' : ':'
     return withenv("JULIA_LOAD_PATH" => "@$(path_sep)$(testdir(source_path))", "JULIA_PROJECT" => nothing) do
-        run_test_subprocess(io, flags, source_path, test_args; with_threads = false)
+        run_test_subprocess(io, flags, source_path, test_args; with_threads = false, maxfailures)
     end
 end
 
 function run_sandboxed_tests!(
         ctx::Context, pkg::PackageSpec, source_path::String, test_args::Cmd,
         coverage::Union{Bool, AbstractString}, julia_args::Cmd, test_fn,
-        pkgs_errored::Vector{Tuple{String, Base.Process}}
+        pkgs_errored::Vector{Tuple{String, Base.Process}};
+        maxfailures::Int = 0
     )
     test_fn !== nothing && test_fn()
     sandbox_ctx = Context(; io = ctx.io)
@@ -3013,7 +3025,7 @@ function run_sandboxed_tests!(
 
     printpkgstyle(ctx.io, :Testing, "Running tests...")
     flush(ctx.io)
-    p, interrupted = run_test_subprocess(ctx.io, flags, source_path, test_args; with_threads = true)
+    p, interrupted = run_test_subprocess(ctx.io, flags, source_path, test_args; with_threads = true, maxfailures)
     if success(p)
         printpkgstyle(ctx.io, :Testing, pkg.name * " tests passed ")
     elseif !interrupted
@@ -3028,7 +3040,8 @@ function test(
         test_fn = nothing,
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
-        allow_reresolve::Bool = true
+        allow_reresolve::Bool = true,
+        maxfailures::Int = 0
     )
     Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
 
@@ -3088,7 +3101,7 @@ function test(
 
             printpkgstyle(ctx.io, :Testing, "Running tests...")
             flush(ctx.io)
-            p, interrupted = run_test_subprocess_in_env(ctx.io, flags, source_path, test_args)
+            p, interrupted = run_test_subprocess_in_env(ctx.io, flags, source_path, test_args; maxfailures)
             if success(p)
                 printpkgstyle(ctx.io, :Testing, pkg.name * " tests passed ")
             elseif !interrupted
@@ -3121,7 +3134,8 @@ function test(
         ) do
             run_sandboxed_tests!(
                 ctx, pkg, source_path, test_args,
-                coverage, julia_args, test_fn, pkgs_errored,
+                coverage, julia_args, test_fn, pkgs_errored;
+                maxfailures,
             )
         end
     end

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -556,6 +556,13 @@ end
 #
 # # Option Maps
 #
+function do_maxfailures(x::String)
+    n = tryparse(Int, x)
+    n === nothing && pkgerror("`--maxfailures` requires a non-negative integer argument, got $(repr(x))")
+    n >= 0 || pkgerror("`--maxfailures` requires a non-negative integer argument, got $n")
+    return n
+end
+
 function do_preserve(x::String)
     x == "installed"        && return Types.PRESERVE_ALL_INSTALLED
     x == "all"              && return Types.PRESERVE_ALL

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -22,8 +22,8 @@ compound_declarations = [
                 in the package directory. The option `--coverage` can be used to run the tests with
                 coverage enabled. The `startup.jl` file is disabled during testing unless
                 julia is started with `--startup-file=yes`. The option `--maxfailures=n` stops the
-                test run after `n` cumulative failures and errors. When `n` is 0 (the default)
-                all tests always run to completion.
+                test run after `n` cumulative failures or errors. When `n` is 0 the run stops on the
+                first failure. When not set, all tests always run to completion.
                 """,
         ],
         PSA[

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -10,17 +10,20 @@ compound_declarations = [
             :arg_parser => parse_package,
             :option_spec => [
                 PSA[:name => "coverage", :api => :coverage => true],
+                PSA[:name => "maxfailures", :takes_arg => true, :api => :maxfailures => do_maxfailures],
             ],
             :completions => :complete_installed_packages,
             :description => "run tests for packages",
             :help => md"""
-                    test [--coverage] [pkg[=uuid]] ...
+                    test [--coverage] [--maxfailures=n] [pkg[=uuid]] ...
 
                 Run the tests for package `pkg`, or for the current project (which thus needs to be
                 a package) if `pkg` is omitted.  This is done by running the file `test/runtests.jl`
                 in the package directory. The option `--coverage` can be used to run the tests with
                 coverage enabled. The `startup.jl` file is disabled during testing unless
-                julia is started with `--startup-file=yes`.
+                julia is started with `--startup-file=yes`. The option `--maxfailures=n` stops the
+                test run after `n` cumulative failures and errors. When `n` is 0 (the default)
+                all tests always run to completion.
                 """,
         ],
         PSA[

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -252,6 +252,57 @@ temp_pkg_dir() do project_path
         Pkg.rm(TEST_PKG.name)
     end
 
+    @testset "maxfailures" begin
+        mktempdir() do dir
+            pkg_path = joinpath(dir, "MaxFailuresPkg")
+            mkpath(joinpath(pkg_path, "src"))
+            write(joinpath(pkg_path, "Project.toml"), """
+                name = "MaxFailuresPkg"
+                uuid = "00000000-dead-beef-0000-000000000001"
+                version = "0.1.0"
+                """)
+            write(joinpath(pkg_path, "src", "MaxFailuresPkg.jl"), """
+                module MaxFailuresPkg
+                end
+                """)
+            mkpath(joinpath(pkg_path, "test"))
+            # 5 testsets: first 3 fail, last 2 pass
+            write(joinpath(pkg_path, "test", "runtests.jl"), """
+                using Test
+                @testset "A" begin; @test false; end
+                @testset "B" begin; @test false; end
+                @testset "C" begin; @test false; end
+                @testset "D" begin; @test true;  end
+                @testset "E" begin; @test true;  end
+                """)
+
+            Pkg.develop(Pkg.PackageSpec(path = pkg_path))
+
+            # Default: no limit — all testsets run.
+            iob = IOBuffer()
+            try; Pkg.test("MaxFailuresPkg"; io = iob); catch; end
+            out = String(take!(iob))
+            @test occursin("D", out) && occursin("E", out)
+
+            # maxfailures=0 means no limit (same as default).
+            iob = IOBuffer()
+            try; Pkg.test("MaxFailuresPkg"; maxfailures = 0, io = iob); catch; end
+            out = String(take!(iob))
+            @test occursin("D", out) && occursin("E", out)
+
+            # maxfailures=2 should stop after the 2nd failure.
+            iob = IOBuffer()
+            try; Pkg.test("MaxFailuresPkg"; maxfailures = 2, io = iob); catch; end
+            out = String(take!(iob))
+            @test occursin("Max failures reached", out)
+
+            # Negative value must error before launching any subprocess.
+            @test_throws Pkg.Types.PkgError Pkg.test("MaxFailuresPkg"; maxfailures = -1)
+
+            Pkg.rm("MaxFailuresPkg")
+        end
+    end
+
     @testset "coverage specific path" begin
         mktempdir() do tmp
             coverage_path = joinpath(tmp, "tracefile.info")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -266,39 +266,45 @@ temp_pkg_dir() do project_path
                 end
                 """)
             mkpath(joinpath(pkg_path, "test"))
-            # 5 testsets: first 3 fail, last 2 pass
+            # Outer testset so all inner testsets run even when some fail.
+            # REACHED_D and REACHED_E are unique enough to check presence/absence.
             write(joinpath(pkg_path, "test", "runtests.jl"), """
                 using Test
-                @testset "A" begin; @test false; end
-                @testset "B" begin; @test false; end
-                @testset "C" begin; @test false; end
-                @testset "D" begin; @test true;  end
-                @testset "E" begin; @test true;  end
+                @testset "AllTests" begin
+                    @testset "A" begin; @test false; end
+                    @testset "B" begin; @test false; end
+                    @testset "C" begin; @test false; end
+                    @testset "REACHED_D" begin; @test true; end
+                    @testset "REACHED_E" begin; @test true; end
+                end
                 """)
-
+            
             Pkg.develop(Pkg.PackageSpec(path = pkg_path))
-
-            # Default: no limit — all testsets run.
+            
+            # Default: no limit, all testsets run including D and E.
             iob = IOBuffer()
             try; Pkg.test("MaxFailuresPkg"; io = iob); catch; end
             out = String(take!(iob))
-            @test occursin("D", out) && occursin("E", out)
-
-            # maxfailures=0 means no limit (same as default).
+            @test occursin("REACHED_D", out)
+            @test occursin("REACHED_E", out)
+            
+            # maxfailures=0: stop on first failure, D and E never run.
             iob = IOBuffer()
             try; Pkg.test("MaxFailuresPkg"; maxfailures = 0, io = iob); catch; end
             out = String(take!(iob))
-            @test occursin("D", out) && occursin("E", out)
-
-            # maxfailures=2 should stop after the 2nd failure.
+            @test !occursin("REACHED_D", out)
+            @test !occursin("REACHED_E", out)
+            
+            # maxfailures=2: stop after 2nd failure (B), D and E never run.
             iob = IOBuffer()
             try; Pkg.test("MaxFailuresPkg"; maxfailures = 2, io = iob); catch; end
             out = String(take!(iob))
-            @test occursin("Max failures reached", out)
-
-            # Negative value must error before launching any subprocess.
+            @test !occursin("REACHED_D", out)
+            @test !occursin("REACHED_E", out)
+            
+            # Negative value must error immediately, before any subprocess launches.
             @test_throws Pkg.Types.PkgError Pkg.test("MaxFailuresPkg"; maxfailures = -1)
-
+            
             Pkg.rm("MaxFailuresPkg")
         end
     end


### PR DESCRIPTION
This is the Pkg side of the `maxfailures` feature. The Test stdlib side lives in JuliaLang/julia#61560 and needs to be merged first for this to work end to end.

**What it does**

Adds a `maxfailures` keyword argument to `Pkg.test`. When not set the behavior is completely unchanged: all tests run to completion. When set to a non-negative integer `n`, the test run stops after `n` cumulative failures or errors:

- `maxfailures=0` stops on the first failure (zero failures tolerated)
- `maxfailures=2` stops after the second failure

**How it works**

Rather than injecting code into the test subprocess, we set `JULIA_TEST_MAXFAILURES` in the parent environment before launching the subprocess. The subprocess inherits the variable, and the Test stdlib reads it via `OncePerProcess` on first use, matching the pattern used by `JULIA_TEST_FAILFAST`. This keeps all internal functions (`gen_test_code`, `run_test_subprocess`, `run_test_subprocess_in_env`, `run_sandboxed_tests!`) completely unchanged.

Also available from the Pkg REPL:

```
pkg> test --maxfailures=n
```

Validation happens before any subprocess is launched, so a negative value throws a `PkgError` immediately.