### PR TITLE
make adding non-sysimage stdlibs by branch work again

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -474,7 +474,7 @@ function load_tree_hash!(
         pkg::PackageSpec,
         julia_version,
     )
-    if is_stdlib(pkg.uuid, julia_version) && pkg.tree_hash !== nothing
+    if is_stdlib(pkg.uuid, julia_version) && pkg.tree_hash !== nothing && pkg.repo.source === nothing
         # manifests from newer julia versions might have stdlibs that are upgradable (FORMER_STDLIBS)
         # that have tree_hash recorded, which we need to clear for this version where they are not upgradable
         # given regular stdlibs don't have tree_hash recorded

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -378,6 +378,7 @@ function destructure(manifest::Manifest)::Dict
     for (uuid, entry) in manifest
         # https://github.com/JuliaLang/Pkg.jl/issues/4086
         @assert !(entry.tree_hash !== nothing && entry.path !== nothing)
+        @assert !(entry.repo.source !== nothing && entry.tree_hash === nothing)
 
         new_entry = something(entry.other, Dict{String, Any}())
         new_entry["uuid"] = string(uuid)


### PR DESCRIPTION
Seems this broke in  ffcf85877.

On nightly:

```
(@v1.14) pkg> activate --temp
  Activating new project at `/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_OU9lQi`

(jl_OU9lQi) pkg> add https://github.com/JuliaSparse/SparseArrays.jl
...

# What? This should use the one from the branch, not the bundled one
julia> Base.find_package("SparseArrays")
"/Users/kc/.julia/juliaup/julia-nightly/Julia-1.14.app/Contents/Resources/julia/share/julia/stdlib/v1.14/SparseArrays/src/SparseArrays.jl"
```

Looking at the manifest:

```
[[deps.SparseArrays]]
deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
repo-rev = "main"
repo-url = "https://github.com/JuliaSparse/SparseArrays.jl"
uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
version = "1.13.0"

    [deps.SparseArrays.syntax]
    julia_version = "1.11.0"
```

This is buggy, there needs to be a git-tree-sha1 there.

With this PR:

```
Pkg) pkg> activate --temp
  Activating new project at `/var/folders/2c/rk2fkhgn6c35lr6qp7cll4t00000gn/T/jl_z8hkX1`

(jl_z8hkX1) pkg> add https://github.com/JuliaSparse/SparseArrays.jl
...

julia> Base.find_package("SparseArrays")
"/Users/kc/.julia/packages/SparseArrays/zbETm/src/SparseArrays.jl"
```
