### PR TITLE
Preserve Project.toml comments across writes

### DIFF
--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -197,7 +197,9 @@ function _resolve(manifest::Manifest, pkgname = nothing)
             cp(original_project_file, projectfile; force = true)
             chmod(projectfile, 0o644)  # Make the copied project file writable
 
-            project_data = TOML.parsefile(projectfile)
+            comments = Pkg.Types.TOML_COMMENTS_SUPPORTED ? TOML.Comments() : nothing
+            project_data = comments === nothing ? TOML.parsefile(projectfile) :
+                TOML.parsefile(projectfile; comments)
 
             # Paths inside the depot are written relative to the app environment
             # so that the depot can be relocated
@@ -243,7 +245,9 @@ function _resolve(manifest::Manifest, pkgname = nothing)
                 isempty(sources) && delete!(project_data, "sources")
             end
 
-            atomic_toml_write(projectfile, project_data)
+            # Writes atomically and preserves Pkg's project key ordering,
+            # inline [sources] tables and (on Julia 1.14+) comments
+            write_project(project_data, projectfile; comments)
         else
             pkgerror("could not find project file for package $pkg")
         end

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -197,9 +197,8 @@ function _resolve(manifest::Manifest, pkgname = nothing)
             cp(original_project_file, projectfile; force = true)
             chmod(projectfile, 0o644)  # Make the copied project file writable
 
-            comments = Pkg.Types.TOML_COMMENTS_SUPPORTED ? TOML.Comments() : nothing
-            project_data = comments === nothing ? TOML.parsefile(projectfile) :
-                TOML.parsefile(projectfile; comments)
+            comments = TOML.Comments()
+            project_data = TOML.parsefile(projectfile; comments)
 
             # Paths inside the depot are written relative to the app environment
             # so that the depot can be relocated
@@ -245,8 +244,7 @@ function _resolve(manifest::Manifest, pkgname = nothing)
                 isempty(sources) && delete!(project_data, "sources")
             end
 
-            # Preserves Pkg's project key ordering, inline [sources] tables
-            # and (on Julia 1.14+) comments
+            # Preserves Pkg's project key ordering, inline [sources] tables and comments
             write_project(project_data, projectfile; comments)
         else
             pkgerror("could not find project file for package $pkg")

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -245,8 +245,8 @@ function _resolve(manifest::Manifest, pkgname = nothing)
                 isempty(sources) && delete!(project_data, "sources")
             end
 
-            # Writes atomically and preserves Pkg's project key ordering,
-            # inline [sources] tables and (on Julia 1.14+) comments
+            # Preserves Pkg's project key ordering, inline [sources] tables
+            # and (on Julia 1.14+) comments
             write_project(project_data, projectfile; comments)
         else
             pkgerror("could not find project file for package $pkg")

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -55,11 +55,6 @@ end
 # See loading.jl
 const TOML_CACHE = Base.TOMLCache(Base.TOML.Parser{Dates}())
 const TOML_LOCK = ReentrantLock()
-
-# Whether the TOML stdlib supports capturing comments (Julia 1.14+, JuliaLang/julia#42697).
-# When it does, Pkg preserves the comments of Project.toml files across writes.
-const TOML_COMMENTS_SUPPORTED = isdefined(TOML, :Comments)
-const TOMLComments = TOML_COMMENTS_SUPPORTED ? TOML.Comments : Nothing
 # Some functions mutate the returning Dict so return a copy of the cached value here
 parse_toml(toml_file::AbstractString) =
     Base.invokelatest(deepcopy_toml, Base.parsed_toml(toml_file, TOML_CACHE, TOML_LOCK))::Dict{String, Any}
@@ -261,7 +256,7 @@ Base.@kwdef mutable struct Project
     # Excluded from `==` and `hash` (like the raw data in `other` is for
     # `PackageEntry`) so that comments never affect whether an environment
     # is considered modified.
-    comments::Union{TOMLComments, Nothing} = nothing
+    comments::Union{TOML.Comments, Nothing} = nothing
     # Fields
     name::Union{String, Nothing} = nothing
     uuid::Union{UUID, Nothing} = nothing

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -10,7 +10,7 @@ import Base.string
 
 using TOML
 import ..Pkg, ..Registry
