### PR TITLE
Make `atomic_toml_write()` preserve the process umask

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -219,7 +219,7 @@ function get_auth_header(url::AbstractString; verbose::Bool = false)
             auth_info["expires_at"] = expires_at
         end
     end
-    atomic_toml_write(auth_file, auth_info, sorted = true)
+    atomic_toml_write(auth_file, auth_info, sorted = true, private = true)
     access_token = auth_info["access_token"]::String
     return "Authorization" => "Bearer $access_token"
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -165,26 +165,39 @@ end
 
 
 """
-    atomic_toml_write(path::String, data; kws...)
+    atomic_toml_write(path::String, data; private::Bool = false, kws...)
 
 Write TOML data to a file atomically by first writing to a temporary file and then moving it into place.
-This prevents "teared" writes if the process is interrupted or if multiple processes write to the same file.
+This prevents "teared" writes if the process is interrupted or if multiple
+processes write to the same file. If `private` is set the file is given `0o600`
+permissions.
 
 The `kws` are passed to `TOML.print`.
 """
-function atomic_toml_write(path::String, data; kws...)
+function atomic_toml_write(path::String, data; private::Bool = false, kws...)
     dir = dirname(path)
     isempty(dir) && (dir = pwd())
 
-    temp_path, temp_io = mktemp(dir)
-    return try
-        TOML.print(temp_io, data; kws...)
-        close(temp_io)
+    mode = if private
+        0o600
+    elseif isfile(path)
+        # Keep the permissions of an existing file, like `open(path, "w")` would
+        filemode(path) & 0o777
+    else
+        nothing
+    end
+
+    # The temp dir is next to the destination so that the move is an atomic rename. `mktemp`
+    # is not used since it always creates files with mode 0o600, which `mv` would preserve.
+    return mktempdir(dir) do temp_dir
+        temp_path = joinpath(temp_dir, basename(path))
+        open(temp_path, "w") do temp_io
+            TOML.print(temp_io, data; kws...)
+        end
+        if mode !== nothing
+            chmod(temp_path, mode)
+        end
         mv(temp_path, path; force = true)
-    catch
-        close(temp_io)
-        rm(temp_path; force = true)
-        rethrow()
     end
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -276,4 +276,33 @@ end
     @test !(v"1.2.4" in v)
 end
 
+@testset "atomic_toml_write" begin
+    mktempdir() do dir
+        path = joinpath(dir, "Foo.toml")
+        Pkg.atomic_toml_write(path, Dict("a" => "b"))
+        @test Pkg.TOML.parsefile(path) == Dict("a" => "b")
+        # no temporary files or directories are left behind
+        @test readdir(dir) == ["Foo.toml"]
+
+        # files are written with the default permissions of the process, not with
+        # `mktemp`'s 0o600, since e.g. registry files may need to be readable by others
+        reference = joinpath(dir, "reference")
+        close(open(reference, "w"))
+        @test filemode(path) & 0o777 == filemode(reference) & 0o777
+
+        private_path = joinpath(dir, "Private.toml")
+        Pkg.atomic_toml_write(private_path, Dict("a" => "b"), private = true)
+        # Windows has no real file modes, `chmod` there only toggles the read-only bit
+        if !Sys.iswindows()
+            @test filemode(private_path) & 0o777 == 0o600
+
+            # the permissions of an existing file are preserved
+            chmod(path, 0o664)
+            Pkg.atomic_toml_write(path, Dict("a" => "c"))
+            @test filemode(path) & 0o777 == 0o664
+            @test Pkg.TOML.parsefile(path) == Dict("a" => "c")
+        end
+    end
+end
+
 end # module


### PR DESCRIPTION
Previously this would use the 0o600 permissions of `mktemp()`, which for files like the registry `General.toml` would make them only readable by the creator, which causes errors when depots are on shared filesystems meant to be used by multiple users. Auth files are kept with 0o600.

Behaviour changed in 1.13 with #4293. Written with help from Claude :robot: 