### PR TITLE
Grab bag of App fixes

### DIFF
--- a/docs/src/apps.md
+++ b/docs/src/apps.md
@@ -44,6 +44,11 @@ reverse = {}
 ```
 The empty table `{}` is to allow for giving metadata about the app.
 
+!!! note
+    In TOML, `reverse = {}` under `[apps]` and a `[apps.reverse]` table are
+    equivalent. Pkg may rewrite between these two forms when it writes out the
+    project file.
+
 After installing this app one could run:
 
 ```
@@ -157,4 +162,30 @@ myapp input.txt
 
 ## Installing Julia apps
 
-The installation of Julia apps is similar to [installing Julia libraries](@ref Managing-Packages) but instead of using e.g. `Pkg.add` or `pkg> add` one uses `Pkg.Apps.add` or `pkg> app add` (`develop` is also available).
+The installation of Julia apps is similar to [installing Julia libraries](@ref Managing-Packages) but instead of using e.g. `Pkg.add` or `pkg> add` one uses `Pkg.Apps.add` or `pkg> app add`.
+Apps can be installed from a registry, a git URL, or a local path:
+
+```julia-repl
+pkg> app add Runic          # from a registry
+pkg> app add Runic@1.5      # specific version
+pkg> app add https://github.com/fredrikekre/Runic.jl
+pkg> app add path/to/Package  # local path (must be a git repository)
+```
+
+To install an app from a local package such that changes to the package are immediately reflected in the app, use `Pkg.Apps.develop` or `pkg> app develop`:
+
+```julia-repl
+pkg> app develop path/to/Package
+```
+
+Installed apps are updated with `pkg> app update [name]` (all apps if no name is given), listed with `pkg> app status`, and removed with `pkg> app rm name`.
+
+## API Reference
+
+```@docs
+Pkg.Apps.add
+Pkg.Apps.develop
+Pkg.Apps.update
+Pkg.Apps.status
+Pkg.Apps.rm
+```

--- a/docs/src/apps.md
+++ b/docs/src/apps.md
@@ -180,7 +180,7 @@ pkg> app develop path/to/Package
 
 Installed apps are updated with `pkg> app update [name]` (all apps if no name is given), listed with `pkg> app status`, and removed with `pkg> app rm name`.
 
-## API Reference
+## Apps API Reference
 
 ```@docs
 Pkg.Apps.add

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -159,10 +159,45 @@ function _resolve(manifest::Manifest, pkgname = nothing)
             cp(original_project_file, projectfile; force = true)
             chmod(projectfile, 0o644)  # Make the copied project file writable
 
-            # Add entryfile stanza pointing to the package entry file
-            # TODO: What if project file has its own entryfile?
             project_data = TOML.parsefile(projectfile)
-            project_data["entryfile"] = joinpath(sourcepath, "src", "$(pkg.name).jl")
+
+            # Add entryfile stanza pointing to the package entry file,
+            # respecting an existing entryfile in the project
+            entryfile = get(project_data, "entryfile", joinpath("src", "$(pkg.name).jl"))
+            project_data["entryfile"] = isabspath(entryfile) ? entryfile : normpath(joinpath(sourcepath, entryfile))
+
+            # Relative paths in [sources] are relative to the original project
+            # location, not the app environment the project file is copied to.
+            # Resolve them against the original location (for packages added
+            # from a local path) or the installed package tree; drop entries
+            # that do not resolve so the dependency comes from a registry.
+            sources = get(project_data, "sources", nothing)
+            if sources !== nothing
+                original_dir = nothing
+                if pkg.repo.source !== nothing && !Pkg.isurl(pkg.repo.source)
+                    original_dir = normpath(joinpath(app_env_folder(), pkg.repo.source))
+                    if pkg.repo.subdir !== nothing
+                        original_dir = joinpath(original_dir, pkg.repo.subdir)
+                    end
+                end
+                for (depname, source) in collect(sources)
+                    path = get(source, "path", nothing)
+                    (path === nothing || isabspath(path)) && continue
+                    candidates = String[]
+                    original_dir !== nothing && push!(candidates, normpath(joinpath(original_dir, path)))
+                    push!(candidates, normpath(joinpath(sourcepath, path)))
+                    resolved = findfirst(isdir, candidates)
+                    if resolved === nothing
+                        @warn "Ignoring source with relative path `$(path)` for dependency $(depname) of package $(pkg.name) since it does not exist relative to the installed package"
+                        delete!(source, "path")
+                        isempty(source) && delete!(sources, depname)
+                    else
+                        source["path"] = candidates[resolved]
+                    end
+                end
+                isempty(sources) && delete!(project_data, "sources")
+            end
+
             atomic_toml_write(projectfile, project_data)
         else
             error("could not find project file for package $pkg")

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -16,6 +16,7 @@ public add, rm, status, update, develop
 app_env_folder() = joinpath(first(DEPOT_PATH), "environments", "apps")
 app_manifest_file() = joinpath(app_env_folder(), "AppManifest.toml")
 julia_bin_path() = joinpath(first(DEPOT_PATH), "bin")
+julia_executable() = joinpath(Sys.BINDIR, "julia" * (Sys.iswindows() ? ".exe" : ""))
 
 app_context() = Context(env = EnvCache(joinpath(app_env_folder(), "Project.toml")))
 
@@ -120,6 +121,11 @@ function get_max_version_register(pkg::PackageSpec, regs)
                     pkg.version == version || continue
                 else
                     version in pkg.version || continue
+                    # Skip versions that are not compatible with the running julia
+                    julia_compat = Registry.query_compat_for_version(pkg_info, version, Registry.JULIA_UUID)
+                    if julia_compat !== nothing && !(VERSION in julia_compat)
+                        continue
+                    end
                 end
                 if max_v === nothing || version > max_v
                     max_v = version
@@ -132,6 +138,26 @@ function get_max_version_register(pkg::PackageSpec, regs)
         error("Suitable package version for $(pkg.name) not found in any registries.")
     end
     return (max_v, tree_hash)
+end
+
+
+# Remove shims from a previous version of the package that it no longer
+# provides and warn about app names that other packages already provide
+function reconcile_shims(manifest::Manifest, pkg::PackageSpec, project)
+    old_entry = get(manifest.deps, pkg.uuid, nothing)
+    if old_entry !== nothing
+        for appname in keys(old_entry.apps)
+            haskey(project.apps, appname) || rm_shim(appname; force = true)
+        end
+    end
+    for (uuid, entry) in manifest.deps
+        uuid == pkg.uuid && continue
+        overlap = sort!(collect(intersect(keys(entry.apps), keys(project.apps))))
+        if !isempty(overlap)
+            @warn "Overwriting apps $(join(overlap, ", ")) provided by package $(entry.name)"
+        end
+    end
+    return
 end
 
 
@@ -210,7 +236,7 @@ function _resolve(manifest::Manifest, pkgname = nothing)
         end
 
         # TODO: Julia path
-        generate_shims_for_apps(pkg.name, pkg.apps, dirname(projectfile), joinpath(Sys.BINDIR, "julia"))
+        generate_shims_for_apps(pkg.name, pkg.apps, dirname(projectfile), julia_executable())
     end
     return write_manifest(manifest, app_manifest_file())
 end
@@ -234,6 +260,7 @@ Pkg.Apps.add(path = "path/to/Package")
 ```
 """
 function add(pkg::Vector{PackageSpec})
+    require_not_empty(pkg, :add)
     for p in pkg
         add(p)
     end
@@ -271,6 +298,7 @@ function add(pkg::PackageSpec)
     Base.rm(joinpath(app_env_folder(), pkg.name); force = true, recursive = true)
     sourcepath = source_path(ctx.env.manifest_file, pkg)
     project = get_project(sourcepath)
+    reconcile_shims(manifest, pkg, project)
     # TODO: Wrong if package itself has a sourcepath?
     # PackageEntry requires version::Union{VersionNumber, Nothing}, but project.version can be VersionSpec
     entry = PackageEntry(; apps = project.apps, name = pkg.name, version = project.version isa VersionNumber ? project.version : nothing, tree_hash = pkg.tree_hash, path = pkg.path, repo = pkg.repo, uuid = pkg.uuid)
@@ -300,6 +328,7 @@ Pkg.Apps.develop(path = "path/to/Package")
 ```
 """
 function develop(pkg::Vector{PackageSpec})
