### PR TITLE
Iterate over `values(reg.pkgs)` in `available_names()`

### DIFF
--- a/src/Registry/registry_instance.jl
+++ b/src/Registry/registry_instance.jl
@@ -501,15 +501,16 @@ registry_info(registry::RegistryInstance, pkg::PkgEntry) = init_package_info!(re
         r.repo = get(d, "repo", nothing)::Union{String, Nothing}
         r.description = get(d, "description", nothing)::Union{String, Nothing}
 
-        r.pkgs = Dict{UUID, PkgEntry}()
+        pkgs = Dict{UUID, PkgEntry}()
         for (uuid, info) in d["packages"]::Dict{String, Any}
             uuid = UUID(uuid::String)
             info::Dict{String, Any}
             name = info["name"]::String
             pkgpath = info["path"]::String
             pkg = PkgEntry(pkgpath, getfield(r, :path), name, uuid)
-            r.pkgs[uuid] = pkg
+            pkgs[uuid] = pkg
         end
+        r.pkgs = pkgs
 
         r.name_to_uuids = Dict{String, Vector{UUID}}()
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1336,7 +1336,7 @@ function available_names(ctx::Context = Context(); manifest::Manifest = ctx.env.
     end
     if include_registries
         for reg in ctx.registries
-            for (_, pkgentry) in reg.pkgs
+            for pkgentry in values(reg.pkgs)
                 push!(all_names, pkgentry.name)
             end
         end


### PR DESCRIPTION
This removes a bunch of invalidations when loading JSON.jl on 1.13.

With:
```julia-repl
julia> using SnoopCompileCore                                                                                                                                                                                                                  
                                                                                                                                                                                                                                               
julia> using Pkg                                                                                                                                                                                                                               
                                                                                                                                                                                                                                               
julia> invs, trees = begin                                                                                                                                                                                                                     
           invs = @snoop_invalidations using JSON                                                                                                                                                                                              
           using SnoopCompile, AbstractTrees                                                                                                                                                                                                   
           trees = invalidation_trees(invs)                                                                                                                                                                                                    
           invs, trees                                                                                                                                                                                                                         
       end;
```

Before:
```julia
 inserting convert(::Type{String}, x::JSON.PtrString) @ JSON ~/.julia/packages/JSON/gMdcG/src/lazy.jl:428 invalidated:
   mt_backedges:  1: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for Base.Terminals.TTYTerminal(::Any, ::Any, ::Any, ::Any) (0 children)
                  2: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Dict{String, String}, ::Any, ::Any) (0 children)
                  3: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for Base.CoreLogging.var"#handle_message#6"(::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (1 children)
                  4: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for Base.CoreLogging.var"#handle_message#3"(::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.SimpleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (1 children)
                  5: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Dict{String, Function}, ::Any, ::Any) (1 children)
                  6: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Vector{String}, ::Any, ::Int64) (2 children)
                  7: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Dict{String, Nothing}, ::Nothing, ::Any) (4 children)
                  8: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for Base.CoreLogging.var"#handle_message#6"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (7 children)
                  9: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for Base.CoreLogging.var"#handle_message#3"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.SimpleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (7 children)
                 10: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Dict{String, String}, ::Any, ::String) (9 children)
                 11: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Memory{String}, ::Any, ::Int64) (10 children)
                 12: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for setindex!(::Dict{String, Any}, ::Any, ::Any) (28 children)
                 13: signature Tuple{typeof(convert), Type{String}, Any} triggered MethodInstance for push!(::Vector{String}, ::Any) (494 children)
```

After:
```julia
 inserting convert(::Type{Symbol}, x::JSON.PtrString) @ JSON ~/.julia/packages/JSON/gMdcG/src/lazy.jl:437 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for Pair{Symbol, Any}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for Base.Compiler.IRShow.LineInfoNode(::Any, ::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for Base.BaseDocs.Keyword(::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for setindex!(::Memory{Symbol}, ::Any, ::Int64) (15 children)
                 5: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for Base.ImmutableDict{Symbol, Any}(::Base.ImmutableDict{Symbol, Any}, ::Any, ::Any) (24 children)
                 6: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for push!(::Vector{Symbol}, ::Any) (42 children)
                 7: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for convert(::Type{Pair{Symbol, Any}}, ::Pair) (60 children)
                 8: signature Tuple{typeof(convert), Type{Symbol}, Any} triggered MethodInstance for setindex!(::Dict{Symbol, Any}, ::Any, ::Any) (65 children)
```

Inference output from Cthulhu:
```julia
var"#available_names#68"(manifest::Pkg.Types.Manifest, include_registries::Bool, ::typeof(Pkg.Types.available_names), ctx::Pkg.Types.Context) @ Pkg.Types ~/git/Pkg.jl/src/Types.jl:1326                                                       
1326 function available_names(ctx::Pkg.Types.Context::Context = Context(); manifest::Pkg.Types.Manifest::Manifest = ctx.env.manifest, include_registries::Bool::Bool = true)::Vector{String}                                                   
1327     all_names::Vector{String} = String[]::Vector{String}                                                                                                                                                                                  
1328     for (_, pkgentry::Pkg.Types.PackageEntry) in manifest::Pkg.Types.Manifest::Union{Nothing, Tuple{Pair{Base.UUID, Pkg.Types.PackageEntry}, Int64}}                                                                                      
1329         push!(all_names::Vector{String}, pkgentry::Pkg.Types.PackageEntry.name::Union{Nothing, String})                                                                                                                                   
1330     end                                                                                                                                                                                                                                   
1331     if include_registries                                                                                                                                                                                                                 
1332         for reg::Pkg.Registry.RegistryInstance in ctx::Pkg.Types.Context.registries::Vector{Pkg.Registry.RegistryInstance}::Union{Nothing, Tuple{Pkg.Registry.RegistryInstance, Int64}}                                                   
1333             for (_, pkgentry::Any) in reg::Pkg.Registry.RegistryInstance.pkgs::Union{Nothing, Base.SHA1, Base.UUID, ReentrantLock, String, Dict}::Union{Nothing, Tuple{Char, Int64}, Tuple{Pair, Int64}}                                  
1334                 push!(all_names::Vector{String}, pkgentry::Any.name::Any)                                                                                                                                                                 
1335             end                                                                                                                                                                                                                           
1336         end                                                                                                                                                                                                                               
1337     end                                                                                                                                                                                                                                   
1338     return unique(all_names::Vector{String})::Vector{String}                                                                                                                                                                              
1339 end                                                                                                                                                                                                                                       
```