### PR TITLE
release-1.12: Actually avoid depwarn, and enable --depwarn=error in CI (#4358)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: true
+          depwarn: error
         env:
           JULIA_PKG_SERVER: ${{ matrix.pkg-server }}
           JULIA_TEST_VERBOSE_LOGS_DIR: ${{ github.workspace }}

--- a/ext/REPLExt/REPLExt.jl
+++ b/ext/REPLExt/REPLExt.jl
@@ -302,7 +302,7 @@ function try_prompt_pkg_add(pkgs::Vector{Symbol})
             push!(keybindings, only("$n"))
             push!(shown_envs, expanded_env)
         end
-        menu = TerminalMenus.RadioMenu(option_list; keybindings = keybindings, pagesize = length(option_list))
+        menu = TerminalMenus.RadioMenu(option_list; keybindings = keybindings, pagesize = length(option_list), charset = :ascii)
         default = something(
             # select the first non-default env by default, if possible
             findfirst(!=(Base.active_project()), shown_envs),

--- a/ext/REPLExt/compat.jl
+++ b/ext/REPLExt/compat.jl
@@ -16,7 +16,7 @@ function _compat(ctx::Context; io = nothing, input_io = stdin)
         push!(opt_strs, Operations.compat_line(io, dep, uuid, compat_str, longest_dep_len, indent = ""))
         push!(opt_pkgs, dep)
     end
-    menu = TerminalMenus.RadioMenu(opt_strs; pagesize = length(opt_strs))
+    menu = TerminalMenus.RadioMenu(opt_strs; pagesize = length(opt_strs), charset = :ascii)
     choice = try
         TerminalMenus.request(TerminalMenus.default_terminal(in = input_io, out = io), "  Select an entry to edit:", menu)
     catch err


### PR DESCRIPTION
(cherry picked from commit 834c62d)