-import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS, atomic_toml_write, atomic_write, create_cachedir_tag, normalize_path_for_toml
+import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS, atomic_toml_write, create_cachedir_tag, normalize_path_for_toml
 import Base.BinaryPlatforms: Platform
 using ..Pkg.Versions
 import FileWatching

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -10,7 +10,7 @@ import Base.string
 
 using TOML
 import ..Pkg, ..Registry
-import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS, atomic_toml_write, create_cachedir_tag, normalize_path_for_toml
+import ..Pkg: GitTools, depots, depots1, logdir, set_readonly, safe_realpath, pkg_server, stdlib_path, isurl, stderr_f, RESPECT_SYSIMAGE_VERSIONS, atomic_toml_write, atomic_write, create_cachedir_tag, normalize_path_for_toml
 import Base.BinaryPlatforms: Platform
 using ..Pkg.Versions
 import FileWatching
@@ -55,6 +55,11 @@ end
 # See loading.jl
 const TOML_CACHE = Base.TOMLCache(Base.TOML.Parser{Dates}())
 const TOML_LOCK = ReentrantLock()
+
+# Whether the TOML stdlib supports capturing comments (Julia 1.14+, JuliaLang/julia#42697).
+# When it does, Pkg preserves the comments of Project.toml files across writes.
+const TOML_COMMENTS_SUPPORTED = isdefined(TOML, :Comments)
+const TOMLComments = TOML_COMMENTS_SUPPORTED ? TOML.Comments : Nothing
 # Some functions mutate the returning Dict so return a copy of the cached value here
 parse_toml(toml_file::AbstractString) =
     Base.invokelatest(deepcopy_toml, Base.parsed_toml(toml_file, TOML_CACHE, TOML_LOCK))::Dict{String, Any}
@@ -252,6 +257,11 @@ struct AppInfo
 end
 Base.@kwdef mutable struct Project
     other::Dict{String, Any} = Dict{String, Any}()
+    # The comments of the project file, preserved across writes.
+    # Excluded from `==` and `hash` (like the raw data in `other` is for
+    # `PackageEntry`) so that comments never affect whether an environment
+    # is considered modified.
+    comments::Union{TOMLComments, Nothing} = nothing
     # Fields
     name::Union{String, Nothing} = nothing
     uuid::Union{UUID, Nothing} = nothing
@@ -275,8 +285,9 @@ Base.@kwdef mutable struct Project
     workspace::Dict{String, Any} = Dict{String, Any}()
     readonly::Bool = false
 end
-Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, fieldnames(Project))
-Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in fieldnames(Project)], init = h)
+const _project_comparison_fields = filter(!=(:comments), collect(fieldnames(Project)))
+Base.:(==)(t1::Project, t2::Project) = all(x -> (getfield(t1, x) == getfield(t2, x))::Bool, _project_comparison_fields)
+Base.hash(t::Project, h::UInt) = foldr(hash, [getfield(t, x) for x in _project_comparison_fields], init = h)
 
 
 Base.@kwdef mutable struct PackageEntry

--- a/src/project.jl
+++ b/src/project.jl
@@ -365,5 +365,5 @@ end
 function write_project(project::Dict, project_file::AbstractString; comments::Union{TOMLComments, Nothing} = nothing)
     str = sprint(io -> write_project(io, project; comments))
     mkpath(dirname(project_file))
-    return atomic_write(project_file, str)
+    return write(project_file, str)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -247,11 +247,19 @@ function Project(raw::Dict; file = nothing)
 end
 
 function read_project(f_or_io::Union{String, IO})
+    # Capture the comments of the project file (when the TOML stdlib supports
+    # it) so that they can be written back out by `write_project`
+    comments = TOML_COMMENTS_SUPPORTED ? TOML.Comments() : nothing
     raw = try
         if f_or_io isa IO
-            TOML.parse(read(f_or_io, String))
+            str = read(f_or_io, String)
+            comments === nothing ? TOML.parse(str) : TOML.parse(str; comments)
+        elseif isfile(f_or_io)
+            # The comment-capturing path bypasses the shared parser cache;
+            # project files are small so the extra parse is cheap
+            comments === nothing ? parse_toml(f_or_io) : TOML.parsefile(f_or_io; comments)
         else
-            isfile(f_or_io) ? parse_toml(f_or_io) : return Project()
+            return Project()
         end
     catch e
         if e isa TOML.ParserError
@@ -259,7 +267,9 @@ function read_project(f_or_io::Union{String, IO})
         end
         pkgerror("Errored when reading $f_or_io, got: ", sprint(showerror, e))
     end
