### PR TITLE
Atomically update usage TOMLs and handle malformed files

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -750,9 +750,14 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
     # Combine the per-depot live paths for the mark-and-sweep phase below.
     all_manifest_tomls = Set(f for (_, files) in manifest_usage_by_depot for f in keys(files))
     all_artifact_tomls = Set(f for (_, files) in artifact_usage_by_depot for f in keys(files))
-    all_scratch_dirs = Set(f for (_, dirs) in scratch_usage_by_depot for f in keys(dirs))
     all_unknown_scratch_parents = Set(
         f for (_, paths) in unknown_scratch_parents_by_depot for f in paths
+    )
+    # Unknown-parent records are deliberately excluded from the condensed usage map,
+    # but must still enter marking so `process_scratchspace` can preserve them.
+    all_scratch_dirs = union(
+        Set(f for (_, dirs) in scratch_usage_by_depot for f in keys(dirs)),
+        all_unknown_scratch_parents,
     )
 
     function process_manifest_pkgs(path)

--- a/src/API.jl
+++ b/src/API.jl
@@ -13,7 +13,7 @@ import Base: StaleCacheKey
 
 import ..depots, ..depots1, ..logdir, ..devdir, ..printpkgstyle, .._autoprecompilation_enabled_scoped, ..manifest_rel_path
 import ..Operations, ..GitTools, ..Pkg, ..Registry
-import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH, ..atomic_toml_write, ..safe_realpath
+import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH, ..safe_realpath
 using ..Types, ..TOML
 using ..Types: VersionTypes
 using Base.BinaryPlatforms
@@ -648,16 +648,21 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
     # Collect both last known usage dates, as well as parent projects for each scratch space
     scratch_usage_by_depot = UsageByDepotDict()
     scratch_parents_by_depot = Dict{String, Dict{String, Set{String}}}()
+    unknown_scratch_parents_by_depot = Dict{String, Set{String}}()
 
-    # Fold every recorded event in one usage log into caller-owned condensed state.
-    # A parse failure returns false so GC can stop rather than treat the log as empty.
-    function reduce_usage!(f::Function, usage_filepath)
-        parsed_usage = Types.read_usage_file(usage_filepath)
-        parsed_usage === nothing && return false
-        for (filename, infos) in parsed_usage
-            f.(Ref(filename), infos)
+    function condense_index_usage(usage_file::String)
+        return Types.with_usage_file(usage_file; create = false, malformed = :preserve) do entries
+            usage = UsageDict()
+            valid_usage = Types.foreach_usage_entry(entries, usage_file) do filename, info
+                time = Types.usage_time(info, usage_file, filename)
+                usage[filename] = max(get(usage, filename, DateTime(0)), time)
+            end
+            valid_usage || return nothing
+            filter!(((path, _),) -> Pkg.isfile_nothrow(path), usage)
+            empty!(entries)
+            merge!(entries, Dict(path => [Dict("time" => time)] for (path, time) in usage))
+            return usage
         end
-        return true
     end
 
     # Read and rewrite each existing usage log as one locked transaction. This prevents
@@ -668,22 +673,7 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
         # the manifest log with that condensed representation.
         manifest_usage_file = joinpath(logdir(depot), "manifest_usage.toml")
         manifest_usage_result = if isfile(manifest_usage_file)
-            Types.with_usage_file_lock(manifest_usage_file) do
-                usage = UsageDict()
-                reduce_usage!(manifest_usage_file) do filename, info
-                    time = Types.usage_time(info, manifest_usage_file, filename)
-                    usage[filename] = max(get(usage, filename, DateTime(0)), time)
-                end || return nothing
-                filter!(((path, time),) -> Pkg.isfile_nothrow(path), usage)
-                condensed_usage =
-                    Dict(path => [Dict("time" => time)] for (path, time) in usage)
-                atomic_toml_write(
-                    manifest_usage_file,
-                    condensed_usage,
-                    sorted = true
-                )
-                return usage
-            end
+            condense_index_usage(manifest_usage_file)
         else
             UsageDict()
         end
@@ -694,22 +684,7 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
         # Apply the same latest-timestamp condensation to extant Artifacts.toml files.
         artifact_usage_file = joinpath(logdir(depot), "artifact_usage.toml")
         artifact_usage_result = if isfile(artifact_usage_file)
-            Types.with_usage_file_lock(artifact_usage_file) do
-                usage = UsageDict()
-                reduce_usage!(artifact_usage_file) do filename, info
-                    time = Types.usage_time(info, artifact_usage_file, filename)
-                    usage[filename] = max(get(usage, filename, DateTime(0)), time)
-                end || return nothing
-                filter!(((path, time),) -> Pkg.isfile_nothrow(path), usage)
-                condensed_usage =
-                    Dict(path => [Dict("time" => time)] for (path, time) in usage)
-                atomic_toml_write(
-                    artifact_usage_file,
-                    condensed_usage,
-                    sorted = true
-                )
-                return usage
-            end
+            condense_index_usage(artifact_usage_file)
         else
             UsageDict()
         end
@@ -721,20 +696,26 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
         # and parents, and atomically rewrite the remaining live associations.
         scratch_usage_file = joinpath(logdir(depot), "scratch_usage.toml")
         scratch_usage_result = if isfile(scratch_usage_file)
-            Types.with_usage_file_lock(scratch_usage_file) do
+            Types.with_usage_file(scratch_usage_file; create = false, malformed = :preserve) do entries
                 usage = UsageDict()
                 parents = Dict{String, Set{String}}()
-                reduce_usage!(scratch_usage_file) do filename, info
+                unknown_parents = Set{String}()
+                valid_usage = Types.foreach_usage_entry(entries, scratch_usage_file) do filename, info
                     time = Types.usage_time(info, scratch_usage_file, filename)
                     usage[filename] = max(get(usage, filename, DateTime(0)), time)
