### PR TITLE
REPLExt: opt-in to precompile keyboard controls in pkg> commands

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -136,7 +136,10 @@ function on_done(s, buf, ok, repl)
     ok || return REPL.transition(s, :abort)
     input = String(take!(buf))
     REPL.reset(repl)
-    do_cmds(repl, input)
+    # Opt this task in to the precompile keyboard menu (see JuliaLang/julia#61698).
+    task_local_storage(:precompile_key_controls, true) do
+        do_cmds(repl, input)
+    end
     REPL.prepare_next(repl)
     REPL.reset_state(s)
     return s.current_mode.sticky || REPL.transition(s, main)


### PR DESCRIPTION
Set the task-local flag `:precompile_key_controls => true` while executing a pkg-mode command, so that
`Base.Precompilation.monitor_background_precompile` enables its keyboard menu (`?`, `c`, `d`, ...) on the task running the command.

Without this, the menu's prompt was shown but key presses were ignored, because the listener is gated on `current_task() === roottask` to avoid stealing stdin from the REPL when precompilation is triggered from an unrelated async task. The pkg REPL command task is a safe place to take over stdin, so opt in explicitly.

Fixes JuliaLang/julia#61698