### PR TITLE
Fix #4750: don't override registry deps with parent's [sources] entries

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -629,7 +629,7 @@ function collect_developed(env::EnvCache, pkgs::Vector{PackageSpec})
     return developed
 end
 
-function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version)
+function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version, all_pkgs::Vector{PackageSpec} = pkgs)
     deps_map = Dict{UUID, Vector{PackageSpec}}()
     weak_map = Dict{UUID, Set{UUID}}()
 
@@ -705,6 +705,21 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
             names[dep.uuid] = dep.name
             dep_uuid = dep.uuid
             if !is_tracking_registry(dep) && dep_uuid !== nothing && !(dep_uuid in seen)
+                # If the dep has a path/repo from a parent package's [sources] section,
+                # but the same UUID is already in the top-level pkgs list as a
+                # registry-tracking package, respect the registry version.
+                # This handles the case where e.g. KernelAbstractions has
+                # KernelInterface in [sources] with a local path, but the user's
+                # environment wants KernelInterface from the registry.
+                existing_in_all = findfirst(p -> p.uuid == dep_uuid, all_pkgs)
+                if existing_in_all !== nothing && is_tracking_registry(all_pkgs[existing_in_all])
+                    # The dep is sourced from a parent's [sources], but the user's
+                    # environment already tracks it from the registry — skip.
+                    if !haskey(pkg_by_uuid, dep_uuid)
+                        pkg_by_uuid[dep_uuid] = all_pkgs[existing_in_all]
+                    end
+                    continue
+                end
                 # Only recursively collect path sources if the path actually exists
                 # Repo sources (with URL/rev) are always collected
                 if is_tracking_path(dep)
@@ -805,7 +820,7 @@ function resolve_versions!(
     end
     # this also sets pkg.version for fixed packages
     pkgs_fixed = filter(!is_tracking_registry, pkgs)
-    fixed, new_fixed_pkgs = collect_fixed!(env, pkgs_fixed, names, julia_version)
+    fixed, new_fixed_pkgs = collect_fixed!(env, pkgs_fixed, names, julia_version, pkgs)
     for new_pkg in new_fixed_pkgs
         any(x -> x.uuid == new_pkg.uuid, pkgs) && continue
         push!(pkgs, new_pkg)

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -238,6 +238,44 @@ temp_pkg_dir() do project_path
             end
         end
     end
+    # Regression test for https://github.com/JuliaLang/Pkg.jl/issues/4750
+    # When a repo-tracked package has a subpackage in [sources] that is also a
+    # standalone registered package, adding both should not error with
+    # "could not find source path for package"
+    @testset "registry dep not overridden by parent's [sources] (#4750)" begin
+        isolate() do
+            mktempdir() do tmp
+                # Prepare the test package that has Example in [sources] as a path dep
+                repo_path = joinpath(tmp, "RepoWithSourcedRegistryDep")
+                cp(joinpath(@__DIR__, "test_packages", "RepoWithSourcedRegistryDep"), repo_path)
+                Utils.ensure_test_package_user_writable(repo_path)
+                git_init_and_commit(repo_path)
+                repo_url = make_file_url(repo_path)
+
+                # Activate a temp env and add both:
+                # - Example from the registry
+                # - RepoWithSourcedRegistryDep from a repo URL
+                # This should not error even though RepoWithSourcedRegistryDep has
+                # Example = {path = "lib/Example"} in its [sources] section
+                Pkg.activate(temp = true)
+                Pkg.add(
+                    [
+                        Pkg.PackageSpec(name = "Example"),
+                        Pkg.PackageSpec(url = repo_url),
+                    ]
+                )
+
+                dep_info_by_name = Dict(info.name => info for info in values(Pkg.dependencies()))
+                @test haskey(dep_info_by_name, "Example")
+                @test haskey(dep_info_by_name, "RepoWithSourcedRegistryDep")
+                # Example should be from the registry (not tracking a path)
+                @test !dep_info_by_name["Example"].is_tracking_path
+                @test dep_info_by_name["Example"].version isa VersionNumber
+                # RepoWithSourcedRegistryDep should be tracking the repo
+                @test dep_info_by_name["RepoWithSourcedRegistryDep"].git_source == repo_url
+            end
+        end
+    end
 end
 
 end # module

--- a/test/test_packages/RepoWithSourcedRegistryDep/Project.toml
+++ b/test/test_packages/RepoWithSourcedRegistryDep/Project.toml
@@ -1,0 +1,9 @@
+name = "RepoWithSourcedRegistryDep"
+uuid = "aaaa0001-0001-0001-0001-000000000001"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[sources]
+Example = {path = "lib/Example"}

--- a/test/test_packages/RepoWithSourcedRegistryDep/lib/Example/Project.toml
+++ b/test/test_packages/RepoWithSourcedRegistryDep/lib/Example/Project.toml
@@ -1,0 +1,3 @@
+name = "Example"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "999.0.0-dev"

--- a/test/test_packages/RepoWithSourcedRegistryDep/lib/Example/src/Example.jl
+++ b/test/test_packages/RepoWithSourcedRegistryDep/lib/Example/src/Example.jl
@@ -1,0 +1,3 @@
+module Example
+greet() = "Hello from local dev Example!"
+end

--- a/test/test_packages/RepoWithSourcedRegistryDep/src/RepoWithSourcedRegistryDep.jl
+++ b/test/test_packages/RepoWithSourcedRegistryDep/src/RepoWithSourcedRegistryDep.jl
@@ -1,0 +1,3 @@
+module RepoWithSourcedRegistryDep
+using Example
+end


### PR DESCRIPTION
## Problem

When a repo-tracked package (e.g., `KernelAbstractions#main`) has a dependency in its `[sources]` section with a local path (e.g., `KernelInterface = {path = "lib/KernelInterface"}`), and the user's environment also has the same package added from the **registry**, the `add` operation fails with:ERROR: could not find source path for package KernelInterface based on manifest ...

This was introduced/surfaced by #4151 which added an explicit `nothing` check in `fixups_from_projectfile!`.

## Root Cause

In `collect_fixed!`, when processing a repo-tracked package's dependencies via `collect_project`, deps with paths from the parent's `[sources]` section were unconditionally added to the `fixed` dict — even when the same UUID was already present in the top-level `pkgs` list as a registry-tracking package.

This caused the resolver to skip assigning the package a version/tree_hash (since fixed packages are excluded from `Resolve.resolve()` output). The registry-tracking `PackageSpec` in `pkgs` was left with `tree_hash=nothing` and `path=nothing`, causing `source_path()` to return `nothing` in `fixups_from_projectfile!`.

## Fix

Added a guard clause in `collect_fixed!` that checks if a dep discovered via a parent package's `[sources]` already exists as a **registry-tracking** package in the full `pkgs` list. If so, the registry version takes precedence and the path-based dep is skipped from the fixed set.

The `collect_fixed!` function now accepts an optional `all_pkgs` parameter (the full package list including registry-tracking packages), which `resolve_versions!` passes at the call site.

## Test

Added a regression test in `test/sources.jl` with a new test fixture `RepoWithSourcedRegistryDep` that reproduces the exact scenario:
- A repo package with `Example` in `[deps]` and `[sources] Example = {path = "lib/Example"}`
- Adding both `Example` (from registry) and the repo package in the same `Pkg.add` call
- Verifies `Example` remains registry-tracked and the operation succeeds