-    return Project(raw; file = f_or_io isa IO ? nothing : f_or_io)
+    project = Project(raw; file = f_or_io isa IO ? nothing : f_or_io)
+    project.comments = comments
+    return project
 end
 
 
@@ -335,8 +345,8 @@ function write_project(env::EnvCache, skip_readonly_check::Bool = false)
     return write_project(env.project, env.project_file)
 end
 write_project(project::Project, project_file::AbstractString) =
-    write_project(destructure(project), project_file)
-function write_project(io::IO, project::Dict)
+    write_project(destructure(project), project_file; comments = project.comments)
+function write_project(io::IO, project::Dict; comments::Union{TOMLComments, Nothing} = nothing)
     inline_tables = Base.IdSet{Dict}()
     if haskey(project, "sources")
         for source in values(project["sources"])
@@ -344,14 +354,16 @@ function write_project(io::IO, project::Dict)
             push!(inline_tables, source)
         end
     end
-    TOML.print(io, project; inline_tables, sorted = true, by = key -> (project_key_order(key), key)) do x
+    # `comments` is only ever non-`nothing` when the TOML stdlib supports the kwarg
+    kws = comments === nothing ? (;) : (; comments)
+    TOML.print(io, project; inline_tables, sorted = true, by = key -> (project_key_order(key), key), kws...) do x
         x isa UUID || x isa VersionNumber || pkgerror("unhandled type `$(typeof(x))`")
         return string(x)
     end
     return nothing
 end
-function write_project(project::Dict, project_file::AbstractString)
-    str = sprint(write_project, project)
+function write_project(project::Dict, project_file::AbstractString; comments::Union{TOMLComments, Nothing} = nothing)
+    str = sprint(io -> write_project(io, project; comments))
     mkpath(dirname(project_file))
-    return write(project_file, str)
+    return atomic_write(project_file, str)
 end

--- a/src/project.jl
+++ b/src/project.jl
@@ -247,17 +247,16 @@ function Project(raw::Dict; file = nothing)
 end
 
 function read_project(f_or_io::Union{String, IO})
-    # Capture the comments of the project file (when the TOML stdlib supports
-    # it) so that they can be written back out by `write_project`
-    comments = TOML_COMMENTS_SUPPORTED ? TOML.Comments() : nothing
+    # Capture the comments of the project file so that they can be written back
+    # out by `write_project`
+    comments = TOML.Comments()
     raw = try
         if f_or_io isa IO
-            str = read(f_or_io, String)
-            comments === nothing ? TOML.parse(str) : TOML.parse(str; comments)
+            TOML.parse(read(f_or_io, String); comments)
         elseif isfile(f_or_io)
             # The comment-capturing path bypasses the shared parser cache;
             # project files are small so the extra parse is cheap
-            comments === nothing ? parse_toml(f_or_io) : TOML.parsefile(f_or_io; comments)
+            TOML.parsefile(f_or_io; comments)
         else
             return Project()
         end
@@ -346,7 +345,7 @@ function write_project(env::EnvCache, skip_readonly_check::Bool = false)
 end
 write_project(project::Project, project_file::AbstractString) =
     write_project(destructure(project), project_file; comments = project.comments)
-function write_project(io::IO, project::Dict; comments::Union{TOMLComments, Nothing} = nothing)
+function write_project(io::IO, project::Dict; comments::Union{TOML.Comments, Nothing} = nothing)
     inline_tables = Base.IdSet{Dict}()
     if haskey(project, "sources")
         for source in values(project["sources"])
