### PR TITLE
artifacts: cancel in-flight downloads when installation is interrupted

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -1623,20 +1623,26 @@ function install_collected_artifacts!(
         end
         sema = Base.Semaphore(ctx.num_concurrent_downloads)
         interrupted = Ref{Bool}(false)
+        cancellation = PlatformEngines.DownloadCancellation()
         try
-            @sync for f in values(download_jobs)
-                interrupted[] && break
-                Base.acquire(sema)
-                Threads.@spawn try
-                    f()
-                catch e
-                    e isa InterruptException && (interrupted[] = true)
-                    put!(errors, e)
-                finally
-                    Base.release(sema)
+            PlatformEngines.with_download_cancellation(cancellation) do
+                @sync for f in values(download_jobs)
+                    interrupted[] && break
+                    Base.acquire(sema)
+                    Threads.@spawn try
+                        f()
+                    catch e
+                        e isa InterruptException && (interrupted[] = true)
+                        put!(errors, e)
+                    finally
+                        Base.release(sema)
+                    end
                 end
             end
         finally
+            # An interrupt unwinds the task waiting above, but the downloads it spawned
+            # would otherwise keep transferring in the background until they finished.
+            PlatformEngines.cancel_downloads(cancellation)
             # `t_print` loops until `is_done[]`, so if we leave via an interrupt or an
             # error it would otherwise keep drawing the progress bar over the prompt
             # forever, and never restore the cursor it hid.

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -5,7 +5,8 @@
 module PlatformEngines
 
 using SHA, Downloads, Tar, Dates, Printf
-using ArgTools: FileSpec
+using ArgTools: FileSpec, arg_write
+using Base.ScopedValues: ScopedValue, @with
 import ...Pkg: Pkg, TOML, pkg_server, depots1, can_fancyprint, stderr_f, atomic_toml_write
 using ..MiniProgressBars
 using Base.BinaryPlatforms, p7zip_jll, Zstd_jll
@@ -288,6 +289,60 @@ function get_metadata_headers(url::AbstractString)
     return headers
 end
 
+"""
+    DownloadCancellation()
+
+Tracks the downloads that are currently in flight inside a
+[`with_download_cancellation`](@ref) scope so that they can all be aborted at once.
+"""
+struct DownloadCancellation
+    lock::ReentrantLock
+    events::Set{Base.Event}
+    cancelled::Base.RefValue{Bool}
+end
+DownloadCancellation() = DownloadCancellation(ReentrantLock(), Set{Base.Event}(), Ref(false))
+
+const DOWNLOAD_CANCELLATION = ScopedValue{Union{Nothing, DownloadCancellation}}(nothing)
+
+"""
+    with_download_cancellation(f, cancellation::DownloadCancellation)
+
+Run `f`, registering every download started within it, including the ones started on
+tasks spawned by `f`, with `cancellation`.
+"""
+with_download_cancellation(f, cancellation::DownloadCancellation) =
+    @with(DOWNLOAD_CANCELLATION => cancellation, f())
+
+"""
+    cancel_downloads(cancellation::DownloadCancellation)
+
+Abort the downloads that are still in flight in `cancellation`'s scope, and make any
+download started in it from now on fail immediately rather than begin transferring.
+"""
+function cancel_downloads(cancellation::DownloadCancellation)
+    return @lock cancellation.lock begin
+        cancellation.cancelled[] = true
+        for event in cancellation.events
+            notify(event)
+        end
+        empty!(cancellation.events)
+    end
+end
+
+function register_download!(cancellation::DownloadCancellation)
+    event = Base.Event()
+    @lock cancellation.lock begin
+        # a download started after the cancellation is not worth beginning
+        cancellation.cancelled[] ? notify(event) : push!(cancellation.events, event)
+    end
+    return event
+end
+register_download!(::Nothing) = nothing
+
+unregister_download!(cancellation::DownloadCancellation, event::Base.Event) =
+    @lock cancellation.lock delete!(cancellation.events, event)
+unregister_download!(::Nothing, ::Nothing) = nothing
+
 function download(
         url::AbstractString,
         dest::Union{AbstractString, FileSpec};
@@ -327,9 +382,18 @@ function download(
     else
         nothing
     end
+    cancellation = DOWNLOAD_CANCELLATION[]
+    interrupt = register_download!(cancellation)
     return try
-        Downloads.download(url, dest; headers, progress)
+        # `Downloads.download` cannot be interrupted once the transfer has started, so do
+        # what it would do for us around `Downloads.request`, which takes an interrupt event.
+        arg_write(dest) do output
+            response = Downloads.request(url; output, headers, progress, interrupt)
+            Downloads.Curl.status_ok(response) && return output
+            throw(Downloads.RequestError(url, Downloads.Curl.CURLE_OK, "", response))
+        end
     finally
+        unregister_download!(cancellation, interrupt)
         do_fancy && end_progress(io, bar)
     end
 end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1342,6 +1342,8 @@ Pkg.can_fancyprint(io::CapturedIO) = io.fancy
             # and nothing keeps redrawing it over the prompt
             sleep(0.5)
             @test isempty(take!(io))
+            # the transfer itself was aborted rather than left running in the background
+            @test timedwait(() -> isready(srv.disconnected), 60) == :ok
             srv.close()
             # the abandoned download job winds down and cleans up after itself
             artifacts_dir = joinpath(DEPOT_PATH[1], "artifacts")

--- a/test/platformengines.jl
+++ b/test/platformengines.jl
@@ -2,7 +2,7 @@ module PlatformEngineTests
 import ..Pkg # ensure we are using the correct Pkg
 
 using Test, Pkg.PlatformEngines, Pkg.BinaryPlatforms, SHA, Sockets
-using ..Utils: list_tarball_files
+using ..Utils: list_tarball_files, http_server, stalling_http_server
 
 function auth_refresh_server(response::String)
     server = listen(Sockets.localhost, 0)
@@ -215,6 +215,90 @@ end
     mktempdir() do tmp
         PlatformEngines.download("https://api.github.com/repos/JuliaPackaging/BinaryProvider.jl/tarball/c2a4fc38f29eb81d66e3322e585d0199722e5d71", joinpath(tmp, "BinaryProvider"); verbose = true)
         @test isfile(joinpath(tmp, "BinaryProvider"))
+    end
+end
+
+# `download` runs on top of `Downloads.request` so that it can be cancelled, and has to
+# turn the response into the same result `Downloads.download` would give.
+@testset "download response handling" begin
+    Downloads = PlatformEngines.Downloads
+    body = "artifact bytes"
+    srv = http_server() do sock, target
+        if target == "/found"
+            write(sock, "HTTP/1.1 200 OK\r\nContent-Length: $(ncodeunits(body))\r\nConnection: close\r\n\r\n", body)
+        else
+            write(sock, "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        end
+    end
+    try
+        mktempdir() do dir
+            dest = joinpath(dir, "download")
+            @test PlatformEngines.download("$(srv.url)/found", dest) == dest
+            @test read(dest, String) == body
+            err = try
+                PlatformEngines.download("$(srv.url)/missing", dest)
+            catch e
+                e
+            end
+            @test err isa Downloads.RequestError
+            @test err.response.status == 404
+            @test !isfile(dest) # the partial download is removed
+        end
+    finally
+        srv.close()
+    end
+    mktempdir() do dir
+        # nothing is listening on that port anymore
+        dest = joinpath(dir, "download")
+        @test_throws Downloads.RequestError PlatformEngines.download("$(srv.url)/found", dest)
+        @test !isfile(dest)
+    end
+end
+
+@testset "Download cancellation" begin
+    Downloads = PlatformEngines.Downloads
+    srv = stalling_http_server()
+    try
+        mktempdir() do dir
+            dest = joinpath(dir, "download")
+            cancellation = PlatformEngines.DownloadCancellation()
+            # like the artifact download jobs, the download runs on a task spawned in the scope
+            t = PlatformEngines.with_download_cancellation(cancellation) do
+                Threads.@spawn PlatformEngines.download(srv.url, dest)
+            end
+            take!(srv.requested) # the transfer is under way
+            @test length(cancellation.events) == 1
+
+            PlatformEngines.cancel_downloads(cancellation)
+            @test timedwait(() -> istaskdone(t), 60) == :ok
+            err = try
+                fetch(t)
+            catch e
+                e
+            end
+            @test err isa TaskFailedException && err.task.result isa Downloads.RequestError
+            @test !isfile(dest)
+            @test isempty(cancellation.events)
+            # the server sees the client go away rather than a transfer that runs on
+            @test timedwait(() -> isready(srv.disconnected), 60) == :ok
+
+            # a download started in the scope after the cancellation fails instead of
+            # beginning a transfer that nobody is waiting for
+            t = PlatformEngines.with_download_cancellation(cancellation) do
+                Threads.@spawn PlatformEngines.download(srv.url, dest)
+            end
+            @test timedwait(() -> istaskdone(t), 60) == :ok
+            err = try
+                fetch(t)
+            catch e
+                e
+            end
+            @test err isa TaskFailedException && err.task.result isa Downloads.RequestError
+            @test !isfile(dest)
+            @test isempty(cancellation.events)
+        end
+    finally
+        srv.close()
     end
 end
 


### PR DESCRIPTION
Further fixes interrupting artifact downloads, by actually cancelling the download.

Claude:

---

Follows #4757.

Interrupting an artifact install unwinds the task waiting on the downloads, but the transfers themselves carried on. Measured on 1.13.0-rc3 against a local server trickling a 50 MB artifact: after a `^C`, stock Pkg either ran the transfer to completion in the background or left it stalled with the connection held open until the process exited, with the server seeing the client disconnect only when the process was killed 15 s later. With this change the server sees the disconnect 0.3 s after the `^C`.

`Downloads.download` cannot abort a transfer that has already started. `Downloads.request` can, through an `interrupt` event, but it notifies that event itself when a request completes normally, so a single event cannot be shared between concurrent requests. So one event is tracked per in-flight request in a scoped `DownloadCancellation`, and `download_artifacts` notifies all of them as it unwinds. Downloads started after the cancellation fail immediately rather than begin transferring, which also stops the retry and alternate-URL loops from carrying on after a `^C`.

`PlatformEngines.download` has to go through `Downloads.request` to pass the event, so it now does the small amount of work `Downloads.download` was doing on top of `request`. That is where the wart is: the status check needs `Downloads.Curl.status_ok` and `Downloads.Curl.CURLE_OK`, which are not public. Adding an `interrupt` keyword to `Downloads.download` upstream would let both go away. Checked against stock on success, HTTP 404, HTTP 500 and connection-refused: same return value, same exception type, same message, same cleanup of the destination file.

Like the parent PR this is aimed at 1.13. Julia 1.14 already aborts these transfers through its own cancellation machinery.

The tests extend the parent PR's to check that the server sees its client hang up once the install is interrupted, and cover `DownloadCancellation` directly, plus the `download` wrapper's result on success, HTTP 404 and connection refused. The server trickles bytes rather than stalling outright so that curl's 20 s low-speed timeout cannot end the transfer on its own; on 1.13 the hang-up check fails without this change, on nightly it passes either way since Base aborts the transfer.

For the 1.13 backport, `arg_write` has to be imported through `Downloads.ArgTools` because ArgTools is not a Pkg dependency there, and Sockets has to be added to the test project.

