### PR TITLE
instantiate: add `update_on_mismatch` kwarg to fall back to `update` on a stale manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Pkg v1.14 Release Notes
 =======================
 
+- `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
+  `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
+  or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and
+  helper environments where any compatible set of dependency versions is acceptable. ([#4678])
 - During package source installation, Pkg now reports when a package has an Artifacts.toml but no artifacts match the
   current platform. ([#4646])
 
@@ -217,3 +221,4 @@ Pkg v1.7 Release Notes
 [#4305]: https://github.com/JuliaLang/Pkg.jl/pull/4305
 [#4170]: https://github.com/JuliaLang/Pkg.jl/pull/4170
 [#4287]: https://github.com/JuliaLang/Pkg.jl/pull/4287
+[#4678]: https://github.com/JuliaLang/Pkg.jl/pull/4678

--- a/src/API.jl
+++ b/src/API.jl
@@ -1339,7 +1339,7 @@ function instantiate(
             saved_initial_snapshot[] = true
         end
         printpkgstyle(ctx.io, :Update, "manifest does not match project or Julia version, falling back to `Pkg.update()`", color = Base.info_color())
-        up(ctx; update_registry)
+        up(ctx; update_registry, mode = workspace ? PKGMODE_MANIFEST : PKGMODE_PROJECT)
         allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
         return
     end

--- a/src/API.jl
+++ b/src/API.jl
@@ -1293,7 +1293,8 @@ function instantiate(
         ctx::Context; manifest::Union{Bool, Nothing} = nothing,
         update_registry::Bool = true, verbose::Bool = false,
         platform::AbstractPlatform = HostPlatform(), allow_build::Bool = true, allow_autoprecomp::Bool = true,
-        workspace::Bool = false, julia_version_strict::Bool = false, kwargs...
+        workspace::Bool = false, julia_version_strict::Bool = false,
+        update_on_mismatch::Bool = false, kwargs...
     )
     Context!(ctx; kwargs...)
     if Registry.download_default_registries(ctx.io)
@@ -1302,7 +1303,9 @@ function instantiate(
     Operations.ensure_manifest_registries!(ctx)
     if !isfile(ctx.env.project_file) && isfile(ctx.env.manifest_file)
         _manifest = Pkg.Types.read_manifest(ctx.env.manifest_file)
-        Types.check_manifest_julia_version_compat(_manifest, ctx.env.manifest_file; julia_version_strict)
+        # Skip the version check when update_on_mismatch is set; the recursion below
+        # will detect the mismatch via manifest_is_mismatched and fall back to update.
+        update_on_mismatch || Types.check_manifest_julia_version_compat(_manifest, ctx.env.manifest_file; julia_version_strict)
         deps = Dict{String, String}()
         for (uuid, pkg) in _manifest
             if pkg.name in keys(deps)
@@ -1312,7 +1315,7 @@ function instantiate(
             deps[pkg.name] = string(uuid)
         end
         Types.write_project(Dict("deps" => deps), ctx.env.project_file)
-        return instantiate(Context(); manifest = manifest, update_registry = update_registry, allow_autoprecomp = allow_autoprecomp, verbose = verbose, platform = platform, kwargs...)
+        return instantiate(Context(); manifest = manifest, update_registry = update_registry, allow_autoprecomp = allow_autoprecomp, verbose = verbose, platform = platform, update_on_mismatch = update_on_mismatch, kwargs...)
     end
     if (!isfile(ctx.env.manifest_file) && manifest === nothing) || manifest == false
         # given no manifest exists, only allow invoking a registry update if there are project deps
@@ -1324,6 +1327,23 @@ function instantiate(
     if !isfile(ctx.env.manifest_file) && manifest == true
         pkgerror("expected manifest file at `$(ctx.env.manifest_file)` but it does not exist")
     end
+
+    if update_on_mismatch && Operations.manifest_is_mismatched(ctx.env)
+        # We're about to mutate the manifest via `up`, so save a pre-mutation snapshot
+        # for `Pkg.undo` to revert to (the convenience macro at the top of this file
+        # does this for other mutating ops, but `instantiate` is not in its list).
+        # Call with no args so the snapshot reads fresh state from disk; passing
+        # `ctx.env` would share the manifest reference that `up` mutates in place.
+        if !saved_initial_snapshot[]
+            add_snapshot_to_undo()
+            saved_initial_snapshot[] = true
+        end
+        printpkgstyle(ctx.io, :Update, "manifest does not match project or Julia version, falling back to `Pkg.update()`", color = Base.info_color())
+        up(ctx; update_registry)
+        allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
+        return
+    end
+
     Types.check_manifest_julia_version_compat(ctx.env.manifest, ctx.env.manifest_file; julia_version_strict)
 
     if Operations.is_manifest_current(ctx.env) === false

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3782,6 +3782,29 @@ function is_manifest_current(env::EnvCache)
     end
 end
 
+# Returns true when the manifest cannot be used as-is and would need a re-resolve
+# (or update) to match the project and current Julia. Used by `instantiate(update_on_mismatch=true)`
+# to decide whether to fall back to `Pkg.update()`.
+function manifest_is_mismatched(env::EnvCache)
+    manifest = env.manifest
+    if !isempty(manifest.deps)
+        # v1 format predates the julia_version entry, so the version is unknown;
+        # treat as mismatched since we can't verify compatibility with current Julia
+        manifest.manifest_format < v"2" && return true
+        v = manifest.julia_version
+        v === nothing && return true
+        Base.thisminor(v) != Base.thisminor(VERSION) && return true
+    end
+    is_manifest_current(env) === false && return true
+    # `project_hash` was added to the v2 format only later, so a v2.0/2.1 manifest
+    # may not have it; in that case `is_manifest_current` returns `nothing` and we
+    # still need an explicit direct-dep check to catch project drift.
+    for (_, uuid) in env.project.deps
+        get(manifest, uuid, nothing) === nothing && return true
+    end
+    return false
+end
+
 function compat_line(io, pkg, uuid, compat_str, longest_dep_len; indent = "  ")
     iob = IOBuffer()
     ioc = IOContext(iob, :color => get(io, :color, false)::Bool)

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -617,7 +617,7 @@ Request a `ProjectInfo` struct which contains information about the active proje
 const project = API.project
 
 """
-    Pkg.instantiate(; verbose = false, workspace=false, io::IO=stderr, julia_version_strict=false)
+    Pkg.instantiate(; verbose = false, workspace=false, io::IO=stderr, julia_version_strict=false, update_on_mismatch=false)
 
 If a `Manifest.toml` file exists in the active project, download all
 the packages declared in that manifest.
@@ -629,6 +629,13 @@ redirecting to the `build.log` file.
 If no `Project.toml` exist in the current active project, create one with all the
 dependencies in the manifest and instantiate the resulting project.
 `julia_version_strict=true` will turn manifest version check failures into errors instead of logging warnings.
+
+`update_on_mismatch=true` falls back to [`Pkg.update`](@ref) when the existing manifest cannot
+be used as-is — for example, when the project's dependencies or compat bounds have changed
+since the manifest was last resolved, or when the manifest was resolved with a different Julia
+minor version. The default (`false`) preserves the existing behavior of warning or erroring in
+those cases. This is intended for tooling and helper environments where any version of the
+dependencies that satisfies the project is acceptable, and the goal is "just make it work".
 
 After packages have been installed the project will be precompiled.
 See more and how to disable auto-precompilation at [Environment Precompilation](@ref).

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -51,17 +51,21 @@ compound_declarations = [
                 PSA[:name => "verbose", :short_name => "v", :api => :verbose => true],
                 PSA[:name => "workspace", :api => :workspace => true],
                 PSA[:name => "julia_version_strict", :api => :julia_version_strict => false],
+                PSA[:name => "update_on_mismatch", :short_name => "u", :api => :update_on_mismatch => true],
             ],
             :description => "downloads all the dependencies for the project",
             :help => md"""
-                    instantiate [-v|--verbose] [--workspace] [--julia_version_strict]
-                    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-m|--manifest]
-                    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-p|--project]
+                    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-u|--update_on_mismatch]
+                    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-u|--update_on_mismatch] [-m|--manifest]
+                    instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-u|--update_on_mismatch] [-p|--project]
 
                 Download all the dependencies for the current project at the version given by the project's manifest.
                 If no manifest exists or the `--project` option is given, resolve and download the dependencies compatible with the project.
                 If `--workspace` is given, all dependencies in the workspace will be downloaded.
                 If `--julia_version_strict` is given, manifest version check failures will error instead of log warnings.
+                If `-u`/`--update_on_mismatch` is given, fall back to `pkg> update` when the manifest does not match the project or
+                was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling environments
+                where any compatible set of dependency versions is acceptable.
 
                 After packages have been installed the project will be precompiled. For more information see `pkg> ?precompile`.
                 """,

--- a/test/manifests.jl
+++ b/test/manifests.jl
@@ -275,6 +275,86 @@ end
             @test Pkg.Operations.get_project_syntax_version(p) == Pkg.Operations.dropbuild(VERSION)
         end
     end
+
+    @testset "update_on_mismatch" begin
+        @testset "manifest from a different julia minor version" begin
+            if VERSION >= v"1.8"
+                # Without the flag, just warns and keeps the stale manifest
+                reference_manifest_isolated_test("v2.0") do env_dir, env_manifest
+                    Pkg.activate(env_dir)
+                    @test_logs (:warn, r"The active manifest file") Pkg.instantiate()
+                    @test Pkg.Types.Context().env.manifest.julia_version == v"1.7.0-DEV"
+                end
+                # With update_on_mismatch=true, falls back to update so the manifest
+                # is regenerated for the current Julia version
+                reference_manifest_isolated_test("v2.0") do env_dir, env_manifest
+                    Pkg.activate(env_dir)
+                    Pkg.instantiate(update_on_mismatch = true)
+                    @test Pkg.Types.Context().env.manifest.julia_version == Pkg.Operations.dropbuild(VERSION)
+                end
+            end
+        end
+
+        @testset "manifest stale due to compat change" begin
+            sync_msg_str = r"The project dependencies or compat requirements have changed since the manifest was last resolved."
+
+            # Default: instantiate just warns, manifest stays stale
+            isolate(loaded_depot = true) do
+                Pkg.activate(; temp = true)
+                Pkg.add("Example")
+                Pkg.compat("Example", "0.4")
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === false
+                @test_logs (:warn, sync_msg_str) Pkg.instantiate()
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === false
+            end
+
+            # update_on_mismatch=true: falls back to update, manifest becomes current
+            isolate(loaded_depot = true) do
+                Pkg.activate(; temp = true)
+                Pkg.add("Example")
+                Pkg.compat("Example", "0.4")
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === false
+                Pkg.instantiate(update_on_mismatch = true)
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === true
+            end
+        end
+
+        @testset "no mismatch: update_on_mismatch=true is a no-op" begin
+            isolate(loaded_depot = true) do
+                Pkg.activate(; temp = true)
+                Pkg.add("Example")
+                ex_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+                version_before = Pkg.Types.Context().env.manifest[ex_uuid].version
+                Pkg.instantiate(update_on_mismatch = true)
+                @test Pkg.is_manifest_current(Pkg.Types.Context()) === true
+                @test Pkg.Types.Context().env.manifest[ex_uuid].version == version_before
+            end
+        end
+
+        @testset "undo reverts the fallback even as first op" begin
+            # If instantiate(update_on_mismatch=true) is the first op in a session and
+            # triggers the fallback, the pre-update state must be snapshotted so that
+            # Pkg.undo can revert to it.
+            isolate(loaded_depot = true) do
+                cd_tempdir() do tmp
+                    Pkg.activate(".")
+                    Pkg.add("Example")
+                    Pkg.compat("Example", "0.4")
+                    proj_file = Pkg.Types.Context().env.project_file
+                    # Simulate "fresh session" by clearing undo state
+                    delete!(Pkg.API.undo_entries, proj_file)
+                    Pkg.API.saved_initial_snapshot[] = false
+                    ex_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+                    version_pre = Pkg.Types.Context().env.manifest[ex_uuid].version
+                    Pkg.instantiate(update_on_mismatch = true)
+                    version_post = Pkg.Types.Context().env.manifest[ex_uuid].version
+                    @test version_post != version_pre
+                    Pkg.undo()
+                    @test Pkg.Types.Context().env.manifest[ex_uuid].version == version_pre
+                end
+            end
+        end
+    end
 end
 
 @testset "Manifest registry tracking" begin


### PR DESCRIPTION
There's currently no Pkg API for the workflow "use the existing manifest if it works, otherwise regenerate it."
Each of the three closest options covers something else:

- `Pkg.instantiate` errors or warns when the manifest can't be used as-is.
- `Pkg.resolve` doesn't install.
- `Pkg.update` always regenerates, even when the manifest was fine.

For tooling and helper environments (formatters, doc-render scripts, language-server bootstraps) what I actually
want is the first option. I don't care about the exact dependency versions; I want the env to keep working across
teammates editing `Project.toml` and Julia minor bumps.

One simple example where I hit this is Makie's [`tooling/formatter/format.jl`](https://github.com/MakieOrg/Makie.jl/blob/master/tooling/formatter/format.jl)): I want to be able to run
`julia ./tooling/formatter/format.jl` and have the formatter just work, no matter which Julia version I happen to
have active that day, no matter whether the formatter's `Project.toml` has been bumped since I last ran it. The
local `Manifest.toml` typically sticks around across git switches because it's gitignored, so any change someone
made on another branch (a new dep, a tightened compat) leaves my local manifest stale rather than getting reset.
Today that script is a plain `Pkg.instantiate()` and breaks the moment the existing manifest is no longer usable.

Just calling `Pkg.update()` instead isn't the answer either: every run may do a registry update (which by itself
takes a noticeable moment), and any time a dep version actually moves it triggers precompilation. Dep versions
moving isn't constant but it happens often enough that, over the lifetime of running the script, the cost adds
up. The whole point of the script is to be quick to invoke.

In Quarto's Julia engine I ended up [reimplementing this kind of logic by hand](https://github.com/PumasAI/quarto-julia-engine/blob/main/_extensions/julia-engine/ensure_environment.jl)),
inspecting `is_manifest_current` and the manifest's recorded `julia_version` and switching between `instantiate`
and `update` myself.

## What this adds

A new `update_on_mismatch::Bool = false` keyword argument to `Pkg.instantiate`, with a corresponding REPL flag
`-u` / `--update_on_mismatch`. When set, `instantiate` falls back to `Pkg.update()` whenever the manifest cannot
be used as-is, instead of warning or erroring. The default (`false`) preserves the existing behavior.

```julia
Pkg.instantiate(update_on_mismatch = true)
```

```
pkg> instantiate -u
```

The fallback fires when any of the following holds (`Operations.manifest_is_mismatched`):

- the manifest is in v1 format (predates the `julia_version` entry, so Julia compatibility can't be verified);
- the manifest's recorded `julia_version` is missing or differs from the current Julia at minor-version granularity;
- `is_manifest_current(env) === false` (project hash recorded in the manifest doesn't match the current project);
- a direct dep in `Project.toml` has no corresponding entry in the manifest. This is caught explicitly because v2.0
  and v2.1 manifests pre-date the `project_hash` entry (see `test/manifest/formats/v2.0/Manifest.toml` and
  `v2.1/Manifest.toml`, neither of which contains it), so `is_manifest_current` returns `nothing` for those and
  can't catch project drift on its own.

These mirror the conditions that the existing `instantiate` flow currently warns or errors about. With the flag,
each branch point falls back to `up(ctx)` instead.
