### PR TITLE
artifacts: tear down the progress bar when installation is interrupted

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1623,20 +1623,32 @@ function install_collected_artifacts!(
         end
         sema = Base.Semaphore(ctx.num_concurrent_downloads)
         interrupted = Ref{Bool}(false)
-        @sync for f in values(download_jobs)
-            interrupted[] && break
-            Base.acquire(sema)
-            Threads.@spawn try
-                f()
-            catch e
-                e isa InterruptException && (interrupted[] = true)
-                put!(errors, e)
-            finally
-                Base.release(sema)
+        try
+            @sync for f in values(download_jobs)
+                interrupted[] && break
+                Base.acquire(sema)
+                Threads.@spawn try
+                    f()
+                catch e
+                    e isa InterruptException && (interrupted[] = true)
+                    put!(errors, e)
+                finally
+                    Base.release(sema)
+                end
+            end
+        finally
+            # `t_print` loops until `is_done[]`, so if we leave via an interrupt or an
+            # error it would otherwise keep drawing the progress bar over the prompt
+            # forever, and never restore the cursor it hid.
+            is_done[] = true
+            if fancyprint
+                try
+                    wait(t_print)
+                catch
+                    # already reported by the `errormonitor` above
+                end
             end
         end
-        is_done[] = true
-        fancyprint && wait(t_print)
         close(errors)
 
         if !isempty(errors)

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1288,6 +1288,69 @@ end
     end
 end
 
+# Pkg only draws progress bars on a terminal. This stands in for one, capturing the output
+# in a buffer that can be inspected; the lock is there because the progress bar is drawn
+# from its own task.
+struct CapturedIO <: IO
+    fancy::Bool
+    buf::IOBuffer
+    lock::ReentrantLock
+end
+CapturedIO(; fancy::Bool) = CapturedIO(fancy, IOBuffer(), ReentrantLock())
+Base.write(io::CapturedIO, b::UInt8) = @lock io.lock write(io.buf, b)
+Base.unsafe_write(io::CapturedIO, p::Ptr{UInt8}, n::UInt) = @lock io.lock unsafe_write(io.buf, p, n)
+Base.take!(io::CapturedIO) = @lock io.lock take!(io.buf)
+Pkg.can_fancyprint(io::CapturedIO) = io.fancy
+
+@testset "interrupting artifact installation" begin
+    ansi_enablecursor = "\e[?25h"
+    @testset "fancyprint = $fancy" for fancy in (false, true)
+        srv = stalling_http_server()
+        temp_pkg_dir() do project_path
+            write(
+                joinpath(project_path, "Artifacts.toml"), """
+                [stalled]
+                git-tree-sha1 = "$("0"^40)"
+
+                    [[stalled.download]]
+                    sha256 = "$("0"^64)"
+                    url = "$(srv.url)/stalled.tar.gz"
+                """
+            )
+            Pkg.activate(project_path)
+            io = CapturedIO(; fancy)
+            t = @async Pkg.instantiate(; io)
+            @test timedwait(() -> isready(srv.requested) || istaskdone(t), 120) == :ok
+            istaskdone(t) && wait(t) # failed before reaching the download; show why
+            # `t` is now parked waiting for the download. This is what `^C` does to it.
+            @test istaskstarted(t) && !istaskdone(t)
+            schedule(t, InterruptException(); error = true)
+
+            @test timedwait(() -> istaskdone(t), 60) == :ok
+            err = try
+                wait(t)
+            catch e
+                e
+            end
+            @test err isa TaskFailedException && err.task.result isa InterruptException
+            output = String(take!(io))
+            if fancy
+                @test occursin("Installing artifacts", output)
+                # the progress bar was torn down, cursor restored, before the interrupt propagated
+                @test endswith(output, ansi_enablecursor)
+            end
+            # and nothing keeps redrawing it over the prompt
+            sleep(0.5)
+            @test isempty(take!(io))
+            srv.close()
+            # the abandoned download job winds down and cleans up after itself
+            artifacts_dir = joinpath(DEPOT_PATH[1], "artifacts")
+            leftovers() = isdir(artifacts_dir) ? filter(!=("CACHEDIR.TAG"), readdir(artifacts_dir)) : String[]
+            @test timedwait(() -> isempty(leftovers()), 60) == :ok
+        end
+    end
+end
+
 @testset "installing artifacts when symlinks are copied" begin
     # copy symlinks to simulate the typical Microsoft Windows user experience where
     # developer mode is not enabled (no admin rights)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,11 +7,13 @@ import Pkg: stdout_f, stderr_f
 using Tar
 using TOML
 using UUIDs
+using Sockets
 
 export temp_pkg_dir, cd_tempdir, isinstalled, write_build, with_current_env,
     with_temp_env, with_pkg_env, git_init_and_commit, copy_test_package,
     git_init_package, add_this_pkg, TEST_SIG, TEST_PKG, isolate, LOADED_DEPOT,
-    list_tarball_files, recursive_rm_cov_files, copy_this_pkg_cache, make_file_url
+    list_tarball_files, recursive_rm_cov_files, copy_this_pkg_cache, make_file_url,
+    http_server, stalling_http_server
 
 # The cache directory is shared between the test-runner main process and its
 # worker processes: the first process to include this file creates the
@@ -551,6 +553,72 @@ function recursive_rm_cov_files(rootdir::String)
         end
     end
     return
+end
+
+# A minimal HTTP/1.1 server on a free localhost port. `respond(sock, target)` is called on
+# its own task for every request once the request line and headers have been consumed,
+# and writes the whole response; the connection is closed when it returns. `close` shuts
+# down the server and every connection it still holds open.
+function http_server(respond::Function)
+    server = listen(Sockets.localhost, 0)
+    url = "http://$(Sockets.localhost):$(Int(last(getsockname(server))))"
+    sockets = TCPSocket[]
+    @async while isopen(server)
+        sock = try
+            accept(server)
+        catch
+            break # closed
+        end
+        push!(sockets, sock)
+        handler = @async try
+            request_line = readline(sock)
+            while !isempty(rstrip(readline(sock)))
+            end
+            words = split(request_line)
+            length(words) >= 2 && respond(sock, String(words[2]))
+        catch
+            # a connection torn down by `close` is not a failure
+            isopen(sock) && rethrow()
+        finally
+            close(sock)
+        end
+        Base.errormonitor(handler)
+    end
+    return (; url, close = () -> (foreach(close, sockets); close(server)))
+end
+
+# Answers every request with the headers and the start of a body that then trickles in far
+# too slowly to ever complete, but fast enough that curl does not give up on it, so the
+# transfer stays in flight until it is cancelled. `requested` gets one item per transfer
+# under way and `disconnected` one per client that hangs up.
+function stalling_http_server()
+    requested = Channel{Nothing}(Inf)
+    disconnected = Channel{Nothing}(Inf)
+    server = http_server() do sock, target
+        write(sock, "HTTP/1.1 200 OK\r\nContent-Type: application/gzip\r\nContent-Length: 1048576\r\nConnection: close\r\n\r\n")
+        write(sock, zeros(UInt8, 4096))
+        flush(sock)
+        put!(requested, nothing)
+        trickle = @async try
+            while true
+                sleep(0.25)
+                write(sock, zeros(UInt8, 64))
+                flush(sock)
+            end
+        catch
+            # the socket was closed
+        end
+        try
+            while !eof(sock)
+                readavailable(sock)
+            end
+        finally
+            close(sock)
+            wait(trickle)
+        end
+        return put!(disconnected, nothing)
+    end
+    return (; server.url, requested, disconnected, server.close)
 end
 
 # Convert a path into a file URL.


### PR DESCRIPTION
Fixes interrupting artifact downloads on 1.13 so the UI cancels properly. https://github.com/JuliaLang/Pkg.jl/pull/4758 goes further and cancels the running download.

Claude:

---

`download_artifacts` spawns a task that redraws the artifact progress bar until `is_done[]` is set, and that flag was only set once the `@sync` block had returned normally. A `^C` during downloading throws out of `@sync`, so the flag was never set: the printing task kept redrawing the bar over the prompt at 10 Hz forever, and never reached the `finally` that restores the cursor it had hidden.

The interrupt itself is delivered promptly and the REPL stays usable, but the terminal is immediately taken back over by the bar, which is why this reads as artifact installation being impossible to interrupt. Downloading is the only stage of an install that runs a persistent printer task, which matches the report that interrupting works everywhere else.

Setting the flag and reaping the printing task from a `finally` block fixes it. Measured on 1.13.0-rc3 against a local server trickling a 50 MB artifact, driven through a pty so fancyprint is active: six seconds after the `^C`, stock Pkg had drawn 151 further bar frames and never restored the cursor, the patched one drew 2 and restored it. Uninterrupted installs are unaffected, in both the fancy and non-fancy paths.

This is about 1.13. On 1.14 the new cancellation machinery kills the printing task on its own, so the runaway bar does not reproduce there, though the cursor is still left hidden and an `Unhandled Task ERROR: CancellationRequest` is printed, which looks like a separate Base issue rather than something Pkg should paper over.

The test drives `Pkg.instantiate` against a local server that trickles an artifact, injects an `InterruptException` into the task while the download is in flight, as `^C` does, and checks that the interrupt propagates, that the bar is torn down with the cursor restored, and that nothing keeps redrawing it. Without the fix it fails on nightly on the last two.
