### PR TITLE
test: set compare strategy on the actual version tag (libstdcxx_versi…

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -262,7 +262,11 @@ end
         # Default HostPlatform() adds a compare_strategy key that doesn't get picked up from
         # the Artifacts.toml
         testhost = Platform("x86_64", "linux", Dict("libstdcxx_version" => "1.2.3"))
-        BinaryPlatforms.set_compare_strategy!(testhost, "libstdcxx_version", BinaryPlatforms.compare_version_cap)
+        # Newer Julia translates the `libstdcxx_version` tag into `cxxlib_version`
+        # (with `cxxlib=libstdcxx`), so set the compare strategy on whichever version
+        # tag the platform actually ended up with.
+        version_key = haskey(tags(testhost), "libstdcxx_version") ? "libstdcxx_version" : "cxxlib_version"
+        BinaryPlatforms.set_compare_strategy!(testhost, version_key, BinaryPlatforms.compare_version_cap)
         @test_throws ErrorException bind_artifact!(artifacts_toml, "foo_txt", hash; download_info = download_info, platform = testhost)
 
         # Next, check that we can get the download_info properly:


### PR DESCRIPTION
…on → cxxlib_version)

JuliaLang/julia#59029 ("binaryplatforms: Add abi tags for ucrt/cxxlib") changed `Base.BinaryPlatforms` so that constructing a `Platform` with a `libstdcxx_version` tag now translates it into `cxxlib=libstdcxx` plus a `cxxlib_version` tag; the literal `libstdcxx_version` key is no longer stored.

The artifacts test set the compare strategy directly on `libstdcxx_version`, which now throws `ArgumentError: Cannot set comparison strategy for nonexistent tag libstdcxx_version!` on nightly, erroring the Pkg test suite.

Set the compare strategy on whichever version tag the platform actually ended up with, so the test passes on both older Julia (which keeps `libstdcxx_version`) and newer Julia (which uses `cxxlib_version`).