### PR TITLE
Assert on conflicting sources in workspaces

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -164,6 +164,38 @@ end
 merge_pkg_source!(target::PackageSpec, source::PackageSpec) =
     merge_pkg_source!(target, source.path, source.repo)
 
+# In a workspace the same package can be a direct dependency of several projects,
+# each of which may point it at a source via `[sources]`. Merging those entries
+# only makes sense if they agree; otherwise the resulting source would depend on
+# the order the projects happen to be iterated in, so reject the configuration.
+function assert_no_conflicting_sources(pkgs)
+    paths = Set{String}()
+    repo_sources = Set{String}()
+    revs = Set{String}()
+    subdirs = Set{String}()
+    for pkg in pkgs
+        isnothing(pkg.path) || push!(paths, pkg.path)
+        isnothing(pkg.repo.source) || push!(repo_sources, pkg.repo.source)
+        isnothing(pkg.repo.rev) || push!(revs, pkg.repo.rev)
+        isnothing(pkg.repo.subdir) || push!(subdirs, pkg.repo.subdir)
+    end
+    conflicts = String[]
+    if !isempty(paths) && (!isempty(repo_sources) || !isempty(revs))
+        push!(conflicts, "both a path and a repository")
+    end
+    showvals(vals) = join((repr(v) for v in sort!(collect(vals))), ", ")
+    length(paths) > 1 && push!(conflicts, "paths $(showvals(paths))")
+    length(repo_sources) > 1 && push!(conflicts, "repositories $(showvals(repo_sources))")
+    length(revs) > 1 && push!(conflicts, "revisions $(showvals(revs))")
+    length(subdirs) > 1 && push!(conflicts, "subdirectories $(showvals(subdirs))")
+    isempty(conflicts) && return
+    pkgerror(
+        """
+        Package $(err_rep(first(pkgs))) has conflicting sources specified by different projects in the workspace: $(join(conflicts, "; ")).
+        Make the `[sources]` entries for this package agree across the workspace."""
+    )
+end
+
 function load_direct_deps(
         env::EnvCache, pkgs::Vector{PackageSpec} = PackageSpec[];
         preserve::PreserveLevel = PRESERVE_DIRECT
@@ -177,7 +209,7 @@ function load_direct_deps(
     unique_uuids = Set{UUID}(pkg.uuid for pkg in pkgs_direct)
     for uuid in unique_uuids
         idxs = findall(pkg -> pkg.uuid == uuid, pkgs_direct)
-        # TODO: Assert that projects do not have conflicting sources
+        assert_no_conflicting_sources(view(pkgs_direct, idxs))
         pkg = pkgs_direct[idxs[1]]
         idx_to_drop = Int[]
         for i in Iterators.drop(idxs, 1)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -159,32 +159,36 @@ function merge_pkg_source!(pkg::PackageSpec, path::Union{Nothing, String}, repo:
     if pkg.repo.rev === nothing && repo.rev !== nothing
         pkg.repo.rev = repo.rev
     end
+    if pkg.repo.subdir === nothing && repo.subdir !== nothing
+        pkg.repo.subdir = repo.subdir
+    end
     return
 end
 merge_pkg_source!(target::PackageSpec, source::PackageSpec) =
     merge_pkg_source!(target, source.path, source.repo)
 
-# In a workspace the same package can be a direct dependency of several projects,
-# each of which may point it at a source via `[sources]`. Merging those entries
-# only makes sense if they agree; otherwise the resulting source would depend on
-# the order the projects happen to be iterated in, so reject the configuration.
-function assert_no_conflicting_sources(pkgs)
-    paths = Set{String}()
+function assert_no_conflicting_sources(pkgs, manifest_file::String)
+    length(pkgs) <= 1 && return
+    paths = Dict{String, String}()
     repo_sources = Set{String}()
     revs = Set{String}()
     subdirs = Set{String}()
     for pkg in pkgs
-        isnothing(pkg.path) || push!(paths, pkg.path)
+        if pkg.path !== nothing
+            normalized = normpath(abspath(dirname(manifest_file), pkg.path))
+            paths[normalized] = pkg.path
+        end
         isnothing(pkg.repo.source) || push!(repo_sources, pkg.repo.source)
         isnothing(pkg.repo.rev) || push!(revs, pkg.repo.rev)
         isnothing(pkg.repo.subdir) || push!(subdirs, pkg.repo.subdir)
     end
     conflicts = String[]
-    if !isempty(paths) && (!isempty(repo_sources) || !isempty(revs))
+    if !isempty(paths) && !isempty(repo_sources)
         push!(conflicts, "both a path and a repository")
     end
+    !isempty(paths) && !isempty(revs) && push!(conflicts, "both a path and a revision")
     showvals(vals) = join((repr(v) for v in sort!(collect(vals))), ", ")
-    length(paths) > 1 && push!(conflicts, "paths $(showvals(paths))")
+    length(paths) > 1 && push!(conflicts, "paths $(showvals(values(paths)))")
     length(repo_sources) > 1 && push!(conflicts, "repositories $(showvals(repo_sources))")
     length(revs) > 1 && push!(conflicts, "revisions $(showvals(revs))")
     length(subdirs) > 1 && push!(conflicts, "subdirectories $(showvals(subdirs))")
@@ -196,20 +200,33 @@ function assert_no_conflicting_sources(pkgs)
     )
 end
 
+function collect_project_sources!(sources, project, project_file, manifest_file)
+    for (name, uuid) in project.deps
+        path, repo = get_path_repo(project, project_file, manifest_file, name)
+        path === nothing && repo == GitRepo() && continue
+        push!(get!(() -> PackageSpec[], sources, uuid), PackageSpec(; uuid, name, path, repo))
+    end
+    return
+end
+
 function load_direct_deps(
         env::EnvCache, pkgs::Vector{PackageSpec} = PackageSpec[];
         preserve::PreserveLevel = PRESERVE_DIRECT
     )
+    project_sources = Dict{UUID, Vector{PackageSpec}}()
+    collect_project_sources!(project_sources, env.project, env.project_file, env.manifest_file)
     pkgs_direct = load_project_deps(env.project, env.project_file, env.manifest, env.manifest_file, pkgs; preserve)
 
     for (path, project) in env.workspace
+        collect_project_sources!(project_sources, project, path, env.manifest_file)
         append!(pkgs_direct, load_project_deps(project, path, env.manifest, env.manifest_file, pkgs; preserve))
     end
+
+    foreach(sources -> assert_no_conflicting_sources(sources, env.manifest_file), values(project_sources))
 
     unique_uuids = Set{UUID}(pkg.uuid for pkg in pkgs_direct)
     for uuid in unique_uuids
         idxs = findall(pkg -> pkg.uuid == uuid, pkgs_direct)
-        assert_no_conflicting_sources(view(pkgs_direct, idxs))
         pkg = pkgs_direct[idxs[1]]
         idx_to_drop = Int[]
         for i in Iterators.drop(idxs, 1)
@@ -220,7 +237,17 @@ function load_direct_deps(
         deleteat!(pkgs_direct, idx_to_drop)
     end
 
-    return vcat(pkgs, pkgs_direct)
+    all_pkgs = vcat(pkgs, pkgs_direct)
+    for (uuid, sources) in project_sources
+        idx = findfirst(pkg -> pkg.uuid == uuid, all_pkgs)
+        idx === nothing && continue
+        declared = PackageSpec(; uuid)
+        foreach(source -> merge_pkg_source!(declared, source), sources)
+        # Explicit project sources override manifest fallbacks, which may be stale.
+        all_pkgs[idx].path = declared.path
+        all_pkgs[idx].repo = declared.repo
+    end
+    return all_pkgs
 end
 
 function load_project_deps(

--- a/test/test_packages/WorkspacePathResolution/SubProjectA/Project.toml
+++ b/test/test_packages/WorkspacePathResolution/SubProjectA/Project.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 SubProjectB = "12345678-1234-1234-1234-123456789012"
 
 [sources]
-SubProjectB = {path = "SubProjectB"}
+SubProjectB = {path = "../SubProjectB"}

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -233,6 +233,72 @@ end
     end
 end
 
+# Two workspace member projects that pin the same dependency to different sources
+# cannot be merged into a single manifest entry, so resolving must error clearly.
+@testset "workspace projects with conflicting [sources]" begin
+    mktempdir() do dir
+        cd(dir) do
+            shared_uuid = "22222222-2222-2222-2222-222222222222"
+            mkpath("ProjectA")
+            mkpath("ProjectB")
+            for parent in ("variant1", "variant2")
+                pkgdir = joinpath(parent, "SharedDep")
+                mkpath(joinpath(pkgdir, "src"))
+                write(
+                    joinpath(pkgdir, "Project.toml"),
+                    """
+                    name = "SharedDep"
+                    uuid = "$shared_uuid"
+                    version = "0.1.0"
+                    """
+                )
+                write(joinpath(pkgdir, "src", "SharedDep.jl"), "module SharedDep\nend\n")
+            end
+            write(
+                "Project.toml",
+                """
+                name = "ConflictRoot"
+                uuid = "33333333-3333-3333-3333-333333333333"
+                version = "0.1.0"
+
+                [workspace]
+                projects = ["ProjectA", "ProjectB"]
+                """
+            )
+            write(
+                joinpath("ProjectA", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant1/SharedDep"}
+                """
+            )
+            write(
+                joinpath("ProjectB", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant2/SharedDep"}
+                """
+            )
+            with_current_env() do
+                err = try
+                    Pkg.resolve()
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa Pkg.Types.PkgError
+                @test occursin("conflicting sources", err.msg)
+            end
+        end
+    end
+end
+
 @testset "selective workspace instantiate" begin
     mktempdir() do dir
         path = copy_test_package(dir, "WorkspaceTestInstantiate")

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -236,6 +236,72 @@ end
     end
 end
 
+# Two workspace member projects that pin the same dependency to different sources
+# cannot be merged into a single manifest entry, so resolving must error clearly.
+@testset "workspace projects with conflicting [sources]" begin
+    mktempdir() do dir
+        cd(dir) do
+            shared_uuid = "22222222-2222-2222-2222-222222222222"
+            mkpath("ProjectA")
+            mkpath("ProjectB")
+            for parent in ("variant1", "variant2")
+                pkgdir = joinpath(parent, "SharedDep")
+                mkpath(joinpath(pkgdir, "src"))
+                write(
+                    joinpath(pkgdir, "Project.toml"),
+                    """
+                    name = "SharedDep"
+                    uuid = "$shared_uuid"
+                    version = "0.1.0"
+                    """
+                )
+                write(joinpath(pkgdir, "src", "SharedDep.jl"), "module SharedDep\nend\n")
+            end
+            write(
+                "Project.toml",
+                """
+                name = "ConflictRoot"
+                uuid = "33333333-3333-3333-3333-333333333333"
+                version = "0.1.0"
+
+                [workspace]
+                projects = ["ProjectA", "ProjectB"]
+                """
+            )
+            write(
+                joinpath("ProjectA", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant1/SharedDep"}
+                """
+            )
+            write(
+                joinpath("ProjectB", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant2/SharedDep"}
+                """
+            )
+            with_current_env() do
+                err = try
+                    Pkg.resolve()
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa Pkg.Types.PkgError
+                @test occursin("conflicting sources", err.msg)
+            end
+        end
+    end
+end
+
 @testset "selective workspace instantiate" begin
     mktempdir() do dir
         path = copy_test_package(dir, "WorkspaceTestInstantiate")

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -242,6 +242,7 @@ end
     mktempdir() do dir
         cd(dir) do
             shared_uuid = "22222222-2222-2222-2222-222222222222"
+            shared_id = UUID(shared_uuid)
             mkpath("ProjectA")
             mkpath("ProjectB")
             for parent in ("variant1", "variant2")
@@ -257,6 +258,17 @@ end
                 )
                 write(joinpath(pkgdir, "src", "SharedDep.jl"), "module SharedDep\nend\n")
             end
+            function write_member(name, source = nothing)
+                source_section = if source === nothing
+                    ""
+                else
+                    "\n[sources]\nSharedDep = $source\n"
+                end
+                return write(
+                    joinpath(name, "Project.toml"),
+                    "[deps]\nSharedDep = \"$shared_uuid\"\n$source_section"
+                )
+            end
             write(
                 "Project.toml",
                 """
@@ -268,35 +280,46 @@ end
                 projects = ["ProjectA", "ProjectB"]
                 """
             )
-            write(
-                joinpath("ProjectA", "Project.toml"),
-                """
-                [deps]
-                SharedDep = "$shared_uuid"
-
-                [sources]
-                SharedDep = {path = "../variant1/SharedDep"}
-                """
-            )
-            write(
-                joinpath("ProjectB", "Project.toml"),
-                """
-                [deps]
-                SharedDep = "$shared_uuid"
-
-                [sources]
-                SharedDep = {path = "../variant2/SharedDep"}
-                """
-            )
+            write_member("ProjectA", "{path = \"../variant1/SharedDep\"}")
+            write_member("ProjectB", "{path = \"../variant2/SharedDep\"}")
             with_current_env() do
-                err = try
-                    Pkg.resolve()
-                    nothing
-                catch e
-                    e
+                @test_throws r"conflicting sources.*paths" Pkg.resolve()
+
+                # A source inherited by ProjectB from the manifest must not
+                # conflict with, or take precedence over, ProjectA's declaration.
+                write_member("ProjectB")
+                Pkg.resolve()
+                @test Pkg.Types.read_manifest("Manifest.toml")[shared_id].path == "variant1/SharedDep"
+                write_member("ProjectA", "{path = \"../variant2/SharedDep\"}")
+                Pkg.resolve()
+                @test Pkg.Types.read_manifest("Manifest.toml")[shared_id].path == "variant2/SharedDep"
+
+                # Equivalent absolute and relative paths are not conflicting.
+                absolute_path = abspath("variant2/SharedDep")
+                write_member("ProjectB", "{path = $(repr(absolute_path))}")
+                Pkg.resolve()
+
+                write_member(
+                    "ProjectA",
+                    "{url = \"https://example.com/A.jl\", rev = \"main\", subdir = \"A\"}"
+                )
+                write_member(
+                    "ProjectB",
+                    "{url = \"https://example.com/B.jl\", rev = \"dev\", subdir = \"B\"}"
+                )
+                @test_throws r"conflicting sources.*repositories.*revisions.*subdirectories" begin
+                    Pkg.Operations.load_direct_deps(Pkg.Types.Context().env)
                 end
-                @test err isa Pkg.Types.PkgError
-                @test occursin("conflicting sources", err.msg)
+
+                # Source fields declared by different members are merged.
+                write_member("ProjectA", "{url = \"https://example.com/SharedDep.jl\"}")
+                write_member(
+                    "ProjectB",
+                    "{url = \"https://example.com/SharedDep.jl\", subdir = \"packages/SharedDep\"}"
+                )
+                deps = Pkg.Operations.load_direct_deps(Pkg.Types.Context().env)
+                shared = only(filter(pkg -> pkg.uuid == shared_id, deps))
+                @test shared.repo.subdir == "packages/SharedDep"
             end
         end
     end


### PR DESCRIPTION
This implements the former TODO to assert that there are no conflicting sources within a workspace. Before this PR you could define different kind of conflicts within a workspace, e.g. one project depending on branch `a` of package `P` and another project depending on branch `b` of package `P`. `Pkg` then selected either `a` or `b` kind of randomly violating one of the constraints without noticing the user.

The user gets an error message in case of conflict where the conflicting sources are listed.

Claude Opus 4.8 wrote the initial version of the patch and the test case.