### PR TITLE
Don't create redundant `[sources]` for workspace-internal deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Pkg v1.14 Release Notes
 =======================
 
+- Pkg no longer creates a `[sources]` entry for a dependency that is itself a project in the same workspace. Such a
+  dependency is already located through workspace membership, so the entry was redundant. Existing `[sources]` entries
+  are still honored.
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Pkg v1.14 Release Notes
   Active-project and workspace preferences are visible to hooks, hook results are cached for the duration of the
   session, `Pkg.status` and offline resolution no longer run hooks, hooks run at the parent's optimization level
   so that dependencies they precompile are reusable, and a hook that loads its own package is an error. ([#4747])
+- Pkg no longer creates redundant `[sources]` entries for dependencies that are projects in the same workspace.
+  Existing entries are still honored.
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/docs/src/creating-packages.md
+++ b/docs/src/creating-packages.md
@@ -320,10 +320,10 @@ The resulting `test/Project.toml` will look like:
 [deps]
 HelloWorld = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # UUID from HelloWorld's Project.toml
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[sources]
-HelloWorld = {path = ".."}
 ```
+
+Note that no `[sources]` entry is written for `HelloWorld`. Because it is a project in the same
+workspace, the package manager locates it automatically, so a source would be redundant.
 
 You can now use `Test` in the test script:
 

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -178,7 +178,7 @@ Sources are read and applied in the following situations:
 
 1. **Active environment**: When resolving dependencies for the currently active environment, sources from the environment's `Project.toml` override registry information for direct dependencies.
 
-2. **Automatic addition**: When you add a package by URL (e.g., `pkg> add https://github.com/...`) or develop a package (e.g., `pkg> dev Example`), Pkg automatically adds an entry to `[sources]` for that package in your active environment's `Project.toml`.
+2. **Automatic addition**: When you add a package by URL (e.g., `pkg> add https://github.com/...`) or develop a package (e.g., `pkg> dev Example`), Pkg automatically adds an entry to `[sources]` for that package in your active environment's `Project.toml`. The exception is a dependency that is itself another project in the same workspace which can be located without a `[sources]` entry.
 
 3. **Recursive collection**: When a package is added by URL or path, Pkg recursively collects `[sources]` entries from that package's dependencies. This allows private dependency chains to resolve without registry metadata. For example:
    - If you `add` Package A by URL, and Package A has a `[sources]` entry for Package B

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -183,7 +183,7 @@ Sources are read and applied in the following situations:
 
 1. **Active environment**: When resolving dependencies for the currently active environment, sources from the environment's `Project.toml` override registry information for direct dependencies.
 
-2. **Automatic addition**: When you add a package by URL (e.g., `pkg> add https://github.com/...`) or develop a package (e.g., `pkg> dev Example`), Pkg automatically adds an entry to `[sources]` for that package in your active environment's `Project.toml`.
+2. **Automatic addition**: When you add a package by URL (e.g., `pkg> add https://github.com/...`) or develop a package (e.g., `pkg> dev Example`), Pkg automatically adds an entry to `[sources]` for that package in your active environment's `Project.toml`. The exception is a dependency that is itself another project in the same workspace which can be located without a `[sources]` entry.
 
 3. **Recursive collection**: When a package is added by URL or path, Pkg recursively collects `[sources]` entries from that package's dependencies. This allows private dependency chains to resolve without registry metadata. For example:
    - If you `add` Package A by URL, and Package A has a `[sources]` entry for Package B

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -164,6 +164,38 @@ end
 merge_pkg_source!(target::PackageSpec, source::PackageSpec) =
     merge_pkg_source!(target, source.path, source.repo)
 
+# In a workspace the same package can be a direct dependency of several projects,
+# each of which may point it at a source via `[sources]`. Merging those entries
+# only makes sense if they agree; otherwise the resulting source would depend on
+# the order the projects happen to be iterated in, so reject the configuration.
+function assert_no_conflicting_sources(pkgs)
+    paths = Set{String}()
+    repo_sources = Set{String}()
+    revs = Set{String}()
+    subdirs = Set{String}()
+    for pkg in pkgs
+        isnothing(pkg.path) || push!(paths, pkg.path)
+        isnothing(pkg.repo.source) || push!(repo_sources, pkg.repo.source)
+        isnothing(pkg.repo.rev) || push!(revs, pkg.repo.rev)
+        isnothing(pkg.repo.subdir) || push!(subdirs, pkg.repo.subdir)
+    end
+    conflicts = String[]
+    if !isempty(paths) && (!isempty(repo_sources) || !isempty(revs))
+        push!(conflicts, "both a path and a repository")
+    end
+    showvals(vals) = join((repr(v) for v in sort!(collect(vals))), ", ")
+    length(paths) > 1 && push!(conflicts, "paths $(showvals(paths))")
+    length(repo_sources) > 1 && push!(conflicts, "repositories $(showvals(repo_sources))")
+    length(revs) > 1 && push!(conflicts, "revisions $(showvals(revs))")
+    length(subdirs) > 1 && push!(conflicts, "subdirectories $(showvals(subdirs))")
+    isempty(conflicts) && return
+    pkgerror(
+        """
+        Package $(err_rep(first(pkgs))) has conflicting sources specified by different projects in the workspace: $(join(conflicts, "; ")).
+        Make the `[sources]` entries for this package agree across the workspace."""
+    )
+end
+
 function load_direct_deps(
         env::EnvCache, pkgs::Vector{PackageSpec} = PackageSpec[];
         preserve::PreserveLevel = PRESERVE_DIRECT
@@ -177,7 +209,7 @@ function load_direct_deps(
     unique_uuids = Set{UUID}(pkg.uuid for pkg in pkgs_direct)
     for uuid in unique_uuids
         idxs = findall(pkg -> pkg.uuid == uuid, pkgs_direct)
-        # TODO: Assert that projects do not have conflicting sources
+        assert_no_conflicting_sources(view(pkgs_direct, idxs))
         pkg = pkgs_direct[idxs[1]]
         idx_to_drop = Int[]
         for i in Iterators.drop(idxs, 1)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -159,32 +159,36 @@ function merge_pkg_source!(pkg::PackageSpec, path::Union{Nothing, String}, repo:
     if pkg.repo.rev === nothing && repo.rev !== nothing
         pkg.repo.rev = repo.rev
     end
+    if pkg.repo.subdir === nothing && repo.subdir !== nothing
+        pkg.repo.subdir = repo.subdir
+    end
     return
 end
 merge_pkg_source!(target::PackageSpec, source::PackageSpec) =
     merge_pkg_source!(target, source.path, source.repo)
 
-# In a workspace the same package can be a direct dependency of several projects,
-# each of which may point it at a source via `[sources]`. Merging those entries
-# only makes sense if they agree; otherwise the resulting source would depend on
-# the order the projects happen to be iterated in, so reject the configuration.
-function assert_no_conflicting_sources(pkgs)
-    paths = Set{String}()
+function assert_no_conflicting_sources(pkgs, manifest_file::String)
+    length(pkgs) <= 1 && return
+    paths = Dict{String, String}()
     repo_sources = Set{String}()
     revs = Set{String}()
     subdirs = Set{String}()
     for pkg in pkgs
-        isnothing(pkg.path) || push!(paths, pkg.path)
+        if pkg.path !== nothing
+            normalized = normpath(abspath(dirname(manifest_file), pkg.path))
+            paths[normalized] = pkg.path
+        end
         isnothing(pkg.repo.source) || push!(repo_sources, pkg.repo.source)
         isnothing(pkg.repo.rev) || push!(revs, pkg.repo.rev)
         isnothing(pkg.repo.subdir) || push!(subdirs, pkg.repo.subdir)
     end
     conflicts = String[]
-    if !isempty(paths) && (!isempty(repo_sources) || !isempty(revs))
+    if !isempty(paths) && !isempty(repo_sources)
         push!(conflicts, "both a path and a repository")
     end
+    !isempty(paths) && !isempty(revs) && push!(conflicts, "both a path and a revision")
     showvals(vals) = join((repr(v) for v in sort!(collect(vals))), ", ")
-    length(paths) > 1 && push!(conflicts, "paths $(showvals(paths))")
+    length(paths) > 1 && push!(conflicts, "paths $(showvals(values(paths)))")
     length(repo_sources) > 1 && push!(conflicts, "repositories $(showvals(repo_sources))")
     length(revs) > 1 && push!(conflicts, "revisions $(showvals(revs))")
     length(subdirs) > 1 && push!(conflicts, "subdirectories $(showvals(subdirs))")
@@ -196,20 +200,33 @@ function assert_no_conflicting_sources(pkgs)
     )
 end
 
+function collect_project_sources!(sources, project, project_file, manifest_file)
+    for (name, uuid) in project.deps
+        path, repo = get_path_repo(project, project_file, manifest_file, name)
+        path === nothing && repo == GitRepo() && continue
+        push!(get!(() -> PackageSpec[], sources, uuid), PackageSpec(; uuid, name, path, repo))
+    end
+    return
+end
+
 function load_direct_deps(
         env::EnvCache, pkgs::Vector{PackageSpec} = PackageSpec[];
         preserve::PreserveLevel = PRESERVE_DIRECT
     )
+    project_sources = Dict{UUID, Vector{PackageSpec}}()
+    collect_project_sources!(project_sources, env.project, env.project_file, env.manifest_file)
     pkgs_direct = load_project_deps(env.project, env.project_file, env.manifest, env.manifest_file, pkgs; preserve)
 
     for (path, project) in env.workspace
+        collect_project_sources!(project_sources, project, path, env.manifest_file)
         append!(pkgs_direct, load_project_deps(project, path, env.manifest, env.manifest_file, pkgs; preserve))
     end
+
+    foreach(sources -> assert_no_conflicting_sources(sources, env.manifest_file), values(project_sources))
 
     unique_uuids = Set{UUID}(pkg.uuid for pkg in pkgs_direct)
     for uuid in unique_uuids
         idxs = findall(pkg -> pkg.uuid == uuid, pkgs_direct)
-        assert_no_conflicting_sources(view(pkgs_direct, idxs))
         pkg = pkgs_direct[idxs[1]]
         idx_to_drop = Int[]
         for i in Iterators.drop(idxs, 1)
@@ -220,7 +237,17 @@ function load_direct_deps(
         deleteat!(pkgs_direct, idx_to_drop)
     end
 
-    return vcat(pkgs, pkgs_direct)
+    all_pkgs = vcat(pkgs, pkgs_direct)
+    for (uuid, sources) in project_sources
+        idx = findfirst(pkg -> pkg.uuid == uuid, all_pkgs)
+        idx === nothing && continue
+        declared = PackageSpec(; uuid)
+        foreach(source -> merge_pkg_source!(declared, source), sources)
+        # Explicit project sources override manifest fallbacks, which may be stale.
+        all_pkgs[idx].path = declared.path
+        all_pkgs[idx].repo = declared.repo
+    end
+    return all_pkgs
 end
 
 function load_project_deps(

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1396,8 +1396,15 @@ function write_env(
         skip_writing_project::Bool = false,
         skip_readonly_check::Bool = false
     )
+    # UUIDs of the other projects in the workspace. A dependency on one of these
+    # resolves to that project's path through workspace membership, so a `[sources]`
+    # entry for it only duplicates information the workspace already provides. Honor
+    # such an entry if the user already authored one, but never synthesize a new one.
+    workspace_uuids = Set{UUID}(p.uuid for p in values(env.workspace) if p.uuid !== nothing)
+
     # Verify that the generated manifest is consistent with `sources`
     for (pkg, uuid) in env.project.deps
+        uuid in workspace_uuids && !haskey(env.original_project.sources, pkg) && continue
         path, repo = get_path_repo(env.project, env.project_file, env.manifest_file, pkg)
         entry = manifest_info(env.manifest, uuid)
         if path !== nothing

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1402,8 +1402,12 @@ function write_env(
         skip_writing_project::Bool = false,
         skip_readonly_check::Bool = false
     )
+    workspace_uuids = Set{UUID}(p.uuid for p in values(env.workspace) if p.uuid !== nothing)
+
     # Verify that the generated manifest is consistent with `sources`
     for (pkg, uuid) in env.project.deps
+        # Preserve user-authored sources, but do not synthesize redundant workspace paths.
+        uuid in workspace_uuids && !haskey(env.original_project.sources, pkg) && continue
         path, repo = get_path_repo(env.project, env.project_file, env.manifest_file, pkg)
         entry = manifest_info(env.manifest, uuid)
         if path !== nothing

--- a/test/test_packages/WorkspacePathResolution/SubProjectA/Project.toml
+++ b/test/test_packages/WorkspacePathResolution/SubProjectA/Project.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 SubProjectB = "12345678-1234-1234-1234-123456789012"
 
 [sources]
-SubProjectB = {path = "SubProjectB"}
+SubProjectB = {path = "../SubProjectB"}

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -233,6 +233,30 @@ end
     end
 end
 
+# A dependency that is itself a workspace project is located through workspace
+# membership, so Pkg must not create a redundant `[sources]` entry for it.
+# `WorkspacePathResolution`'s SubProjectA depends on its sibling SubProjectB;
+# with the authored source removed, resolving must not write it back.
+@testset "no [sources] created for workspace-internal dependencies" begin
+    isolate() do
+        mktempdir() do dir
+            path = copy_test_package(dir, "WorkspacePathResolution")
+            cd(path) do
+                with_current_env() do
+                    project_file = joinpath("SubProjectA", "Project.toml")
+                    project = TOML.parsefile(project_file)
+                    delete!(project, "sources")
+                    Pkg.Types.write_project(project, project_file)
+
+                    Pkg.activate("SubProjectA")
+                    Pkg.resolve()
+                    @test !haskey(TOML.parsefile(project_file), "sources")
+                end
+            end
+        end
+    end
+end
+
 # Two workspace member projects that pin the same dependency to different sources
 # cannot be merged into a single manifest entry, so resolving must error clearly.
 @testset "workspace projects with conflicting [sources]" begin

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -233,6 +233,72 @@ end
     end
 end
 
+# Two workspace member projects that pin the same dependency to different sources
+# cannot be merged into a single manifest entry, so resolving must error clearly.
+@testset "workspace projects with conflicting [sources]" begin
+    mktempdir() do dir
+        cd(dir) do
+            shared_uuid = "22222222-2222-2222-2222-222222222222"
+            mkpath("ProjectA")
+            mkpath("ProjectB")
+            for parent in ("variant1", "variant2")
+                pkgdir = joinpath(parent, "SharedDep")
+                mkpath(joinpath(pkgdir, "src"))
+                write(
+                    joinpath(pkgdir, "Project.toml"),
+                    """
+                    name = "SharedDep"
+                    uuid = "$shared_uuid"
+                    version = "0.1.0"
+                    """
+                )
+                write(joinpath(pkgdir, "src", "SharedDep.jl"), "module SharedDep\nend\n")
+            end
+            write(
+                "Project.toml",
+                """
+                name = "ConflictRoot"
+                uuid = "33333333-3333-3333-3333-333333333333"
+                version = "0.1.0"
+
+                [workspace]
+                projects = ["ProjectA", "ProjectB"]
+                """
+            )
+            write(
+                joinpath("ProjectA", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant1/SharedDep"}
+                """
+            )
+            write(
+                joinpath("ProjectB", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant2/SharedDep"}
+                """
+            )
+            with_current_env() do
+                err = try
+                    Pkg.resolve()
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa Pkg.Types.PkgError
+                @test occursin("conflicting sources", err.msg)
+            end
+        end
+    end
+end
+
 @testset "selective workspace instantiate" begin
     mktempdir() do dir
         path = copy_test_package(dir, "WorkspaceTestInstantiate")

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -236,6 +236,72 @@ end
     end
 end
 
+# Two workspace member projects that pin the same dependency to different sources
+# cannot be merged into a single manifest entry, so resolving must error clearly.
+@testset "workspace projects with conflicting [sources]" begin
+    mktempdir() do dir
+        cd(dir) do
+            shared_uuid = "22222222-2222-2222-2222-222222222222"
+            mkpath("ProjectA")
+            mkpath("ProjectB")
+            for parent in ("variant1", "variant2")
+                pkgdir = joinpath(parent, "SharedDep")
+                mkpath(joinpath(pkgdir, "src"))
+                write(
+                    joinpath(pkgdir, "Project.toml"),
+                    """
+                    name = "SharedDep"
+                    uuid = "$shared_uuid"
+                    version = "0.1.0"
+                    """
+                )
+                write(joinpath(pkgdir, "src", "SharedDep.jl"), "module SharedDep\nend\n")
+            end
+            write(
+                "Project.toml",
+                """
+                name = "ConflictRoot"
+                uuid = "33333333-3333-3333-3333-333333333333"
+                version = "0.1.0"
+
+                [workspace]
+                projects = ["ProjectA", "ProjectB"]
+                """
+            )
+            write(
+                joinpath("ProjectA", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant1/SharedDep"}
+                """
+            )
+            write(
+                joinpath("ProjectB", "Project.toml"),
+                """
+                [deps]
+                SharedDep = "$shared_uuid"
+
+                [sources]
+                SharedDep = {path = "../variant2/SharedDep"}
+                """
+            )
+            with_current_env() do
+                err = try
+                    Pkg.resolve()
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa Pkg.Types.PkgError
+                @test occursin("conflicting sources", err.msg)
+            end
+        end
+    end
+end
+
 @testset "selective workspace instantiate" begin
     mktempdir() do dir
         path = copy_test_package(dir, "WorkspaceTestInstantiate")

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -242,6 +242,7 @@ end
     mktempdir() do dir
         cd(dir) do
             shared_uuid = "22222222-2222-2222-2222-222222222222"
+            shared_id = UUID(shared_uuid)
             mkpath("ProjectA")
             mkpath("ProjectB")
             for parent in ("variant1", "variant2")
@@ -257,6 +258,17 @@ end
                 )
                 write(joinpath(pkgdir, "src", "SharedDep.jl"), "module SharedDep\nend\n")
             end
+            function write_member(name, source = nothing)
+                source_section = if source === nothing
+                    ""
+                else
+                    "\n[sources]\nSharedDep = $source\n"
+                end
+                return write(
+                    joinpath(name, "Project.toml"),
+                    "[deps]\nSharedDep = \"$shared_uuid\"\n$source_section"
+                )
+            end
             write(
                 "Project.toml",
                 """
@@ -268,35 +280,46 @@ end
                 projects = ["ProjectA", "ProjectB"]
                 """
             )
-            write(
-                joinpath("ProjectA", "Project.toml"),
-                """
-                [deps]
-                SharedDep = "$shared_uuid"
-
-                [sources]
-                SharedDep = {path = "../variant1/SharedDep"}
-                """
-            )
-            write(
-                joinpath("ProjectB", "Project.toml"),
-                """
-                [deps]
-                SharedDep = "$shared_uuid"
-
-                [sources]
-                SharedDep = {path = "../variant2/SharedDep"}
-                """
-            )
+            write_member("ProjectA", "{path = \"../variant1/SharedDep\"}")
+            write_member("ProjectB", "{path = \"../variant2/SharedDep\"}")
             with_current_env() do
-                err = try
-                    Pkg.resolve()
-                    nothing
-                catch e
-                    e
+                @test_throws r"conflicting sources.*paths" Pkg.resolve()
+
+                # A source inherited by ProjectB from the manifest must not
+                # conflict with, or take precedence over, ProjectA's declaration.
+                write_member("ProjectB")
+                Pkg.resolve()
+                @test Pkg.Types.read_manifest("Manifest.toml")[shared_id].path == "variant1/SharedDep"
+                write_member("ProjectA", "{path = \"../variant2/SharedDep\"}")
+                Pkg.resolve()
+                @test Pkg.Types.read_manifest("Manifest.toml")[shared_id].path == "variant2/SharedDep"
+
+                # Equivalent absolute and relative paths are not conflicting.
+                absolute_path = abspath("variant2/SharedDep")
+                write_member("ProjectB", "{path = $(repr(absolute_path))}")
+                Pkg.resolve()
+
+                write_member(
+                    "ProjectA",
+                    "{url = \"https://example.com/A.jl\", rev = \"main\", subdir = \"A\"}"
+                )
+                write_member(
+                    "ProjectB",
+                    "{url = \"https://example.com/B.jl\", rev = \"dev\", subdir = \"B\"}"
+                )
+                @test_throws r"conflicting sources.*repositories.*revisions.*subdirectories" begin
+                    Pkg.Operations.load_direct_deps(Pkg.Types.Context().env)
                 end
-                @test err isa Pkg.Types.PkgError
-                @test occursin("conflicting sources", err.msg)
+
+                # Source fields declared by different members are merged.
+                write_member("ProjectA", "{url = \"https://example.com/SharedDep.jl\"}")
+                write_member(
+                    "ProjectB",
+                    "{url = \"https://example.com/SharedDep.jl\", subdir = \"packages/SharedDep\"}"
+                )
+                deps = Pkg.Operations.load_direct_deps(Pkg.Types.Context().env)
+                shared = only(filter(pkg -> pkg.uuid == shared_id, deps))
+                @test shared.repo.subdir == "packages/SharedDep"
             end
         end
     end

--- a/test/workspaces.jl
+++ b/test/workspaces.jl
@@ -236,6 +236,29 @@ end
     end
 end
 
+@testset "no [sources] created for workspace-internal dependencies" begin
+    isolate() do
+        mktempdir() do dir
+            path = copy_test_package(dir, "WorkspacePathResolution")
+            cd(path) do
+                with_current_env() do
+                    project_file = joinpath("SubProjectA", "Project.toml")
+                    Pkg.activate("SubProjectA")
+                    Pkg.resolve()
+                    @test TOML.parsefile(project_file)["sources"]["SubProjectB"] == Dict("path" => "../SubProjectB")
+
+                    project = TOML.parsefile(project_file)
+                    delete!(project, "sources")
+                    Pkg.Types.write_project(project, project_file)
+
+                    Pkg.resolve()
+                    @test !haskey(TOML.parsefile(project_file), "sources")
+                end
+            end
+        end
+    end
+end
+
 # Two workspace member projects that pin the same dependency to different sources
 # cannot be merged into a single manifest entry, so resolving must error clearly.
 @testset "workspace projects with conflicting [sources]" begin


### PR DESCRIPTION
A dependency that is itself an environment in the same workspace is located
through workspace membership. This is already working before the PR.

In this PR we stop adding a (completely redundant) `[sources]` entry for such
dependencies. We do respect, however, the existing entries to avoid changing
project files which the user might want to be preserved.

An especially good (and common) example why the previous behavior has not
made too much sense (to me) is the following:
Assume a package which is a workspace which has a test directory with a
separate environment. Per default `Pkg` created a source entry in the test
environment to locate the package in "..".

So we effectively told the user:
> Don't worry, as you are in the test environment we've located the root of the
> workspace automatically, but please tell me explicitly where the package is
> you want to test, because I can't find that automatically although I already
> found it as it is identical to the workspace environment.

I used Claude Opus 4.8 when creating this PR.

This PR is based on #4709, so should be merged after #4709.