### PR TITLE
Support running tests in parallel

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -568,6 +568,7 @@ function test(
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
         allow_reresolve::Bool = true,
+        ntasks::Int = 1,
         kwargs...
     )
     julia_args = Cmd(julia_args)
@@ -594,6 +595,7 @@ function test(
         force_latest_compatible_version,
         allow_earlier_backwards_compatible_versions,
         allow_reresolve,
+        ntasks,
     )
     return
 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -568,8 +568,10 @@ function test(
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
         allow_reresolve::Bool = true,
+        ntasks::Int = 1,
         kwargs...
     )
+    ntasks > 0 || pkgerror("`ntasks` must be positive")
     julia_args = Cmd(julia_args)
     test_args = Cmd(test_args)
     Context!(ctx; kwargs...)
@@ -594,6 +596,7 @@ function test(
         force_latest_compatible_version,
         allow_earlier_backwards_compatible_versions,
         allow_reresolve,
+        ntasks,
     )
     return
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3126,13 +3126,127 @@ function run_sandboxed_tests!(
     return
 end
 
+# Code run by each child process: test a single package against the parent environment.
+function gen_parallel_test_code(
+        pkg::PackageSpec; coverage, julia_args::Cmd, test_args::Cmd,
+        force_latest_compatible_version::Bool,
+        allow_earlier_backwards_compatible_versions::Bool,
+        allow_reresolve::Bool
+    )
+    return """
+    import Pkg
+    Pkg.test(
+        Pkg.PackageSpec(name = $(repr(pkg.name)), uuid = Base.UUID($(repr(string(pkg.uuid)))));
+        coverage = $(repr(coverage)),
+        julia_args = Cmd($(repr(collect(String, julia_args.exec)))),
+        test_args = Cmd($(repr(collect(String, test_args.exec)))),
+        force_latest_compatible_version = $(repr(force_latest_compatible_version)),
+        allow_earlier_backwards_compatible_versions = $(repr(allow_earlier_backwards_compatible_versions)),
+        allow_reresolve = $(repr(allow_reresolve)),
+    )
+    """
+end
+
+# Set up a precompilation jobserver shared by the child test processes so their codegen
+# threads draw on one machine-wide CPU budget instead of each child claiming a whole
+# machine's worth at once. Returns the pool state; only a `:created` pool is owned here
+# and needs tearing down. A pinned per-worker thread count (`JULIA_IMAGE_THREADS`) bypasses
+# the shared budget, matching the precompiler. Julia versions without the jobserver give
+# `:none`.
+function setup_parallel_test_jobserver!()
+    isdefined(Base.Precompilation, :setup_precompile_jobserver!) || return :none
+    haskey(ENV, "JULIA_IMAGE_THREADS") && return :none
+    default_budget = Sys.EFFECTIVE_CPU_THREADS + 1
+    budget = max(1, something(tryparse(Int, get(ENV, "JULIA_PRECOMPILE_THREADS", "")), default_budget))
+    return Base.Precompilation.setup_precompile_jobserver!(budget)
+end
+
+# Run the tests for several packages concurrently, one child `Pkg.test` process per
+# package, with at most `ntasks` running at a time. Each child's combined output is
+# captured into its own in-memory buffer; the buffers are concatenated in package order
+# once every child has finished, so there is no interleaving and no shared IO to guard.
+function test_parallel!(
+        ctx::Context, pkgs::Vector{PackageSpec},
+        pkgs_errored::Vector{Tuple{String, Base.Process}};
+        ntasks::Int, coverage, julia_args::Cmd, test_args::Cmd,
+        force_latest_compatible_version::Bool,
+        allow_earlier_backwards_compatible_versions::Bool,
+        allow_reresolve::Bool
+    )
+    project = dirname(ctx.env.project_file)
+    color = get(ctx.io, :color, false)::Bool
+
+    # Each task records its child in its own slot so a Ctrl-C can tear them all down.
+    # Distinct indices are written from distinct tasks, so no lock is needed.
+    procs = Vector{Union{Nothing, Base.Process}}(nothing, length(pkgs))
+
+    printpkgstyle(
+        ctx.io, :Testing,
+        "Running tests for $(length(pkgs)) packages with up to $(ntasks) parallel tasks"
+    )
+    flush(ctx.io)
+
+    # The pool must exist before the children spawn so they inherit it through the
+    # environment variable that `setup_precompile_jobserver!` writes.
+    jobserver = setup_parallel_test_jobserver!()
+
+    local results
+    try
+        results = asyncmap(enumerate(pkgs); ntasks) do (i, pkg)
+            code = gen_parallel_test_code(
+                pkg; coverage, julia_args, test_args,
+                force_latest_compatible_version,
+                allow_earlier_backwards_compatible_versions,
+                allow_reresolve,
+            )
+            # `Base.julia_cmd()` reconstructs the parent's flags (depwarn, inline,
+            # optimization, track-allocation, ...) for the child. Color is set explicitly
+            # because the child's output is captured into a buffer, where terminal
+            # detection would otherwise turn it off.
+            cmd = `$(Base.julia_cmd()) --color=$(color ? "yes" : "no") --project=$project --eval $code`
+            buf = IOBuffer()
+            p = run(pipeline(ignorestatus(cmd); stdout = buf, stderr = buf), wait = false)
+            procs[i] = p
+            wait(p)
+            (pkg.name, p, String(take!(buf)))
+        end
+    catch err
+        # On interrupt (or any failure of the orchestration) make sure no child is left
+        # behind. Terminate everything still running, escalating to SIGKILL if needed.
+        # `kill` checks liveness itself and is a no-op on an already-exited process.
+        for p in procs
+            isnothing(p) || kill(p)
+        end
+        deadline = time() + 4
+        for p in procs
+            isnothing(p) || timedwait(() -> process_exited(p), deadline - time()) === :timed_out && kill(p, Base.SIGKILL)
+        end
+        if err isa InterruptException
+            printpkgstyle(ctx.io, :Testing, "Tests interrupted. Exiting the test process", color = Base.error_color())
+        end
+        rethrow()
+    else
+        # Print each package's captured output in order, then aggregate failures.
+        for (name, p, output) in results
+            print(ctx.io, output)
+            success(p) || push!(pkgs_errored, (name, p))
+        end
+        flush(ctx.io)
+    finally
+        # Only tear down a pool this call created; a `:joined` pool is owned elsewhere.
+        jobserver === :created && Base.Precompilation.teardown_precompile_jobserver!()
+    end
+    return
+end
+
 function test(
         ctx::Context, pkgs::Vector{PackageSpec};
         coverage = false, julia_args::Cmd = ``, test_args::Cmd = ``,
         test_fn = nothing,
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
-        allow_reresolve::Bool = true
+        allow_reresolve::Bool = true,
+        ntasks::Int = 1
     )
     Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
 
@@ -3170,7 +3284,23 @@ function test(
 
     # sandbox
     pkgs_errored = Tuple{String, Base.Process}[]
+    # When more than one package is being tested, run each package's tests in its own
+    # child `Pkg.test` process, up to `ntasks` at a time (see `test_parallel!`). Each
+    # child does its own instantiate/resolve/precompile/run in a separate process, so the
+    # process-global state touched during sandboxing never races. `test_fn` is a closure
+    # that cannot cross the process boundary, so its presence keeps the run serial.
+    parallel = ntasks > 1 && length(pkgs) > 1 && test_fn === nothing
+    if parallel
+        test_parallel!(
+            ctx, pkgs, pkgs_errored;
+            ntasks, coverage, julia_args, test_args,
+            force_latest_compatible_version,
+            allow_earlier_backwards_compatible_versions,
+            allow_reresolve,
+        )
+    end
     for (pkg, source_path) in zip(pkgs, source_paths)
+        parallel && break
         # If the test is in our "workspace", no need to create a temp env etc, just activate and run the tests
         if testdir(source_path) in dirname.(keys(ctx.env.workspace))
             proj = Base.locate_project_file(abspath(testdir(source_path)))

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -3468,13 +3468,114 @@ function run_sandboxed_tests!(
     return
 end
 
+# Code run by each child process: test a single package against the parent environment.
+function gen_parallel_test_code(
+        pkg::PackageSpec; coverage, julia_args::Cmd, test_args::Cmd,
+        force_latest_compatible_version::Bool,
+        allow_earlier_backwards_compatible_versions::Bool,
+        allow_reresolve::Bool
+    )
+    pkg_project = dirname(dirname(pathof(Pkg)))
+    return """
+    pushfirst!(LOAD_PATH, $(repr(pkg_project)))
+    import Pkg
+    Pkg.test(
+        Pkg.PackageSpec(name = $(repr(pkg.name)), uuid = Base.UUID($(repr(string(pkg.uuid)))));
+        coverage = $(repr(coverage)),
+        julia_args = Cmd($(repr(collect(String, julia_args.exec)))),
+        test_args = Cmd($(repr(collect(String, test_args.exec)))),
+        force_latest_compatible_version = $(repr(force_latest_compatible_version)),
+        allow_earlier_backwards_compatible_versions = $(repr(allow_earlier_backwards_compatible_versions)),
+        allow_reresolve = $(repr(allow_reresolve)),
+    )
+    """
+end
+
+# Share one precompilation CPU budget across child test processes when supported.
+function setup_parallel_test_jobserver!()
+    isdefined(Base.Precompilation, :setup_precompile_jobserver!) || return :none
+    haskey(ENV, "JULIA_IMAGE_THREADS") && return :none
+    default_budget = Sys.EFFECTIVE_CPU_THREADS + 1
+    budget = max(1, something(tryparse(Int, get(ENV, "JULIA_PRECOMPILE_THREADS", "")), default_budget))
+    return Base.Precompilation.setup_precompile_jobserver!(budget)
+end
+
+# Run each package in a child process, preserving package order in the output.
+function test_parallel!(
+        ctx::Context, pkgs::Vector{PackageSpec},
+        pkgs_errored::Vector{Tuple{String, Base.Process}};
+        ntasks::Int, coverage, julia_args::Cmd, test_args::Cmd,
+        force_latest_compatible_version::Bool,
+        allow_earlier_backwards_compatible_versions::Bool,
+        allow_reresolve::Bool
+    )
+    project = dirname(ctx.env.project_file)
+    color = get(ctx.io, :color, false)::Bool
+
+    procs = Vector{Union{Nothing, Base.Process}}(nothing, length(pkgs))
+
+    printpkgstyle(
+        ctx.io, :Testing,
+        "Running tests for $(length(pkgs)) packages with up to $(ntasks) parallel tasks"
+    )
+    flush(ctx.io)
+
+    jobserver = setup_parallel_test_jobserver!()
+    try
+        mktempdir() do output_dir
+            results = try
+                asyncmap(enumerate(pkgs); ntasks) do (i, pkg)
+                    code = gen_parallel_test_code(
+                        pkg; coverage, julia_args, test_args,
+                        force_latest_compatible_version,
+                        allow_earlier_backwards_compatible_versions,
+                        allow_reresolve,
+                    )
+                    cmd = `$(Base.julia_cmd()) --color=$(color ? "yes" : "no") --project=$project --eval $code`
+                    output_file = joinpath(output_dir, "$i.log")
+                    p = open(output_file, "w") do output
+                        process = run(pipeline(ignorestatus(cmd); stdout = output, stderr = output), wait = false)
+                        procs[i] = process
+                        wait(process)
+                        process
+                    end
+                    (pkg.name, p, output_file)
+                end
+            catch err
+                for p in procs
+                    isnothing(p) || kill(p)
+                end
+                deadline = time() + 4
+                for p in procs
+                    isnothing(p) && continue
+                    timeout = max(0.0, deadline - time())
+                    timedwait(() -> process_exited(p), timeout) === :timed_out && kill(p, Base.SIGKILL)
+                end
+                if err isa InterruptException
+                    printpkgstyle(ctx.io, :Testing, "Tests interrupted. Exiting the test process", color = Base.error_color())
+                end
+                rethrow()
+            end
+            for (name, p, output_file) in results
+                write(ctx.io, read(output_file))
+                success(p) || push!(pkgs_errored, (name, p))
+            end
+            flush(ctx.io)
+        end
+    finally
+        jobserver === :created && Base.Precompilation.teardown_precompile_jobserver!()
+    end
+    return
+end
+
 function test(
         ctx::Context, pkgs::Vector{PackageSpec};
         coverage = false, julia_args::Cmd = ``, test_args::Cmd = ``,
         test_fn = nothing,
         force_latest_compatible_version::Bool = false,
         allow_earlier_backwards_compatible_versions::Bool = true,
-        allow_reresolve::Bool = true
+        allow_reresolve::Bool = true,
+        ntasks::Int = 1
     )
     Pkg.instantiate(ctx; allow_autoprecomp = false) # do precomp later within sandbox
 
@@ -3512,7 +3613,19 @@ function test(
 
     # sandbox
     pkgs_errored = Tuple{String, Base.Process}[]
+    # A test_fn closure cannot cross the child-process boundary.
+    parallel = ntasks > 1 && length(pkgs) > 1 && test_fn === nothing
+    if parallel
+        test_parallel!(
+            ctx, pkgs, pkgs_errored;
+            ntasks, coverage, julia_args, test_args,
+            force_latest_compatible_version,
+            allow_earlier_backwards_compatible_versions,
+            allow_reresolve,
+        )
+    end
     for (pkg, source_path) in zip(pkgs, source_paths)
+        parallel && break
         # If the test is in our "workspace", no need to create a temp env etc, just activate and run the tests
         if testdir(source_path) in dirname.(keys(ctx.env.workspace))
             proj = Base.locate_project_file(abspath(testdir(source_path)))

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -392,6 +392,9 @@ const update = API.up
   - `allow_reresolve::Bool=true`: allow Pkg to reresolve the package versions in the test environment
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
+  - `ntasks::Int=1`: when more than one package is tested, the maximum number of packages to test
+    concurrently. Each package is tested in its own child process; its output is captured and printed
+    as a single block once it finishes. Has no effect when testing a single package.
 
 !!! compat "Julia 1.9"
     `allow_reresolve` requires at least Julia 1.9.

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -392,6 +392,8 @@ const update = API.up
   - `allow_reresolve::Bool=true`: allow Pkg to reresolve the package versions in the test environment
   - `julia_args::Union{Cmd, Vector{String}}`: options to be passed the test process.
   - `test_args::Union{Cmd, Vector{String}}`: test arguments (`ARGS`) available in the test process.
+  - `ntasks::Int=1`: when more than one package is tested, the maximum number of packages to test
+    concurrently. Output is grouped by package. Has no effect for one package or with `test_fn`.
 
 !!! compat "Julia 1.9"
     `allow_reresolve` requires at least Julia 1.9.

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1040,6 +1040,28 @@ end
     end
 end
 
+@testset "parallel testing" begin
+    temp_pkg_dir() do project_path
+        mktempdir() do dir
+            pkgnames = ["ParallelTestA", "ParallelTestB"]
+            for name in pkgnames
+                cp(joinpath(@__DIR__, "test_packages", name), joinpath(dir, name))
+            end
+            with_temp_env() do
+                Pkg.develop([Pkg.PackageSpec(path = joinpath(dir, name)) for name in pkgnames])
+                mktempdir() do sync_dir
+                    # Each package's test process blocks until it sees the other start
+                    # (see the packages' runtests.jl), so testing only succeeds if the
+                    # processes ran concurrently. A serial run would time out and fail.
+                    withenv("PKG_PARALLEL_SYNC_DIR" => sync_dir) do
+                        @test Pkg.test(pkgnames; ntasks = 2) === nothing
+                    end
+                end
+            end
+        end
+    end
+end
+
 import Pkg.Resolve.range_compressed_versionspec
 @testset "range_compressed_versionspec" begin
     pool = [v"1.0.0", v"1.1.0", v"1.2.0", v"1.2.1", v"2.0.0", v"2.0.1", v"3.0.0", v"3.1.0"]

--- a/test/pkgtest.jl
+++ b/test/pkgtest.jl
@@ -377,6 +377,26 @@ end
     end
 end
 
+@testset "parallel testing" begin
+    @test_throws PkgError("`ntasks` must be positive") Pkg.test(; ntasks = 0)
+    isolate(loaded_depot = true) do
+        mktempdir() do dir
+            pkgnames = ["ParallelTestA", "ParallelTestB"]
+            for name in pkgnames
+                cp(joinpath(@__DIR__, "test_packages", name), joinpath(dir, name))
+            end
+            with_temp_env() do
+                Pkg.develop([Pkg.PackageSpec(path = joinpath(dir, name)) for name in pkgnames])
+                mktempdir() do sync_dir
+                    withenv("PKG_PARALLEL_SYNC_DIR" => sync_dir) do
+                        @test Pkg.test(pkgnames; ntasks = 2) === nothing
+                    end
+                end
+            end
+        end
+    end
+end
+
 @testset "Pkg.test process failure" begin
     temp_pkg_dir() do project_path
         mktempdir() do dir

--- a/test/test_packages/ParallelTestA/Project.toml
+++ b/test/test_packages/ParallelTestA/Project.toml
@@ -1,0 +1,9 @@
+name = "ParallelTestA"
+uuid = "5a8f3e21-0b6c-4d7e-9a1f-2c3b4d5e6f70"
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/ParallelTestA/src/ParallelTestA.jl
+++ b/test/test_packages/ParallelTestA/src/ParallelTestA.jl
@@ -1,0 +1,3 @@
+module ParallelTestA
+
+end

--- a/test/test_packages/ParallelTestA/test/runtests.jl
+++ b/test/test_packages/ParallelTestA/test/runtests.jl
@@ -1,0 +1,14 @@
+using Test
+
+# Part of the parallel `Pkg.test` regression test (see test/pkg.jl). Each package's
+# test process announces itself in a shared directory and then waits until every
+# sibling process has announced too. When the packages are tested concurrently all
+# announcements appear and the wait returns quickly; when tested serially a process
+# only ever sees its own announcement and the wait times out. A passing run therefore
+# proves the test processes ran at the same time.
+@testset "ParallelTestA" begin
+    sync_dir = ENV["PKG_PARALLEL_SYNC_DIR"]
+    touch(joinpath(sync_dir, "ParallelTestA"))
+    # Block until ParallelTestB's process starts, proving the two ran concurrently.
+    @test timedwait(() -> isfile(joinpath(sync_dir, "ParallelTestB")), 60) === :ok
+end

--- a/test/test_packages/ParallelTestA/test/runtests.jl
+++ b/test/test_packages/ParallelTestA/test/runtests.jl
@@ -1,0 +1,7 @@
+using Test
+
+@testset "ParallelTestA" begin
+    sync_dir = ENV["PKG_PARALLEL_SYNC_DIR"]
+    touch(joinpath(sync_dir, "ParallelTestA"))
+    @test timedwait(() -> isfile(joinpath(sync_dir, "ParallelTestB")), 60) === :ok
+end

--- a/test/test_packages/ParallelTestB/Project.toml
+++ b/test/test_packages/ParallelTestB/Project.toml
@@ -1,0 +1,9 @@
+name = "ParallelTestB"
+uuid = "6b9f4f32-1c7d-4e8f-8b2a-3d4c5e6f7081"
+version = "0.1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/test_packages/ParallelTestB/src/ParallelTestB.jl
+++ b/test/test_packages/ParallelTestB/src/ParallelTestB.jl
@@ -1,0 +1,3 @@
+module ParallelTestB
+
+end

--- a/test/test_packages/ParallelTestB/test/runtests.jl
+++ b/test/test_packages/ParallelTestB/test/runtests.jl
@@ -1,0 +1,14 @@
+using Test
+
+# Part of the parallel `Pkg.test` regression test (see test/pkg.jl). Each package's
+# test process announces itself in a shared directory and then waits until every
+# sibling process has announced too. When the packages are tested concurrently all
+# announcements appear and the wait returns quickly; when tested serially a process
+# only ever sees its own announcement and the wait times out. A passing run therefore
+# proves the test processes ran at the same time.
+@testset "ParallelTestB" begin
+    sync_dir = ENV["PKG_PARALLEL_SYNC_DIR"]
+    touch(joinpath(sync_dir, "ParallelTestB"))
+    # Block until ParallelTestA's process starts, proving the two ran concurrently.
+    @test timedwait(() -> isfile(joinpath(sync_dir, "ParallelTestA")), 60) === :ok
+end

--- a/test/test_packages/ParallelTestB/test/runtests.jl
+++ b/test/test_packages/ParallelTestB/test/runtests.jl
@@ -1,0 +1,7 @@
+using Test
+
+@testset "ParallelTestB" begin
+    sync_dir = ENV["PKG_PARALLEL_SYNC_DIR"]
+    touch(joinpath(sync_dir, "ParallelTestB"))
+    @test timedwait(() -> isfile(joinpath(sync_dir, "ParallelTestA")), 60) === :ok
+end


### PR DESCRIPTION
Given [Julia has a jobserver](https://github.com/JuliaLang/julia/commit/e319a303a7401f0151246323b53c03f9255b8586) now, we can finally support parallel testing without starting too many processes during precompilation. This does not help avoiding oversubscription during running the tests, but it is at least a start worth making use of, given that there are a lot of single-threaded runtests.jl.

With this change, you can start your tests with
```
Pkg.test(pkgnames; ntasks = Sys.CPU_THREADS)
```
to test multiple packages in parallel.

I used Claude Opus 4.8 while generating this PR.