-                    for parent in info["parent_projects"]
-                        push!(get!(Set{String}, parents, filename), parent)
+                    entry_parents = Types.usage_parents(info, scratch_usage_file, filename)
+                    if entry_parents === nothing
+                        push!(unknown_parents, filename)
+                    else
+                        union!(get!(Set{String}, parents, filename), entry_parents)
                     end
-                end || return nothing
+                end
+                valid_usage || return nothing
                 filter!(((path, time),) -> Pkg.isdir_nothrow(path), usage)
                 filter!(pair -> first(pair) in keys(usage), parents)
-                expanded_usage = Dict{String, Vector{Dict}}()
+                expanded_usage = Dict{String, Any}()
                 for (path, time) in usage
+                    path in unknown_parents && continue
                     parent_paths = parents[path]
                     filter!(Pkg.isfile_nothrow, parent_paths)
                     isempty(parent_paths) && continue
@@ -747,22 +728,32 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
                 end
                 filter!(pair -> first(pair) in keys(expanded_usage), usage)
                 filter!(pair -> first(pair) in keys(expanded_usage), parents)
-                atomic_toml_write(scratch_usage_file, expanded_usage, sorted = true)
-                return (usage, parents)
+                # Retain records with unknown parents unchanged: they cannot safely be
+                # condensed or considered orphaned until a later valid writer repairs them.
+                for path in unknown_parents
+                    haskey(entries, path) && (expanded_usage[path] = entries[path])
+                end
+                empty!(entries)
+                merge!(entries, expanded_usage)
+                return (usage, parents, unknown_parents)
             end
         else
-            (UsageDict(), Dict{String, Set{String}}())
+            (UsageDict(), Dict{String, Set{String}}(), Set{String}())
         end
         scratch_usage_result === nothing && return
-        scratch_usage, scratch_parents = scratch_usage_result
+        scratch_usage, scratch_parents, unknown_scratch_parents = scratch_usage_result
         scratch_usage_by_depot[depot] = scratch_usage
         scratch_parents_by_depot[depot] = scratch_parents
+        unknown_scratch_parents_by_depot[depot] = unknown_scratch_parents
     end
 
     # Combine the per-depot live paths for the mark-and-sweep phase below.
     all_manifest_tomls = Set(f for (_, files) in manifest_usage_by_depot for f in keys(files))
     all_artifact_tomls = Set(f for (_, files) in artifact_usage_by_depot for f in keys(files))
     all_scratch_dirs = Set(f for (_, dirs) in scratch_usage_by_depot for f in keys(dirs))
+    all_unknown_scratch_parents = Set(
+        f for (_, paths) in unknown_scratch_parents_by_depot for f in paths
+    )
 
     function process_manifest_pkgs(path)
         # Read the manifest in
@@ -832,6 +823,8 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
     end
 
     function process_scratchspace(path, pkgs_to_delete)
+        path in all_unknown_scratch_parents && return [path]
+
         # Find all parents of this path
         parents = String[]
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -8,7 +8,6 @@ import Random
 using Dates
 import LibGit2
 import Logging
-import FileWatching
 
 import Base: StaleCacheKey
 
