### PR TITLE
sandbox: don't write empty JuliaLocalPreferences.toml

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2822,8 +2822,8 @@ function sandbox(
         end
 
         Types.write_manifest(working_manifest, tmp_manifest)
-        # Copy over preferences
-        if preferences !== nothing
+        # Copy over preferences (skip if empty to avoid shadowing LocalPreferences.toml)
+        if preferences !== nothing && !isempty(preferences)
             open(tmp_preferences, "w") do io
                 TOML.print(io, preferences::Dict{String, Any})
             end


### PR DESCRIPTION
## Summary

When `Pkg.test` builds its sandbox environment, it collects preferences from the test project and writes them to `JuliaLocalPreferences.toml` in the temp directory. If the test project has no preferences the collected dict is empty (not `nothing`), so an empty file was written unconditionally.

`Base.collect_preferences` checks `JuliaLocalPreferences.toml` before `LocalPreferences.toml` and stops at the first match. An empty `JuliaLocalPreferences.toml` therefore silently shadows any `LocalPreferences.toml` the test itself writes, making it impossible to read preferences set there during the test run.

This caused the `revise_structs preference` test in Revise v3.16.0 (timholy/Revise.jl#1019) to fail on CI: the test writes `[Revise]\nrevise_structs = true` to `LocalPreferences.toml`, but the subprocess launched with `--project=<sandbox>` finds the empty `JuliaLocalPreferences.toml` first and never sees the preference.

**Fix:** skip writing `JuliaLocalPreferences.toml` when the collected preferences dict is empty.

## Test plan

- The Revise CI failure that motivated this: https://buildkite.com/julialang/julia-release-1-dot-13/builds/214#019f194f-31b5-4521-9cd5-c9ebfa97ed9e
- Once merged, update the Pkg SHA in `stdlib/Pkg.version` on `backports-release-1.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)