### PR TITLE
Pkg.test: don't warn about loaded packages during precompilation

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3093,7 +3093,9 @@ function run_sandboxed_tests!(
 
     if should_autoprecompile()
         cacheflags = parse(CacheFlags, read(`$(Base.julia_cmd()) $(flags) --eval 'show(Base.CacheFlags())'`, String))
-        Pkg.precompile(sandbox_ctx; io = sandbox_ctx.io, configs = flags => cacheflags)
+        # Don't warn about already loaded packages, since we are going to run tests in a new
+        # subprocess anyway.
+        Pkg.precompile(sandbox_ctx; io = sandbox_ctx.io, warn_loaded = false, configs = flags => cacheflags)
     end
 
     printpkgstyle(ctx.io, :Testing, "Running tests...")


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/62186

Probably caused because of code duplication.

DRY-ing the code separately in case that can't be backported #4701 