@@ -650,144 +649,120 @@ function gc(ctx::Context = Context(); collect_delay::Union{Period, Nothing} = no
     scratch_usage_by_depot = UsageByDepotDict()
     scratch_parents_by_depot = Dict{String, Dict{String, Set{String}}}()
 
-    # Load manifest files from all depots
+    # Fold every recorded event in one usage log into caller-owned condensed state.
+    # A parse failure returns false so GC can stop rather than treat the log as empty.
+    function reduce_usage!(f::Function, usage_filepath)
+        parsed_usage = Types.read_usage_file(usage_filepath)
+        parsed_usage === nothing && return false
+        for (filename, infos) in parsed_usage
+            f.(Ref(filename), infos)
+        end
+        return true
+    end
+
+    # Read and rewrite each existing usage log as one locked transaction. This prevents
+    # GC from replacing a concurrent writer's update with a stale condensed snapshot.
+    # Logs that do not yet exist remain absent and are not rewritten by this GC pass.
     for depot in gc_depots
-        # When a manifest/artifact.toml is installed/used, we log it within the
-        # `manifest_usage.toml` files within `write_env_usage()` and `bind_artifact!()`
-        function reduce_usage!(f::Function, usage_filepath)
-            if !isfile(usage_filepath)
-                return
+        # Keep the latest timestamp for every manifest that still exists, then replace
+        # the manifest log with that condensed representation.
+        manifest_usage_file = joinpath(logdir(depot), "manifest_usage.toml")
+        manifest_usage_result = if isfile(manifest_usage_file)
+            Types.with_usage_file_lock(manifest_usage_file) do
+                usage = UsageDict()
+                reduce_usage!(manifest_usage_file) do filename, info
+                    time = Types.usage_time(info, manifest_usage_file, filename)
+                    usage[filename] = max(get(usage, filename, DateTime(0)), time)
+                end || return nothing
+                filter!(((path, time),) -> Pkg.isfile_nothrow(path), usage)
+                condensed_usage =
+                    Dict(path => [Dict("time" => time)] for (path, time) in usage)
+                atomic_toml_write(
+                    manifest_usage_file,
+                    condensed_usage,
+                    sorted = true
+                )
+                return usage
             end
-
-            for (filename, infos) in parse_toml(usage_filepath)
-                f.(Ref(filename), infos)
-            end
-            return
+        else
+            UsageDict()
         end
+        manifest_usage_result === nothing && return
+        manifest_usage = manifest_usage_result::UsageDict
+        manifest_usage_by_depot[depot] = manifest_usage
 
-        # Extract usage data from this depot, (taking only the latest state for each
-        # tracked manifest/artifact.toml), then merge the usage values from each file
-        # into the overall list across depots to create a single, coherent view across
-        # all depots.
-        usage = UsageDict()
-        let usage = usage
-            reduce_usage!(joinpath(logdir(depot), "manifest_usage.toml")) do filename, info
-                # For Manifest usage, store only the last DateTime for each filename found
-                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"])::DateTime)
+        # Apply the same latest-timestamp condensation to extant Artifacts.toml files.
+        artifact_usage_file = joinpath(logdir(depot), "artifact_usage.toml")
+        artifact_usage_result = if isfile(artifact_usage_file)
+            Types.with_usage_file_lock(artifact_usage_file) do
+                usage = UsageDict()
+                reduce_usage!(artifact_usage_file) do filename, info
+                    time = Types.usage_time(info, artifact_usage_file, filename)
+                    usage[filename] = max(get(usage, filename, DateTime(0)), time)
+                end || return nothing
+                filter!(((path, time),) -> Pkg.isfile_nothrow(path), usage)
+                condensed_usage =
+                    Dict(path => [Dict("time" => time)] for (path, time) in usage)
+                atomic_toml_write(
+                    artifact_usage_file,
+                    condensed_usage,
+                    sorted = true
+                )
+                return usage
             end
+        else
+            UsageDict()
         end
-        manifest_usage_by_depot[depot] = usage
+        artifact_usage_result === nothing && return
+        artifact_usage = artifact_usage_result::UsageDict
+        artifact_usage_by_depot[depot] = artifact_usage
 
-        usage = UsageDict()
-        let usage = usage
-            reduce_usage!(joinpath(logdir(depot), "artifact_usage.toml")) do filename, info
-                # For Artifact usage, store only the last DateTime for each filename found
-                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"])::DateTime)
-            end
-        end
-        artifact_usage_by_depot[depot] = usage
-
-        # track last-used
-        usage = UsageDict()
-        parents = Dict{String, Set{String}}()
-        let usage = usage
-            reduce_usage!(joinpath(logdir(depot), "scratch_usage.toml")) do filename, info
-                # For Artifact usage, store only the last DateTime for each filename found
-                usage[filename] = max(get(usage, filename, DateTime(0)), DateTime(info["time"])::DateTime)
-                if !haskey(parents, filename)
-                    parents[filename] = Set{String}()
+        # Merge scratch timestamps and parent projects, discard missing scratchspaces
+        # and parents, and atomically rewrite the remaining live associations.
+        scratch_usage_file = joinpath(logdir(depot), "scratch_usage.toml")
+        scratch_usage_result = if isfile(scratch_usage_file)
+            Types.with_usage_file_lock(scratch_usage_file) do
+                usage = UsageDict()
+                parents = Dict{String, Set{String}}()
+                reduce_usage!(scratch_usage_file) do filename, info
+                    time = Types.usage_time(info, scratch_usage_file, filename)
+                    usage[filename] = max(get(usage, filename, DateTime(0)), time)
+                    for parent in info["parent_projects"]
+                        push!(get!(Set{String}, parents, filename), parent)
+                    end
+                end || return nothing
+                filter!(((path, time),) -> Pkg.isdir_nothrow(path), usage)
+                filter!(pair -> first(pair) in keys(usage), parents)
+                expanded_usage = Dict{String, Vector{Dict}}()
+                for (path, time) in usage
+                    parent_paths = parents[path]
+                    filter!(Pkg.isfile_nothrow, parent_paths)
+                    isempty(parent_paths) && continue
+                    expanded_usage[path] = [
+                        Dict(
+                            "time" => time,
+                            "parent_projects" => collect(parent_paths),
+                        ),
+                    ]
                 end
-                for parent in info["parent_projects"]
-                    push!(parents[filename], parent)
-                end
+                filter!(pair -> first(pair) in keys(expanded_usage), usage)
+                filter!(pair -> first(pair) in keys(expanded_usage), parents)
+                atomic_toml_write(scratch_usage_file, expanded_usage, sorted = true)
+                return (usage, parents)
             end
+        else
+            (UsageDict(), Dict{String, Set{String}}())
         end
-        scratch_usage_by_depot[depot] = usage
-        scratch_parents_by_depot[depot] = parents
+        scratch_usage_result === nothing && return
+        scratch_usage, scratch_parents = scratch_usage_result
+        scratch_usage_by_depot[depot] = scratch_usage
+        scratch_parents_by_depot[depot] = scratch_parents
     end
 
-    # Next, figure out which files are still existent
-    all_manifest_tomls = unique(f for (_, files) in manifest_usage_by_depot for f in keys(files))
-    all_artifact_tomls = unique(f for (_, files) in artifact_usage_by_depot for f in keys(files))
-    all_scratch_dirs = unique(f for (_, dirs) in scratch_usage_by_depot for f in keys(dirs))
-    all_scratch_parents = Set{String}()
-    for (depot, parents) in scratch_parents_by_depot
-        for parent in values(parents)
-            union!(all_scratch_parents, parent)
-        end
-    end
-
-    all_manifest_tomls = Set(filter(Pkg.isfile_nothrow, all_manifest_tomls))
-    all_artifact_tomls = Set(filter(Pkg.isfile_nothrow, all_artifact_tomls))
-    all_scratch_dirs = Set(filter(Pkg.isdir_nothrow, all_scratch_dirs))
-    all_scratch_parents = Set(filter(Pkg.isfile_nothrow, all_scratch_parents))
-
-    # Immediately write these back as condensed toml files
-    function write_condensed_toml(f::Function, usage_by_depot, fname)
-        for (depot, usage) in usage_by_depot
-            # Run through user-provided filter/condenser
-            usage = f(depot, usage)
-
-            # Write out the TOML file for this depot
-            usage_path = joinpath(logdir(depot), fname)
-            if !(isempty(usage)::Bool) || isfile(usage_path)
-                let usage = usage
-                    atomic_toml_write(usage_path, usage, sorted = true)
-                end
-            end
-        end
-        return
-    end
-
-    # Write condensed Manifest usage
-    let all_manifest_tomls = all_manifest_tomls
-        write_condensed_toml(manifest_usage_by_depot, "manifest_usage.toml") do depot, usage
-            # Keep only manifest usage markers that are still existent
-            let usage = usage
-                filter!(((k, v),) -> k in all_manifest_tomls, usage)
-
-                # Expand it back into a dict-of-dicts
-                return Dict(k => [Dict("time" => v)] for (k, v) in usage)
-            end
-        end
-    end
-
-    # Write condensed Artifact usage
-    let all_artifact_tomls = all_artifact_tomls
-        write_condensed_toml(artifact_usage_by_depot, "artifact_usage.toml") do depot, usage
-            let usage = usage
-                filter!(((k, v),) -> k in all_artifact_tomls, usage)
-                return Dict(k => [Dict("time" => v)] for (k, v) in usage)
-            end
-        end
-    end
-
-    # Write condensed scratch space usage
-    let all_scratch_parents = all_scratch_parents, all_scratch_dirs = all_scratch_dirs
-        write_condensed_toml(scratch_usage_by_depot, "scratch_usage.toml") do depot, usage
-            # Keep only scratch directories that still exist
-            filter!(((k, v),) -> k in all_scratch_dirs, usage)
-
-            # Expand it back into a dict-of-dicts
-            expanded_usage = Dict{String, Vector{Dict}}()
-            for (k, v) in usage
-                # Drop scratch spaces whose parents are all non-existent
-                parents = scratch_parents_by_depot[depot][k]
-                filter!(p -> p in all_scratch_parents, parents)
-                if isempty(parents)
-                    continue
-                end
-
-                expanded_usage[k] = [
-                    Dict(
-                        "time" => v,
-                        "parent_projects" => collect(parents),
-                    ),
-                ]
-            end
-            return expanded_usage
-        end
-    end
+    # Combine the per-depot live paths for the mark-and-sweep phase below.
+    all_manifest_tomls = Set(f for (_, files) in manifest_usage_by_depot for f in keys(files))
+    all_artifact_tomls = Set(f for (_, files) in artifact_usage_by_depot for f in keys(files))
+    all_scratch_dirs = Set(f for (_, dirs) in scratch_usage_by_depot for f in keys(dirs))
 
     function process_manifest_pkgs(path)
         # Read the manifest in

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -16,7 +16,7 @@ using Base.BinaryPlatforms
 import ...Pkg
 import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
-import ...Pkg: usable_io, discover_repo, create_cachedir_tag, manifest_rel_path, atomic_toml_write
+import ...Pkg: usable_io, discover_repo, create_cachedir_tag, manifest_rel_path
 
 #########
 # Utils #
@@ -1562,7 +1562,7 @@ function download_artifacts(
     end
 
 
-    return write_env_usage(used_artifact_tomls, "artifact_usage.toml")
+    return write_env_usage(collect(used_artifact_tomls), "artifact_usage.toml")
 end
 
 function download_artifacts(
@@ -1943,28 +1943,23 @@ const PkgUUID = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 pkg_scratchpath() = joinpath(depots1(), "scratchspaces", PkgUUID)
 
 function write_scratch_usage(scratch::AbstractString, parent_project::AbstractString)
-    !ispath(logdir()) && mkpath(logdir())
     usage_file = joinpath(logdir(), "scratch_usage.toml")
-    Types.with_usage_file_lock(usage_file) do
-        usage = @something(
-            isfile(usage_file) ? Types.read_usage_file(usage_file) : nothing,
-            Dict{String, Any}()
-        )
-        parents = Set{String}([parent_project])
-        for info in get(usage, scratch, [])
-            union!(parents, get(info, "parent_projects", String[]))
+    try
+        Types.with_usage_file(usage_file; create = true, malformed = :replace) do usage
+            parents = Set{String}([parent_project])
+            for info in get(usage, scratch, [])
+                existing_parents = Types.usage_parents(info, usage_file, scratch)
+                existing_parents === nothing || union!(parents, existing_parents)
+            end
+            usage[scratch] = [
+                Dict(
+                    "time" => Dates.now(),
+                    "parent_projects" => collect(parents),
+                ),
+            ]
         end
-        usage[scratch] = [
-            Dict(
-                "time" => Dates.now(),
-                "parent_projects" => collect(parents),
-            ),
-        ]
-        try
-            atomic_toml_write(usage_file, usage, sorted = true)
-        catch err
-            @error "Failed to write valid usage file `$usage_file`" exception = err
-        end
+    catch err
+        @error "Failed to write valid usage file `$usage_file`" exception = err
     end
     return
 end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -9,14 +9,14 @@ using Random: randstring
 import LibGit2, Dates, TOML
 
 using ..Types, ..Resolve, ..PlatformEngines, ..GitTools, ..MiniProgressBars
-import ..depots, ..depots1, ..devdir, ..set_readonly, ..Types.PackageEntry
+import ..depots, ..depots1, ..logdir, ..devdir, ..set_readonly, ..Types.PackageEntry
 import ..Artifacts: ensure_artifact_installed, artifact_names, extract_all_hashes,
     artifact_exists, select_downloadable_artifacts, mv_temp_dir_retries
 using Base.BinaryPlatforms
 import ...Pkg
 import ...Pkg: pkg_server, Registry, pathrepr, can_fancyprint, printpkgstyle, stderr_f, OFFLINE_MODE
 import ...Pkg: UPDATED_REGISTRY_THIS_SESSION, RESPECT_SYSIMAGE_VERSIONS, should_autoprecompile
-import ...Pkg: usable_io, discover_repo, create_cachedir_tag, manifest_rel_path
+import ...Pkg: usable_io, discover_repo, create_cachedir_tag, manifest_rel_path, atomic_toml_write
 
 #########
 # Utils #
@@ -1942,6 +1942,33 @@ end
 const PkgUUID = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 pkg_scratchpath() = joinpath(depots1(), "scratchspaces", PkgUUID)
 
+function write_scratch_usage(scratch::AbstractString, parent_project::AbstractString)
+    !ispath(logdir()) && mkpath(logdir())
+    usage_file = joinpath(logdir(), "scratch_usage.toml")
+    Types.with_usage_file_lock(usage_file) do
+        usage = @something(
+            isfile(usage_file) ? Types.read_usage_file(usage_file) : nothing,
+            Dict{String, Any}()
+        )
+        parents = Set{String}([parent_project])
+        for info in get(usage, scratch, [])
+            union!(parents, get(info, "parent_projects", String[]))
+        end
+        usage[scratch] = [
+            Dict(
+                "time" => Dates.now(),
+                "parent_projects" => collect(parents),
+            ),
+        ]
+        try
+            atomic_toml_write(usage_file, usage, sorted = true)
+        catch err
+            @error "Failed to write valid usage file `$usage_file`" exception = err
+        end
+    end
+    return
+end
+
 builddir(source_path::String) = joinpath(source_path, "deps")
 buildfile(source_path::String) = joinpath(builddir(source_path), "build.jl")
 function build_versions(ctx::Context, uuids::Set{UUID}; verbose = false, allow_reresolve::Bool = true)
@@ -2010,14 +2037,7 @@ function build_versions(ctx::Context, uuids::Set{UUID}; verbose = false, allow_r
                 create_cachedir_tag(joinpath(depots1(), "scratchspaces"))
                 log_file = joinpath(scratch, "build.log")
                 # Associate the logfile with the package being built
-                dict = Dict{String, Any}()
-                inner_dict = Dict{String, Any}()
-                inner_dict["time"] = Dates.now()
-                inner_dict["parent_projects"] = [projectfile_path(source_path)]
-                dict[scratch] = [inner_dict]
-                open(joinpath(depots1(), "logs", "scratch_usage.toml"), "a") do io
-                    TOML.print(io, dict)
-                end
+                write_scratch_usage(scratch, projectfile_path(source_path))
             else
                 log_file = splitext(build_file)[1] * ".log"
             end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -703,20 +703,51 @@ end
 write_env_usage(source_file::AbstractString, usage_filepath::AbstractString) =
     write_env_usage([source_file], usage_filepath)
 
-function read_usage_file(usage_file::AbstractString)
-    usage = TOML.tryparsefile(usage_file)
-    if usage isa TOML.ParserError
-        @warn "Failed to parse usage file `$usage_file`." exception = usage
-        return nothing
+"""
+    with_usage_file(f, usage_file; create, malformed)
+
+Run `f` with the parsed contents of a usage log while holding that log's pidfile lock.
+Changes made by `f` to the parsed `Dict` are atomically written back after it returns.
+Returning `nothing` from `f` leaves the file untouched and returns `nothing`.
+A missing log is created only when `create` is true; otherwise this function throws.
+For malformed TOML, `malformed = :replace`
+starts `f` with an empty log, while `malformed = :preserve` leaves the file untouched
+and returns `nothing` without invoking `f`.
+"""
+function with_usage_file(
+    f::Function,
+    usage_file::AbstractString;
+    create::Bool,
+    malformed::Symbol,
+)
+    malformed in (:replace, :preserve) ||
+        throw(ArgumentError("`malformed` must be `:replace` or `:preserve`"))
+    create && mkpath(dirname(usage_file))
+
+    return FileWatching.mkpidlock(usage_file * ".pid", stale_age = 3) do
+        usage = if isfile(usage_file)
+            parsed = TOML.tryparsefile(usage_file)
+            if parsed isa TOML.ParserError
+                @warn "Failed to parse usage file `$usage_file`." exception = parsed
+                malformed === :preserve && return nothing
+                Dict{String, Any}()
+            else
+                parsed::Dict{String, Any}
+            end
+        elseif create
+            Dict{String, Any}()
+        else
+            throw(ArgumentError("Usage file `$usage_file` does not exist"))
+        end
+        result = f(usage)
+        result === nothing && return nothing
+        atomic_toml_write(usage_file, usage, sorted = true)
+        return result
     end
-    return usage
 end
 
-with_usage_file_lock(f::Function, usage_file::AbstractString) =
-    FileWatching.mkpidlock(f, usage_file * ".pid", stale_age = 3)
-
 function usage_time(info, usage_file::AbstractString, source_file::AbstractString)
-    if !haskey(info, "time")
+    if !(info isa AbstractDict) || !haskey(info, "time")
         @warn(
             "Usage file `$usage_file` has a missing `time` entry for `$source_file`. " *
                 "Marking as used `now()`."
@@ -735,42 +766,76 @@ function usage_time(info, usage_file::AbstractString, source_file::AbstractStrin
     end
 end
 
-function write_env_usage(source_files, usage_filepath::AbstractString)
+function usage_parents(info, usage_file::AbstractString, source_file::AbstractString)
+    parents = info isa AbstractDict ? get(info, "parent_projects", nothing) : nothing
+    if parents isa AbstractVector && all(parent -> parent isa AbstractString, parents)
+        return Set{String}(parents)
+    end
+    @warn(
+        "Usage file `$usage_file` has an invalid `parent_projects` entry for `$source_file`. " *
+            "Preserving the scratchspace conservatively."
+    )
+    return nothing
+end
+
+"""
+    foreach_usage_entry(f, usage, usage_file) -> Bool
+
+Call `f(source_file, entry)` for every usage record in the TOML-parsed `usage` log.
+Return `false` and warn if an entry is not an array of TOML tables; otherwise return
+`true` after visiting every record.
+"""
+function foreach_usage_entry(
+    f::Function,
+    usage::Dict{String, Any},
+    usage_file::AbstractString,
+)
+    for (source_file, entries) in usage
+        if !(entries isa AbstractVector)
+            @warn "Usage file `$usage_file` has an invalid entry for `$source_file`."
+            return false
+        end
+        for entry in entries
+            if !(entry isa Dict{String, Any})
+                @warn "Usage file `$usage_file` has an invalid usage record for `$source_file`."
+                return false
+            end
+            f(source_file, entry)
+        end
+    end
+    return true
+end
+
+function write_env_usage(
+    source_files::AbstractVector{<:AbstractString},
+    usage_filepath::AbstractString,
+)
     # Don't record ghost usage
     source_files = filter(isfile, source_files)
     isempty(source_files) && return
 
-    # Ensure that log dir exists
-    !ispath(logdir()) && mkpath(logdir())
-
     usage_file = joinpath(logdir(), usage_filepath)
     timestamp = now()
 
-    ## Atomically write usage file using process id locking
-    with_usage_file_lock(usage_file) do
-        usage = @something(
-            isfile(usage_file) ? read_usage_file(usage_file) : nothing,
-            Dict{String, Any}()
-        )
-
-        # record new usage
-        for source_file in source_files
-            usage[source_file] = [Dict("time" => timestamp)]
-        end
-
-        # keep only latest usage info
-        for k in keys(usage)
-            times = map(usage[k]) do d
-                usage_time(d, usage_file, k)
+    try
+        with_usage_file(usage_file; create = true, malformed = :replace) do usage
+            # keep only latest usage info
+            condensed_usage = Dict{String, Vector{Dict}}()
+            foreach_usage_entry(usage, usage_file) do source_file, info
+                time = usage_time(info, usage_file, source_file)
+                previous = get(condensed_usage, source_file, nothing)
+                if previous === nothing || time > only(previous)["time"]
+                    condensed_usage[source_file] = [Dict("time" => time)]
+                end
             end
-            usage[k] = [Dict("time" => maximum(times))]
+            # Record new usage after condensing so every written entry has one timestamp.
+            for source_file in source_files
+                condensed_usage[source_file] = [Dict("time" => timestamp)]
+            end
+            copy!(usage, condensed_usage)
         end
-
-        try
-            atomic_toml_write(usage_file, usage, sorted = true)
-        catch err
-            @error "Failed to write valid usage file `$usage_file`" exception = err
-        end
+    catch err
+        @error "Failed to write valid usage file `$usage_file`" exception = err
     end
     return
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -715,11 +715,11 @@ starts `f` with an empty log, while `malformed = :preserve` leaves the file unto
 and returns `nothing` without invoking `f`.
 """
 function with_usage_file(
-    f::Function,
-    usage_file::AbstractString;
-    create::Bool,
-    malformed::Symbol,
-)
+        f::Function,
+        usage_file::AbstractString;
+        create::Bool,
+        malformed::Symbol,
+    )
     malformed in (:replace, :preserve) ||
         throw(ArgumentError("`malformed` must be `:replace` or `:preserve`"))
     create && mkpath(dirname(usage_file))
@@ -786,10 +786,10 @@ Return `false` and warn if an entry is not an array of TOML tables; otherwise re
 `true` after visiting every record.
 """
 function foreach_usage_entry(
-    f::Function,
-    usage::Dict{String, Any},
-    usage_file::AbstractString,
-)
+        f::Function,
+        usage::Dict{String, Any},
+        usage_file::AbstractString,
+    )
     for (source_file, entries) in usage
         if !(entries isa AbstractVector)
             @warn "Usage file `$usage_file` has an invalid entry for `$source_file`."
@@ -807,9 +807,9 @@ function foreach_usage_entry(
 end
 
 function write_env_usage(
-    source_files::AbstractVector{<:AbstractString},
-    usage_filepath::AbstractString,
-)
+        source_files::AbstractVector{<:AbstractString},
+        usage_filepath::AbstractString,
+    )
     # Don't record ghost usage
     source_files = filter(isfile, source_files)
     isempty(source_files) && return

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -703,6 +703,38 @@ end
 write_env_usage(source_file::AbstractString, usage_filepath::AbstractString) =
     write_env_usage([source_file], usage_filepath)
 
+function read_usage_file(usage_file::AbstractString)
+    usage = TOML.tryparsefile(usage_file)
+    if usage isa TOML.ParserError
+        @warn "Failed to parse usage file `$usage_file`." exception = usage
+        return nothing
+    end
+    return usage
+end
+
+with_usage_file_lock(f::Function, usage_file::AbstractString) =
+    FileWatching.mkpidlock(f, usage_file * ".pid", stale_age = 3)
+
+function usage_time(info, usage_file::AbstractString, source_file::AbstractString)
+    if !haskey(info, "time")
+        @warn(
+            "Usage file `$usage_file` has a missing `time` entry for `$source_file`. " *
+                "Marking as used `now()`."
+        )
+        return Dates.now()
+    end
+    return try
+        Dates.DateTime(info["time"])
+    catch err
+        @warn(
+            "Usage file `$usage_file` has an invalid `time` entry for `$source_file`. " *
+                "Marking as used `now()`.",
+            exception = err
+        )
+        Dates.now()
+    end
+end
+
 function write_env_usage(source_files, usage_filepath::AbstractString)
     # Don't record ghost usage
     source_files = filter(isfile, source_files)
@@ -715,17 +747,11 @@ function write_env_usage(source_files, usage_filepath::AbstractString)
     timestamp = now()
 
     ## Atomically write usage file using process id locking
-    FileWatching.mkpidlock(usage_file * ".pid", stale_age = 3) do
-        usage = if isfile(usage_file)
-            try
-                TOML.parsefile(usage_file)
-            catch err
-                @warn "Failed to parse usage file `$usage_file`, ignoring." err
-                Dict{String, Any}()
-            end
-        else
+    with_usage_file_lock(usage_file) do
+        usage = @something(
+            isfile(usage_file) ? read_usage_file(usage_file) : nothing,
             Dict{String, Any}()
-        end
+        )
 
         # record new usage
         for source_file in source_files
@@ -735,13 +761,7 @@ function write_env_usage(source_files, usage_filepath::AbstractString)
         # keep only latest usage info
         for k in keys(usage)
             times = map(usage[k]) do d
-                if haskey(d, "time")
-                    Dates.DateTime(d["time"])
-                else
-                    # if there's no time entry because of a write failure be conservative and mark it as being used now
-                    @debug "Usage file `$usage_filepath` has a missing `time` entry for `$k`. Marking as used `now()`"
-                    Dates.now()
-                end
+                usage_time(d, usage_file, k)
             end
             usage[k] = [Dict("time" => maximum(times))]
         end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -699,15 +699,19 @@ end
 
 # Ensure usage logs are synchronized and malformed entries are handled conservatively.
 @testset "usage logs" begin
-    # Check missing files throw and the usage lock serializes concurrent updates.
+    # Check usage-file transactions handle missing files and serialize updates.
     isolate() do
-        @test_throws Exception Pkg.Types.read_usage_file(tempname())
+        @test_throws ArgumentError (
+            Pkg.Types.with_usage_file(tempname(); create = false, malformed = :preserve) do _
+                error("a missing usage file should not invoke its callback")
+            end
+        )
 
         inside_lock = Threads.Atomic{Int}(0)
         overlaps = Threads.Atomic{Int}(0)
         lock_file = tempname()
         @sync for _ in 1:8
-            Threads.@spawn Pkg.Types.with_usage_file_lock(lock_file) do
+            Threads.@spawn Pkg.Types.with_usage_file(lock_file; create = true, malformed = :replace) do _
                 if Threads.atomic_add!(inside_lock, 1) != 0
                     Threads.atomic_add!(overlaps, 1)
                 end
@@ -717,7 +721,35 @@ end
         end
         @test overlaps[] == 0
 
+        write(lock_file, "invalid = [")
+        @test_logs (:warn, r"Failed to parse usage file") begin
+            @test isnothing(
+                Pkg.Types.with_usage_file(lock_file; create = false, malformed = :preserve) do _
+                    error("a preserved malformed usage file should not invoke its callback")
+                end
+            )
+        end
+        @test read(lock_file, String) == "invalid = ["
+        @test_logs (:warn, r"Failed to parse usage file") begin
+            Pkg.Types.with_usage_file(lock_file; create = true, malformed = :replace) do usage
+                usage["repaired"] = [Dict("time" => now())]
+            end
+        end
+        @test haskey(TOML.parsefile(lock_file), "repaired")
+
+        source_file = tempname()
+        touch(source_file)
         mkpath(Pkg.logdir())
+        for filename in ("manifest_usage.toml", "artifact_usage.toml")
+            usage_path = joinpath(Pkg.logdir(), filename)
+            write(usage_path, "invalid = [")
+            @test_logs(
+                (:warn, r"Failed to parse usage file"),
+                Pkg.Types.write_env_usage(source_file, filename),
+            )
+            @test haskey(TOML.parsefile(usage_path), source_file)
+        end
+
         usage_file = joinpath(Pkg.logdir(), "scratch_usage.toml")
         first_scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "first")
         second_scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "second")
@@ -770,6 +802,22 @@ end
         @test isempty(TOML.parsefile(joinpath(Pkg.logdir(), "artifact_usage.toml")))
     end
 
+    # Check GC preserves a usage log with structurally invalid records.
+    for filename in ("manifest_usage.toml", "artifact_usage.toml")
+        isolate() do
+            mkpath(Pkg.logdir())
+            usage_file = joinpath(Pkg.logdir(), filename)
+            open(usage_file, "w") do io
+                TOML.print(io, Dict(tempname() => "not an array of usage records"))
+            end
+            original = read(usage_file, String)
+
+            @test_logs (:warn, r"invalid entry") Pkg.gc(io = devnull)
+
+            @test read(usage_file, String) == original
+        end
+    end
+
     # Check GC repairs a missing timestamp without deleting the scratchspace.
     isolate() do
         scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "hash")
@@ -807,6 +855,30 @@ end
 
         @test isdir(scratch)
         @test haskey(only(TOML.parsefile(usage_file)[scratch]), "time")
+    end
+
+    # Check GC preserves a scratchspace when its parents cannot be decoded.
+    isolate() do
+        scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "hash")
+        mkpath(scratch)
+        mkpath(Pkg.logdir())
+        usage_file = joinpath(Pkg.logdir(), "scratch_usage.toml")
+        open(usage_file, "w") do io
+            TOML.print(io, Dict(scratch => [Dict("time" => now())]))
+        end
+
+        @test_logs (:warn, r"invalid `parent_projects` entry") Pkg.gc(io = devnull)
+
+        @test isdir(scratch)
+        @test !haskey(only(TOML.parsefile(usage_file)[scratch]), "parent_projects")
+
+        parent = tempname()
+        touch(parent)
+        @test_logs(
+            (:warn, r"invalid `parent_projects` entry"),
+            Pkg.Operations.write_scratch_usage(scratch, parent),
+        )
+        @test only(TOML.parsefile(usage_file)[scratch])["parent_projects"] == [parent]
     end
 
     # Check GC preserves scratchspaces and the log when the usage TOML cannot be parsed.

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -788,6 +788,27 @@ end
         @test haskey(only(TOML.parsefile(usage_file)[scratch]), "time")
     end
 
+    # Check GC repairs an invalid timestamp without deleting the scratchspace.
+    isolate() do
+        scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "hash")
+        mkpath(scratch)
+        parent = tempname()
+        touch(parent)
+        mkpath(Pkg.logdir())
+        usage_file = joinpath(Pkg.logdir(), "scratch_usage.toml")
+        open(usage_file, "w") do io
+            TOML.print(
+                io,
+                Dict(scratch => [Dict("time" => "not a timestamp", "parent_projects" => [parent])])
+            )
+        end
+
+        @test_logs (:warn, r"invalid `time` entry") Pkg.gc(io = devnull)
+
+        @test isdir(scratch)
+        @test haskey(only(TOML.parsefile(usage_file)[scratch]), "time")
+    end
+
     # Check GC preserves scratchspaces and the log when the usage TOML cannot be parsed.
     isolate() do
         scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "hash")

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -697,6 +697,112 @@ end
     end
 end
 
