### PR TITLE
REPLExt: cache the pkg> prompt until the next command

### DIFF
--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -56,9 +56,10 @@ function LineEdit.complete_line(c::PkgCompletionProvider, s; hint::Bool = false)
     return named_completions, region, should_complete
 end
 
-prev_project_file = nothing
-prev_project_timestamp = nothing
-prev_prefix = ""
+# Cached `pkg>` prompt. Computed once per prompt display and reused on every
+# subsequent line refresh to avoid per-keystroke stat/TOML work on the active
+# project (#4683). Invalidated when a command is entered or pkg mode is re-entered.
+const cached_prompt = Ref{Union{String, Nothing}}(nothing)
 
 function projname(project_file::String)
     project = try
@@ -81,7 +82,8 @@ function projname(project_file::String)
 end
 
 function promptf()
-    global prev_project_timestamp, prev_prefix, prev_project_file
+    cached = cached_prompt[]
+    cached === nothing || return cached
     project_file = try
         Types.find_project_file()
     catch
@@ -89,33 +91,30 @@ function promptf()
     end
     prefix = ""
     if project_file !== nothing
-        if prev_project_file == project_file && prev_project_timestamp == mtime(project_file)
-            prefix = prev_prefix
-        else
-            project_name = projname(project_file)
-            if project_name !== nothing
-                root = Types.find_root_base_project(project_file)
-                rootname = projname(root)
-                if root !== project_file
-                    path_prefix = "/" * dirname(Types.relative_project_path(root, project_file))
-                else
-                    path_prefix = ""
-                end
-                if textwidth(rootname) > 30
-                    rootname = first(rootname, 27) * "..."
-                end
-                prefix = "($(rootname)$(path_prefix)) "
-                prev_prefix = prefix
-                prev_project_timestamp = mtime(project_file)
-                prev_project_file = project_file
+        project_name = projname(project_file)
+        if project_name !== nothing
+            root = Types.find_root_base_project(project_file)
+            rootname = projname(root)
+            if root !== project_file
+                path_prefix = "/" * dirname(Types.relative_project_path(root, project_file))
+            else
+                path_prefix = ""
             end
+            if textwidth(rootname) > 30
+                rootname = first(rootname, 27) * "..."
+            end
+            prefix = "($(rootname)$(path_prefix)) "
         end
     end
     if Pkg.OFFLINE_MODE[]
         prefix = "$(prefix)[offline] "
     end
-    return "$(prefix)pkg> "
+    prompt = "$(prefix)pkg> "
+    cached_prompt[] = prompt
+    return prompt
 end
+
+invalidate_prompt!() = (cached_prompt[] = nothing; nothing)
 
 function do_cmds(repl::REPL.AbstractREPL, commands::Union{String, Vector{Command}})
     try
@@ -142,6 +141,9 @@ function on_done(s, buf, ok, repl)
     Base.@as_foreground_task do_cmds(repl, input)
     REPL.prepare_next(repl)
     REPL.reset_state(s)
+    # The command may have changed the active project (e.g. `activate`), so
+    # recompute the prompt on the next render.
+    invalidate_prompt!()
     return s.current_mode.sticky || REPL.transition(s, main)
 end
 
@@ -214,6 +216,9 @@ function repl_init(repl::REPL.LineEditREPL)
         ']' => function (s, args...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
                 buf = copy(LineEdit.buffer(s))
+                # Active project may have changed in julia mode (e.g. via
+                # `Pkg.activate`), so force a fresh prompt computation.
+                invalidate_prompt!()
                 return LineEdit.transition(s, pkg_mode) do
                     LineEdit.state(s, pkg_mode).input_buffer = buf
                 end
@@ -351,6 +356,8 @@ end
 
 
 function __init__()
+    # Clear any cached prompt baked in during precompilation.
+    invalidate_prompt!()
     if isdefined(Base, :active_repl)
         if Base.active_repl isa REPL.LineEditREPL
             repl_init(Base.active_repl)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -689,7 +689,6 @@ end
 
 @testset "unit test for REPLMode.promptf" begin
     function set_name(projfile_path, newname)
-        sleep(1.1)
         project = TOML.parsefile(projfile_path)
         project["name"] = newname
         open(projfile_path, "w") do io
@@ -697,33 +696,37 @@ end
         end
     end
 
+    # `promptf` caches its result; invalidate before each call so the test
+    # exercises a fresh computation.
+    fresh_prompt() = (REPLExt.invalidate_prompt!(); REPLExt.promptf())
+
     with_temp_env("SomeEnv") do
-        @test REPLExt.promptf() == "(SomeEnv) pkg> "
+        @test fresh_prompt() == "(SomeEnv) pkg> "
     end
 
     with_temp_env("this_is_a_test_for_truncating_long_folder_names_in_the_prompt") do
-        @test REPLExt.promptf() == "(this_is_a_test_for_truncati...) pkg> "
+        @test fresh_prompt() == "(this_is_a_test_for_truncati...) pkg> "
     end
 
     env_name = "Test2"
     with_temp_env(env_name) do env_path
         projfile_path = joinpath(env_path, "Project.toml")
-        @test REPLExt.promptf() == "($env_name) pkg> "
+        @test fresh_prompt() == "($env_name) pkg> "
 
         newname = "NewName"
         set_name(projfile_path, newname)
-        @test REPLExt.promptf() == "($newname) pkg> "
+        @test fresh_prompt() == "($newname) pkg> "
         cd(env_path) do
-            @test REPLExt.promptf() == "($newname) pkg> "
+            @test fresh_prompt() == "($newname) pkg> "
         end
-        @test REPLExt.promptf() == "($newname) pkg> "
+        @test fresh_prompt() == "($newname) pkg> "
 
         newname = "NewNameII"
         set_name(projfile_path, newname)
         cd(env_path) do
-            @test REPLExt.promptf() == "($newname) pkg> "
+            @test fresh_prompt() == "($newname) pkg> "
         end
-        @test REPLExt.promptf() == "($newname) pkg> "
+        @test fresh_prompt() == "($newname) pkg> "
     end
 end
 


### PR DESCRIPTION
TIL we do quite a lot of stuff including stat calls every keypress in the pkg repl....!

Fixes #4683

Fixed by Claude:

----

`promptf()` runs on every line refresh (i.e. every keystroke) and does several stat / realpath / TOML-parse operations on the active project file via `Types.find_project_file`, `mtime`, and
`Types.find_root_base_project`. On a slow filesystem (e.g. a remote share) this dominates per-keystroke latency in the Pkg REPL, while the standard `julia>` prompt is unaffected because it is a static string.

The prompt for an in-progress line cannot meaningfully change while the user is typing, so compute it once when the prompt is first shown and reuse the cached string on subsequent calls. Invalidate the cache after each command (since e.g. `activate` may change the project) and when re-entering pkg mode via `]` (in case the active project was changed from julia mode via `Pkg.activate`).

Fixes #4683