+    require_not_empty(pkg, :develop)
     for p in pkg
         develop(p)
     end
@@ -328,6 +357,7 @@ function develop(pkg::PackageSpec)
     # PackageEntry requires version::Union{VersionNumber, Nothing}, but project.version can be VersionSpec
     entry = PackageEntry(; apps = project.apps, name = pkg.name, version = project.version isa VersionNumber ? project.version : nothing, tree_hash = pkg.tree_hash, path = sourcepath, repo = pkg.repo, uuid = pkg.uuid)
     manifest = ctx.env.manifest
+    reconcile_shims(manifest, pkg, project)
     manifest.deps[pkg.uuid] = entry
 
     # For dev, we don't create an app environment - just point shims directly to the dev'd project
@@ -339,7 +369,7 @@ function develop(pkg::PackageSpec)
         Pkg.instantiate()
     end
 
-    generate_shims_for_apps(pkg.name, project.apps, sourcepath, joinpath(Sys.BINDIR, "julia"))
+    generate_shims_for_apps(pkg.name, project.apps, sourcepath, julia_executable())
 
     @info "For package: $(pkg.name) installed apps: $(join(keys(project.apps), ","))"
     return check_apps_in_path(project.apps)
@@ -463,7 +493,10 @@ function precompile(pkg::Union{Nothing, String} = nothing)
         if pkg !== nothing && info.name !== pkg
             continue
         end
-        Pkg.activate(joinpath(app_env_folder(), info.name)) do
+        # Developed apps run directly from their project, tracked ones from the app environment
+        env_dir = info.path !== nothing ? abspath(source_path(app_manifest_file(), info)) :
+            joinpath(app_env_folder(), info.name)
+        Pkg.activate(env_dir) do
             Pkg.instantiate()
             Pkg.precompile()
         end

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -1,7 +1,7 @@
 module Apps
 
 using Pkg
-using Pkg: atomic_toml_write
+using Pkg: atomic_toml_write, stdout_f
 using Pkg.Versions
 using Pkg.Types: AppInfo, PackageSpec, Context, EnvCache, PackageEntry, Manifest, handle_repo_add!, handle_repo_develop!, write_manifest, write_project,
     pkgerror, projectfile_path
@@ -9,6 +9,7 @@ using Pkg.Operations: print_single, source_path, update_package_add
 using Pkg.API: handle_package_input!
 using TOML, UUIDs
 using Dates
+import FileWatching
 import Pkg.Registry
 
 public add, rm, status, update, develop
