### PR TITLE
Make `dependencies` and `project` workspace-aware with a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Pkg v1.14 Release Notes
 =======================
 
+- `Pkg.dependencies` and `Pkg.project` now accept a `workspace::Bool=false` keyword argument.
+  With `workspace=true`, `Pkg.dependencies` returns the dependency graphs of all projects in the
+  workspace, and `Pkg.project` returns a `ProjectInfo` whose `dependencies` field holds the merged
+  direct dependencies of the whole workspace. The default preserves the previous active-project-only
+  behavior.
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Pkg v1.14 Release Notes
   Active-project and workspace preferences are visible to hooks, hook results are cached for the duration of the
   session, `Pkg.status` and offline resolution no longer run hooks, hooks run at the parent's optimization level
   so that dependencies they precompile are reusable, and a hook that loads its own package is an error. ([#4747])
+- `Pkg.dependencies` and `Pkg.project` now accept a `workspace::Bool=false` keyword argument.
+  With `workspace=true`, they include all workspace projects rather than only the active project.
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/src/API.jl
+++ b/src/API.jl
@@ -87,9 +87,9 @@ function package_info(env::EnvCache, pkg::PackageSpec, entry::PackageEntry)::Pac
     return info
 end
 
-dependencies() = dependencies(EnvCache())
-function dependencies(env::EnvCache)
-    pkgs = Operations.load_all_deps_loadable(env)
+dependencies(; workspace::Bool = false) = dependencies(EnvCache(); workspace)
+function dependencies(env::EnvCache; workspace::Bool = false)
+    pkgs = Operations.load_all_deps_loadable(env; workspace)
     return Dict(pkg.uuid::UUID => package_info(env, pkg) for pkg in pkgs)
 end
 function dependencies(fn::Function, uuid::UUID)
@@ -111,15 +111,23 @@ Base.@kwdef struct ProjectInfo
     path::String
 end
 
-project() = project(EnvCache())
-function project(env::EnvCache)::ProjectInfo
+project(; workspace::Bool = false) = project(EnvCache(); workspace)
+function project(env::EnvCache; workspace::Bool = false)::ProjectInfo
     pkg = env.pkg
+    if workspace
+        deps = copy(env.project.deps)
+        for (_, wproj) in env.workspace
+            merge!(deps, wproj.deps)
+        end
+    else
+        deps = env.project.deps
+    end
     return ProjectInfo(
         name = pkg === nothing ? nothing : pkg.name,
         uuid = pkg === nothing ? nothing : pkg.uuid,
         version = pkg === nothing ? nothing : pkg.version::VersionNumber,
         ispackage = pkg !== nothing,
-        dependencies = env.project.deps,
+        dependencies = deps,
         sources = env.project.sources,
         path = env.project_file
     )

--- a/src/API.jl
+++ b/src/API.jl
@@ -50,7 +50,10 @@ function Base.:(==)(a::PackageInfo, b::PackageInfo)
         a.source == b.source && a.dependencies == b.dependencies
 end
 
-function package_info(env::EnvCache, pkg::PackageSpec)::PackageInfo
+function package_info(
+        env::EnvCache, pkg::PackageSpec;
+        is_direct_dep::Bool = pkg.uuid in values(env.project.deps)
+    )::PackageInfo
     entry = manifest_info(env.manifest, pkg.uuid)
     if entry === nothing
         pkgerror(
@@ -58,10 +61,13 @@ function package_info(env::EnvCache, pkg::PackageSpec)::PackageInfo
             " (use `resolve` to populate the manifest)"
         )
     end
-    return package_info(env, pkg, entry)
+    return package_info(env, pkg, entry; is_direct_dep)
 end
 
-function package_info(env::EnvCache, pkg::PackageSpec, entry::PackageEntry)::PackageInfo
+function package_info(
+        env::EnvCache, pkg::PackageSpec, entry::PackageEntry;
+        is_direct_dep::Bool = pkg.uuid in values(env.project.deps)
+    )::PackageInfo
     git_source = pkg.repo.source === nothing ? nothing :
         isurl(pkg.repo.source::String) ? pkg.repo.source::String :
         safe_realpath(manifest_rel_path(env, pkg.repo.source::String))
@@ -74,7 +80,7 @@ function package_info(env::EnvCache, pkg::PackageSpec, entry::PackageEntry)::Pac
         name = pkg.name,
         version = pkg.version != VersionSpec() ? pkg.version : nothing,
         tree_hash = pkg.tree_hash === nothing ? nothing : string(pkg.tree_hash), # TODO or should it just be a SHA?
-        is_direct_dep = pkg.uuid in values(env.project.deps),
+        is_direct_dep = is_direct_dep,
         is_pinned = pkg.pinned,
         is_tracking_path = pkg.path !== nothing,
         is_tracking_repo = pkg.repo.rev !== nothing || pkg.repo.source !== nothing,
@@ -87,10 +93,12 @@ function package_info(env::EnvCache, pkg::PackageSpec, entry::PackageEntry)::Pac
     return info
 end
 
-dependencies() = dependencies(EnvCache())
-function dependencies(env::EnvCache)
-    pkgs = Operations.load_all_deps_loadable(env)
-    return Dict(pkg.uuid::UUID => package_info(env, pkg) for pkg in pkgs)
+dependencies(; workspace::Bool = false) = dependencies(EnvCache(); workspace)
+function dependencies(env::EnvCache; workspace::Bool = false)
+    pkgs = Operations.load_all_deps_loadable(env; workspace)
+    direct_deps = Set(values(env.project.deps))
+    workspace && foreach(project -> union!(direct_deps, values(project.deps)), values(env.workspace))
+    return Dict(pkg.uuid::UUID => package_info(env, pkg; is_direct_dep = pkg.uuid in direct_deps) for pkg in pkgs)
 end
 function dependencies(fn::Function, uuid::UUID)
     dep = get(dependencies(), uuid, nothing)
@@ -111,15 +119,28 @@ Base.@kwdef struct ProjectInfo
     path::String
 end
 
-project() = project(EnvCache())
-function project(env::EnvCache)::ProjectInfo
+project(; workspace::Bool = false) = project(EnvCache(); workspace)
+function project(env::EnvCache; workspace::Bool = false)::ProjectInfo
     pkg = env.pkg
+    if workspace
+        deps = copy(env.project.deps)
+        for (_, wproj) in env.workspace
+            for (name, uuid) in wproj.deps
+                if haskey(deps, name) && deps[name] != uuid
+                    pkgerror("dependency `$name` has different UUIDs across workspace projects")
+                end
+                deps[name] = uuid
+            end
+        end
+    else
+        deps = env.project.deps
+    end
     return ProjectInfo(
         name = pkg === nothing ? nothing : pkg.name,
         uuid = pkg === nothing ? nothing : pkg.uuid,
         version = pkg === nothing ? nothing : pkg.version::VersionNumber,
         ispackage = pkg !== nothing,
-        dependencies = env.project.deps,
+        dependencies = deps,
         sources = env.project.sources,
         path = env.project_file
     )

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -272,9 +272,14 @@ function load_all_deps(
     return load_direct_deps(env, pkgs; preserve = preserve)
 end
 
-function load_all_deps_loadable(env::EnvCache)
+function load_all_deps_loadable(env::EnvCache; workspace::Bool = false)
     deps = load_all_deps(env)
     keep = Set{UUID}(values(env.project.deps))
+    if workspace
+        for (_, project) in env.workspace
+            union!(keep, values(project.deps))
+        end
+    end
     prune_deps(env.manifest, keep)
     filtered = filter(pkg -> pkg.uuid in keep, deps)
     return filtered

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -583,12 +583,15 @@ Create a minimal project called `pkgname` in the current folder. For more featur
 const generate = API.generate
 
 """
-    Pkg.dependencies()::Dict{UUID, PackageInfo}
+    Pkg.dependencies(; workspace::Bool=false)::Dict{UUID, PackageInfo}
 
 This feature is considered experimental.
 
 Query the dependency graph of the active project.
 The result is a `Dict` that maps a package UUID to a `PackageInfo` struct representing the dependency (a package).
+
+If `workspace` is `true`, the dependency graphs of all projects in the workspace are
+included, not just that of the active project.
 
 # `PackageInfo` fields
 
@@ -610,11 +613,15 @@ The result is a `Dict` that maps a package UUID to a `PackageInfo` struct repres
 const dependencies = API.dependencies
 
 """
-    Pkg.project()::ProjectInfo
+    Pkg.project(; workspace::Bool=false)::ProjectInfo
 
 This feature is considered experimental.
 
 Request a `ProjectInfo` struct which contains information about the active project.
+
+If `workspace` is `true`, the `dependencies` field holds the merged direct dependencies
+of the whole workspace, i.e. the active project's direct dependencies combined with those
+of every workspace member project.
 
 # `ProjectInfo` fields
 

--- a/src/Pkg.jl
+++ b/src/Pkg.jl
@@ -583,12 +583,15 @@ Create a minimal project called `pkgname` in the current folder. For more featur
 const generate = API.generate
 
 """
-    Pkg.dependencies()::Dict{UUID, PackageInfo}
+    Pkg.dependencies(; workspace::Bool=false)::Dict{UUID, PackageInfo}
 
 This feature is considered experimental.
 
 Query the dependency graph of the active project.
 The result is a `Dict` that maps a package UUID to a `PackageInfo` struct representing the dependency (a package).
+
+If `workspace` is `true`, the dependency graphs of all projects in the workspace are
+included, not just that of the active project.
 
 # `PackageInfo` fields
 
@@ -610,11 +613,14 @@ The result is a `Dict` that maps a package UUID to a `PackageInfo` struct repres
 const dependencies = API.dependencies
 
 """
-    Pkg.project()::ProjectInfo
+    Pkg.project(; workspace::Bool=false)::ProjectInfo
 
 This feature is considered experimental.
 
 Request a `ProjectInfo` struct which contains information about the active project.
+
+If `workspace` is `true`, `dependencies` contains the merged direct dependencies of all
+workspace projects. Other fields still describe the active project.
 
 # `ProjectInfo` fields
 
@@ -625,6 +631,7 @@ Request a `ProjectInfo` struct which contains information about the active proje
 | `version`      | The project's version                                                                       |
 | `ispackage`    | Whether the project is a package (has a name and uuid)                                      |
 | `dependencies` | The project's direct dependencies as a `Dict` which maps dependency name to dependency UUID |
+| `sources`      | The project's source overrides                                                               |
 | `path`         | The location of the project file which defines the active project                           |
 """
 const project = API.project

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -147,6 +147,25 @@ temp_pkg_dir() do project_path
                     @test pkg.version > v"1.1.2"
                 end
 
+                # dependencies/project with workspace reflect the whole workspace, not just the root.
+                # TestSpecificPackage is a direct dep of the `test` workspace member only, and is not
+                # reachable from the root project's dependency closure.
+                active_dep_names = Set(info.name for info in values(Pkg.dependencies()))
+                ws_dep_names = Set(info.name for info in values(Pkg.dependencies(; workspace = true)))
+                @test !("TestSpecificPackage" in active_dep_names)
+                @test "TestSpecificPackage" in ws_dep_names
+
+                root_deps = keys(Pkg.project().dependencies)
+                ws_deps = keys(Pkg.project(; workspace = true).dependencies)
+                # the active project's direct deps do not include a subproject-only dep
+                @test "Example" in root_deps
+                @test !("TestSpecificPackage" in root_deps)
+                # the workspace-merged direct deps include subproject-only deps
+                @test "Example" in ws_deps
+                @test "TestSpecificPackage" in ws_deps
+                # project() must not be mutated by the workspace merge
+                @test !("TestSpecificPackage" in keys(Pkg.project().dependencies))
+
                 # Test that the subprojects are working
                 depot_path_string = join(Base.DEPOT_PATH, Sys.iswindows() ? ";" : ":")
                 withenv("JULIA_DEPOT_PATH" => depot_path_string) do

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -147,6 +147,23 @@ temp_pkg_dir() do project_path
                     @test pkg.version > v"1.1.2"
                 end
 
+                active_dependencies = Pkg.dependencies()
+                workspace_dependencies = Pkg.dependencies(; workspace = true)
+                active_dep_names = Set(info.name for info in values(active_dependencies))
+                ws_dep_names = Set(info.name for info in values(workspace_dependencies))
+                @test !("TestSpecificPackage" in active_dep_names)
+                @test "TestSpecificPackage" in ws_dep_names
+                @test !active_dependencies[chairmarks_uuid].is_direct_dep
+                @test workspace_dependencies[chairmarks_uuid].is_direct_dep
+
+                root_deps = keys(Pkg.project().dependencies)
+                ws_deps = keys(Pkg.project(; workspace = true).dependencies)
+                @test "Example" in root_deps
+                @test !("TestSpecificPackage" in root_deps)
+                @test "Example" in ws_deps
+                @test "TestSpecificPackage" in ws_deps
+                @test !("TestSpecificPackage" in keys(Pkg.project().dependencies))
+
                 # Test that the subprojects are working
                 depot_path_string = join(Base.DEPOT_PATH, Sys.iswindows() ? ";" : ":")
                 # The subprocesses run no Pkg code; with coverage enabled they
@@ -287,6 +304,34 @@ end
                 ctx = Pkg.Types.Context()
                 @test Pkg.Operations.is_instantiated(ctx.env, false)   # Root project complete (has Crayons)
                 @test !Pkg.Operations.is_instantiated(ctx.env, true)   # Workspace incomplete (missing Example)
+            end
+        end
+    end
+end
+
+@testset "workspace dependency name conflicts" begin
+    mktempdir() do dir
+        mkpath(joinpath(dir, "member"))
+        write(
+            joinpath(dir, "Project.toml"),
+            """
+            [deps]
+            SharedName = "00000000-0000-0000-0000-000000000001"
+
+            [workspace]
+            projects = ["member"]
+            """
+        )
+        write(
+            joinpath(dir, "member", "Project.toml"),
+            """
+            [deps]
+            SharedName = "00000000-0000-0000-0000-000000000002"
+            """
+        )
+        cd(dir) do
+            with_current_env() do
+                @test_throws Pkg.Types.PkgError Pkg.project(; workspace = true)
             end
         end
     end


### PR DESCRIPTION
This seems to be a logical extension of available functionality to better support workspaces. This would also allow [reducing the private API surface of `PkgToSoftwareBOM.jl` significantly](https://github.com/SamuraiAku/PkgToSoftwareBOM.jl/pull/48).

Claude Opus 4.8 helped in creating this PR.