### PR TITLE
REPLExt: don't shell-escape path completions

### DIFF
--- a/ext/REPLExt/completions.jl
+++ b/ext/REPLExt/completions.jl
@@ -34,7 +34,10 @@ function complete_local_dir(s, i1, i2)
 end
 
 function complete_expanded_local_dir(s, i1, i2, expanded_user, oldi2)
-    paths, dir, success = REPL.REPLCompletions.complete_path(s; cmd_escape = true)
+    # Don't shell-escape: Pkg's REPL lexer doesn't interpret backslashes or
+    # other shell metacharacters, and shell-escaping path separators (e.g.
+    # `\` on Windows becoming `'foo\'`) breaks the `isaccessibledir` filter.
+    paths, dir, success = REPL.REPLCompletions.complete_path(s)
     completions = [REPL.REPLCompletions.completion_text(p) for p in paths]
     filter!(completions) do x
         Base.isaccessibledir(joinpath(dir, x))

--- a/test/registry.jl
+++ b/test/registry.jl
@@ -304,7 +304,7 @@ end
             Registry.update(; depots = [depot_off_path], io, update_cooldown = Second(0))
             closewrite(io)
             output = read(io, String)
-            @test occursin("registry at `$(depot_off_path)", output)
+            @test occursin("registry at `$(Base.contractuser(depot_off_path))", output)
 
             # Show that we can install `Example` off of that depot
             empty!(Base.DEPOT_PATH)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -452,16 +452,16 @@ temp_pkg_dir() do project_path
             # local paths
             mkpath("testdir/foo/bar")
             c, r = test_complete("add ")
-            @test Sys.iswindows() ? ("testdir\\\\" in c) : ("testdir/" in c)
-            @test apply_completion("add tes") == (Sys.iswindows() ? "add testdir\\\\" : "add testdir/")
-            @test apply_completion("add ./tes") == (Sys.iswindows() ? "add ./testdir\\\\" : "add ./testdir/")
+            @test Sys.iswindows() ? ("testdir\\" in c) : ("testdir/" in c)
+            @test apply_completion("add tes") == (Sys.iswindows() ? "add testdir\\" : "add testdir/")
+            @test apply_completion("add ./tes") == (Sys.iswindows() ? "add ./testdir\\" : "add ./testdir/")
             c, r = test_complete("dev ./")
-            @test (Sys.iswindows() ? ("testdir\\\\" in c) : ("testdir/" in c))
+            @test (Sys.iswindows() ? ("testdir\\" in c) : ("testdir/" in c))
 
             # complete subdirs
             c, r = test_complete("add testdir/f")
-            @test Sys.iswindows() ? ("foo\\\\" in c) : ("foo/" in c)
-            @test apply_completion("add testdir/f") == (Sys.iswindows() ? "add testdir/foo\\\\" : "add testdir/foo/")
+            @test Sys.iswindows() ? ("foo\\" in c) : ("foo/" in c)
+            @test apply_completion("add testdir/f") == (Sys.iswindows() ? "add testdir/foo\\" : "add testdir/foo/")
             # dont complete files
             touch("README.md")
             c, r = test_complete("add RE")


### PR DESCRIPTION
@StefanKarpinski I threw claude at #4663 
I've not reviewed this. Does it make sense?

----

JuliaLang/julia#61397 unified backtick and shell-mode escaping, so `complete_path(...; cmd_escape=true)` now runs results through `Base.shell_escape_posixly`. On Windows this wraps paths containing `\` in single quotes (e.g. `'testdir\'`), which the Pkg REPL lexer doesn't interpret and which broke the `isaccessibledir` filter, returning empty completions. Pkg paths should be passed through verbatim.

Also update the registry test to apply `Base.contractuser` to the expected path, since #61397 made `contractuser` work on Windows (temp dirs under `C:\Users\...\AppData\Local\Temp` are now printed as `~\AppData\Local\Temp\...`).

Fixes #4663