+# Ensure usage logs are synchronized and malformed entries are handled conservatively.
+@testset "usage logs" begin
+    # Check missing files throw and the usage lock serializes concurrent updates.
+    isolate() do
+        @test_throws Exception Pkg.Types.read_usage_file(tempname())
+
+        inside_lock = Threads.Atomic{Int}(0)
+        overlaps = Threads.Atomic{Int}(0)
+        lock_file = tempname()
+        @sync for _ in 1:8
+            Threads.@spawn Pkg.Types.with_usage_file_lock(lock_file) do
+                if Threads.atomic_add!(inside_lock, 1) != 0
+                    Threads.atomic_add!(overlaps, 1)
+                end
+                yield()
+                Threads.atomic_sub!(inside_lock, 1)
+            end
+        end
+        @test overlaps[] == 0
+
+        mkpath(Pkg.logdir())
+        usage_file = joinpath(Pkg.logdir(), "scratch_usage.toml")
+        first_scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "first")
+        second_scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "second")
+        first_parent = tempname()
+        new_parents = [tempname() for _ in 1:8]
+        other_parent = tempname()
+        open(usage_file, "w") do io
+            TOML.print(
+                io,
+                Dict(
+                    first_scratch => [
+                        Dict(
+                            "time" => now(),
+                            "parent_projects" => [first_parent],
+                        ),
+                    ],
+                    second_scratch => [
+                        Dict(
+                            "time" => now(),
+                            "parent_projects" => [other_parent],
+                        ),
+                    ],
+                );
+                sorted = true
+            )
+        end
+
+        @sync for parent in new_parents
+            Threads.@spawn Pkg.Operations.write_scratch_usage(first_scratch, parent)
+        end
+
+        usage = TOML.parsefile(usage_file)
+        @test Set(only(usage[first_scratch])["parent_projects"]) == Set([first_parent; new_parents])
+        @test only(usage[second_scratch])["parent_projects"] == [other_parent]
+    end
+
+    # Check GC safely condenses manifest and artifact usage logs.
+    isolate() do
+        mkpath(Pkg.logdir())
+        unused_path = tempname()
+        for filename in ("manifest_usage.toml", "artifact_usage.toml")
+            open(joinpath(Pkg.logdir(), filename), "w") do io
+                TOML.print(io, Dict(unused_path => [Dict("time" => now())]))
+            end
+        end
+
+        Pkg.gc(io = devnull)
+
+        @test isempty(TOML.parsefile(joinpath(Pkg.logdir(), "manifest_usage.toml")))
+        @test isempty(TOML.parsefile(joinpath(Pkg.logdir(), "artifact_usage.toml")))
+    end
+
+    # Check GC repairs a missing timestamp without deleting the scratchspace.
+    isolate() do
+        scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "hash")
+        mkpath(scratch)
+        parent = tempname()
+        touch(parent)
+        mkpath(Pkg.logdir())
+        usage_file = joinpath(Pkg.logdir(), "scratch_usage.toml")
+        open(usage_file, "w") do io
+            TOML.print(io, Dict(scratch => [Dict("parent_projects" => [parent])]))
+        end
+
+        @test_logs (:warn, r"missing `time` entry") Pkg.gc(io = devnull)
+
+        @test isdir(scratch)
+        @test haskey(only(TOML.parsefile(usage_file)[scratch]), "time")
+    end
+
+    # Check GC preserves scratchspaces and the log when the usage TOML cannot be parsed.
+    isolate() do
+        scratch = joinpath(Pkg.depots1(), "scratchspaces", "uuid", "hash")
+        mkpath(scratch)
+        mkpath(Pkg.logdir())
+        usage_file = joinpath(Pkg.logdir(), "scratch_usage.toml")
+        write(usage_file, "invalid = [")
+
+        @test_logs (:warn, r"Failed to parse usage file") Pkg.gc(io = devnull)
+
+        @test isdir(scratch)
+        @test read(usage_file, String) == "invalid = ["
+    end
+end
+
 if isdefined(Base.Filesystem, :delayed_delete_ref)
     @testset "Pkg.gc for delayed deletes" begin
         mktempdir() do root


### PR DESCRIPTION
The files {artifact,scratch,manifest}_usage.toml were written by incremental appending instead of atomically. This means a user Ctrl-C-ing Pkg could leave these files in a malformed state. Malformed files would throw an internal KeyError as expected fields were not written before interruption.

Fix this both by using the existing `atomic_toml_write` to atomically update these files to prevent corruption, and also by handling malformedness more consistently. Malformed TOML files were already handled, but not in the `.gc()` function.

Closes #4742 

This PR was made using an AI agent and manually reviewed.