### PR TITLE
Run artifact selectors in resolved environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Pkg v1.14 Release Notes
 =======================
 
+- Artifact selection hooks can now load dependencies from their package's `[deps]`. Pkg runs hooks against the resolved
+  manifest and installs dependency artifacts first, preventing selectors from loading stale, incompatible versions.
+  Active-project and workspace preferences are visible to hooks, hook results are cached for the duration of the
+  session, and hooks run at the parent's optimization level so that dependencies they precompile are reusable. ([#4747])
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and
@@ -232,3 +236,4 @@ Pkg v1.7 Release Notes
 [#4287]: https://github.com/JuliaLang/Pkg.jl/pull/4287
 [#4678]: https://github.com/JuliaLang/Pkg.jl/pull/4678
 [#4679]: https://github.com/JuliaLang/Pkg.jl/pull/4679
+[#4747]: https://github.com/JuliaLang/Pkg.jl/pull/4747

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Pkg v1.14 Release Notes
 - Artifact selection hooks can now load dependencies from their package's `[deps]`. Pkg runs hooks against the resolved
   manifest and installs dependency artifacts first, preventing selectors from loading stale, incompatible versions.
   Active-project and workspace preferences are visible to hooks, hook results are cached for the duration of the
-  session, `Pkg.status` and offline resolution no longer run hooks, and hooks run at the parent's optimization level
-  so that dependencies they precompile are reusable. ([#4747])
+  session, `Pkg.status` and offline resolution no longer run hooks, hooks run at the parent's optimization level
+  so that dependencies they precompile are reusable, and a hook that loads its own package is an error. ([#4747])
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Pkg v1.14 Release Notes
 - Artifact selection hooks can now load dependencies from their package's `[deps]`. Pkg runs hooks against the resolved
   manifest and installs dependency artifacts first, preventing selectors from loading stale, incompatible versions.
   Active-project and workspace preferences are visible to hooks, hook results are cached for the duration of the
-  session, `Pkg.status` no longer runs hooks, and hooks run at the parent's optimization level so that dependencies
-  they precompile are reusable. ([#4747])
+  session, `Pkg.status` and offline resolution no longer run hooks, and hooks run at the parent's optimization level
+  so that dependencies they precompile are reusable. ([#4747])
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Pkg v1.14 Release Notes
 - Artifact selection hooks can now load dependencies from their package's `[deps]`. Pkg runs hooks against the resolved
   manifest and installs dependency artifacts first, preventing selectors from loading stale, incompatible versions.
   Active-project and workspace preferences are visible to hooks, hook results are cached for the duration of the
-  session, and hooks run at the parent's optimization level so that dependencies they precompile are reusable. ([#4747])
+  session, `Pkg.status` no longer runs hooks, and hooks run at the parent's optimization level so that dependencies
+  they precompile are reusable. ([#4747])
 - `Pkg.instantiate` now accepts an `update_on_mismatch::Bool` keyword argument (and a corresponding `-u` /
   `--update_on_mismatch` REPL flag) that falls back to `Pkg.update()` when the manifest does not match the project
   or was resolved with a different Julia minor version, instead of warning or erroring. Useful for tooling and

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -299,4 +299,13 @@ end
 
 This ensures that the same artifact is used by your code as Pkg attempted to install.
 
-Artifact selection hooks are only allowed to use `Base`, `Artifacts`, `Libdl`, and `TOML`. They are not allowed to use any other standard libraries, and they are not allowed to use any packages (including the package to which they belong).
+Hooks may use standard libraries and load their package's `[deps]` with `using MyDependency`.
+Pkg supplies the resolved dependency versions and installs their artifacts before running the hook.
+Preferences come from the active project and its workspace parents; unrelated stacked environments and the package checkout's own manifest and preferences are excluded.
+
+Hooks run before package build scripts and should not load their own package, whose artifacts have not yet been selected.
+Dependencies must be loadable without a build step, and hooks should handle initialization failures when installing for another platform.
+Keep diagnostics, including those from dependencies, on `stderr` so they do not corrupt the TOML output.
+
+Successful selections are cached for the Julia session and invalidated by changes to the environment, preferences, selector script, or artifact TOML file.
+Changes to other inputs, such as system state or included augmentation files, require a new session.

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -309,4 +309,4 @@ Keep diagnostics, including those from dependencies, on `stderr` so they do not 
 
 Successful selections are cached for the Julia session and invalidated by changes to the environment, preferences, selector script, or artifact TOML file.
 Changes to other inputs, such as system state or included augmentation files, require a new session.
-`Pkg.status` never runs hooks: it reports a package with a hook as downloaded once its source is present, and leaves checking the selected artifacts to `Pkg.instantiate`.
+`Pkg.status` and offline resolution never run hooks: they treat a package with a hook as downloaded once its source is present, and leave checking the selected artifacts to `Pkg.instantiate` and the installing operations.

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -303,7 +303,7 @@ Hooks may use standard libraries and load their package's `[deps]` with `using M
 Pkg supplies the resolved dependency versions and installs their artifacts before running the hook.
 Preferences come from the active project and its workspace parents; unrelated stacked environments and the package checkout's own manifest and preferences are excluded.
 
-Hooks run before package build scripts and should not load their own package, whose artifacts have not yet been selected.
+Hooks run before package build scripts and cannot load their own package, whose artifacts have not yet been selected; Pkg reports an error when a hook does.
 Dependencies must be loadable without a build step, and hooks should handle initialization failures when installing for another platform.
 Keep diagnostics, including those from dependencies, on `stderr` so they do not corrupt the TOML output.
 

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -309,3 +309,4 @@ Keep diagnostics, including those from dependencies, on `stderr` so they do not 
 
 Successful selections are cached for the Julia session and invalidated by changes to the environment, preferences, selector script, or artifact TOML file.
 Changes to other inputs, such as system state or included augmentation files, require a new session.
+`Pkg.status` never runs hooks: it reports a package with a hook as downloaded once its source is present, and leaves checking the selected artifacts to `Pkg.instantiate`.

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1597,7 +1597,6 @@ function check_artifacts_downloaded(pkg_root::String; platform::AbstractPlatform
             if !artifact_exists(Base.SHA1(artifacts[name]["git-tree-sha1"]))
                 return false
             end
-            break
         end
     end
     return true

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1840,8 +1840,12 @@ end
 function check_artifacts_downloaded(
         pkg_root::String;
         platform::AbstractPlatform = HostPlatform(), selector_project::Union{Nothing, String} = nothing,
-        env_key::Union{Nothing, UInt} = nothing
+        env_key::Union{Nothing, UInt} = nothing, run_selectors::Bool = true
     )
+    # Without running the selector there is no way to know which artifacts it would pick,
+    # so callers that opt out treat such packages as downloaded. Installation still runs
+    # the selector, so a missing selection is corrected there.
+    run_selectors || !has_artifact_selector(pkg_root) || return true
     collected_artifacts = try
         collect_artifacts(pkg_root; platform, selector_project, env_key)
     catch err
@@ -3743,13 +3747,12 @@ end
 
 function is_package_downloaded(
         manifest_file::String, pkg::PackageSpec;
-        platform = HostPlatform(), selector_project::Union{Nothing, String} = nothing,
-        env_key::Union{Nothing, UInt} = nothing
+        platform = HostPlatform(), run_selectors::Bool = true
     )
     sourcepath = source_path(manifest_file, pkg)
     sourcepath === nothing && return false
     isdir(sourcepath) || return false
-    check_artifacts_downloaded(sourcepath; platform, selector_project, env_key) || return false
+    check_artifacts_downloaded(sourcepath; platform, run_selectors) || return false
     return true
 end
 
@@ -3879,16 +3882,6 @@ function print_status(
     no_visible_packages_heldback = true
     no_packages_heldback = true
     lpadding = 2
-    # Fingerprinting the environment is only needed to reuse cached selector results
-    env_key = if any(xs) do (_, _, new)
-            new === nothing && return false
-            root = source_path(env.manifest_file, new)
-            root !== nothing && has_artifact_selector(root)
-        end
-        selector_env_key(env)
-    else
-        nothing
-    end
 
     package_statuses = PackageStatusData[]
     for (uuid, old, new) in xs
@@ -3938,9 +3931,10 @@ function print_status(
 
         # TODO: Show extension deps for project as well?
 
-        pkg_downloaded = !is_instantiated(new) || is_package_downloaded(
-            env.manifest_file, new; selector_project = env.project_file, env_key
-        )
+        # Status must stay cheap, so it never spawns artifact selectors: a package with a
+        # selector counts as downloaded once its source is present.
+        pkg_downloaded = !is_instantiated(new) ||
+            is_package_downloaded(env.manifest_file, new; run_selectors = false)
 
         new_ver_avail = !latest_version && !Operations.is_tracking_repo(new) && !Operations.is_tracking_path(new)
         pkg_upgradable = new_ver_avail && cinfo !== nothing && isempty(cinfo[1])

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1139,7 +1139,10 @@ function deps_graph(
                         Registry.isyanked(info, v) && continue
                         if installed_only
                             pkg_spec = PackageSpec(name = pkg.name, uuid = pkg.uuid, version = v, tree_hash = Registry.treehash(info, v))
-                            is_package_downloaded(env.manifest_file, pkg_spec) || continue
+                            # Resolution has not happened yet, so there is no environment to run
+                            # artifact selectors in; a version with a selector counts as installed
+                            # once its source is present. Installing it still runs the selector.
+                            is_package_downloaded(env.manifest_file, pkg_spec; run_selectors = false) || continue
                         end
 
                         # Skip package version that are not the same as external packages in sysimage

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -296,12 +296,33 @@ function is_instantiated(env::EnvCache, workspace::Bool = false; platform = Host
         if idx === nothing
             push!(pkgs, Types.PackageSpec(name = env.pkg.name, uuid = env.pkg.uuid, version = env.pkg.version, path = dirname(env.project_file)))
         end
-    else
-        # Make sure artifacts for project exist even if it is not a package
-        check_artifacts_downloaded(dirname(env.project_file); platform) || return false
     end
-    # Make sure all paths/artifacts exist
-    return all(pkg -> is_package_downloaded(env.manifest_file, pkg; platform), pkgs)
+    # Make sure all sources exist before running any artifact selector, since a selector
+    # may load a dependency whose source or artifacts are missing.
+    for pkg in pkgs
+        sourcepath = source_path(env.manifest_file, pkg)
+        sourcepath === nothing && return false
+        isdir(sourcepath) || return false
+    end
+    # Make sure artifacts exist, including those of the project even if it is not a package
+    pkg_info = artifact_package_info(env, [pkg.uuid => pkg for pkg in pkgs])
+    for info in pkg_info
+        info.has_selector && continue
+        check_artifacts_downloaded(info.root; platform) || return false
+    end
+    # Run selectors in dependency order and stop at the first missing artifact, so a
+    # selector never runs while a dependency it may load cannot initialize.
+    levels = selector_levels(env, pkg_info)
+    isempty(levels) && return true
+    env_key = selector_env_key(env)
+    for level in levels
+        for info in level
+            check_artifacts_downloaded(
+                info.root; platform, selector_project = env.project_file, env_key
+            ) || return false
+        end
+    end
+    return true
 end
 
 function update_manifest!(env::EnvCache, pkgs::Vector{PackageSpec}, deps_map, julia_version, registries::Vector{Registry.RegistryInstance})
@@ -1355,7 +1376,80 @@ function install_git(
     end
 end
 
-function collect_artifacts(pkg_root::String; platform::AbstractPlatform = HostPlatform(), include_lazy::Bool = false)
+# Cache successful selections across operations and status checks in this session.
+# Key: artifact file path, platform, environment fingerprint, script and artifact hashes.
+const SELECTOR_CACHE_LOCK = Base.ReentrantLock()
+const SelectorCacheKey = Tuple{String, String, UInt, UInt, UInt}
+const SELECTOR_CACHE = Dict{SelectorCacheKey, Base.TOML.TOMLDict}()
+
+clear_selector_cache!() = @lock SELECTOR_CACHE_LOCK empty!(SELECTOR_CACHE)
+selector_cache_enabled() = get(ENV, "JULIA_PKG_SELECTOR_CACHE", "1") != "0"
+
+function run_artifact_selector(
+        selector_path::String, artifacts_toml::String, platform::AbstractPlatform;
+        selector_project::Union{Nothing, String}, env_key::Union{Nothing, UInt}
+    )
+    cache_key = if selector_project !== nothing && env_key !== nothing && selector_cache_enabled()
+        (
+            artifacts_toml, triplet(platform), env_key,
+            hash(read(selector_path)), hash(read(artifacts_toml)),
+        )
+    else
+        nothing
+    end
+    if cache_key !== nothing
+        cached = @lock SELECTOR_CACHE_LOCK get(SELECTOR_CACHE, cache_key, nothing)
+        cached === nothing || return cached
+    end
+
+    # Inherit the parent's optimization level so dependency precompilation is reusable.
+    # Forcing -O0 would produce caches rejected by an -O2 parent. Keep --compile=min
+    # to limit compilation of the hook itself; it is not part of the cache flags.
+    meta_toml = mktempdir() do tmp
+        project = selector_project === nothing ? Base.active_project() : selector_project
+        # Give the hook's dependency names precedence over the active project's.
+        # List workspace ancestors explicitly: Julia only inherits ancestor preferences
+        # automatically for the first load path entry.
+        deps_project = write_selector_deps_project(dirname(dirname(selector_path)), tmp, project)
+        projects = project === nothing ? ["@"] : Base.get_projects_workspace_to_root(project)
+        select_cmd = gen_build_code(
+            selector_path; inherit_project = selector_project === nothing, project = selector_project,
+            load_path = [deps_project; projects; "@stdlib"], optimize = true
+        )
+        select_cmd = Cmd(`$select_cmd --compile=min -t1 --startup-file=no $(triplet(platform))`)
+        String(read(select_cmd))
+    end
+    artifacts = TOML.tryparse(meta_toml)
+    if artifacts isa TOML.ParserError
+        errstr = sprint(showerror, artifacts; context = stderr)
+        pkgerror("failed to parse TOML output from running $(repr(selector_path)), got: \n$errstr")
+    end
+    # Only successful runs are cached; a failing selector is retried on the next call.
+    cache_key === nothing || @lock SELECTOR_CACHE_LOCK SELECTOR_CACHE[cache_key] = artifacts
+    return artifacts
+end
+
+# Combine the package's dependency names with the resolved manifest, excluding any
+# manifest or preferences in its checkout. Checkout preferences do not apply at runtime.
+function write_selector_deps_project(pkg_root::String, dir::String, project::Union{Nothing, String})
+    project_file = projectfile_path(pkg_root; strict = true)
+    deps = project_file === nothing ? Dict{String, UUID}() : Types.read_project(project_file).deps
+    deps_project = Dict{String, Any}(
+        "deps" => Dict{String, Any}(name => string(uuid) for (name, uuid) in deps)
+    )
+    manifest = project === nothing ? nothing : Base.project_file_manifest_path(project)
+    manifest === nothing || (deps_project["manifest"] = manifest)
+    deps_project_file = joinpath(dir, "Project.toml")
+    Types.write_project(deps_project, deps_project_file)
+    return deps_project_file
+end
+
+function collect_artifacts(
+        pkg_root::String;
+        platform::AbstractPlatform = HostPlatform(), include_lazy::Bool = false,
+        selector_project::Union{Nothing, String} = nothing,
+        env_key::Union{Nothing, UInt} = nothing
+    )
     # Check to see if this package has an (Julia)Artifacts.toml
     artifacts_tomls = Tuple{String, Base.TOML.TOMLDict}[]
     for f in artifact_names
@@ -1365,19 +1459,10 @@ function collect_artifacts(pkg_root::String; platform::AbstractPlatform = HostPl
 
             # If there is a dynamic artifact selector, run that in an appropriate sandbox to select artifacts
             if isfile(selector_path)
-                # Despite the fact that we inherit the project, since the in-memory manifest
-                # has not been updated yet, if we try to load any dependencies, it may fail.
-                # Therefore, this project inheritance is really only for Preferences, not dependencies.
-                # We only guarantee access to the `stdlib`, which is why we set `add_stdlib` here.
-                select_cmd = Cmd(`$(gen_build_code(selector_path; inherit_project=true, add_stdlib=true)) --compile=min -t1 --startup-file=no $(triplet(platform))`)
-                meta_toml = String(read(select_cmd))
-                res = TOML.tryparse(meta_toml)
-                if res isa TOML.ParserError
-                    errstr = sprint(showerror, res; context = stderr)
-                    pkgerror("failed to parse TOML output from running $(repr(selector_path)), got: \n$errstr")
-                else
-                    push!(artifacts_tomls, (artifacts_toml, TOML.parse(meta_toml)))
-                end
+                artifacts = run_artifact_selector(
+                    selector_path, artifacts_toml, platform; selector_project, env_key
+                )
+                push!(artifacts_tomls, (artifacts_toml, artifacts))
             else
                 # Otherwise, use the standard selector from `Artifacts`
                 artifacts = select_downloadable_artifacts(artifacts_toml; platform, include_lazy)
@@ -1397,57 +1482,25 @@ mutable struct DownloadState
     const bar::MiniProgressBar
 end
 
-function download_artifacts(
-        ctx::Context, pkgs;
-        platform::AbstractPlatform = HostPlatform(),
-        julia_version = VERSION,
-        verbose::Bool = false,
-        io::IO = stderr_f(),
-        include_lazy::Bool = false
+function install_collected_artifacts!(
+        ctx::Context, all_collected_artifacts;
+        server_registry_info, verbose::Bool, io::IO
     )
-    env = ctx.env
-    io = ctx.io
+    isempty(all_collected_artifacts) && return
+
     fancyprint = can_fancyprint(io)
-    pkg_info = Tuple{String, Union{Base.UUID, Nothing}}[]
-    pkg_uuids = Set(pkg.uuid for pkg in pkgs)
-    for (uuid, pkg) in env.manifest
-        uuid in pkg_uuids || continue
-        pkg = manifest_info(env.manifest, uuid)
-        pkg_root = source_path(env.manifest_file, pkg, julia_version)
-        pkg_root === nothing || push!(pkg_info, (pkg_root, uuid))
-    end
-    push!(pkg_info, (dirname(env.project_file), env.pkg !== nothing ? env.pkg.uuid : nothing))
-    download_jobs = Dict{SHA1, Function}()
-
-    # Check what registries the current pkg server tracks
-    # Disable if precompiling to not access internet
-    server_registry_info = if Base.JLOptions().incremental == 0
-        Registry.pkg_server_registry_info()
-    else
-        nothing
-    end
-
     print_lock = Base.ReentrantLock() # for non-fancyprint printing
-
-    download_states = Dict{SHA1, DownloadState}()
-
-    errors = Channel{Any}(Inf)
-    is_done = Ref{Bool}(false)
     ansi_moveup(n::Int) = string("\e[", n, "A")
     ansi_movecol1 = "\e[1G"
     ansi_cleartoend = "\e[0J"
     ansi_cleartoendofline = "\e[0K"
     ansi_enablecursor = "\e[?25h"
     ansi_disablecursor = "\e[?25l"
-
-    all_collected_artifacts = reduce(
-        vcat, map(
-            ((pkg_root, pkg_uuid),) ->
-            map(ca -> (ca[1], ca[2], pkg_uuid), collect_artifacts(pkg_root; platform, include_lazy)), pkg_info
-        )
-    )
-    used_artifact_tomls = Set{String}(map(ca -> ca[1], all_collected_artifacts))
-    longest_name_length = maximum(all_collected_artifacts; init = 0) do (artifacts_toml, artifacts, pkg_uuid)
+    download_jobs = Dict{SHA1, Function}()
+    download_states = Dict{SHA1, DownloadState}()
+    errors = Channel{Any}(Inf)
+    is_done = Ref(false)
+    longest_name_length = maximum(all_collected_artifacts; init = 0) do (_, artifacts, _)
         maximum(textwidth, keys(artifacts); init = 0)
     end
     for (artifacts_toml, artifacts, pkg_uuid) in all_collected_artifacts
@@ -1575,7 +1628,200 @@ function download_artifacts(
             pkgerror("Failed to install some artifacts:\n\n$(strip(str, '\n'))")
         end
     end
+    return
+end
 
+# Copy the resolved environment and its workspace ancestors. The ancestors supply
+# preferences, but all projects must use the resolved manifest in the temporary tree.
+function selector_environment(env::EnvCache)
+    manifest = deepcopy(env.manifest)
+    abspath!(env, manifest)
+    projects = map(enumerate(Base.get_projects_workspace_to_root(env.project_file))) do (i, file)
+        project = deepcopy(i == 1 ? env.project : env.workspace[file])
+        project.manifest = nothing
+        empty!(project.workspace)
+        i == 1 || (project.workspace["projects"] = ["child"])
+        # Source overrides are resolver inputs; the manifest already records their paths.
+        empty!(project.sources)
+        preferences = Pair{String, String}[]
+        for name in Base.preferences_names
+            preferences_file = joinpath(dirname(file), name)
+            isfile(preferences_file) && push!(preferences, name => read(preferences_file, String))
+        end
+        (; project, preferences)
+    end
+    return (; projects, manifest)
+end
+
+# Use content rather than the temporary location so checks after writing the user's
+# environment can reuse the selection made during installation.
+function selector_env_key(env::EnvCache)
+    (; projects, manifest) = selector_environment(env)
+    key = hash(sprint(Types.write_manifest, manifest))
+    for (; project, preferences) in projects
+        key = hash(sprint(Types.write_project, Types.destructure(project)), key)
+        for (name, content) in preferences
+            key = hash(content, hash(name, key))
+        end
+    end
+    return key
+end
+
+function with_resolved_artifact_env(f::Function, env::EnvCache)
+    return mktempdir() do tmp
+        (; projects, manifest) = selector_environment(env)
+        Types.write_manifest(manifest, manifestfile_path(tmp))
+        # Recreate the ancestry so Julia merges workspace preferences with its usual
+        # UUID mapping and precedence, without exposing unrelated stacked environments.
+        for (; project, preferences) in reverse(projects)
+            mkpath(tmp)
+            Types.write_project(project, projectfile_path(tmp))
+            for (name, content) in preferences
+                write(joinpath(tmp, name), content)
+            end
+            tmp = joinpath(tmp, "child")
+        end
+        return f(projectfile_path(dirname(tmp)))
+    end
+end
+
+const ArtifactPackageInfo = NamedTuple{
+    (:root, :uuid, :has_selector), Tuple{String, Union{UUID, Nothing}, Bool},
+}
+
+has_artifact_selector(pkg_root::String) = isfile(joinpath(pkg_root, ".pkg", "select_artifacts.jl"))
+
+# Collect the source roots whose artifacts need to be considered: every package in `pkgs`
+# (given as `uuid => pkg` pairs) with a source directory, plus the project itself even if
+# it is not a package.
+function artifact_package_info(env::EnvCache, pkgs; julia_version = VERSION)
+    pkg_info = ArtifactPackageInfo[]
+    for (uuid, pkg) in pkgs
+        pkg_root = source_path(env.manifest_file, pkg, julia_version)
+        pkg_root === nothing && continue
+        push!(pkg_info, (; root = pkg_root, uuid, has_selector = has_artifact_selector(pkg_root)))
+    end
+    project_root = dirname(env.project_file)
+    if !any(info -> info.root == project_root, pkg_info)
+        push!(
+            pkg_info, (;
+                root = project_root,
+                uuid = env.pkg !== nothing ? env.pkg.uuid : nothing,
+                has_selector = has_artifact_selector(project_root),
+            )
+        )
+    end
+    return pkg_info
+end
+
+# Group the packages with an artifact selector into levels such that no selector in a
+# level depends on a package with a selector in the same or a later level. A selector
+# dependency must be able to initialize before its consumer's hook runs.
+function selector_levels(env::EnvCache, pkg_info::Vector{ArtifactPackageInfo})
+    levels = Vector{ArtifactPackageInfo}[]
+    selector_pkg_info = Dict(info.uuid => info for info in pkg_info if info.has_selector)
+    isempty(selector_pkg_info) && return levels
+
+    selector_uuids = Set(uuid for uuid in keys(selector_pkg_info) if uuid !== nothing)
+    selector_dependencies = Dict{Union{UUID, Nothing}, Set{UUID}}()
+    for uuid in keys(selector_pkg_info)
+        roots = if uuid === nothing || Types.is_project_uuid(env, uuid)
+            values(env.project.deps)
+        else
+            values(manifest_info(env.manifest, uuid).deps)
+        end
+        dependencies = _get_deps!(Set{UUID}(), env, roots)
+        selector_dependencies[uuid] = intersect(dependencies, selector_uuids)
+        uuid !== nothing && delete!(selector_dependencies[uuid], uuid)
+    end
+
+    remaining = Set(keys(selector_pkg_info))
+    completed = Set{Union{UUID, Nothing}}()
+    while !isempty(remaining)
+        ready = filter(uuid -> selector_dependencies[uuid] ⊆ completed, remaining)
+        if isempty(ready)
+            names = sort!([selector_pkg_info[uuid].root for uuid in remaining])
+            pkgerror("artifact selectors have a cyclic dependency: $(join(names, ", "))")
+        end
+        push!(levels, sort!([selector_pkg_info[uuid] for uuid in ready]; by = info -> info.root))
+        union!(completed, ready)
+        setdiff!(remaining, ready)
+    end
+    return levels
+end
+
+function collect_package_artifacts(
+        info, used_artifact_tomls;
+        platform::AbstractPlatform, include_lazy::Bool,
+        selector_project::Union{Nothing, String} = nothing,
+        env_key::Union{Nothing, UInt} = nothing
+    )
+    artifacts = collect_artifacts(info.root; platform, include_lazy, selector_project, env_key)
+    union!(used_artifact_tomls, map(first, artifacts))
+    return map(ca -> (ca[1], ca[2], info.uuid), artifacts)
+end
+
+function download_artifacts(
+        ctx::Context, pkgs;
+        platform::AbstractPlatform = HostPlatform(),
+        julia_version = VERSION,
+        verbose::Bool = false,
+        io::IO = stderr_f(),
+        include_lazy::Bool = false
+    )
+    env = ctx.env
+    io = ctx.io
+    pkg_uuids = Set(pkg.uuid for pkg in pkgs)
+    manifest_pkgs = [uuid => manifest_info(env.manifest, uuid) for uuid in keys(env.manifest) if uuid in pkg_uuids]
+    pkg_info = artifact_package_info(env, manifest_pkgs; julia_version)
+
+    # Check what registries the current pkg server tracks
+    # Disable if precompiling to not access internet
+    server_registry_info = if Base.JLOptions().incremental == 0
+        Registry.pkg_server_registry_info()
+    else
+        nothing
+    end
+    used_artifact_tomls = Set{String}()
+
+    # A selector dependency must be able to initialize before its consumer's hook runs.
+    # Install all statically selected artifacts first, retaining parallel downloads.
+    static_pkg_info = filter(info -> !info.has_selector, pkg_info)
+    static_artifacts = reduce(
+        vcat,
+        map(
+            info -> collect_package_artifacts(
+                info, used_artifact_tomls; platform, include_lazy
+            ),
+            static_pkg_info,
+        );
+        init = []
+    )
+    install_collected_artifacts!(ctx, static_artifacts; server_registry_info, verbose, io)
+
+    levels = selector_levels(env, pkg_info)
+    if !isempty(levels)
+        env_key = selector_env_key(env)
+        with_resolved_artifact_env(env) do selector_project
+            # Run each level's selectors, then download their artifacts concurrently
+            # before starting selectors that may load those packages.
+            for level in levels
+                selected_artifacts = reduce(
+                    vcat,
+                    [
+                        collect_package_artifacts(
+                                info, used_artifact_tomls;
+                                platform, include_lazy, selector_project, env_key,
+                            ) for info in level
+                    ];
+                    init = []
+                )
+                install_collected_artifacts!(
+                    ctx, selected_artifacts; server_registry_info, verbose, io
+                )
+            end
+        end
+    end
 
     return write_env_usage(used_artifact_tomls, "artifact_usage.toml")
 end
@@ -1591,8 +1837,22 @@ function download_artifacts(
     return download_artifacts(ctx, values(ctx.env.manifest); platform, julia_version, verbose, io, include_lazy)
 end
 
-function check_artifacts_downloaded(pkg_root::String; platform::AbstractPlatform = HostPlatform())
-    for (artifacts_toml, artifacts) in collect_artifacts(pkg_root; platform)
+function check_artifacts_downloaded(
+        pkg_root::String;
+        platform::AbstractPlatform = HostPlatform(), selector_project::Union{Nothing, String} = nothing,
+        env_key::Union{Nothing, UInt} = nothing
+    )
+    collected_artifacts = try
+        collect_artifacts(pkg_root; platform, selector_project, env_key)
+    catch err
+        err isa ProcessFailedException || rethrow()
+        # Dependencies may be missing, particularly during a status check. Report the
+        # package as not downloaded and let installation retry the selector after
+        # bootstrapping its dependencies.
+        @debug "Artifact selector failed" pkg_root exception = err
+        return false
+    end
+    for (artifacts_toml, artifacts) in collected_artifacts
         for name in keys(artifacts)
             if !artifact_exists(Base.SHA1(artifacts[name]["git-tree-sha1"]))
                 return false
@@ -1922,11 +2182,18 @@ function dependency_order_uuids(env::EnvCache, uuids::Vector{UUID})::Dict{UUID, 
     return order
 end
 
-function gen_build_code(build_file::String; inherit_project::Bool = false, add_stdlib::Bool = false)
+function gen_build_code(
+        build_file::String;
+        inherit_project::Bool = false,
+        project::Union{Nothing, String} = nothing,
+        load_path::Union{Nothing, Vector{String}} = nothing,
+        optimize::Bool = false
+    )
+    inherit_project && project !== nothing && error("cannot both inherit and explicitly set a project")
     code = """
     $(Base.load_path_setup_code(false))
-    if $(add_stdlib)
-        push!(Base.LOAD_PATH, "@stdlib")
+    if $(load_path !== nothing)
+        append!(empty!(Base.LOAD_PATH), $(repr(load_path)))
     end
     cd($(repr(dirname(build_file))))
     include($(repr(build_file)))
@@ -1934,10 +2201,11 @@ function gen_build_code(build_file::String; inherit_project::Bool = false, add_s
     # This will make it so that running Pkg.build runs the build in a session with --startup=no
     # *unless* the parent julia session is started with --startup=yes explicitly.
     startup_flag = Base.JLOptions().startupfile == 1 ? "yes" : "no"
+    project = inherit_project ? Base.active_project() : project
     return ```
-    $(Base.julia_cmd()) -O0 --color=no --history-file=no
+    $(Base.julia_cmd()) $(optimize ? `` : `-O0`) --color=no --history-file=no
     --startup-file=$startup_flag
-    $(inherit_project ? `--project=$(Base.active_project())` : ``)
+    $(project === nothing ? `` : `--project=$project`)
     --eval $code
     ```
 end
@@ -3473,11 +3741,15 @@ function diff_array(old_env::Union{EnvCache, Nothing}, new_env::EnvCache; manife
     return Tuple{T, S, S}[(uuid, index_pkgs(old, uuid), index_pkgs(new, uuid))::Tuple{T, S, S} for uuid in all_uuids]
 end
 
-function is_package_downloaded(manifest_file::String, pkg::PackageSpec; platform = HostPlatform())
+function is_package_downloaded(
+        manifest_file::String, pkg::PackageSpec;
+        platform = HostPlatform(), selector_project::Union{Nothing, String} = nothing,
+        env_key::Union{Nothing, UInt} = nothing
+    )
     sourcepath = source_path(manifest_file, pkg)
     sourcepath === nothing && return false
     isdir(sourcepath) || return false
-    check_artifacts_downloaded(sourcepath; platform) || return false
+    check_artifacts_downloaded(sourcepath; platform, selector_project, env_key) || return false
     return true
 end
 
@@ -3607,6 +3879,16 @@ function print_status(
     no_visible_packages_heldback = true
     no_packages_heldback = true
     lpadding = 2
+    # Fingerprinting the environment is only needed to reuse cached selector results
+    env_key = if any(xs) do (_, _, new)
+            new === nothing && return false
+            root = source_path(env.manifest_file, new)
+            root !== nothing && has_artifact_selector(root)
+        end
+        selector_env_key(env)
+    else
+        nothing
+    end
 
     package_statuses = PackageStatusData[]
     for (uuid, old, new) in xs
@@ -3656,7 +3938,9 @@ function print_status(
 
         # TODO: Show extension deps for project as well?
 
-        pkg_downloaded = !is_instantiated(new) || is_package_downloaded(env.manifest_file, new)
+        pkg_downloaded = !is_instantiated(new) || is_package_downloaded(
+            env.manifest_file, new; selector_project = env.project_file, env_key
+        )
 
         new_ver_avail = !latest_version && !Operations.is_tracking_repo(new) && !Operations.is_tracking_path(new)
         pkg_upgradable = new_ver_avail && cinfo !== nothing && isempty(cinfo[1])

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1413,11 +1413,13 @@ function run_artifact_selector(
         # Give the hook's dependency names precedence over the active project's.
         # List workspace ancestors explicitly: Julia only inherits ancestor preferences
         # automatically for the first load path entry.
-        deps_project = write_selector_deps_project(dirname(dirname(selector_path)), tmp, project)
+        pkg_root = dirname(dirname(selector_path))
+        deps_project = write_selector_deps_project(pkg_root, tmp, project)
         projects = project === nothing ? ["@"] : Base.get_projects_workspace_to_root(project)
         select_cmd = gen_build_code(
             selector_path; inherit_project = selector_project === nothing, project = selector_project,
-            load_path = [deps_project; projects; "@stdlib"], optimize = true
+            load_path = [deps_project; projects; "@stdlib"], optimize = true,
+            epilogue = selector_self_load_check(pkg_root)
         )
         select_cmd = Cmd(`$select_cmd --compile=min -t1 --startup-file=no $(triplet(platform))`)
         String(read(select_cmd))
@@ -1430,6 +1432,23 @@ function run_artifact_selector(
     # Only successful runs are cached; a failing selector is retried on the next call.
     cache_key === nothing || @lock SELECTOR_CACHE_LOCK SELECTOR_CACHE[cache_key] = artifacts
     return artifacts
+end
+
+# A hook runs before its package's artifacts are selected, so loading that package
+# cannot work reliably: it fails when the artifacts are missing and silently uses stale
+# ones otherwise. The package may be loadable through the active project, so the hook
+# process checks after the selection that it did not load the package.
+function selector_self_load_check(pkg_root::String)
+    project_file = projectfile_path(pkg_root; strict = true)
+    project_file === nothing && return ""
+    (; name, uuid) = Types.read_project(project_file)
+    (name === nothing || uuid === nothing) && return ""
+    return """
+    if haskey(Base.loaded_modules, Base.PkgId(Base.UUID($(repr(string(uuid)))), $(repr(name))))
+        println(stderr, "ERROR: the artifact selector of $name loaded $name itself. Selectors run before the artifacts of their package are selected, so they must not load the package; only its dependencies and standard libraries may be loaded.")
+        exit(1)
+    end
+    """
 end
 
 # Combine the package's dependency names with the resolved manifest, excluding any
@@ -2194,7 +2213,8 @@ function gen_build_code(
         inherit_project::Bool = false,
         project::Union{Nothing, String} = nothing,
         load_path::Union{Nothing, Vector{String}} = nothing,
-        optimize::Bool = false
+        optimize::Bool = false,
+        epilogue::String = ""
     )
     inherit_project && project !== nothing && error("cannot both inherit and explicitly set a project")
     code = """
@@ -2204,6 +2224,7 @@ function gen_build_code(
     end
     cd($(repr(dirname(build_file))))
     include($(repr(build_file)))
+    $epilogue
     """
     # This will make it so that running Pkg.build runs the build in a session with --startup=no
     # *unless* the parent julia session is started with --startup=yes explicitly.

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -6,6 +6,7 @@ import Pkg.Artifacts: pack_platform!, unpack_platform, with_artifacts_directory,
 import Pkg.Operations: count_artifacts, artifact_suffix
 using TOML, Dates, SHA
 import Base: SHA1
+import LibGit2
 
 using ..Utils
 using Preferences
@@ -509,6 +510,84 @@ end
         @test selector_runs() == runs_before + 1
     end
 end
+@testset "offline resolution does not run artifact selectors" begin
+    temp_pkg_dir() do project_path
+        # A registered package with a selector that records every run
+        pkg_uuid = "7c1e3b2a-9d4f-4e6b-8a5c-2f0d1e9b3c04"
+        pkg_repo_path = joinpath(project_path, "OfflineSelector")
+        mkpath(joinpath(pkg_repo_path, "src"))
+        mkpath(joinpath(pkg_repo_path, ".pkg"))
+        write(
+            joinpath(pkg_repo_path, "Project.toml"), """
+            name = "OfflineSelector"
+            uuid = "$pkg_uuid"
+            version = "0.1.0"
+            """
+        )
+        write(joinpath(pkg_repo_path, "src", "OfflineSelector.jl"), "module OfflineSelector end\n")
+        write(joinpath(pkg_repo_path, "Artifacts.toml"), "")
+        selector_runs_file = joinpath(project_path, "selector_runs")
+        selector_runs() = isfile(selector_runs_file) ? countlines(selector_runs_file) : 0
+        write(
+            joinpath(pkg_repo_path, ".pkg", "select_artifacts.jl"), """
+            open($(repr(selector_runs_file)), "a") do io
+                println(io, "run")
+            end
+            """
+        )
+        git_init_and_commit(pkg_repo_path)
+        pkg_tree_hash = LibGit2.with(LibGit2.GitRepo(pkg_repo_path)) do repo
+            string(LibGit2.GitHash(LibGit2.peel(LibGit2.GitTree, LibGit2.head(repo))))
+        end
+
+        regpath = joinpath(project_path, "OfflineReg")
+        mkpath(joinpath(regpath, "OfflineSelector"))
+        regpath_toml = replace(regpath, "\\" => "/")
+        pkg_repo_path_toml = replace(pkg_repo_path, "\\" => "/")
+        write(
+            joinpath(regpath, "Registry.toml"), """
+            name = "OfflineReg"
+            uuid = "3a2b1c0d-4e5f-4a6b-9c8d-7e6f5a4b3c05"
+            repo = "$regpath_toml"
+            [packages]
+            $pkg_uuid = { name = "OfflineSelector", path = "OfflineSelector" }
+            """
+        )
+        write(
+            joinpath(regpath, "OfflineSelector", "Package.toml"), """
+            name = "OfflineSelector"
+            uuid = "$pkg_uuid"
+            repo = "$pkg_repo_path_toml"
+            """
+        )
+        write(
+            joinpath(regpath, "OfflineSelector", "Versions.toml"), """
+            ["0.1.0"]
+            git-tree-sha1 = "$pkg_tree_hash"
+            """
+        )
+        git_init_and_commit(regpath)
+        Pkg.Registry.add(url = regpath)
+
+        Pkg.activate(project_path)
+        Pkg.add("OfflineSelector")
+        @test selector_runs() == 1
+
+        # Offline resolution only considers installed versions. Deciding whether a
+        # registered version is installed must not run its selector, which would
+        # execute outside any resolved environment. The environment does not change,
+        # so the installation check afterwards reuses the cached selection.
+        Pkg.offline()
+        try
+            Pkg.update()
+        finally
+            Pkg.offline(false)
+        end
+        @test Pkg.dependencies()[Base.UUID(pkg_uuid)].version == v"0.1.0"
+        @test selector_runs() == 1
+    end
+end
+
 
 @testset "with_artifacts_directory()" begin
     mktempdir() do art_dir

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -161,6 +161,29 @@ end
     end
 end
 
+@testset "all selected artifacts must be installed" begin
+    mktempdir() do root
+        with_artifacts_directory(joinpath(root, "artifacts")) do
+            hashes = map(("first", "second")) do name
+                create_artifact() do dir
+                    write(joinpath(dir, "name"), name)
+                end
+            end
+            toml = joinpath(root, "Artifacts.toml")
+            for (name, hash) in zip(("first", "second"), hashes)
+                bind_artifact!(toml, name, hash; download_info = [("file:///unused", "0"^64)])
+            end
+            @test Pkg.Operations.check_artifacts_downloaded(root)
+            # Delete whichever entry is visited second, so the check cannot pass after
+            # inspecting only the first artifact in the dictionary.
+            artifacts = only(Pkg.Operations.collect_artifacts(root))[2]
+            missing = last(collect(values(artifacts)))["git-tree-sha1"]
+            remove_artifact(SHA1(missing))
+            @test !Pkg.Operations.check_artifacts_downloaded(root)
+        end
+    end
+end
+
 @testset "with_artifacts_directory()" begin
     mktempdir() do art_dir
         with_artifacts_directory(art_dir) do

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -390,24 +390,32 @@ end
         @test artifact_exists(selected["new"].hash)
         @test !artifact_exists(selected["old"].hash)
 
-        # The selector ran once for the resolution. Status checks in the same session,
-        # whether from the in-memory environment or from the one written to disk, reuse
-        # the cached result rather than running it again.
-        @test selector_runs() == 1
-        Pkg.status(; io = IOBuffer())
+        # The selector ran once for the resolution. Instantiating the environment written
+        # to disk reuses the cached result rather than running it again.
         @test selector_runs() == 1
         Pkg.instantiate()
         @test selector_runs() == 1
+
+        # Status never runs selectors, whether or not a result is cached, and reports the
+        # package as downloaded as soon as its source is present.
+        Pkg.Operations.clear_selector_cache!()
+        remove_artifact(selected["new"].hash)
+        status = sprint(io -> Pkg.status(; io))
+        @test selector_runs() == 1
+        @test !occursin("not downloaded", status)
+        Pkg.instantiate()
+        @test selector_runs() == 2
+        @test artifact_exists(selected["new"].hash)
 
         # Editing a development hook invalidates the cached result in the same session.
         selector_path = joinpath(selector, ".pkg", "select_artifacts.jl")
         open(selector_path, "a") do io
             println(io)
         end
-        Pkg.status(; io = IOBuffer())
-        @test selector_runs() == 2
-        Pkg.status(; io = IOBuffer())
-        @test selector_runs() == 2
+        Pkg.instantiate()
+        @test selector_runs() == 3
+        Pkg.instantiate()
+        @test selector_runs() == 3
 
         depot_env = "JULIA_DEPOT_PATH" => join(Base.DEPOT_PATH, Sys.iswindows() ? ";" : ":")
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -4,7 +4,7 @@ import ..Pkg # ensure we are using the correct Pkg
 using Test, Random, Pkg.Artifacts, Base.BinaryPlatforms, Pkg.PlatformEngines
 import Pkg.Artifacts: pack_platform!, unpack_platform, with_artifacts_directory, ensure_all_artifacts_installed, extract_all_hashes
 import Pkg.Operations: count_artifacts, artifact_suffix
-using TOML, Dates
+using TOML, Dates, SHA
 import Base: SHA1
 
 using ..Utils
@@ -181,6 +181,324 @@ end
             remove_artifact(SHA1(missing))
             @test !Pkg.Operations.check_artifacts_downloaded(root)
         end
+    end
+end
+
+@testset "artifact selector environment relocation" begin
+    mktempdir() do root
+        uuid = "b8df255f-45df-4e3b-8d04-6a7f7496dbd4"
+        manifest = joinpath(root, "custom-manifest.toml")
+        write(
+            manifest, """
+            manifest_format = "2.0"
+            [[deps.ArtifactSelectorDependency]]
+            uuid = "$uuid"
+            version = "0.1.0"
+            path = "dependency"
+            """
+        )
+        write(
+            joinpath(root, "Project.toml"), """
+            manifest = $(repr(manifest))
+            [deps]
+            ArtifactSelectorDependency = "$uuid"
+            [preferences.ArtifactSelectorDependency]
+            inherited = "root"
+            overridden = "root"
+            """
+        )
+        pkgroot = joinpath(root, "Consumer")
+        mkpath(joinpath(pkgroot, ".pkg"))
+        write(joinpath(pkgroot, "Project.toml"), "[deps]\nArtifactSelectorDependency = \"$uuid\"\n")
+        script = joinpath(pkgroot, ".pkg", "select_artifacts.jl")
+        artifacts = joinpath(pkgroot, "Artifacts.toml")
+        write(artifacts, "")
+        write(
+            script, """
+            using TOML
+            manifest = TOML.parsefile(Base.project_file_manifest_path(Base.active_project()))
+            TOML.print(Dict(
+                "version" => only(manifest["deps"]["ArtifactSelectorDependency"])["version"],
+                "preferences" => Base.get_preferences(Base.UUID("$uuid")),
+            ))
+            """
+        )
+        function select(env)
+            Pkg.Operations.with_resolved_artifact_env(env) do project
+                Pkg.Operations.run_artifact_selector(script, artifacts, HostPlatform(); selector_project = project, env_key = nothing)
+            end
+        end
+
+        env = Pkg.Types.EnvCache(joinpath(root, "Project.toml"))
+        env.manifest[Base.UUID(uuid)].version = v"0.2.0"
+        @test select(env)["version"] == "0.2.0"
+        @test only(TOML.parsefile(manifest)["deps"]["ArtifactSelectorDependency"])["version"] == "0.1.0"
+
+        # A workspace member shares its parent's manifest and inherits its preferences.
+        child = joinpath(root, "member")
+        mkpath(child)
+        open(joinpath(root, "Project.toml"), "a") do io
+            println(io, "\n[workspace]\nprojects = [\"member\"]")
+        end
+        cp(manifest, joinpath(root, "Manifest.toml"))
+        write(
+            joinpath(child, "Project.toml"), """
+            [deps]
+            ArtifactSelectorDependency = "$uuid"
+            """
+        )
+        write(
+            joinpath(child, "LocalPreferences.toml"), """
+            [ArtifactSelectorDependency]
+            overridden = "child"
+            """
+        )
+        env = Pkg.Types.EnvCache(joinpath(child, "Project.toml"))
+        env.manifest[Base.UUID(uuid)].version = v"0.2.0"
+        selected = select(env)
+        @test selected["version"] == "0.2.0"
+        @test selected["preferences"] == Dict("inherited" => "root", "overridden" => "child")
+        key = Pkg.Operations.selector_env_key(env)
+        write(
+            joinpath(root, "LocalPreferences.toml"), """
+            [ArtifactSelectorDependency]
+            inherited = "changed"
+            """
+        )
+        @test Pkg.Operations.selector_env_key(env) != key
+        @test select(env)["preferences"]["inherited"] == "changed"
+    end
+end
+
+@testset "artifact selector dependency identity" begin
+    mktempdir() do root
+        # Two packages share a name. The active project depends on one and the hook's
+        # package on the other; the hook must get the one from its own [deps].
+        function write_dependency(dir, uuid, origin)
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "Project.toml"), "name = \"Dep\"\nuuid = \"$uuid\"\n")
+            return write(joinpath(dir, "src", "Dep.jl"), "module Dep\nconst origin = $(repr(origin))\nend\n")
+        end
+        user_uuid = "1e8a6f17-4a4f-4b6c-9a4b-2f4a0b2a5d01"
+        hook_uuid = "5c3d2b21-8f2e-4d1a-b6e5-7a9c0d1e2f02"
+        write_dependency(joinpath(root, "user"), user_uuid, "user")
+        write_dependency(joinpath(root, "hook"), hook_uuid, "hook")
+        write(joinpath(root, "Project.toml"), "[deps]\nDep = \"$user_uuid\"\n")
+        write(
+            joinpath(root, "Manifest.toml"), """
+            manifest_format = "2.0"
+            [[deps.Dep]]
+            uuid = "$user_uuid"
+            path = "user"
+            [[deps.Dep]]
+            uuid = "$hook_uuid"
+            path = "hook"
+            """
+        )
+        consumer = joinpath(root, "Consumer")
+        mkpath(joinpath(consumer, ".pkg"))
+        write(
+            joinpath(consumer, "Project.toml"), """
+            name = "Consumer"
+            uuid = "9b7e6d5c-4a3b-4c2d-8e1f-0a9b8c7d6e03"
+            [deps]
+            Dep = "$hook_uuid"
+            """
+        )
+        artifacts_toml = joinpath(consumer, "Artifacts.toml")
+        write(artifacts_toml, "")
+        selector = joinpath(consumer, ".pkg", "select_artifacts.jl")
+        write(selector, "using Dep, TOML\nTOML.print(Dict(\"origin\" => Dep.origin))\n")
+        env = Pkg.Types.EnvCache(joinpath(root, "Project.toml"))
+        selected = Pkg.Operations.with_resolved_artifact_env(env) do project
+            Pkg.Operations.run_artifact_selector(
+                selector, artifacts_toml, HostPlatform(); selector_project = project, env_key = nothing
+            )
+        end
+        @test selected["origin"] == "hook"
+    end
+end
+
+@testset "artifact selectors use resolved dependencies" begin
+    temp_pkg_dir() do project_path
+        for package in (
+                "ArtifactSelectorDependencyOld",
+                "ArtifactSelectorDependencyNew",
+                "ArtifactSelectorWithDependency",
+            )
+            copy_test_package(project_path, package)
+        end
+
+        old_dependency = joinpath(project_path, "ArtifactSelectorDependencyOld")
+        new_dependency = joinpath(project_path, "ArtifactSelectorDependencyNew")
+        selector = joinpath(project_path, "ArtifactSelectorWithDependency")
+
+        # The selector appends a line to this file on every run
+        selector_runs_file = joinpath(selector, "selector_runs")
+        selector_runs() = isfile(selector_runs_file) ? countlines(selector_runs_file) : 0
+
+        function downloadable_artifact(name, selection)
+            hash = create_artifact() do path
+                write(joinpath(path, "selection"), selection)
+                write(joinpath(path, "artifact"), name)
+            end
+            tarball = joinpath(project_path, "$name.tar.gz")
+            archive_artifact(hash, tarball)
+            sha256 = bytes2hex(open(SHA.sha256, tarball))
+            remove_artifact(hash)
+            return (; hash, url = make_file_url(tarball), sha256)
+        end
+
+        bootstrap = downloadable_artifact("bootstrap", "new")
+        bind_artifact!(
+            joinpath(new_dependency, "Artifacts.toml"), "bootstrap", bootstrap.hash;
+            download_info = [(bootstrap.url, bootstrap.sha256)],
+        )
+
+        selected = Dict(
+            selection => downloadable_artifact("selected-$selection", selection)
+                for selection in ("old", "new")
+        )
+        for selection in ("old", "new")
+            platform = HostPlatform()
+            platform["selection"] = selection
+            artifact = selected[selection]
+            bind_artifact!(
+                joinpath(selector, "Artifacts.toml"), "selected", artifact.hash;
+                download_info = [(artifact.url, artifact.sha256)], platform,
+            )
+        end
+
+        @test !artifact_exists(bootstrap.hash)
+        @test !artifact_exists(selected["old"].hash)
+        @test !artifact_exists(selected["new"].hash)
+
+        Pkg.activate(project_path)
+        Pkg.develop(path = old_dependency)
+
+        # Update the dependency and add its consumer in one resolution. The selector must
+        # see the new version even though the old version is still recorded on disk, and
+        # the new version's artifact must be installed before its module can be loaded.
+        Pkg.develop(
+            [
+                Pkg.Types.PackageSpec(path = new_dependency),
+                Pkg.Types.PackageSpec(path = selector),
+            ]
+        )
+
+        @test artifact_exists(bootstrap.hash)
+        @test artifact_exists(selected["new"].hash)
+        @test !artifact_exists(selected["old"].hash)
+
+        # The selector ran once for the resolution. Status checks in the same session,
+        # whether from the in-memory environment or from the one written to disk, reuse
+        # the cached result rather than running it again.
+        @test selector_runs() == 1
+        Pkg.status(; io = IOBuffer())
+        @test selector_runs() == 1
+        Pkg.instantiate()
+        @test selector_runs() == 1
+
+        # Editing a development hook invalidates the cached result in the same session.
+        selector_path = joinpath(selector, ".pkg", "select_artifacts.jl")
+        open(selector_path, "a") do io
+            println(io)
+        end
+        Pkg.status(; io = IOBuffer())
+        @test selector_runs() == 2
+        Pkg.status(; io = IOBuffer())
+        @test selector_runs() == 2
+
+        depot_env = "JULIA_DEPOT_PATH" => join(Base.DEPOT_PATH, Sys.iswindows() ? ";" : ":")
+
+        # Loading the dependency from the selector precompiled it. That cache must be
+        # usable at the default optimization level, or it is recompiled on first use.
+        dependency_id = "Base.PkgId(Base.UUID(\"b8df255f-45df-4e3b-8d04-6a7f7496dbd4\"), \"ArtifactSelectorDependency\")"
+        cmd = addenv(
+            `$(Base.julia_cmd()) --startup-file=no --project=$(project_path) -e "print(Base.isprecompiled($dependency_id))"`,
+            depot_env,
+        )
+        @test read(cmd, String) == "true"
+
+        # Instantiation checks a dependency's static artifacts before running the
+        # selectors that may load it. A missing bootstrap artifact must make that check
+        # fail without running the dependent selector, which then runs exactly once
+        # during the dependency-first download.
+        remove_artifact(bootstrap.hash)
+        remove_artifact(selected["new"].hash)
+        Pkg.Operations.clear_selector_cache!()
+        runs_before = selector_runs()
+        Pkg.instantiate()
+        @test artifact_exists(bootstrap.hash)
+        @test artifact_exists(selected["new"].hash)
+        @test selector_runs() == runs_before + 1
+
+        cmd = addenv(
+            `$(Base.julia_cmd()) --startup-file=no --project=$(project_path) -e 'using ArtifactSelectorWithDependency; print(ArtifactSelectorWithDependency.selected_artifact())'`,
+            depot_env,
+        )
+        @test chomp(read(cmd, String)) == "new"
+
+        # Exercise loading through the consumer's [deps], without a direct dependency
+        # in the active project providing the name-to-UUID mapping.
+        Pkg.rm("ArtifactSelectorDependency")
+        @test !haskey(Pkg.project().dependencies, "ArtifactSelectorDependency")
+
+        # The checkout's manifest must not redirect the dependency to the old version,
+        # and its LocalPreferences.toml must not reach the hook.
+        write(
+            joinpath(selector, "Manifest.toml"), """
+            manifest_format = "2.0"
+            [[deps.ArtifactSelectorDependency]]
+            uuid = "b8df255f-45df-4e3b-8d04-6a7f7496dbd4"
+            version = "0.1.0"
+            path = $(repr(old_dependency))
+            """
+        )
+        write(
+            joinpath(selector, "LocalPreferences.toml"), """
+            [ArtifactSelectorDependency]
+            leaked = "checkout"
+            """
+        )
+        write(
+            selector_path, """
+            open(io -> println(io, join(ARGS, " ")), joinpath(dirname(@__DIR__), "selector_runs"), "a")
+            using ArtifactSelectorDependency
+            using Artifacts, TOML
+            using Base.BinaryPlatforms
+            isempty(Base.get_preferences(Base.PkgId(ArtifactSelectorDependency).uuid)) ||
+                error("checkout preferences leaked into the selector")
+            platform = HostPlatform(parse(Platform, only(ARGS)))
+            platform["selection"] = ArtifactSelectorDependency.selection
+            TOML.print(stdout, select_downloadable_artifacts(joinpath(@__DIR__, "..", "Artifacts.toml"); platform))
+            """
+        )
+        remove_artifact(selected["new"].hash)
+        Pkg.Operations.clear_selector_cache!()
+        Pkg.instantiate()
+        @test artifact_exists(selected["new"].hash)
+        @test !artifact_exists(selected["old"].hash)
+        rm(joinpath(selector, "Manifest.toml"))
+        rm(joinpath(selector, "LocalPreferences.toml"))
+
+        # The bootstrap dependency can itself have a selector. Its artifacts must be
+        # installed before the consumer runs, including on a cold selector cache.
+        mkpath(joinpath(new_dependency, ".pkg"))
+        write(
+            joinpath(new_dependency, ".pkg", "select_artifacts.jl"), """
+            using Artifacts, TOML
+            TOML.print(select_downloadable_artifacts(joinpath(@__DIR__, "..", "Artifacts.toml")))
+            """
+        )
+        remove_artifact(bootstrap.hash)
+        remove_artifact(selected["new"].hash)
+        Pkg.Operations.clear_selector_cache!()
+        runs_before = selector_runs()
+        Pkg.instantiate()
+        @test artifact_exists(bootstrap.hash)
+        @test artifact_exists(selected["new"].hash)
+        @test selector_runs() == runs_before + 1
     end
 end
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -320,6 +320,50 @@ end
     end
 end
 
+@testset "artifact selectors cannot load their own package" begin
+    mktempdir() do root
+        # The active project makes the hook's package loadable, but its artifacts are
+        # selected by that very hook, so loading it must fail rather than pick up
+        # whatever artifacts happen to be installed.
+        pkg = joinpath(root, "SelfLoader")
+        pkg_uuid = "2a1b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c05"
+        mkpath(joinpath(pkg, "src"))
+        mkpath(joinpath(pkg, ".pkg"))
+        write(
+            joinpath(pkg, "Project.toml"), """
+            name = "SelfLoader"
+            uuid = "$pkg_uuid"
+            [deps]
+            TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+            """
+        )
+        write(joinpath(pkg, "src", "SelfLoader.jl"), "module SelfLoader end\n")
+        artifacts_toml = joinpath(pkg, "Artifacts.toml")
+        write(artifacts_toml, "")
+        selector = joinpath(pkg, ".pkg", "select_artifacts.jl")
+        write(joinpath(root, "Project.toml"), "[deps]\nSelfLoader = \"$pkg_uuid\"\n")
+        write(
+            joinpath(root, "Manifest.toml"), """
+            manifest_format = "2.0"
+            [[deps.SelfLoader]]
+            uuid = "$pkg_uuid"
+            path = "SelfLoader"
+            """
+        )
+        env = Pkg.Types.EnvCache(joinpath(root, "Project.toml"))
+        function select(hook)
+            write(selector, hook)
+            return Pkg.Operations.with_resolved_artifact_env(env) do project
+                Pkg.Operations.run_artifact_selector(
+                    selector, artifacts_toml, HostPlatform(); selector_project = project, env_key = nothing
+                )
+            end
+        end
+        @test select("using TOML\nTOML.print(Dict(\"ok\" => true))\n") == Dict("ok" => true)
+        @test_throws ProcessFailedException select("using SelfLoader, TOML\nTOML.print(Dict(\"ok\" => true))\n")
+    end
+end
+
 @testset "artifact selectors use resolved dependencies" begin
     temp_pkg_dir() do project_path
         for package in (

--- a/test/test_packages/ArtifactSelectorDependencyNew/Project.toml
+++ b/test/test_packages/ArtifactSelectorDependencyNew/Project.toml
@@ -1,0 +1,6 @@
+name = "ArtifactSelectorDependency"
+uuid = "b8df255f-45df-4e3b-8d04-6a7f7496dbd4"
+version = "0.2.0"
+
+[deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/test/test_packages/ArtifactSelectorDependencyNew/src/ArtifactSelectorDependency.jl
+++ b/test/test_packages/ArtifactSelectorDependencyNew/src/ArtifactSelectorDependency.jl
@@ -1,0 +1,7 @@
+module ArtifactSelectorDependency
+
+using Artifacts
+
+const selection = String(strip(read(joinpath(artifact"bootstrap", "selection"), String)))
+
+end

--- a/test/test_packages/ArtifactSelectorDependencyOld/Project.toml
+++ b/test/test_packages/ArtifactSelectorDependencyOld/Project.toml
@@ -1,0 +1,3 @@
+name = "ArtifactSelectorDependency"
+uuid = "b8df255f-45df-4e3b-8d04-6a7f7496dbd4"
+version = "0.1.0"

--- a/test/test_packages/ArtifactSelectorDependencyOld/src/ArtifactSelectorDependency.jl
+++ b/test/test_packages/ArtifactSelectorDependencyOld/src/ArtifactSelectorDependency.jl
@@ -1,0 +1,5 @@
+module ArtifactSelectorDependency
+
+const selection = "old"
+
+end

--- a/test/test_packages/ArtifactSelectorWithDependency/.pkg/select_artifacts.jl
+++ b/test/test_packages/ArtifactSelectorWithDependency/.pkg/select_artifacts.jl
@@ -1,0 +1,11 @@
+# Record every run so tests can count how often the selector is invoked.
+open(io -> println(io, join(ARGS, " ")), joinpath(dirname(@__DIR__), "selector_runs"), "a")
+
+using ArtifactSelectorDependency
+using Artifacts, TOML
+using Base.BinaryPlatforms
+
+platform = HostPlatform(parse(Platform, only(ARGS)))
+platform["selection"] = ArtifactSelectorDependency.selection
+artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
+TOML.print(stdout, select_downloadable_artifacts(artifacts_toml; platform))

--- a/test/test_packages/ArtifactSelectorWithDependency/Project.toml
+++ b/test/test_packages/ArtifactSelectorWithDependency/Project.toml
@@ -1,0 +1,11 @@
+name = "ArtifactSelectorWithDependency"
+uuid = "7c6079c5-a915-4b4f-9520-edc242524eb1"
+version = "0.1.0"
+
+[deps]
+ArtifactSelectorDependency = "b8df255f-45df-4e3b-8d04-6a7f7496dbd4"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[compat]
+ArtifactSelectorDependency = "0.2"

--- a/test/test_packages/ArtifactSelectorWithDependency/src/ArtifactSelectorWithDependency.jl
+++ b/test/test_packages/ArtifactSelectorWithDependency/src/ArtifactSelectorWithDependency.jl
@@ -1,0 +1,15 @@
+module ArtifactSelectorWithDependency
+
+using ArtifactSelectorDependency
+using Artifacts
+using Base.BinaryPlatforms
+
+function selected_artifact()
+    platform = HostPlatform()
+    platform["selection"] = ArtifactSelectorDependency.selection
+    artifacts_toml = joinpath(dirname(@__DIR__), "Artifacts.toml")
+    hash = artifact_hash("selected", artifacts_toml; platform)
+    return strip(read(joinpath(artifact_path(hash), "selection"), String))
+end
+
+end


### PR DESCRIPTION
Artifact hooks run before Pkg writes the newly resolved manifest. Dependency imports can therefore load stale versions or fail on a fresh installation, making installation-time artifact selection disagree with runtime initialization.

Run hooks against a temporary copy of the resolved environment. Hooks can use plain `using` for their package's dependencies; those dependency names take precedence over the active project's, while source locations come from the resolved manifest. Preserve active-project and workspace preferences, and exclude checkout manifests, checkout preferences, and unrelated stacked environments.

Install static artifacts first, then selector artifacts in dependency order, with parallel downloads within each level. Cache successful selections for the session and reuse them during status checks. Hooks retain `--compile=min` and inherit the parent's optimization level so dependency precompilation is reusable. A separate prerequisite commit fixes installation checks to inspect every selected artifact.

Validation: the final artifact suite passes 204 assertions on nightly, covering dependency loading and identity, bootstrap ordering, manifest relocation, workspace preferences, checkout isolation, and cache invalidation. Closure-box detection and formatting checks pass. The preceding implementation also passed all 30 test files across a full run and targeted reruns, and installed and imported `CCCL_C_jll` 3.5.0+0 in a fresh depot. Those broader checks were not repeated after the dependency-load-path update; cross-platform CI is still needed.

Hooks execute before build scripts, must reserve stdout for TOML, and must tolerate dependencies that cannot initialize on the host during cross-installation. Cache inputs exclude arbitrary system state and included augmentation files; changes outside the key require a new session.

Fixes #3225.