### PR TITLE
Document preservation of custom Project.toml entries

### DIFF
--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -19,6 +19,11 @@ The project file describes the project on a high level, for example, the package
 dependencies and compatibility constraints are listed in the project file. The file entries
 are described below.
 
+!!! note
+    Pkg preserves unknown top-level fields and tables when it rewrites
+    `Project.toml`, allowing external tools to use them for project metadata.
+    Preservation applies to the TOML data, but not to its textual formatting
+    or ordering.
 
 ### The `authors` field
 

--- a/test/project/good/custom.toml
+++ b/test/project/good/custom.toml
@@ -1,0 +1,12 @@
+name = "CustomMetadata"
+uuid = "7c4d59f0-8e61-4f62-92c9-bbd24b94131d"
+version = "0.1.0"
+custom_field = "custom value"
+
+[tool_metadata]
+string = "value"
+number = 42
+array = ["one", "two"]
+
+[tool_metadata.nested]
+enabled = true


### PR DESCRIPTION
## Summary

- Document that Pkg preserves unknown top-level fields and tables when rewriting `Project.toml`.
- Clarify that semantic TOML data is preserved, but formatting and ordering are not.
- Add a round-trip fixture covering custom fields and nested tables.

Closes #4691

## Testing

- Built and inspected the documentation locally.
- Verified the custom `Project.toml` fixture with a focused read/write/read round-trip test.
- `git diff --check` passes.