### PR TITLE
precompile: pass the io through once Base compiles the driver for one type

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1256,15 +1256,15 @@ function precompile(
     end
 
     return activate(dirname(ctx.env.project_file)) do
-        io = if ctx.io isa IOContext{IO} && !isa(ctx.io.io, Base.PipeEndpoint)
-            # precompile does quite a bit of output and using the IOContext{IO} can cause
-            # some slowdowns, the important part here is to not specialize the whole
-            # precompile function on the io.
-            # But don't unwrap the IOContext if it is a PipeEndpoint, as that would
-            # cause the output to lose color.
-            ctx.io.io
-        else
+        # Since JuliaLang/julia#62970 the driver in Base is compiled for a single
+        # `IOContext{IO}` and takes `ctx.io` as is. Before that it specialized on the
+        # stream, and only the unwrapped variants come precompiled, apart from a pipe,
+        # which keeps the wrapper for its colour.
+        io = if isdefined(Base.Precompilation, :unstable_iocontext) ||
+                !(ctx.io isa IOContext{IO}) || ctx.io.io isa Base.PipeEndpoint
             ctx.io
+        else
+            ctx.io.io
         end
         pkgs_name = String[pkg.name for pkg in pkgs]
         # Allow user to press 'd' to detach when running interactively


### PR DESCRIPTION
Claude:

---

`Pkg.precompile` unwraps its `IOContext{IO}` to the raw stream before calling the driver in Base, so that the precompiled TTY, file and devnull variants of the driver are hit, and leaves a pipe wrapped for its colour. JuliaLang/julia#62970 makes Base normalise whatever it is given to a single `IOContext{IO}` specialization, so on such a Julia the unwrapping is dead weight and the piped case, which was never precompiled, no longer pays 0.6s of inference per process.

Gate the unwrap on Base having that driver, so older Julia keeps the current behaviour. JuliaLang/julia#62970 has merged, so this is live on nightly.

Checked on a julia build with #62970: the driver compiles 0.03s for pipe, file, devnull and TTY alike, with fancy terminal output unchanged.
