### PR TITLE
Keep the project's own manifest entry in sync with its deps

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -512,11 +512,21 @@ function reset_all_compat!(proj::Project)
     return nothing
 end
 
-function collect_project(pkg::Union{PackageSpec, Nothing}, path::String, manifest_file::String, julia_version)
+function collect_project(
+        pkg::Union{PackageSpec, Nothing}, path::String, manifest_file::String, julia_version;
+        # For projects that are loaded into the env (the active project and the workspace
+        # members) the caller passes the in-memory project and its file, since the project
+        # may have modifications that have not been written to disk yet.
+        loaded::Union{Nothing, Tuple{String, Project}} = nothing
+    )
     deps = PackageSpec[]
     weakdeps = Set{UUID}()
-    project_file = projectfile_path(path; strict = true)
-    project = project_file === nothing ? Project() : read_project(project_file)
+    project_file, project = if loaded === nothing
+        file = projectfile_path(path; strict = true)
+        file, file === nothing ? Project() : read_project(file)
+    else
+        loaded
+    end
     julia_compat = get_compat(project, "julia")
     if !isnothing(julia_compat) && !isnothing(julia_version) && !(julia_version in julia_compat)
         pkgerror("julia version requirement for package at `$path` not satisfied: compat entry \"julia = $(get_compat_str(project, "julia"))\" does not include Julia version $julia_version")
@@ -584,18 +594,26 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
     deps_map = Dict{UUID, Vector{PackageSpec}}()
     weak_map = Dict{UUID, Set{UUID}}()
 
+    # The active project and the workspace projects are already loaded into the env and may
+    # have unwritten modifications (e.g. a dep that `add` just recorded), so their deps must
+    # be read from memory rather than from their project files.
+    loaded_projects = Dict{UUID, Tuple{String, Project}}(Types.project_uuid(env) => (env.project_file, env.project))
+    for (project_file, project) in env.workspace
+        loaded_projects[Types.project_uuid(project, project_file)] = (project_file, project)
+    end
+
     uuid = Types.project_uuid(env)
-    deps, weakdeps = collect_project(env.pkg, dirname(env.project_file), env.manifest_file, julia_version)
+    deps, weakdeps = collect_project(env.pkg, dirname(env.project_file), env.manifest_file, julia_version; loaded = loaded_projects[uuid])
     deps_map[uuid] = deps
     weak_map[uuid] = weakdeps
     names[uuid] = env.pkg === nothing ? "project" : env.pkg.name
 
-    for (path, project) in env.workspace
-        uuid = Types.project_uuid(project, path)
+    for (project_file, project) in env.workspace
+        uuid = Types.project_uuid(project, project_file)
         pkg = project.name === nothing ? nothing : PackageSpec(name = project.name, uuid = uuid)
-        deps, weakdeps = collect_project(pkg, path, env.manifest_file, julia_version)
-        deps_map[Types.project_uuid(env)] = deps
-        weak_map[Types.project_uuid(env)] = weakdeps
+        deps, weakdeps = collect_project(pkg, dirname(project_file), env.manifest_file, julia_version; loaded = (project_file, project))
+        deps_map[uuid] = deps
+        weak_map[uuid] = weakdeps
         names[uuid] = project.name === nothing ? "project" : project.name
     end
 
@@ -641,7 +659,7 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
             end
             pkgerror(error_msg)
         end
-        deps, weakdeps = collect_project(pkg, path, env.manifest_file, julia_version)
+        deps, weakdeps = collect_project(pkg, path, env.manifest_file, julia_version; loaded = get(loaded_projects, pkg.uuid, nothing))
         deps_map[pkg.uuid] = deps
         weak_map[pkg.uuid] = weakdeps
         for dep in deps
@@ -1985,6 +2003,14 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
     filter!(ctx.env.project.targets) do (target, deps)
         !isempty(filter!(in(deps_names), deps))
     end
+    # the project may have an entry in the manifest (e.g. if something depends back on it),
+    # which mirrors the project deps and therefore needs the drops removed as well
+    proj_entry = manifest_info(ctx.env.manifest, Types.project_uuid(ctx.env))
+    if proj_entry !== nothing
+        filter!(proj_entry.deps) do (_, uuid)
+            uuid ∉ drop
+        end
+    end
     # only keep reachable manifest entries
     prune_manifest(ctx.env)
     record_project_hash(ctx.env)
@@ -2263,6 +2289,12 @@ function add(
         # All packages are already in manifest with compatible versions
         # Just promote to direct dependencies without resolving
         foreach(pkg -> target_field[pkg.name] = pkg.uuid, pkgs) # update set of deps/weakdeps/extras
+
+        # keep the manifest entry of the project itself (if any) in sync with the project deps
+        proj_entry = manifest_info(ctx.env.manifest, Types.project_uuid(ctx.env))
+        if proj_entry !== nothing
+            foreach(pkg -> proj_entry.deps[pkg.name] = pkg.uuid, pkgs)
+        end
 
         # if env is a package add compat entries
         add_compat_entries!(ctx, pkgs)

--- a/test/new.jl
+++ b/test/new.jl
@@ -2411,6 +2411,20 @@ end
             @test pkg.is_tracking_registry
         end
     end
+    # free developed package when the active project is itself a package (#4686)
+    isolate(loaded_depot = true) do
+        cd_tempdir() do dir
+            Pkg.generate("MyPkg")
+            Pkg.activate("MyPkg")
+            Pkg.develop("Example")
+            Pkg.free("Example")
+            Pkg.dependencies(exuuid) do pkg
+                @test pkg.name == "Example"
+                @test pkg.is_tracking_registry
+            end
+            @test !haskey(Pkg.project().sources, "Example")
+        end
+    end
     # free should error when called on packages tracking unregistered packages
     isolate(loaded_depot = true) do
         Pkg.add(url = "https://github.com/00vareladavid/Unregistered.jl")
@@ -3409,6 +3423,33 @@ end
             manifest_b = Pkg.Types.read_manifest("Cycle_B/Manifest.toml")
             @test cycle_a_uuid in keys(manifest_b)
             @test_broken !(cycle_b_uuid in keys(manifest_b))
+        end
+    end
+end
+
+@testset "manifest entry of the active project tracks its deps" begin
+    isolate(loaded_depot = true) do
+        cd_tempdir() do dir
+            Pkg.generate("MyProject")
+            Pkg.activate("MyProject")
+            uuid = Pkg.Types.read_project(joinpath("MyProject", "Project.toml")).uuid
+            manifest() = Pkg.Types.read_manifest(joinpath("MyProject", "Manifest.toml"))
+            project_deps() = sort!(collect(keys(manifest()[uuid].deps)))
+            Pkg.resolve()
+            @test project_deps() == String[]
+            # the entry must be updated by the same operation that adds the dep, not the next one
+            Pkg.add("JSON")
+            @test project_deps() == ["JSON"]
+            @test "Unicode" in keys(manifest()[json_uuid].deps)
+            Pkg.add("Example")
+            @test project_deps() == ["Example", "JSON"]
+            # promoting an indirect dep skips resolving entirely
+            Pkg.add("Unicode")
+            @test project_deps() == ["Example", "JSON", "Unicode"]
+            # a stale entry would keep JSON reachable and thus unpruned
+            Pkg.rm("JSON")
+            @test project_deps() == ["Example", "Unicode"]
+            @test !haskey(manifest(), json_uuid)
         end
     end
 end


### PR DESCRIPTION
Backport of https://github.com/JuliaLang/Pkg.jl/pull/4739, which I run into quite frequently on 1.13.