@@ -20,35 +21,47 @@ julia_executable() = joinpath(Sys.BINDIR, "julia" * (Sys.iswindows() ? ".exe" : 
 
 app_context() = Context(env = EnvCache(joinpath(app_env_folder(), "Project.toml")))
 
+const _apps_lock_held = Base.ScopedValues.ScopedValue(false)
+
+# Serialize operations that mutate the app environments and the AppManifest
+function with_apps_lock(f)
+    # Operations can be nested (e.g. update calls add) so the lock is reentrant
+    _apps_lock_held[] && return f()
+    mkpath(app_env_folder())
+    return FileWatching.mkpidlock(joinpath(app_env_folder(), ".pid"), stale_age = 10) do
+        Base.ScopedValues.@with _apps_lock_held => true f()
+    end
+end
+
 function validate_app_name(name::AbstractString)
     if isempty(name)
-        error("App name cannot be empty")
+        pkgerror("App name cannot be empty")
     end
     if !occursin(r"^[a-zA-Z][a-zA-Z0-9_-]*$", name)
-        error("App name must start with a letter and contain only letters, numbers, underscores, and hyphens")
+        pkgerror("App name must start with a letter and contain only letters, numbers, underscores, and hyphens")
     end
     return if occursin(r"\.\.", name) || occursin(r"[/\\]", name)
-        error("App name cannot contain path traversal sequences or path separators")
+        pkgerror("App name cannot contain path traversal sequences or path separators")
     end
 end
 
 function validate_package_name(name::AbstractString)
     if isempty(name)
-        error("Package name cannot be empty")
+        pkgerror("Package name cannot be empty")
     end
     return if !occursin(r"^[a-zA-Z][a-zA-Z0-9_]*$", name)
-        error("Package name must start with a letter and contain only letters, numbers, and underscores")
+        pkgerror("Package name must start with a letter and contain only letters, numbers, and underscores")
     end
 end
 
 function validate_submodule_name(name::Union{AbstractString, Nothing})
     return if name !== nothing
         if isempty(name)
-            error("Submodule name cannot be empty")
+            pkgerror("Submodule name cannot be empty")
         end
         # Nested submodules are allowed, e.g. `Foo.Bar`
         if !occursin(r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*$", name)
-            error("Submodule name must be dot-separated identifiers, each starting with a letter and containing only letters, numbers, and underscores")
+            pkgerror("Submodule name must be dot-separated identifiers, each starting with a letter and containing only letters, numbers, and underscores")
         end
     end
 end
@@ -62,10 +75,10 @@ end
 function get_project(sourcepath)
     project_file = projectfile_path(sourcepath)
 
-    isfile(project_file) || error("Project file not found: $project_file")
+    isfile(project_file) || pkgerror("Project file not found: $project_file")
 
     project = Pkg.Types.read_project(project_file)
-    isempty(project.apps) && error("No apps found in Project.toml for package $(project.name) at version $(project.version)")
+    isempty(project.apps) && pkgerror("No apps found in Project.toml for package $(project.name) at version $(project.version)")
     return project
 end
 
@@ -135,7 +148,7 @@ function get_max_version_register(pkg::PackageSpec, regs)
         end
     end
     if max_v === nothing
-        error("Suitable package version for $(pkg.name) not found in any registries.")
+        pkgerror("Suitable package version for $(pkg.name) not found in any registries.")
     end
     return (max_v, tree_hash)
 end
@@ -186,10 +199,17 @@ function _resolve(manifest::Manifest, pkgname = nothing)
 
             project_data = TOML.parsefile(projectfile)
 
+            # Paths inside the depot are written relative to the app environment
+            # so that the depot can be relocated
+            depot_prefix = joinpath(normpath(first(DEPOT_PATH)), "")
+            project_dir = dirname(projectfile)
+            relative_to_depot(path) = startswith(normpath(path), depot_prefix) ? relpath(path, project_dir) : path
+
             # Add entryfile stanza pointing to the package entry file,
             # respecting an existing entryfile in the project
             entryfile = get(project_data, "entryfile", joinpath("src", "$(pkg.name).jl"))
-            project_data["entryfile"] = isabspath(entryfile) ? entryfile : normpath(joinpath(sourcepath, entryfile))
+            entryfile = isabspath(entryfile) ? entryfile : normpath(joinpath(sourcepath, entryfile))
+            project_data["entryfile"] = relative_to_depot(entryfile)
 
             # Relative paths in [sources] are relative to the original project
             # location, not the app environment the project file is copied to.
@@ -217,7 +237,7 @@ function _resolve(manifest::Manifest, pkgname = nothing)
                         delete!(source, "path")
                         isempty(source) && delete!(sources, depname)
                     else
-                        source["path"] = candidates[resolved]
+                        source["path"] = relative_to_depot(candidates[resolved])
                     end
                 end
                 isempty(sources) && delete!(project_data, "sources")
@@ -225,7 +245,7 @@ function _resolve(manifest::Manifest, pkgname = nothing)
 
             atomic_toml_write(projectfile, project_data)
         else
-            error("could not find project file for package $pkg")
+            pkgerror("could not find project file for package $pkg")
         end
 
         # Create a manifest with the manifest entry
@@ -268,7 +288,8 @@ function add(pkg::Vector{PackageSpec})
 end
 
 
-function add(pkg::PackageSpec)
+add(pkg::PackageSpec) = with_apps_lock(() -> _add(pkg))
+function _add(pkg::PackageSpec)
     handle_package_input!(pkg)
 
     ctx = app_context()
@@ -335,7 +356,8 @@ function develop(pkg::Vector{PackageSpec})
     return
 end
 
-function develop(pkg::PackageSpec)
+develop(pkg::PackageSpec) = with_apps_lock(() -> _develop(pkg))
+function _develop(pkg::PackageSpec)
     if pkg.path !== nothing
         pkg.path = abspath(pkg.path)
     end
@@ -398,7 +420,8 @@ function update(pkgs_or_apps::Vector)
     return
 end
 
-function update(pkg::Union{PackageSpec, Nothing} = nothing)
+update(pkg::Union{PackageSpec, Nothing} = nothing) = with_apps_lock(() -> _update(pkg))
+function _update(pkg::Union{PackageSpec, Nothing})
     ctx = app_context()
     manifest = ctx.env.manifest
     deps = Pkg.Operations.load_manifest_deps(manifest)
@@ -437,20 +460,20 @@ end
 Show the installed apps, the version of their package, and the julia command
 used to run them. If `name` is given, limit the output to that app or package.
 """
-function status(pkgs_or_apps::Vector)
+function status(pkgs_or_apps::Vector; io::IO = stdout_f())
     return if isempty(pkgs_or_apps)
-        status()
+        status(; io)
     else
         for pkg_or_app in pkgs_or_apps
             if pkg_or_app isa String
                 pkg_or_app = PackageSpec(pkg_or_app)
             end
-            status(pkg_or_app)
+            status(pkg_or_app; io)
         end
     end
 end
 
-function status(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
+function status(pkg_or_app::Union{PackageSpec, Nothing} = nothing; io::IO = stdout_f())
     # TODO: Sort.
     pkg_or_app = pkg_or_app === nothing ? nothing : pkg_or_app.name
     manifest = Pkg.Types.read_manifest(app_manifest_file())
@@ -469,16 +492,16 @@ function status(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
             end
         end
 
-        printstyled("[", string(dep.uuid)[1:8], "] "; color = :light_black)
-        print_single(stdout, dep)
-        println()
+        printstyled(io, "[", string(dep.uuid)[1:8], "] "; color = :light_black)
+        print_single(io, dep)
+        println(io)
         for (appname, appinfo) in info.apps
             if !is_pkg && pkg_or_app !== nothing && appname !== pkg_or_app
                 continue
             end
             julia_cmd = contractuser(appinfo.julia_command)
-            printstyled("  $(appname)", color = :green)
-            printstyled(" $(julia_cmd) \n", color = :gray)
+            printstyled(io, "  $(appname)", color = :green)
+            printstyled(io, " $(julia_cmd) \n", color = :gray)
         end
     end
     return
@@ -529,7 +552,8 @@ function rm(pkgs_or_apps::Vector)
     return
 end
 
-function rm(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
+rm(pkg_or_app::Union{PackageSpec, Nothing} = nothing) = with_apps_lock(() -> _rm(pkg_or_app))
+function _rm(pkg_or_app::Union{PackageSpec, Nothing})
     pkg_or_app = pkg_or_app === nothing ? nothing : pkg_or_app.name
 
     require_not_empty(pkg_or_app, :rm)
@@ -601,7 +625,7 @@ end
 #########
 
 const SHIM_COMMENT = Sys.iswindows() ? "REM " : "#"
-const SHIM_VERSION = 1.1
+const SHIM_VERSION = 1.2
 const SHIM_HEADER = """$SHIM_COMMENT This file is generated by the Julia package manager.
 $SHIM_COMMENT Shim version: $SHIM_VERSION"""
 
@@ -642,8 +666,16 @@ function shell_shim(julia_escaped::String, module_spec_escaped::String, env, jul
     julia_flags_escaped = join(Base.shell_escape.(julia_flags), " ")
     julia_flags_part = isempty(julia_flags) ? "" : " $julia_flags_escaped"
 
-    load_path_escaped = Base.shell_escape(env)
-    depot_path_escaped = Base.shell_escape(join(DEPOT_PATH, ':'))
+    depot = normpath(first(DEPOT_PATH))
+    depot_escaped = Base.shell_escape(depot)
+    env = normpath(env)
+    # Environments inside the depot are located relative to it so that the
+    # depot can be relocated (developed projects keep their absolute path)
+    load_path_part = if startswith(env, joinpath(depot, ""))
+        "\"\$depot/$(join(splitpath(relpath(env, depot)), '/'))\""
+    else
+        Base.shell_escape(env)
+    end
 
     return """
     #!/bin/sh
@@ -651,9 +683,18 @@ function shell_shim(julia_escaped::String, module_spec_escaped::String, env, jul
 
     $SHIM_HEADER
 
+    # Locate the depot from the location of this script (<depot>/bin/<app>) so
+    # that a relocated depot keeps working; fall back to the install time depot
+    script_dir=\$(CDPATH= cd -- "\$(dirname -- "\$0")" && pwd -P)
+    depot=\$(dirname -- "\$script_dir")
+    if [ ! -e "\$depot/environments/apps/AppManifest.toml" ]; then
+        depot=$depot_escaped
+    fi
+
     # Pin Julia paths for the child process
-    export JULIA_LOAD_PATH=$load_path_escaped
-    export JULIA_DEPOT_PATH=$depot_path_escaped
+    # (the trailing ':' appends the default system depots)
+    export JULIA_DEPOT_PATH="\$depot:"
+    export JULIA_LOAD_PATH=$load_path_part
 
     # Allow overriding Julia executable via environment variable
     if [ -n "\${JULIA_APPS_JULIA_CMD:-}" ]; then
@@ -663,27 +704,28 @@ function shell_shim(julia_escaped::String, module_spec_escaped::String, env, jul
     fi
 
     # If a `--` appears, args before it go to Julia, after it to the app.
-    # If no `--` appears, all original args go to the app (no Julia args).
-    found_separator=false
-    for a in "\$@"; do
-        [ "\$a" = "--" ] && { found_separator=true; break; }
+    # If no `--` appears, all args go to the app (no Julia args).
+    # Rebuild "\$@" in place as: <julia args> -m <module> <app args>, which
+    # preserves argument boundaries exactly.
+    orig_count=\$#
+    seen_sep=false
+    i=0
+    while [ "\$i" -lt "\$orig_count" ]; do
+        arg=\$1
+        shift
+        if [ "\$seen_sep" = false ] && [ "\$arg" = "--" ]; then
+            seen_sep=true
+            set -- "\$@" -m $module_spec_escaped
+        else
+            set -- "\$@" "\$arg"
+        fi
+        i=\$((i + 1))
     done
-
-    if [ "\$found_separator" = "true" ]; then
-        # Build julia_args until `--`, then leave the rest in "\$@"
-        julia_args=""
-        while [ "\$#" -gt 0 ]; do
-            case "\$1" in
-            --) shift; break ;;
-            *)  julia_args="\$julia_args\${julia_args:+ }\$1"; shift ;;
-            esac
-        done
-        # Here: "\$@" are the app args after the separator
-        exec "\$julia_cmd" --startup-file=no$julia_flags_part \$julia_args -m $module_spec_escaped "\$@"
-    else
-        # No separator: all original args go straight to the app
-        exec "\$julia_cmd" --startup-file=no$julia_flags_part -m $module_spec_escaped "\$@"
+    if [ "\$seen_sep" = false ]; then
+        set -- -m $module_spec_escaped "\$@"
     fi
+
+    exec "\$julia_cmd" --startup-file=no$julia_flags_part "\$@"
     """
 end
 
@@ -696,7 +738,15 @@ function windows_shim(
     flags_escaped = join(Base.shell_escape_wincmd.(julia_flags), " ")
     flags_part = isempty(julia_flags) ? "" : " $flags_escaped"
 
-    depot_path = join(DEPOT_PATH, ';')
+    depot = normpath(first(DEPOT_PATH))
+    env = normpath(env)
+    # Environments inside the depot are located relative to it so that the
+    # depot can be relocated (developed projects keep their absolute path)
+    load_path = if startswith(env, joinpath(depot, ""))
+        "%depot%\\$(relpath(env, depot))"
+    else
+        env
+    end
 
     return """
     @echo off
@@ -704,9 +754,15 @@ function windows_shim(
 
     $SHIM_HEADER
 
+    rem --- Locate the depot from the location of this script (<depot>\\bin\\<app>) so
+    rem --- that a relocated depot keeps working; fall back to the install time depot
+    for %%I in ("%~dp0..") do set "depot=%%~fI"
+    if not exist "%depot%\\environments\\apps\\AppManifest.toml" set "depot=$depot"
+
     rem --- Environment (no delayed expansion here to keep '!' literal) ---
-    set "JULIA_LOAD_PATH=$env"
-    set "JULIA_DEPOT_PATH=$depot_path"
+    rem --- (the trailing ';' appends the default system depots) ---
+    set "JULIA_LOAD_PATH=$load_path"
+    set "JULIA_DEPOT_PATH=%depot%;"
 
     rem --- Allow overriding Julia executable via environment variable ---
     if defined JULIA_APPS_JULIA_CMD (

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -216,6 +216,23 @@ function _resolve(manifest::Manifest, pkgname = nothing)
 end
 
 
+"""
+    Pkg.Apps.add(pkg::Union{String, PackageSpec})
+    Pkg.Apps.add(; name, uuid, version, url, rev, path, subdir)
+
+Install the apps of package `pkg`. The package is installed into an isolated
+environment and shims for its apps are created in `~/.julia/bin` (which should
+be added to `PATH`). Apps can be added from a registry, a git URL, or a local
+path (which needs to be a git repository).
+
+# Examples
+```julia
+Pkg.Apps.add("Runic")
+Pkg.Apps.add(name = "Runic", version = "1.5")
+Pkg.Apps.add(url = "https://github.com/fredrikekre/Runic.jl", rev = "master")
+Pkg.Apps.add(path = "path/to/Package")
+```
+"""
 function add(pkg::Vector{PackageSpec})
     for p in pkg
         add(p)
@@ -269,6 +286,19 @@ function add(pkg::PackageSpec)
     return check_apps_in_path(project.apps)
 end
 
+"""
+    Pkg.Apps.develop(pkg::Union{String, PackageSpec})
+    Pkg.Apps.develop(; name, uuid, version, url, rev, path, subdir)
+
+Like [`Pkg.Apps.add`](@ref) but the apps run directly from the developed
+project so changes made to it are immediately reflected in the apps.
+
+# Examples
+```julia
+Pkg.Apps.develop("Runic")
+Pkg.Apps.develop(path = "path/to/Package")
+```
+"""
 function develop(pkg::Vector{PackageSpec})
     for p in pkg
         develop(p)
@@ -316,6 +346,13 @@ function develop(pkg::PackageSpec)
 end
 
 
+"""
+    Pkg.Apps.update(name::Union{Nothing, String} = nothing)
+
+Update the package providing the app `name` (or the package named `name`) to
+the latest compatible version, or all installed apps if no name is given.
+For developed packages the dependencies of the project are updated instead.
+"""
 update(pkgs_or_apps::String) = update([pkgs_or_apps])
 function update(pkgs_or_apps::Vector)
     if isempty(pkgs_or_apps)
@@ -364,6 +401,12 @@ function update(pkg::Union{PackageSpec, Nothing} = nothing)
     return
 end
 
+"""
+    Pkg.Apps.status(name::Union{Nothing, String} = nothing)
+
+Show the installed apps, the version of their package, and the julia command
+used to run them. If `name` is given, limit the output to that app or package.
+"""
 function status(pkgs_or_apps::Vector)
     return if isempty(pkgs_or_apps)
         status()
@@ -435,6 +478,13 @@ function require_not_empty(pkgs, f::Symbol)
     end
 end
 
+"""
+    Pkg.Apps.rm(name::String)
+
+Remove the app `name`, or all apps of the package named `name`. This removes
+the shims from `~/.julia/bin` and, when the last app of a package is removed,
+its app environment.
+"""
 rm(pkgs_or_apps::String) = rm([pkgs_or_apps])
 function rm(pkgs_or_apps::Vector)
     for pkg_or_app in pkgs_or_apps

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -4,7 +4,7 @@ using Pkg
 using Pkg: atomic_toml_write
 using Pkg.Versions
 using Pkg.Types: AppInfo, PackageSpec, Context, EnvCache, PackageEntry, Manifest, handle_repo_add!, handle_repo_develop!, write_manifest, write_project,
-    pkgerror, projectfile_path, manifestfile_path
+    pkgerror, projectfile_path
 using Pkg.Operations: print_single, source_path, update_package_add
 using Pkg.API: handle_package_input!
 using TOML, UUIDs
@@ -319,43 +319,48 @@ end
 
 update(pkgs_or_apps::String) = update([pkgs_or_apps])
 function update(pkgs_or_apps::Vector)
-    for pkg_or_app in pkgs_or_apps
-        if pkg_or_app isa String
-            pkg_or_app = PackageSpec(pkg_or_app)
+    if isempty(pkgs_or_apps)
+        update(nothing)
+    else
+        for pkg_or_app in pkgs_or_apps
+            if pkg_or_app isa String
+                pkg_or_app = PackageSpec(pkg_or_app)
+            end
+            update(pkg_or_app)
         end
-        update(pkg_or_app)
     end
     return
 end
 
-# XXX: Is updating an app ever different from rm-ing and adding it from scratch?
 function update(pkg::Union{PackageSpec, Nothing} = nothing)
     ctx = app_context()
     manifest = ctx.env.manifest
     deps = Pkg.Operations.load_manifest_deps(manifest)
+    updated = false
     for dep in deps
         info = manifest.deps[dep.uuid]
-        if pkg === nothing || info.name !== pkg.name
+        if pkg !== nothing && info.name != pkg.name && !(pkg.name in keys(info.apps))
             continue
         end
-        Pkg.activate(joinpath(app_env_folder(), info.name)) do
-            # precompile only after updating all apps?
-            Pkg.update()
+        updated = true
+        if info.path !== nothing
+            # Developed app: update the dependencies of the developed project
+            # and refresh the app info from it
+            sourcepath = abspath(source_path(ctx.env.manifest_file, info))
+            Pkg.activate(sourcepath) do
+                Pkg.update()
+            end
+            develop(PackageSpec(path = sourcepath))
+        elseif info.repo.source !== nothing || info.repo.rev !== nothing
+            # Repo tracked app: re-add to fetch the latest revision
+            add(PackageSpec(name = info.name, uuid = info.uuid, url = info.repo.source, rev = info.repo.rev, subdir = info.repo.subdir))
+        else
+            # Registry tracked app: re-add to resolve the latest version
+            add(PackageSpec(name = info.name, uuid = info.uuid))
         end
-        sourcepath = abspath(source_path(ctx.env.manifest_file, info))
-        project = get_project(sourcepath)
-        # Get the tree hash from the project file
-        manifest_file = manifestfile_path(joinpath(app_env_folder(), info.name))
-        manifest_app = Pkg.Types.read_manifest(manifest_file)
-        manifest_entry = manifest_app.deps[info.uuid]
-
-        entry = PackageEntry(;
-            apps = project.apps, name = manifest_entry.name, version = manifest_entry.version, tree_hash = manifest_entry.tree_hash,
-            path = manifest_entry.path, repo = manifest_entry.repo, uuid = manifest_entry.uuid
-        )
-
-        manifest.deps[dep.uuid] = entry
-        Pkg.Types.write_manifest(manifest, app_manifest_file())
+    end
+    if pkg !== nothing && !updated
+        pkgerror("no app or package named `$(pkg.name)` found in the app manifest")
     end
     return
 end

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -45,8 +45,9 @@ function validate_submodule_name(name::Union{AbstractString, Nothing})
         if isempty(name)
             error("Submodule name cannot be empty")
         end
-        if !occursin(r"^[a-zA-Z][a-zA-Z0-9_]*$", name)
-            error("Submodule name must start with a letter and contain only letters, numbers, and underscores")
+        # Nested submodules are allowed, e.g. `Foo.Bar`
+        if !occursin(r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*$", name)
+            error("Submodule name must be dot-separated identifiers, each starting with a letter and containing only letters, numbers, and underscores")
         end
     end
 end

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -303,6 +303,13 @@ function develop(pkg::PackageSpec)
 
     # For dev, we don't create an app environment - just point shims directly to the dev'd project
     write_manifest(manifest, app_manifest_file())
+
+    # The shims run with the dev'd project as the load path so it needs
+    # a resolved manifest for the dependencies to be loadable
+    Pkg.activate(sourcepath) do
+        Pkg.instantiate()
+    end
+
     generate_shims_for_apps(pkg.name, project.apps, sourcepath, joinpath(Sys.BINDIR, "julia"))
 
     @info "For package: $(pkg.name) installed apps: $(join(keys(project.apps), ","))"

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -111,9 +111,8 @@ function get_max_version_register(pkg::PackageSpec, regs)
     max_v = nothing
     tree_hash = nothing
     for reg in regs
-        if get(reg, pkg.uuid, nothing) !== nothing
-            reg_pkg = get(reg, pkg.uuid, nothing)
-            reg_pkg === nothing && continue
+        reg_pkg = get(reg, pkg.uuid, nothing)
+        if reg_pkg !== nothing
             pkg_info = Registry.registry_info(reg, reg_pkg)
             for (version, info) in pkg_info.version_info
                 info.yanked && continue
@@ -381,7 +380,7 @@ end
 function status(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
     # TODO: Sort.
     pkg_or_app = pkg_or_app === nothing ? nothing : pkg_or_app.name
-    manifest = Pkg.Types.read_manifest(joinpath(app_env_folder(), "AppManifest.toml"))
+    manifest = Pkg.Types.read_manifest(app_manifest_file())
     deps = Pkg.Operations.load_manifest_deps(manifest)
 
     is_pkg = pkg_or_app !== nothing && any(dep -> dep.name == pkg_or_app, values(manifest.deps))
@@ -413,7 +412,7 @@ function status(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
 end
 
 function precompile(pkg::Union{Nothing, String} = nothing)
-    manifest = Pkg.Types.read_manifest(joinpath(app_env_folder(), "AppManifest.toml"))
+    manifest = Pkg.Types.read_manifest(app_manifest_file())
     deps = Pkg.Operations.load_manifest_deps(manifest)
     for dep in deps
         # TODO: Parallel app compilation..?
@@ -452,7 +451,7 @@ function rm(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
 
     require_not_empty(pkg_or_app, :rm)
 
-    manifest = Pkg.Types.read_manifest(joinpath(app_env_folder(), "AppManifest.toml"))
+    manifest = Pkg.Types.read_manifest(app_manifest_file())
     dep_idx = findfirst(dep -> dep.name == pkg_or_app, manifest.deps)
     if dep_idx !== nothing
         dep = manifest.deps[dep_idx]
@@ -463,21 +462,27 @@ function rm(pkg_or_app::Union{PackageSpec, Nothing} = nothing)
             rm_shim(appname; force = true)
         end
         if dep.path === nothing
-            Base.rm(joinpath(app_env_folder(), dep.name); recursive = true)
+            Base.rm(joinpath(app_env_folder(), dep.name); recursive = true, force = true)
         end
     else
-        for (uuid, pkg) in manifest.deps
+        found = false
+        for (uuid, pkg) in collect(manifest.deps)
             app_idx = findfirst(app -> app.name == pkg_or_app, pkg.apps)
-            if app_idx !== nothing
-                app = pkg.apps[app_idx]
-                @info "Deleted app $(app.name)"
-                delete!(pkg.apps, app.name)
-                rm_shim(app.name; force = true)
-            end
+            app_idx === nothing && continue
+            found = true
+            app = pkg.apps[app_idx]
+            @info "Deleted app $(app.name)"
+            delete!(pkg.apps, app.name)
+            rm_shim(app.name; force = true)
             if isempty(pkg.apps)
                 delete!(manifest.deps, uuid)
-                Base.rm(joinpath(app_env_folder(), pkg.name); recursive = true)
+                if pkg.path === nothing
+                    Base.rm(joinpath(app_env_folder(), pkg.name); recursive = true, force = true)
+                end
             end
+        end
+        if !found
+            pkgerror("no app or package named `$(pkg_or_app)` found in the app manifest")
         end
     end
     # XXX: What happens if something fails above and we do not write out the updated manifest?

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -200,7 +200,18 @@ using Test
     isolate(loaded_depot = true) do
         Pkg.Registry.add("General")
         Pkg.Apps.add(name = "Runic", version = "1.5.1")
+        app_manifest() = Pkg.Types.read_manifest(joinpath(first(DEPOT_PATH), "environments", "apps", "AppManifest.toml"))
+        runic_version() = only(e for e in values(app_manifest().deps) if e.name == "Runic").version
+        @test runic_version() == v"1.5.1"
+        # updating should bump the app itself to the latest version (#4634)
         Pkg.Apps.update("Runic")
+        @test runic_version() > v"1.5.1"
+        # update with no arguments updates all apps
+        Pkg.Apps.update()
+        # updating by app name also works
+        Pkg.Apps.update("runic")
+        # unknown app/package name errors
+        @test_throws Pkg.Types.PkgError Pkg.Apps.update("DoesNotExist")
     end
 end
 

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -67,6 +67,18 @@ using Test
             @test Sys.which(cliexename) == nothing
             @test Sys.which(nestedexename) == nothing
             @test Sys.which(flagsexename) == nothing
+
+            # Removing apps one by one; removing the last one removes the package
+            Pkg.Apps.develop(path = joinpath(@__DIR__, "test_packages", "Rot13.jl"))
+            for app in ("juliarot13", "juliarot13cli", "juliarot13nested", "juliarot13flags")
+                Pkg.Apps.rm(app)
+            end
+            @test Sys.which(exename) == nothing
+            @test Sys.which(flagsexename) == nothing
+            manifest = Pkg.Types.read_manifest(joinpath(first(DEPOT_PATH), "environments", "apps", "AppManifest.toml"))
+            @test isempty(manifest.deps)
+            # Removing something that is not installed errors
+            @test_throws Pkg.Types.PkgError Pkg.Apps.rm("juliarot13")
         end
     end
 

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -185,6 +185,15 @@ using Test
                 @test read(`$exename`, String) == "hello from SomeDep\n"
             end
             Pkg.Apps.rm("SomeApp")
+
+            # develop of an app with dependencies should give it a resolved
+            # manifest so the dependencies can be loaded (#4697)
+            Pkg.Apps.develop(path = someapp)
+            @test isfile(joinpath(someapp, "Manifest.toml"))
+            withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
+                @test read(`$exename`, String) == "hello from SomeDep\n"
+            end
+            Pkg.Apps.rm("SomeApp")
         end
     end
 

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -196,6 +196,25 @@ using Test
             withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
                 @test read(`$exename`, String) == "hello from SomeDep\n"
             end
+
+            # update of a repo-tracked app fetches the latest commit (#4634)
+            write(
+                joinpath(someapp, "src", "SomeApp.jl"), """
+                module SomeApp
+                using SomeDep
+                function (@main)(ARGS)
+                    SomeDep.greet()
+                    println("v2")
+                    return 0
+                end
+                end
+                """
+            )
+            git_init_and_commit(someapp; msg = "v2")
+            Pkg.Apps.update("SomeApp")
+            withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
+                @test read(`$exename`, String) == "hello from SomeDep\nv2\n"
+            end
             Pkg.Apps.rm("SomeApp")
 
             # develop of an app with dependencies should give it a resolved
@@ -203,7 +222,7 @@ using Test
             Pkg.Apps.develop(path = someapp)
             @test isfile(joinpath(someapp, "Manifest.toml"))
             withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
-                @test read(`$exename`, String) == "hello from SomeDep\n"
+                @test read(`$exename`, String) == "hello from SomeDep\nv2\n"
             end
             Pkg.Apps.rm("SomeApp")
         end

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -13,6 +13,7 @@ using Test
         current_path = ENV["PATH"]
         exename = Sys.iswindows() ? "juliarot13.bat" : "juliarot13"
         cliexename = Sys.iswindows() ? "juliarot13cli.bat" : "juliarot13cli"
+        nestedexename = Sys.iswindows() ? "juliarot13nested.bat" : "juliarot13nested"
         flagsexename = Sys.iswindows() ? "juliarot13flags.bat" : "juliarot13flags"
         withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
             # Test original app
@@ -22,6 +23,10 @@ using Test
             # Test submodule app
             @test contains(Sys.which("$cliexename"), first(DEPOT_PATH))
             @test read(`$cliexename test`, String) == "CLI: grfg\n"
+
+            # Test nested submodule app
+            @test contains(Sys.which("$nestedexename"), first(DEPOT_PATH))
+            @test read(`$nestedexename test`, String) == "Nested: grfg\n"
 
             # Test flags app with default julia_flags
             @test contains(Sys.which("$flagsexename"), first(DEPOT_PATH))
@@ -60,6 +65,7 @@ using Test
             Pkg.Apps.rm("Rot13")
             @test Sys.which(exename) == nothing
             @test Sys.which(cliexename) == nothing
+            @test Sys.which(nestedexename) == nothing
             @test Sys.which(flagsexename) == nothing
         end
     end

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -79,6 +79,9 @@ using Test
             @test isempty(manifest.deps)
             # Removing something that is not installed errors
             @test_throws Pkg.Types.PkgError Pkg.Apps.rm("juliarot13")
+            # add/develop with nothing to add errors
+            @test_throws Pkg.Types.PkgError Pkg.Apps.add()
+            @test_throws Pkg.Types.PkgError Pkg.Apps.develop()
         end
     end
 
@@ -176,6 +179,7 @@ using Test
 
                 [apps]
                 someapp = {}
+                someapp2 = {}
                 """
             )
             write(
@@ -198,6 +202,9 @@ using Test
             end
 
             # update of a repo-tracked app fetches the latest commit (#4634)
+            # and removes shims for apps the new version no longer provides
+            exename2 = Sys.iswindows() ? "someapp2.bat" : "someapp2"
+            @test isfile(joinpath(first(DEPOT_PATH), "bin", exename2))
             write(
                 joinpath(someapp, "src", "SomeApp.jl"), """
                 module SomeApp
@@ -210,11 +217,28 @@ using Test
                 end
                 """
             )
+            write(
+                joinpath(someapp, "Project.toml"), """
+                name = "SomeApp"
+                uuid = "6fe06ad9-5ce4-4b58-bb0c-29b0d7e1fd75"
+                version = "0.2.0"
+
+                [deps]
+                SomeDep = "b5c6e794-171e-4c69-906b-483714562d9a"
+
+                [sources]
+                SomeDep = {path = "../SomeDep"}
+
+                [apps]
+                someapp = {}
+                """
+            )
             git_init_and_commit(someapp; msg = "v2")
             Pkg.Apps.update("SomeApp")
             withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
                 @test read(`$exename`, String) == "hello from SomeDep\nv2\n"
             end
+            @test !isfile(joinpath(first(DEPOT_PATH), "bin", exename2))
             Pkg.Apps.rm("SomeApp")
 
             # develop of an app with dependencies should give it a resolved

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -129,6 +129,66 @@ using Test
     end
 
     isolate(loaded_depot = true) do
+        # Relative paths in [sources] of an app's Project.toml (#4532)
+        mktempdir() do tmpdir
+            sep = Sys.iswindows() ? ';' : ':'
+            somedep = joinpath(tmpdir, "SomeDep")
+            mkpath(joinpath(somedep, "src"))
+            write(
+                joinpath(somedep, "Project.toml"), """
+                name = "SomeDep"
+                uuid = "b5c6e794-171e-4c69-906b-483714562d9a"
+                version = "0.1.0"
+                """
+            )
+            write(
+                joinpath(somedep, "src", "SomeDep.jl"), """
+                module SomeDep
+                greet() = println("hello from SomeDep")
+                end
+                """
+            )
+            someapp_stage = joinpath(tmpdir, "staging", "SomeApp")
+            mkpath(joinpath(someapp_stage, "src"))
+            write(
+                joinpath(someapp_stage, "Project.toml"), """
+                name = "SomeApp"
+                uuid = "6fe06ad9-5ce4-4b58-bb0c-29b0d7e1fd75"
+                version = "0.1.0"
+
+                [deps]
+                SomeDep = "b5c6e794-171e-4c69-906b-483714562d9a"
+
+                [sources]
+                SomeDep = {path = "../SomeDep"}
+
+                [apps]
+                someapp = {}
+                """
+            )
+            write(
+                joinpath(someapp_stage, "src", "SomeApp.jl"), """
+                module SomeApp
+                using SomeDep
+                function (@main)(ARGS)
+                    SomeDep.greet()
+                    return 0
+                end
+                end
+                """
+            )
+            someapp = git_init_package(tmpdir, someapp_stage)
+            Pkg.Apps.add(path = someapp)
+            exename = Sys.iswindows() ? "someapp.bat" : "someapp"
+            current_path = ENV["PATH"]
+            withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
+                @test read(`$exename`, String) == "hello from SomeDep\n"
+            end
+            Pkg.Apps.rm("SomeApp")
+        end
+    end
+
+    isolate(loaded_depot = true) do
         Pkg.Registry.add("General")
         Pkg.Apps.add(name = "Runic", version = "1.5.1")
         Pkg.Apps.update("Runic")

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -60,6 +60,24 @@ using Test
                     mock_output = read(`$exename test`, String)
                     @test contains(mock_output, "MOCK_JULIA_EXECUTED")
                 end
+
+                # Test that argument boundaries are preserved exactly
+                if !Sys.iswindows()
+                    argv_mock = joinpath(tmpdir, "argv-julia")
+                    write(argv_mock, "#!/bin/sh\nfor a in \"\$@\"; do printf '%s\\n' \"\$a\"; done\n")
+                    chmod(argv_mock, 0o755)
+                    argv(args) = withenv("JULIA_APPS_JULIA_CMD" => argv_mock) do
+                        split(read(`$exename $args`, String), "\n"; keepempty = true)[1:(end - 1)]
+                    end
+                    # app args with spaces and empty strings
+                    @test argv(["a b", "", "c"]) == ["--startup-file=no", "-m", "Rot13", "a b", "", "c"]
+                    # julia arg containing a space
+                    @test argv(["--project=a b", "--", "z"]) == ["--startup-file=no", "--project=a b", "-m", "Rot13", "z"]
+                    # only the first -- is the separator
+                    @test argv(["--", "a", "--", "b"]) == ["--startup-file=no", "-m", "Rot13", "a", "--", "b"]
+                    # glob characters are not expanded
+                    @test argv(["*"]) == ["--startup-file=no", "-m", "Rot13", "*"]
+                end
             end
 
             Pkg.Apps.rm("Rot13")
@@ -200,6 +218,16 @@ using Test
             withenv("PATH" => string(joinpath(first(DEPOT_PATH), "bin"), sep, current_path)) do
                 @test read(`$exename`, String) == "hello from SomeDep\n"
             end
+
+            # a relocated depot keeps working: shims locate the depot from
+            # their own location and the app environment uses relative paths
+            relocated = joinpath(mktempdir(), "relocated-depot")
+            mkpath(relocated)
+            for dir in ("bin", "environments", "packages")
+                srcdir = joinpath(first(DEPOT_PATH), dir)
+                isdir(srcdir) && cp(srcdir, joinpath(relocated, dir))
+            end
+            @test read(`$(joinpath(relocated, "bin", exename))`, String) == "hello from SomeDep\n"
 
             # update of a repo-tracked app fetches the latest commit (#4634)
             # and removes shims for apps the new version no longer provides

--- a/test/test_packages/Rot13.jl/Project.toml
+++ b/test/test_packages/Rot13.jl/Project.toml
@@ -5,4 +5,5 @@ version = "0.1.0"
 [apps]
 juliarot13 = {}
 juliarot13cli = { submodule = "CLI" }
+juliarot13nested = { submodule = "CLI.Nested" }
 juliarot13flags = { submodule = "FlagsDemo", julia_flags = ["--threads=2", "--optimize=3"] }

--- a/test/test_packages/Rot13.jl/src/CLI.jl
+++ b/test/test_packages/Rot13.jl/src/CLI.jl
@@ -15,4 +15,17 @@ function (@main)(ARGS)
     return 0
 end
 
+module Nested
+
+    using ...Rot13: rot13
+
+    function (@main)(ARGS)
+        for arg in ARGS
+            println("Nested: $(rot13(arg))")
+        end
+        return 0
+    end
+
+end # module Nested
+
 end # module CLI


### PR DESCRIPTION
Grab bag of App fixes. Mostly done by Claude Fable. Reviewed by me.

- **Apps: allow nested submodules in app definitions**
- **Apps: handle relative [sources] paths and custom entryfile on app add**
- **Apps: instantiate the developed project so app dependencies load**
- **Apps: make update actually update apps**
- **Apps: fix rm of individual apps**
- **Apps: document the Apps API**
- **Apps: test that update of a repo-tracked app fetches new commits**
- **Apps: second pass of fixes**
- **Apps: locking, robust shim arguments, relocatable depots, status io, error types**

 Fixes #4634, fixes #4714, fixes #4532, fixes #4697, fixes #4551, fixes #4525, fixes #4591.