### PR TITLE
Support multiple projects to `instantiate` at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Pkg v1.14 Release Notes
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and
   helper environments where any compatible set of dependency versions is acceptable. ([#4678])
+- `Pkg.instantiate` can now instantiate several environments in one call by passing multiple paths
+  (`Pkg.instantiate("env1", "env2")`, or `pkg> instantiate env1 env2`). The registries are read from disk once and
+  shared across all environments, and the active environment is left unchanged. ([#4698])
 - `Pkg.activate` now warns when packages already loaded into the session differ
   from what the newly activated environment specifies (different version or
   source path). This makes accidental reproducibility issues and unnecessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Pkg v1.14 Release Notes
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and
   helper environments where any compatible set of dependency versions is acceptable. ([#4678])
+- `Pkg.instantiate` can now instantiate several environments in one call by passing multiple paths
+  (`Pkg.instantiate("env1", "env2")`, or `pkg> instantiate env1 env2`). The registries are read from disk once and
+  shared across all environments, and the active environment is left unchanged. ([#4698])
 - `Pkg.activate` now warns when packages already loaded into the session differ
   from what the newly activated environment specifies (different version or
   source path). This makes accidental reproducibility issues and unnecessary

--- a/src/API.jl
+++ b/src/API.jl
@@ -1290,6 +1290,23 @@ function tree_hash(repo::LibGit2.GitRepo, tree_hash::String)
 end
 
 instantiate(; kwargs...) = instantiate(Context(); kwargs...)
+
+function instantiate(path::AbstractString, paths::AbstractString...; kwargs...)
+    # Reading the registries from disk is one of the more expensive parts of setting up
+    # a context, so do it once and share the result across every environment instead of
+    # paying that cost separately for each path.
+    registries = Registry.reachable_registries()
+    for p in (path, paths...)
+        # Accept either a path to a project file or to a directory containing one.
+        project_file = isdir(p) ? projectfile_path(p) : p
+        # `copy` so that any per-environment registry mutation (e.g. installing a
+        # registry referenced by a manifest) does not affect the shared list.
+        ctx = Context(; env = EnvCache(project_file), registries = copy(registries))
+        instantiate(ctx; kwargs...)
+    end
+    return
+end
+
 function instantiate(
         ctx::Context; manifest::Union{Bool, Nothing} = nothing,
         update_registry::Bool = true, verbose::Bool = false,

--- a/src/API.jl
+++ b/src/API.jl
@@ -1292,16 +1292,10 @@ end
 instantiate(; kwargs...) = instantiate(Context(); kwargs...)
 
 function instantiate(path::AbstractString, paths::AbstractString...; kwargs...)
-    # Reading the registries from disk is one of the more expensive parts of setting up
-    # a context, so do it once and share the result across every environment instead of
-    # paying that cost separately for each path.
     registries = Registry.reachable_registries()
     for p in (path, paths...)
-        # Accept either a path to a project file or to a directory containing one.
         project_file = isdir(p) ? projectfile_path(p) : p
-        # `copy` so that any per-environment registry mutation (e.g. installing a
-        # registry referenced by a manifest) does not affect the shared list.
-        ctx = Context(; env = EnvCache(project_file), registries = copy(registries))
+        ctx = Context(; env = EnvCache(project_file), registries)
         instantiate(ctx; kwargs...)
     end
     return

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -631,6 +631,7 @@ const project = API.project
 
 """
     Pkg.instantiate(; verbose = false, workspace=false, io::IO=stderr, julia_version_strict=false, update_on_mismatch=false)
+    Pkg.instantiate(paths::AbstractString...; kwargs...)
 
 If a `Manifest.toml` file exists in the active project, download all
 the packages declared in that manifest.
@@ -642,6 +643,12 @@ redirecting to the `build.log` file.
 If no `Project.toml` exist in the current active project, create one with all the
 dependencies in the manifest and instantiate the resulting project.
 `julia_version_strict=true` will turn manifest version check failures into errors instead of logging warnings.
+
+When passed one or more `paths` (each a path to a project file or to a directory
+containing one), each environment is instantiated in turn. The registries are read
+from disk once and shared across all of the environments, which is more convenient
+and efficient than activating and instantiating each environment separately. All
+keyword arguments are forwarded to each instantiation.
 
 `update_on_mismatch=true` falls back to [`Pkg.update`](@ref) when the existing manifest cannot
 be used as-is — for example, when the project's dependencies or compat bounds have changed
@@ -655,6 +662,9 @@ See more and how to disable auto-precompilation at [Environment Precompilation](
 
 !!! compat "Julia 1.12"
     The `julia_version_strict` keyword argument requires at least Julia 1.12.
+
+!!! compat "Julia 1.14"
+    Passing `paths` requires at least Julia 1.14.
 
 """
 const instantiate = API.instantiate

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -644,11 +644,9 @@ If no `Project.toml` exist in the current active project, create one with all th
 dependencies in the manifest and instantiate the resulting project.
 `julia_version_strict=true` will turn manifest version check failures into errors instead of logging warnings.
 
-When passed one or more `paths` (each a path to a project file or to a directory
-containing one), each environment is instantiated in turn. The registries are read
-from disk once and shared across all of the environments, which is more convenient
-and efficient than activating and instantiating each environment separately. All
-keyword arguments are forwarded to each instantiation.
+When passed one or more `paths` to project files or directories, instantiate each
+environment in turn without changing the active environment. Registries are loaded
+once and keyword arguments apply to every environment.
 
 `update_on_mismatch=true` falls back to [`Pkg.update`](@ref) when the existing manifest cannot
 be used as-is — for example, when the project's dependencies or compat bounds have changed

--- a/src/REPLMode/argument_parsers.jl
+++ b/src/REPLMode/argument_parsers.jl
@@ -553,6 +553,10 @@ function parse_activate(args::Vector{QString}, options)
     return args # this is currently invalid input for "activate"
 end
 
+function parse_instantiate(args::Vector{QString}, options)
+    return [x.isquoted ? x.raw : expanduser(x.raw) for x in args]
+end
+
 #
 # # Option Maps
 #

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -45,6 +45,8 @@ compound_declarations = [
         PSA[
             :name => "instantiate",
             :api => API.instantiate,
+            :arg_count => 0 => Inf,
+            :arg_parser => parse_instantiate,
             :option_spec => [
                 PSA[:name => "project", :short_name => "p", :api => :manifest => false],
                 PSA[:name => "manifest", :short_name => "m", :api => :manifest => true],
@@ -58,6 +60,7 @@ compound_declarations = [
                     instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-u|--update_on_mismatch]
                     instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-u|--update_on_mismatch] [-m|--manifest]
                     instantiate [-v|--verbose] [--workspace] [--julia_version_strict] [-u|--update_on_mismatch] [-p|--project]
+                    instantiate [options] path...
 
                 Download all the dependencies for the current project at the version given by the project's manifest.
                 If no manifest exists or the `--project` option is given, resolve and download the dependencies compatible with the project.
@@ -66,6 +69,10 @@ compound_declarations = [
                 If `-u`/`--update_on_mismatch` is given, fall back to `pkg> update` when the manifest does not match the project or
                 was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling environments
                 where any compatible set of dependency versions is acceptable.
+
+                If one or more `path`s are given, each environment at those paths (a project file or a directory containing one)
+                is instantiated in turn, without changing the active environment. The registries are read once and shared across
+                all of them, which is more convenient and efficient than activating and instantiating each separately.
 
                 After packages have been installed the project will be precompiled. For more information see `pkg> ?precompile`.
                 """,

--- a/src/REPLMode/command_declarations.jl
+++ b/src/REPLMode/command_declarations.jl
@@ -70,9 +70,8 @@ compound_declarations = [
                 was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling environments
                 where any compatible set of dependency versions is acceptable.
 
-                If one or more `path`s are given, each environment at those paths (a project file or a directory containing one)
-                is instantiated in turn, without changing the active environment. The registries are read once and shared across
-                all of them, which is more convenient and efficient than activating and instantiating each separately.
+                If paths to project files or directories are given, instantiate each environment without changing the active
+                environment. Registries are loaded once and options apply to every environment.
 
                 After packages have been installed the project will be precompiled. For more information see `pkg> ?precompile`.
                 """,

--- a/test/api.jl
+++ b/test/api.jl
@@ -242,6 +242,28 @@ import .FakeTerminals.FakeTerminal
                 @test occursin("Precompiling", String(take!(iob)))
             end
 
+            @testset "instantiate multiple paths" begin
+                iob = IOBuffer()
+                Pkg.activate("packages/Dep6")
+                active_before = Base.active_project()
+                envs = ("packages/Dep7", "packages/Dep8")
+                manifests = joinpath.(envs, "Manifest.toml")
+                # Remove the manifests left over from the previous testset so the
+                # assertions below verify that this call recreates them.
+                rm.(manifests, force = true)
+                # Instantiating several environments in one call should not change
+                # the active project.
+                Pkg.instantiate(envs...; io = iob)
+                @test Base.active_project() == active_before
+                @test all(isfile, manifests)
+
+                # The REPL form `pkg> instantiate path...` should behave the same.
+                rm.(manifests, force = true)
+                Pkg.REPLMode.pkgstr("instantiate $(envs[1]) $(envs[2])")
+                @test Base.active_project() == active_before
+                @test all(isfile, manifests)
+            end
+
             ENV["JULIA_PKG_PRECOMPILE_AUTO"] = 0
 
             @testset "waiting for trailing tasks" begin

--- a/test/api.jl
+++ b/test/api.jl
@@ -248,16 +248,11 @@ import .FakeTerminals.FakeTerminal
                 active_before = Base.active_project()
                 envs = ("packages/Dep7", "packages/Dep8")
                 manifests = joinpath.(envs, "Manifest.toml")
-                # Remove the manifests left over from the previous testset so the
-                # assertions below verify that this call recreates them.
                 rm.(manifests, force = true)
-                # Instantiating several environments in one call should not change
-                # the active project.
-                Pkg.instantiate(envs...; io = iob)
+                Pkg.instantiate(joinpath(envs[1], "Project.toml"), envs[2]; io = iob)
                 @test Base.active_project() == active_before
                 @test all(isfile, manifests)
 
-                # The REPL form `pkg> instantiate path...` should behave the same.
                 rm.(manifests, force = true)
                 Pkg.REPLMode.pkgstr("instantiate $(envs[1]) $(envs[2])")
                 @test Base.active_project() == active_before


### PR DESCRIPTION
Support to `instantiate` several environments in one call by passing (possibly) multiple paths (`Pkg.instantiate("env1", "env2")`, or `pkg> instantiate env1 env2`). The registries are read from disk once and shared across all environments, and the active environment is left unchanged.

This is more intuitive, more convenient and faster.

Claude Opus 4.8 supported in creating the PR.