### PR TITLE
Don't let a dependency's [sources] override already-tracked packages

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -629,7 +629,13 @@ function collect_developed(env::EnvCache, pkgs::Vector{PackageSpec})
     return developed
 end
 
-function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version)
+function collect_fixed!(
+        env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version;
+        # UUIDs of packages that the environment being resolved already has a source for,
+        # including the ones that are tracking a registry. A `[sources]` entry in a
+        # dependency's project file must not take over such a package, see #4750.
+        env_uuids::Set{UUID} = Set{UUID}()
+    )
     deps_map = Dict{UUID, Vector{PackageSpec}}()
     weak_map = Dict{UUID, Set{UUID}}()
 
@@ -663,7 +669,8 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
         pkg_by_uuid[pkg.uuid] = pkg
     end
     new_fixed_pkgs = PackageSpec[]
-    seen = Set(keys(pkg_by_uuid))
+    seen = Set{UUID}(keys(pkg_by_uuid))
+    union!(seen, env_uuids)
     while !isempty(pkg_queue)
         pkg = popfirst!(pkg_queue)
         pkg.uuid === nothing && continue
@@ -805,7 +812,12 @@ function resolve_versions!(
     end
     # this also sets pkg.version for fixed packages
     pkgs_fixed = filter(!is_tracking_registry, pkgs)
-    fixed, new_fixed_pkgs = collect_fixed!(env, pkgs_fixed, names, julia_version)
+    env_uuids = Set{UUID}()
+    for pkg in pkgs
+        pkg.uuid === nothing && continue
+        push!(env_uuids, pkg.uuid)
+    end
+    fixed, new_fixed_pkgs = collect_fixed!(env, pkgs_fixed, names, julia_version; env_uuids)
     for new_pkg in new_fixed_pkgs
         any(x -> x.uuid == new_pkg.uuid, pkgs) && continue
         push!(pkgs, new_pkg)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -631,9 +631,8 @@ end
 
 function collect_fixed!(
         env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version;
-        # UUIDs of packages that the environment being resolved already has a source for,
-        # including the ones that are tracking a registry. A `[sources]` entry in a
-        # dependency's project file must not take over such a package, see #4750.
+        # A `[sources]` entry in a dependency's project file must not take over such a
+        # package for which the environment already has a source for, see #4750.
         env_uuids::Set{UUID} = Set{UUID}()
     )
     deps_map = Dict{UUID, Vector{PackageSpec}}()

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -249,6 +249,65 @@ temp_pkg_dir() do project_path
             end
         end
     end
+
+    # Regression test for https://github.com/JuliaLang/Pkg.jl/issues/4750
+    # A `[sources]` entry in a dependency's project file must not take over a package that
+    # the environment being resolved already tracks itself (here: from a registry).
+    @testset "dependency [sources] don't hijack a registered direct dep (#4750)" begin
+        isolate() do
+            mktempdir() do tmp
+                example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+                main_uuid = UUID("00000000-0000-0000-0000-000000004750")
+                main = joinpath(tmp, "MainPkg")
+
+                # MainPkg ships a copy of the registered package `Example` in a subdirectory
+                # and points at it with `[sources]`, like KernelAbstractions does for
+                # KernelInterface.
+                mkpath(joinpath(main, "src"))
+                mkpath(joinpath(main, "lib", "Example", "src"))
+                write(
+                    joinpath(main, "Project.toml"), """
+                    name = "MainPkg"
+                    uuid = "$main_uuid"
+                    version = "0.1.0"
+
+                    [deps]
+                    Example = "$example_uuid"
+
+                    [sources]
+                    Example = {path = "lib/Example"}
+                    """
+                )
+                write(joinpath(main, "src", "MainPkg.jl"), "module MainPkg\nusing Example\nend")
+                write(
+                    joinpath(main, "lib", "Example", "Project.toml"), """
+                    name = "Example"
+                    uuid = "$example_uuid"
+                    version = "999.0.0-dev"
+                    """
+                )
+                write(joinpath(main, "lib", "Example", "src", "Example.jl"), "module Example end")
+                git_init_and_commit(main)
+
+                Pkg.activate(joinpath(tmp, "env"))
+                # Adding the registered `Example` alongside `MainPkg` used to error with
+                # "could not find source path for package Example based on manifest ..."
+                Pkg.add([
+                    PackageSpec(name = "Example", uuid = example_uuid),
+                    PackageSpec(url = make_file_url(main)),
+                ])
+                manifest = Pkg.Types.read_manifest(joinpath(tmp, "env", "Manifest.toml"))
+                # `Example` stays tracked by the registry, not by MainPkg's `[sources]` path
+                # (the vendored copy carries an impossible version so a regression that
+                # resolves to it is also caught by the version check below)
+                @test manifest[example_uuid].path === nothing
+                @test manifest[example_uuid].tree_hash !== nothing
+                @test manifest[example_uuid].version < v"999"
+                @test !haskey(Pkg.project().sources, "Example")
+                @test manifest[main_uuid].repo.source !== nothing
+            end
+        end
+    end
 end
 
 end # module

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -292,10 +292,12 @@ temp_pkg_dir() do project_path
                 Pkg.activate(joinpath(tmp, "env"))
                 # Adding the registered `Example` alongside `MainPkg` used to error with
                 # "could not find source path for package Example based on manifest ..."
-                Pkg.add([
-                    PackageSpec(name = "Example", uuid = example_uuid),
-                    PackageSpec(url = make_file_url(main)),
-                ])
+                Pkg.add(
+                    [
+                        PackageSpec(name = "Example", uuid = example_uuid),
+                        PackageSpec(url = make_file_url(main)),
+                    ]
+                )
                 manifest = Pkg.Types.read_manifest(joinpath(tmp, "env", "Manifest.toml"))
                 # `Example` stays tracked by the registry, not by MainPkg's `[sources]` path
                 # (the vendored copy carries an impossible version so a regression that


### PR DESCRIPTION
Fixes #4750. Should be backported to 1.13. This also shouldn’t regress the tests from https://github.com/JuliaLang/Pkg.jl/pull/4151

<details>

<summary>Robot 🤖</summary>

When a package added by URL/rev has a `[sources]` entry pointing into its own
tree (e.g. KernelAbstractions -> `lib/KernelInterface`), `collect_fixed!`
recursively picked that subpackage up as a fixed, path-tracked package even
when the environment being resolved already tracked the same package itself,
e.g. from a registry.

The subpackage then landed in the resolver's `fixed` set, but
`resolve_versions!` refused to overwrite the existing registry-tracking
`PackageSpec` in `pkgs`. The two went out of sync: the resolver never assigned
a version to that spec (fixed packages are not returned by `resolve`), so
`load_tree_hash!` recorded nothing and `update_manifest!` wrote a manifest
entry with no `path`, no `tree_hash` and no `repo`. `fixups_from_projectfile!`
then failed with

    could not find source path for package KernelInterface based on manifest ...

Pass the UUIDs the environment already has a source decision for into
`collect_fixed!` and seed its `seen` set with them, so recursive `[sources]`
collection only fills in packages the environment has no other source for.

</details>