### PR TITLE
Fix workspace instantiate without existing manifest

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -451,6 +451,7 @@ function up(
         update_registry::Bool = true,
         skip_writing_project::Bool = false,
         workspace::Bool = false,
+        download_loadable_only::Bool = false,
         kwargs...
     )
     Context!(ctx; kwargs...)
@@ -477,7 +478,7 @@ function up(
     for pkg in pkgs
         update_source_if_set(ctx.env, pkg)
     end
-    Operations.up(ctx, pkgs, level; skip_writing_project, preserve)
+    Operations.up(ctx, pkgs, level; skip_writing_project, preserve, download_loadable_only)
     return
 end
 
@@ -1321,7 +1322,7 @@ function instantiate(
     if (!isfile(ctx.env.manifest_file) && manifest === nothing) || manifest == false
         # given no manifest exists, only allow invoking a registry update if there are project deps
         allow_registry_update = isfile(ctx.env.project_file) && !isempty(ctx.env.project.deps)
-        up(ctx; update_registry = update_registry && allow_registry_update)
+        up(ctx; update_registry = update_registry && allow_registry_update, download_loadable_only = !workspace)
         allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
         return
     end
@@ -1340,7 +1341,7 @@ function instantiate(
             saved_initial_snapshot[] = true
         end
         printpkgstyle(ctx.io, :Update, "manifest does not match project or Julia version, falling back to `Pkg.update()`", color = Base.info_color())
-        up(ctx; update_registry, mode = workspace ? PKGMODE_MANIFEST : PKGMODE_PROJECT)
+        up(ctx; update_registry, mode = workspace ? PKGMODE_MANIFEST : PKGMODE_PROJECT, download_loadable_only = !workspace)
         allow_autoprecomp && Pkg._auto_precompile(ctx, already_instantiated = true)
         return
     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2593,9 +2593,24 @@ function targeted_resolve_up(env::EnvCache, registries::Vector{Registry.Registry
     return pkgs, deps_map
 end
 
+# Whether a package version might provide extensions, determined from the registry's
+# weak dependencies without needing the package source. Used when scoping which sources
+# must be downloaded so the shared manifest still records extension info correctly.
+function pkg_may_have_extensions(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec)
+    pkg.version isa VersionNumber || return true
+    for reg in registries
+        reg_pkg = get(reg, pkg.uuid, nothing)
+        isnothing(reg_pkg) && continue
+        info = Registry.registry_info(reg, reg_pkg)
+        any(((vr, wd),) -> pkg.version ∈ vr && !isempty(wd), info.weak_deps) && return true
+    end
+    return false
+end
+
 function up(
         ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
-        skip_writing_project::Bool = false, preserve::Union{Nothing, PreserveLevel} = nothing
+        skip_writing_project::Bool = false, preserve::Union{Nothing, PreserveLevel} = nothing,
+        download_loadable_only::Bool = false
     )
 
     requested_pkgs = pkgs
@@ -2622,9 +2637,27 @@ function up(
         deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version, false)
     end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version, ctx.registries)
-    new_apply = download_source(ctx)
-    fixups_from_projectfile!(ctx)
-    download_artifacts(ctx, julia_version = ctx.julia_version)
+    if download_loadable_only
+        # Resolve the whole workspace so the shared manifest stays consistent, but only
+        # fetch sources for the active project's loadable dependencies. Sources are also
+        # kept for packages that may provide extensions (so the manifest records their weak
+        # deps and extensions) and for packages tracked by path or repo (sources are local).
+        loadable_uuids = Set{UUID}(pkg.uuid for pkg in load_all_deps_loadable(ctx.env))
+        manifest_pkgs = load_all_deps(ctx.env)
+        source_pkgs = filter(manifest_pkgs) do pkg
+            pkg.uuid in loadable_uuids && return true
+            is_tracking_registry(pkg) || return true
+            return pkg_may_have_extensions(ctx.registries, pkg)
+        end
+        artifact_pkgs = filter(pkg -> pkg.uuid in loadable_uuids, manifest_pkgs)
+        new_apply = download_source(ctx, source_pkgs)
+        fixups_from_projectfile!(ctx)
+        download_artifacts(ctx, artifact_pkgs; julia_version = ctx.julia_version)
+    else
+        new_apply = download_source(ctx)
+        fixups_from_projectfile!(ctx)
+        download_artifacts(ctx, julia_version = ctx.julia_version)
+    end
     write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env, ctx.registries; io = ctx.io, hidden_upgrades_info = true)
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2935,9 +2935,24 @@ function targeted_resolve_up(env::EnvCache, registries::Vector{Registry.Registry
     return pkgs, deps_map
 end
 
+# Whether a package version might provide extensions, determined from the registry's
+# weak dependencies without needing the package source. Used when scoping which sources
+# must be downloaded so the shared manifest still records extension info correctly.
+function pkg_may_have_extensions(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec)
+    pkg.version isa VersionNumber || return true
+    for reg in registries
+        reg_pkg = get(reg, pkg.uuid, nothing)
+        isnothing(reg_pkg) && continue
+        info = Registry.registry_info(reg, reg_pkg)
+        any(((vr, wd),) -> pkg.version ∈ vr && !isempty(wd), info.weak_deps) && return true
+    end
+    return false
+end
+
 function up(
         ctx::Context, pkgs::Vector{PackageSpec}, level::UpgradeLevel;
-        skip_writing_project::Bool = false, preserve::Union{Nothing, PreserveLevel} = nothing
+        skip_writing_project::Bool = false, preserve::Union{Nothing, PreserveLevel} = nothing,
+        download_loadable_only::Bool = false
     )
 
     requested_pkgs = pkgs
@@ -2964,9 +2979,27 @@ function up(
         deps_map = resolve_versions!(ctx.env, ctx.registries, pkgs, ctx.julia_version, false)
     end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version, ctx.registries)
-    new_apply = download_source(ctx)
-    fixups_from_projectfile!(ctx)
-    download_artifacts(ctx, julia_version = ctx.julia_version)
+    if download_loadable_only
+        # Resolve the whole workspace so the shared manifest stays consistent, but only
+        # fetch sources for the active project's loadable dependencies. Sources are also
+        # kept for packages that may provide extensions (so the manifest records their weak
+        # deps and extensions) and for packages tracked by path or repo (sources are local).
+        loadable_uuids = Set{UUID}(pkg.uuid for pkg in load_all_deps_loadable(ctx.env))
+        manifest_pkgs = load_all_deps(ctx.env)
+        source_pkgs = filter(manifest_pkgs) do pkg
+            pkg.uuid in loadable_uuids && return true
+            is_tracking_registry(pkg) || return true
+            return pkg_may_have_extensions(ctx.registries, pkg)
+        end
+        artifact_pkgs = filter(pkg -> pkg.uuid in loadable_uuids, manifest_pkgs)
+        new_apply = download_source(ctx, source_pkgs)
+        fixups_from_projectfile!(ctx)
+        download_artifacts(ctx, artifact_pkgs; julia_version = ctx.julia_version)
+    else
+        new_apply = download_source(ctx)
+        fixups_from_projectfile!(ctx)
+        download_artifacts(ctx, julia_version = ctx.julia_version)
+    end
     write_env(ctx.env; skip_writing_project) # write env before building
     show_update(ctx.env, ctx.registries; io = ctx.io, hidden_upgrades_info = true)
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2935,9 +2935,7 @@ function targeted_resolve_up(env::EnvCache, registries::Vector{Registry.Registry
     return pkgs, deps_map
 end
 
-# Whether a package version might provide extensions, determined from the registry's
-# weak dependencies without needing the package source. Used when scoping which sources
-# must be downloaded so the shared manifest still records extension info correctly.
+# Registry weak dependencies conservatively identify possible extensions.
 function pkg_may_have_extensions(registries::Vector{Registry.RegistryInstance}, pkg::PackageSpec)
     pkg.version isa VersionNumber || return true
     for reg in registries
@@ -2980,10 +2978,6 @@ function up(
     end
     update_manifest!(ctx.env, pkgs, deps_map, ctx.julia_version, ctx.registries)
     if download_loadable_only
-        # Resolve the whole workspace so the shared manifest stays consistent, but only
-        # fetch sources for the active project's loadable dependencies. Sources are also
-        # kept for packages that may provide extensions (so the manifest records their weak
-        # deps and extensions) and for packages tracked by path or repo (sources are local).
         loadable_uuids = Set{UUID}(pkg.uuid for pkg in load_all_deps_loadable(ctx.env))
         manifest_pkgs = load_all_deps(ctx.env)
         source_pkgs = filter(manifest_pkgs) do pkg
@@ -2992,7 +2986,8 @@ function up(
             return pkg_may_have_extensions(ctx.registries, pkg)
         end
         artifact_pkgs = filter(pkg -> pkg.uuid in loadable_uuids, manifest_pkgs)
-        new_apply = download_source(ctx, source_pkgs)
+        downloaded = download_source(ctx, source_pkgs)
+        new_apply = intersect(downloaded, loadable_uuids)
         fixups_from_projectfile!(ctx)
         download_artifacts(ctx, artifact_pkgs; julia_version = ctx.julia_version)
     else

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -234,59 +234,62 @@ end
 end
 
 @testset "selective workspace instantiate" begin
-    mktempdir() do dir
-        path = copy_test_package(dir, "WorkspaceTestInstantiate")
-        cd(path) do
-            with_current_env() do
-                # Add Crayons dependency to root project to differentiate from subproject's Example
-                Pkg.activate(".")
-                Pkg.add("Crayons")
+    isolate() do
+        mktempdir() do dir
+            path = copy_test_package(dir, "WorkspaceTestInstantiate")
+            cd(path) do
+                with_current_env() do
+                    # Add Crayons dependency to root project to differentiate from subproject's Example
+                    Pkg.activate(".")
+                    Pkg.add("Crayons")
 
-                # The test subproject already has Example dependency
-                # Workspace structure is already set up in the test package
+                    # The test subproject already has Example dependency
+                    # Workspace structure is already set up in the test package
 
-                # Resolve to create full manifest
-                Pkg.resolve()
-                @test isfile("Manifest.toml")
+                    # Resolve to create full manifest
+                    Pkg.resolve()
+                    @test isfile("Manifest.toml")
 
-                # Verify manifest contains both dependencies
-                manifest = Pkg.Types.read_manifest("Manifest.toml")
-                example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
-                crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
-                @test haskey(manifest.deps, example_uuid)
-                @test haskey(manifest.deps, crayons_uuid)
+                    # Verify manifest contains both dependencies
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
+                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
+                    @test haskey(manifest.deps, example_uuid)
+                    @test haskey(manifest.deps, crayons_uuid)
 
-                # Clear package installations to test selective download
-                depot_path = first(Pkg.depots())
-                packages_dir = joinpath(depot_path, "packages")
-                for pkg_name in ["Example", "Crayons"]
-                    pkg_dir = joinpath(packages_dir, pkg_name)
-                    rm(pkg_dir, recursive = true, force = true)
+                    # Clear package installations to test selective download
+                    depot_path = first(Pkg.depots())
+                    packages_dir = joinpath(depot_path, "packages")
+                    for pkg_name in ["Example", "Crayons"]
+                        pkg_dir = joinpath(packages_dir, pkg_name)
+                        rm(pkg_dir, recursive = true, force = true)
+                    end
+
+                    # Test workspace=false only downloads root project deps (Crayons)
+                    Pkg.instantiate(workspace = false)
+                    example_installed = isdir(joinpath(packages_dir, "Example"))
+                    crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
+                    @test crayons_installed   # Should be installed (root project dependency)
+                    @test !example_installed  # Should not be installed with workspace=false
+
+                    # Clear and test workspace=true downloads all deps
+                    rm(joinpath(packages_dir, "Crayons"), recursive = true, force = true)
+                    Pkg.instantiate(workspace = true)
+                    example_installed = isdir(joinpath(packages_dir, "Example"))
+                    crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
+                    @test crayons_installed   # Should be installed
+                    @test example_installed   # Should be installed with workspace=true
+
+                    # Test is_instantiated behavior
+                    rm(joinpath(packages_dir, "Example"), recursive = true, force = true)
+                    ctx = Pkg.Types.Context()
+                    @test Pkg.Operations.is_instantiated(ctx.env, false)   # Root project complete (has Crayons)
+                    @test !Pkg.Operations.is_instantiated(ctx.env, true)   # Workspace incomplete (missing Example)
                 end
-
-                # Test workspace=false only downloads root project deps (Crayons)
-                Pkg.instantiate(workspace = false)
-                example_installed = isdir(joinpath(packages_dir, "Example"))
-                crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
-                @test crayons_installed   # Should be installed (root project dependency)
-                @test !example_installed  # Should not be installed with workspace=false
-
-                # Clear and test workspace=true downloads all deps
-                rm(joinpath(packages_dir, "Crayons"), recursive = true, force = true)
-                Pkg.instantiate(workspace = true)
-                example_installed = isdir(joinpath(packages_dir, "Example"))
-                crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
-                @test crayons_installed   # Should be installed
-                @test example_installed   # Should be installed with workspace=true
-
-                # Test is_instantiated behavior
-                rm(joinpath(packages_dir, "Example"), recursive = true, force = true)
-                ctx = Pkg.Types.Context()
-                @test Pkg.Operations.is_instantiated(ctx.env, false)   # Root project complete (has Crayons)
-                @test !Pkg.Operations.is_instantiated(ctx.env, true)   # Workspace incomplete (missing Example)
             end
         end
     end
 end
+
 
 end # module

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -291,5 +291,46 @@ end
     end
 end
 
+@testset "selective workspace instantiate without manifest" begin
+    isolate() do
+        mktempdir() do dir
+            path = copy_test_package(dir, "WorkspaceTestInstantiate")
+            cd(path) do
+                with_current_env() do
+                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
+                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
+
+                    # Add a root-only dependency to differentiate from the subproject's Example
+                    Pkg.activate(".")
+                    Pkg.add("Crayons")
+                    Pkg.resolve()
+
+                    depot_path = first(Pkg.depots())
+                    packages_dir = joinpath(depot_path, "packages")
+
+                    # Force the no-manifest fallback path in `instantiate` (resolves via `up`),
+                    # and clear installs so we can observe what actually gets downloaded.
+                    rm("Manifest.toml", force = true)
+                    for pkg_name in ["Example", "Crayons"]
+                        rm(joinpath(packages_dir, pkg_name), recursive = true, force = true)
+                    end
+
+                    # Instantiating the subproject without `workspace` should resolve the whole
+                    # workspace manifest but only download the subproject's loadable deps.
+                    Pkg.activate("test")
+                    Pkg.instantiate(workspace = false)
+                    @test isdir(joinpath(packages_dir, "Example"))   # subproject dep
+                    @test !isdir(joinpath(packages_dir, "Crayons"))  # root-only leaf dep
+
+                    # The shared manifest must still be fully resolved for the whole workspace
+                    @test isfile("Manifest.toml")
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+                    @test haskey(manifest.deps, example_uuid)
+                    @test haskey(manifest.deps, crayons_uuid)
+                end
+            end
+        end
+    end
+end
 
 end # module

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -237,59 +237,62 @@ end
 end
 
 @testset "selective workspace instantiate" begin
-    mktempdir() do dir
-        path = copy_test_package(dir, "WorkspaceTestInstantiate")
-        cd(path) do
-            with_current_env() do
-                # Add Crayons dependency to root project to differentiate from subproject's Example
-                Pkg.activate(".")
-                Pkg.add("Crayons")
+    isolate() do
+        mktempdir() do dir
+            path = copy_test_package(dir, "WorkspaceTestInstantiate")
+            cd(path) do
+                with_current_env() do
+                    # Add Crayons dependency to root project to differentiate from subproject's Example
+                    Pkg.activate(".")
+                    Pkg.add("Crayons")
 
-                # The test subproject already has Example dependency
-                # Workspace structure is already set up in the test package
+                    # The test subproject already has Example dependency
+                    # Workspace structure is already set up in the test package
 
-                # Resolve to create full manifest
-                Pkg.resolve()
-                @test isfile("Manifest.toml")
+                    # Resolve to create full manifest
+                    Pkg.resolve()
+                    @test isfile("Manifest.toml")
 
-                # Verify manifest contains both dependencies
-                manifest = Pkg.Types.read_manifest("Manifest.toml")
-                example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
-                crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
-                @test haskey(manifest.deps, example_uuid)
-                @test haskey(manifest.deps, crayons_uuid)
+                    # Verify manifest contains both dependencies
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
+                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
+                    @test haskey(manifest.deps, example_uuid)
+                    @test haskey(manifest.deps, crayons_uuid)
 
-                # Clear package installations to test selective download
-                depot_path = first(Pkg.depots())
-                packages_dir = joinpath(depot_path, "packages")
-                for pkg_name in ["Example", "Crayons"]
-                    pkg_dir = joinpath(packages_dir, pkg_name)
-                    rm(pkg_dir, recursive = true, force = true)
+                    # Clear package installations to test selective download
+                    depot_path = first(Pkg.depots())
+                    packages_dir = joinpath(depot_path, "packages")
+                    for pkg_name in ["Example", "Crayons"]
+                        pkg_dir = joinpath(packages_dir, pkg_name)
+                        rm(pkg_dir, recursive = true, force = true)
+                    end
+
+                    # Test workspace=false only downloads root project deps (Crayons)
+                    Pkg.instantiate(workspace = false)
+                    example_installed = isdir(joinpath(packages_dir, "Example"))
+                    crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
+                    @test crayons_installed   # Should be installed (root project dependency)
+                    @test !example_installed  # Should not be installed with workspace=false
+
+                    # Clear and test workspace=true downloads all deps
+                    rm(joinpath(packages_dir, "Crayons"), recursive = true, force = true)
+                    Pkg.instantiate(workspace = true)
+                    example_installed = isdir(joinpath(packages_dir, "Example"))
+                    crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
+                    @test crayons_installed   # Should be installed
+                    @test example_installed   # Should be installed with workspace=true
+
+                    # Test is_instantiated behavior
+                    rm(joinpath(packages_dir, "Example"), recursive = true, force = true)
+                    ctx = Pkg.Types.Context()
+                    @test Pkg.Operations.is_instantiated(ctx.env, false)   # Root project complete (has Crayons)
+                    @test !Pkg.Operations.is_instantiated(ctx.env, true)   # Workspace incomplete (missing Example)
                 end
-
-                # Test workspace=false only downloads root project deps (Crayons)
-                Pkg.instantiate(workspace = false)
-                example_installed = isdir(joinpath(packages_dir, "Example"))
-                crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
-                @test crayons_installed   # Should be installed (root project dependency)
-                @test !example_installed  # Should not be installed with workspace=false
-
-                # Clear and test workspace=true downloads all deps
-                rm(joinpath(packages_dir, "Crayons"), recursive = true, force = true)
-                Pkg.instantiate(workspace = true)
-                example_installed = isdir(joinpath(packages_dir, "Example"))
-                crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
-                @test crayons_installed   # Should be installed
-                @test example_installed   # Should be installed with workspace=true
-
-                # Test is_instantiated behavior
-                rm(joinpath(packages_dir, "Example"), recursive = true, force = true)
-                ctx = Pkg.Types.Context()
-                @test Pkg.Operations.is_instantiated(ctx.env, false)   # Root project complete (has Crayons)
-                @test !Pkg.Operations.is_instantiated(ctx.env, true)   # Workspace incomplete (missing Example)
             end
         end
     end
 end
+
 
 end # module

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -242,25 +242,17 @@ end
             path = copy_test_package(dir, "WorkspaceTestInstantiate")
             cd(path) do
                 with_current_env() do
-                    # Add Crayons dependency to root project to differentiate from subproject's Example
                     Pkg.activate(".")
                     Pkg.add("Crayons")
-
-                    # The test subproject already has Example dependency
-                    # Workspace structure is already set up in the test package
-
-                    # Resolve to create full manifest
                     Pkg.resolve()
                     @test isfile("Manifest.toml")
 
-                    # Verify manifest contains both dependencies
                     manifest = Pkg.Types.read_manifest("Manifest.toml")
-                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
-                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
+                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")
                     @test haskey(manifest.deps, example_uuid)
                     @test haskey(manifest.deps, crayons_uuid)
 
-                    # Clear package installations to test selective download
                     depot_path = first(Pkg.depots())
                     packages_dir = joinpath(depot_path, "packages")
                     for pkg_name in ["Example", "Crayons"]
@@ -268,26 +260,23 @@ end
                         rm(pkg_dir, recursive = true, force = true)
                     end
 
-                    # Test workspace=false only downloads root project deps (Crayons)
                     Pkg.instantiate(workspace = false)
                     example_installed = isdir(joinpath(packages_dir, "Example"))
                     crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
-                    @test crayons_installed   # Should be installed (root project dependency)
-                    @test !example_installed  # Should not be installed with workspace=false
+                    @test crayons_installed
+                    @test !example_installed
 
-                    # Clear and test workspace=true downloads all deps
                     rm(joinpath(packages_dir, "Crayons"), recursive = true, force = true)
                     Pkg.instantiate(workspace = true)
                     example_installed = isdir(joinpath(packages_dir, "Example"))
                     crayons_installed = isdir(joinpath(packages_dir, "Crayons"))
-                    @test crayons_installed   # Should be installed
-                    @test example_installed   # Should be installed with workspace=true
+                    @test crayons_installed
+                    @test example_installed
 
-                    # Test is_instantiated behavior
                     rm(joinpath(packages_dir, "Example"), recursive = true, force = true)
                     ctx = Pkg.Types.Context()
-                    @test Pkg.Operations.is_instantiated(ctx.env, false)   # Root project complete (has Crayons)
-                    @test !Pkg.Operations.is_instantiated(ctx.env, true)   # Workspace incomplete (missing Example)
+                    @test Pkg.Operations.is_instantiated(ctx.env, false)
+                    @test !Pkg.Operations.is_instantiated(ctx.env, true)
                 end
             end
         end
@@ -300,10 +289,9 @@ end
             path = copy_test_package(dir, "WorkspaceTestInstantiate")
             cd(path) do
                 with_current_env() do
-                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
-                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
+                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")
 
-                    # Add a root-only dependency to differentiate from the subproject's Example
                     Pkg.activate(".")
                     Pkg.add("Crayons")
                     Pkg.resolve()
@@ -311,21 +299,17 @@ end
                     depot_path = first(Pkg.depots())
                     packages_dir = joinpath(depot_path, "packages")
 
-                    # Force the no-manifest fallback path in `instantiate` (resolves via `up`),
-                    # and clear installs so we can observe what actually gets downloaded.
+                    # Exercise instantiate's no-manifest fallback.
                     rm("Manifest.toml", force = true)
                     for pkg_name in ["Example", "Crayons"]
                         rm(joinpath(packages_dir, pkg_name), recursive = true, force = true)
                     end
 
-                    # Instantiating the subproject without `workspace` should resolve the whole
-                    # workspace manifest but only download the subproject's loadable deps.
                     Pkg.activate("test")
                     Pkg.instantiate(workspace = false)
-                    @test isdir(joinpath(packages_dir, "Example"))   # subproject dep
-                    @test !isdir(joinpath(packages_dir, "Crayons"))  # root-only leaf dep
+                    @test isdir(joinpath(packages_dir, "Example"))
+                    @test !isdir(joinpath(packages_dir, "Crayons"))
 
-                    # The shared manifest must still be fully resolved for the whole workspace
                     @test isfile("Manifest.toml")
                     manifest = Pkg.Types.read_manifest("Manifest.toml")
                     @test haskey(manifest.deps, example_uuid)

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -294,5 +294,46 @@ end
     end
 end
 
+@testset "selective workspace instantiate without manifest" begin
+    isolate() do
+        mktempdir() do dir
+            path = copy_test_package(dir, "WorkspaceTestInstantiate")
+            cd(path) do
+                with_current_env() do
+                    example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")  # From test subproject
+                    crayons_uuid = UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f")  # From root project
+
+                    # Add a root-only dependency to differentiate from the subproject's Example
+                    Pkg.activate(".")
+                    Pkg.add("Crayons")
+                    Pkg.resolve()
+
+                    depot_path = first(Pkg.depots())
+                    packages_dir = joinpath(depot_path, "packages")
+
+                    # Force the no-manifest fallback path in `instantiate` (resolves via `up`),
+                    # and clear installs so we can observe what actually gets downloaded.
+                    rm("Manifest.toml", force = true)
+                    for pkg_name in ["Example", "Crayons"]
+                        rm(joinpath(packages_dir, pkg_name), recursive = true, force = true)
+                    end
+
+                    # Instantiating the subproject without `workspace` should resolve the whole
+                    # workspace manifest but only download the subproject's loadable deps.
+                    Pkg.activate("test")
+                    Pkg.instantiate(workspace = false)
+                    @test isdir(joinpath(packages_dir, "Example"))   # subproject dep
+                    @test !isdir(joinpath(packages_dir, "Crayons"))  # root-only leaf dep
+
+                    # The shared manifest must still be fully resolved for the whole workspace
+                    @test isfile("Manifest.toml")
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+                    @test haskey(manifest.deps, example_uuid)
+                    @test haskey(manifest.deps, crayons_uuid)
+                end
+            end
+        end
+    end
+end
 
 end # module


### PR DESCRIPTION
In an environment which is part of a workspace where the workspace lacks the manifest, all packages in the manifest were instantiated when only the packages of the environment should have been instantiated.

Claude Opus 4.8 supported in creating the PR.