### PR TITLE
Operations: drop build number from syntax julia_version

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -401,7 +401,7 @@ correct syntax version.
 function get_project_syntax_version(p::Project)::VersionNumber
     # First check syntax.julia_version entry in Project.other
     if p.julia_syntax_version !== nothing
-        return VersionNumber(syntax_table["julia_version"])
+        return p.julia_syntax_version
     end
 
     # If not found, default to minimum(compat["julia"])
@@ -416,7 +416,7 @@ function get_project_syntax_version(p::Project)::VersionNumber
     end
 
     # Finally, if neither of those are set, default to the current Julia version
-    return VERSION
+    return dropbuild(VERSION)
 end
 
 # This has to be done after the packages have been downloaded

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -268,6 +268,13 @@ end
             end
         end
     end
+    @testset "syntax julia_version" begin
+        @testset "dropbuild applied: dev build number dropped" begin
+            # syntax.julia_version should drop the DEV build number to avoid manifest churn
+            p = Pkg.Types.Project()
+            @test Pkg.Operations.get_project_syntax_version(p) == Pkg.Operations.dropbuild(VERSION)
+        end
+    end
 end
 
 @testset "Manifest registry tracking" begin


### PR DESCRIPTION
The `syntax.julia_version` field written to Manifest.toml was recording the full DEV build number (e.g. `1.13.0-DEV.1234`) instead of dropping it to just `1.13.0-DEV`. This caused unnecessary manifest churn on each build, inconsistent with the behavior of the top-level `julia_version` field which already uses `dropbuild`.

Fix `get_project_syntax_version` to:
- Return `p.julia_syntax_version` directly instead of the undefined `syntax_table["julia_version"]` (which was a bug)
- Apply `dropbuild(VERSION)` when falling back to the current Julia version

Fixes JuliaLang/julia#61578