@@ -354,15 +353,13 @@ function write_project(io::IO, project::Dict; comments::Union{TOMLComments, Noth
             push!(inline_tables, source)
         end
     end
-    # `comments` is only ever non-`nothing` when the TOML stdlib supports the kwarg
-    kws = comments === nothing ? (;) : (; comments)
-    TOML.print(io, project; inline_tables, sorted = true, by = key -> (project_key_order(key), key), kws...) do x
+    TOML.print(io, project; inline_tables, sorted = true, by = key -> (project_key_order(key), key), comments) do x
         x isa UUID || x isa VersionNumber || pkgerror("unhandled type `$(typeof(x))`")
         return string(x)
     end
     return nothing
 end
-function write_project(project::Dict, project_file::AbstractString; comments::Union{TOMLComments, Nothing} = nothing)
+function write_project(project::Dict, project_file::AbstractString; comments::Union{TOML.Comments, Nothing} = nothing)
     str = sprint(io -> write_project(io, project; comments))
     mkpath(dirname(project_file))
     return write(project_file, str)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -188,6 +188,28 @@ function atomic_toml_write(path::String, data; kws...)
     end
 end
 
+"""
+    atomic_write(path::String, contents)
+
+Write `contents` to a file atomically by first writing to a temporary file and
+then moving it into place, like [`atomic_toml_write`](@ref).
+"""
+function atomic_write(path::String, contents)
+    dir = dirname(path)
+    isempty(dir) && (dir = pwd())
+
+    temp_path, temp_io = mktemp(dir)
+    return try
+        write(temp_io, contents)
+        close(temp_io)
+        mv(temp_path, path; force = true)
+    catch
+        close(temp_io)
+        rm(temp_path; force = true)
+        rethrow()
+    end
+end
+
 ## ordering of UUIDs ##
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -188,28 +188,6 @@ function atomic_toml_write(path::String, data; kws...)
     end
 end
 
-"""
-    atomic_write(path::String, contents)
-
-Write `contents` to a file atomically by first writing to a temporary file and
-then moving it into place, like [`atomic_toml_write`](@ref).
-"""
-function atomic_write(path::String, contents)
-    dir = dirname(path)
-    isempty(dir) && (dir = pwd())
-
-    temp_path, temp_io = mktemp(dir)
-    return try
-        write(temp_io, contents)
-        close(temp_io)
-        mv(temp_path, path; force = true)
-    catch
-        close(temp_io)
-        rm(temp_path; force = true)
-        rethrow()
-    end
-end
-
 ## ordering of UUIDs ##
 if VERSION < v"1.2.0-DEV.269"  # Defined in Base as of #30947
     Base.isless(a::UUID, b::UUID) = a.value < b.value

--- a/test/project_comments.jl
+++ b/test/project_comments.jl
@@ -1,0 +1,101 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module ProjectCommentsTest
+
+import ..Pkg # ensure we are using the correct Pkg
+using Test, Pkg, TOML
+using ..Utils
+
+# Comment preservation requires TOML stdlib support (Julia 1.14+, JuliaLang/julia#42697)
+if !Pkg.Types.TOML_COMMENTS_SUPPORTED
+    @info "Skipping Project.toml comment preservation tests (TOML stdlib does not support comments)"
+else
+    @testset "Project.toml comment preservation" begin
+        commented_project = """
+        # This is my package
+
+        name = "MyPkg"
+        uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+        version = "1.0.3"
+
+        [deps]
+        # `Example` is used for fooing bars
+        Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+        [compat]
+        Example = "0.5" # see issue 123 before bumping
+        julia = "1"
+        """
+
+        @testset "read_project/write_project round trip" begin
+            mktempdir() do dir
+                project_file = joinpath(dir, "Project.toml")
+                write(project_file, commented_project)
+                project = Pkg.Types.read_project(project_file)
+                @test project.comments isa TOML.Comments
+                out_file = joinpath(dir, "Project_out.toml")
+                Pkg.Types.write_project(project, out_file)
+                str = read(out_file, String)
+                @test occursin("# This is my package", str)
+                @test occursin("# `Example` is used for fooing bars", str)
+                @test occursin("Example = \"0.5\" # see issue 123 before bumping", str)
+                # the floating preamble comment is at the top of the file
+                @test startswith(str, "# This is my package")
+                # a second write of the re-read project is byte-identical
+                project2 = Pkg.Types.read_project(out_file)
+                out_file2 = joinpath(dir, "Project_out2.toml")
+                Pkg.Types.write_project(project2, out_file2)
+                @test read(out_file2, String) == str
+            end
+        end
+
+        @testset "comments do not affect Project equality" begin
+            io = IOBuffer(commented_project)
+            a = Pkg.Types.read_project(io)
+            b = Pkg.Types.read_project(IOBuffer(replace(commented_project, "# This is my package" => "# Changed comment")))
+            @test a == b
+            @test hash(a) == hash(b)
+        end
+
+        @testset "Pkg.compat preserves comments" begin
+            isolate(loaded_depot = true) do
+                mktempdir() do dir
+                    project_file = joinpath(dir, "Project.toml")
+                    write(project_file, commented_project)
+                    Pkg.activate(dir)
+                    # instantiate the environment first; `Pkg.compat` resolves
+                    # to check compliance, which requires an installed registry
+                    Pkg.add("Example")
+                    Pkg.compat("Example", "0.5.1")
+                    str = read(project_file, String)
+                    @test occursin("Example = \"0.5.1\"", str)
+                    @test occursin("# This is my package", str)
+                    @test occursin("# `Example` is used for fooing bars", str)
+                    # the inline comment stays attached to the compat entry it was on
+                    @test occursin("Example = \"0.5.1\" # see issue 123 before bumping", str)
+                end
+            end
+        end
+
+        @testset "Pkg.rm drops the removed dep's comments" begin
+            isolate(loaded_depot = true) do
+                mktempdir() do dir
+                    project_file = joinpath(dir, "Project.toml")
+                    write(project_file, commented_project)
+                    Pkg.activate(dir)
+                    Pkg.add("Example")
+                    str = read(project_file, String)
+                    @test occursin("# `Example` is used for fooing bars", str)
+                    @test occursin("# This is my package", str)
+                    Pkg.rm("Example")
+                    str = read(project_file, String)
+                    @test !occursin("fooing bars", str)
+                    @test !occursin("issue 123", str)
+                    @test occursin("# This is my package", str)
+                end
+            end
+        end
+    end
+end
+
+end # module

--- a/test/project_comments.jl
+++ b/test/project_comments.jl
@@ -6,93 +6,88 @@ import ..Pkg # ensure we are using the correct Pkg
 using Test, Pkg, TOML
 using ..Utils
 
-# Comment preservation requires TOML stdlib support (Julia 1.14+, JuliaLang/julia#42697)
-if !Pkg.Types.TOML_COMMENTS_SUPPORTED
-    @info "Skipping Project.toml comment preservation tests (TOML stdlib does not support comments)"
-else
-    @testset "Project.toml comment preservation" begin
-        commented_project = """
-        # This is my package
+@testset "Project.toml comment preservation" begin
+    commented_project = """
+    # This is my package
 
-        name = "MyPkg"
-        uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-        version = "1.0.3"
+    name = "MyPkg"
+    uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+    version = "1.0.3"
 
-        [deps]
-        # `Example` is used for fooing bars
-        Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+    [deps]
+    # `Example` is used for fooing bars
+    Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 
-        [compat]
-        Example = "0.5" # see issue 123 before bumping
-        julia = "1"
-        """
+    [compat]
+    Example = "0.5" # see issue 123 before bumping
+    julia = "1"
+    """
 
-        @testset "read_project/write_project round trip" begin
+    @testset "read_project/write_project round trip" begin
+        mktempdir() do dir
+            project_file = joinpath(dir, "Project.toml")
+            write(project_file, commented_project)
+            project = Pkg.Types.read_project(project_file)
+            @test project.comments isa TOML.Comments
+            out_file = joinpath(dir, "Project_out.toml")
+            Pkg.Types.write_project(project, out_file)
+            str = read(out_file, String)
+            @test occursin("# This is my package", str)
+            @test occursin("# `Example` is used for fooing bars", str)
+            @test occursin("Example = \"0.5\" # see issue 123 before bumping", str)
+            # the floating preamble comment is at the top of the file
+            @test startswith(str, "# This is my package")
+            # a second write of the re-read project is byte-identical
+            project2 = Pkg.Types.read_project(out_file)
+            out_file2 = joinpath(dir, "Project_out2.toml")
+            Pkg.Types.write_project(project2, out_file2)
+            @test read(out_file2, String) == str
+        end
+    end
+
+    @testset "comments do not affect Project equality" begin
+        io = IOBuffer(commented_project)
+        a = Pkg.Types.read_project(io)
+        b = Pkg.Types.read_project(IOBuffer(replace(commented_project, "# This is my package" => "# Changed comment")))
+        @test a == b
+        @test hash(a) == hash(b)
+    end
+
+    @testset "Pkg.compat preserves comments" begin
+        isolate(loaded_depot = true) do
             mktempdir() do dir
                 project_file = joinpath(dir, "Project.toml")
                 write(project_file, commented_project)
-                project = Pkg.Types.read_project(project_file)
-                @test project.comments isa TOML.Comments
-                out_file = joinpath(dir, "Project_out.toml")
-                Pkg.Types.write_project(project, out_file)
-                str = read(out_file, String)
+                Pkg.activate(dir)
+                # instantiate the environment first; `Pkg.compat` resolves
+                # to check compliance, which requires an installed registry
+                Pkg.add("Example")
+                Pkg.compat("Example", "0.5.1")
+                str = read(project_file, String)
+                @test occursin("Example = \"0.5.1\"", str)
                 @test occursin("# This is my package", str)
                 @test occursin("# `Example` is used for fooing bars", str)
-                @test occursin("Example = \"0.5\" # see issue 123 before bumping", str)
-                # the floating preamble comment is at the top of the file
-                @test startswith(str, "# This is my package")
-                # a second write of the re-read project is byte-identical
-                project2 = Pkg.Types.read_project(out_file)
-                out_file2 = joinpath(dir, "Project_out2.toml")
-                Pkg.Types.write_project(project2, out_file2)
-                @test read(out_file2, String) == str
+                # the inline comment stays attached to the compat entry it was on
+                @test occursin("Example = \"0.5.1\" # see issue 123 before bumping", str)
             end
         end
+    end
 
-        @testset "comments do not affect Project equality" begin
-            io = IOBuffer(commented_project)
-            a = Pkg.Types.read_project(io)
-            b = Pkg.Types.read_project(IOBuffer(replace(commented_project, "# This is my package" => "# Changed comment")))
-            @test a == b
-            @test hash(a) == hash(b)
-        end
-
-        @testset "Pkg.compat preserves comments" begin
-            isolate(loaded_depot = true) do
-                mktempdir() do dir
-                    project_file = joinpath(dir, "Project.toml")
-                    write(project_file, commented_project)
-                    Pkg.activate(dir)
-                    # instantiate the environment first; `Pkg.compat` resolves
-                    # to check compliance, which requires an installed registry
-                    Pkg.add("Example")
-                    Pkg.compat("Example", "0.5.1")
-                    str = read(project_file, String)
-                    @test occursin("Example = \"0.5.1\"", str)
-                    @test occursin("# This is my package", str)
-                    @test occursin("# `Example` is used for fooing bars", str)
-                    # the inline comment stays attached to the compat entry it was on
-                    @test occursin("Example = \"0.5.1\" # see issue 123 before bumping", str)
-                end
-            end
-        end
-
-        @testset "Pkg.rm drops the removed dep's comments" begin
-            isolate(loaded_depot = true) do
-                mktempdir() do dir
-                    project_file = joinpath(dir, "Project.toml")
-                    write(project_file, commented_project)
-                    Pkg.activate(dir)
-                    Pkg.add("Example")
-                    str = read(project_file, String)
-                    @test occursin("# `Example` is used for fooing bars", str)
-                    @test occursin("# This is my package", str)
-                    Pkg.rm("Example")
-                    str = read(project_file, String)
-                    @test !occursin("fooing bars", str)
-                    @test !occursin("issue 123", str)
-                    @test occursin("# This is my package", str)
-                end
+    @testset "Pkg.rm drops the removed dep's comments" begin
+        isolate(loaded_depot = true) do
+            mktempdir() do dir
+                project_file = joinpath(dir, "Project.toml")
+                write(project_file, commented_project)
+                Pkg.activate(dir)
+                Pkg.add("Example")
+                str = read(project_file, String)
+                @test occursin("# `Example` is used for fooing bars", str)
+                @test occursin("# This is my package", str)
+                Pkg.rm("Example")
+                str = read(project_file, String)
+                @test !occursin("fooing bars", str)
+                @test !occursin("issue 123", str)
+                @test occursin("# This is my package", str)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ module PkgTestsInner
                 "force_latest_compatible_version.jl",
                 "manifests.jl",
                 "project_manifest.jl",
+                "project_comments.jl",
                 "sources.jl",
                 "workspaces.jl",
                 "apps.jl",


### PR DESCRIPTION
Claude:

---

Companion PR to JuliaLang/julia#62672 (implementing JuliaLang/julia#42697): make Pkg preserve comments in `Project.toml` across writes, so `Pkg.add`, `Pkg.rm`, `Pkg.compat`, `Pkg.up`, etc. no longer delete user comments like

```toml
[deps]
# `Dep` is used for fooing bars
Dep = "0796e94c-ce3b-5d07-9a54-7f471281c624"

[compat]
Dep = "~1.1" # see issue #123 before bumping
```
