### PR TITLE
Allow a `[sources]` entry to give both a `path` and an `url`/`rev` repo (fix #4089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Pkg v1.14 Release Notes
   recompilation easier to spot. ([#4679])
 - During package source installation, Pkg now reports when a package has an Artifacts.toml but no artifacts match the
   current platform. ([#4646])
+- A `[sources]` entry may now give both a local `path` *and* a repo `url`/`rev` to fall back on. The path is used if it
+  exists and the repository otherwise, so a local checkout can shadow the repository without the entry being edited.
+  ([#4764])
 
 Pkg v1.13 Release Notes
 =======================
@@ -232,3 +235,4 @@ Pkg v1.7 Release Notes
 [#4287]: https://github.com/JuliaLang/Pkg.jl/pull/4287
 [#4678]: https://github.com/JuliaLang/Pkg.jl/pull/4678
 [#4679]: https://github.com/JuliaLang/Pkg.jl/pull/4679
+[#4764]: https://github.com/JuliaLang/Pkg.jl/issues/4764

--- a/docs/src/toml-files.md
+++ b/docs/src/toml-files.md
@@ -163,10 +163,14 @@ corresponding manifest file.
 
 Each entry in the `[sources]` section supports the following keys:
 
-- **`url`**: The URL of the Git repository. Cannot be used with `path`.
-- **`rev`**: The Git revision (branch name, tag, or commit hash) to use. Only valid with `url`.
+- **`url`**: The URL of the Git repository.
+- **`rev`**: The Git revision (branch name, tag, or commit hash) to use.
 - **`subdir`**: A subdirectory within the repository containing the package.
-- **`path`**: A local filesystem path to the package. Cannot be used with `url` or `rev`. This will `dev` the package.
+- **`path`**: A local filesystem path to the package, relative to `Project.toml`. This will `dev` the package.
+
+!!! tip "Simultaneous `path` and `url`/`rev` entries"
+    If both a `path` and an `url`/`rev` entry is provided, `path` takes precedence *if it exists locally*; if not, the repository is used. This can be useful for a package that is checked out next to the project using it: whoever has that checkout works against it, while everyone else transparently gets the repository. If neither the path nor the repository exists, an error is raised.
+    Simultaneous entries require Julia 1.14+ (and are an error in earlier versions).
 
 This might in practice look something like:
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -17,6 +17,7 @@ import ..Operations, ..GitTools, ..Pkg, ..Registry
 import ..can_fancyprint, ..pathrepr, ..isurl, ..PREV_ENV_PATH, ..atomic_toml_write, ..safe_realpath
 using ..Types, ..TOML
 using ..Types: VersionTypes
+using ..Types: has_repo_fallback
 using Base.BinaryPlatforms
 import ..stderr_f, ..stdout_f
 using ..Artifacts: artifact_paths
@@ -201,22 +202,27 @@ function update_source_if_set(env, pkg)
     project = env.project
     source = get(project.sources, pkg.name, nothing)
     if source !== nothing
-        if pkg.repo == GitRepo()
+        # An entry that lists a `path` as well as a repo to fall back on keeps both keys:
+        # it is only rewritten below if `pkg` carries a source that the entry does not give
+        entry_path, entry_repo = has_repo_fallback(source) ?
+            get_path_repo(project, env.project_file, env.manifest_file, pkg.name) :
+            (nothing, GitRepo())
+        if pkg.repo == GitRepo() && (pkg.path === nothing || pkg.path != entry_path)
             delete!(project.sources, pkg.name)
         else
             # This should probably not modify the dicts directly...
-            if pkg.repo.source !== nothing
+            if pkg.repo.source !== nothing && pkg.repo.source != entry_repo.source
                 source["url"] = pkg.repo.source
                 delete!(source, "path")
             end
-            if pkg.repo.rev !== nothing
+            if pkg.repo.rev !== nothing && pkg.repo.rev != entry_repo.rev
                 source["rev"] = pkg.repo.rev
                 delete!(source, "path")
             end
             if pkg.repo.subdir !== nothing
                 source["subdir"] = pkg.repo.subdir
             end
-            if pkg.path !== nothing
+            if pkg.path !== nothing && pkg.path != entry_path
                 source["path"] = pkg.path
                 delete!(source, "url")
                 delete!(source, "rev")

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1417,7 +1417,9 @@ function write_env(
                 @assert entry.repo.subdir == repo.subdir
             end
         end
-        if entry !== nothing
+        # NB: an entry that lists both a `path` and a repo (`url`/`rev`) is left as it is
+        #     (which of the two is in use is decided by whether the path exists)
+        if entry !== nothing && !has_repo_fallback(get(env.project.sources, pkg, nothing))
             if entry.path !== nothing
                 # Convert path from manifest-relative to project-relative before writing
                 project_relative_path = manifest_path_to_project_path(env.project_file, env.manifest_file, entry.path)

--- a/src/project.jl
+++ b/src/project.jl
@@ -4,6 +4,24 @@
 listed_deps(project::Project; include_weak::Bool) =
     vcat(collect(keys(project.deps)), collect(keys(project.extras)), include_weak ? collect(keys(project.weakdeps)) : String[])
 
+# Whether a `[sources]` entry lists both a local `path` *and* a fall-back repo (`url`/`rev`)
+has_repo_fallback(source::Dict{String, String}) =
+    haskey(source, "path") && (haskey(source, "url") || haskey(source, "rev"))
+has_repo_fallback(::Nothing) = false
+
+# A repo source naming a directory on this machine, either as a plain path or as a `file://`
+# URL, can be checked for right away; a remote repository is left for git to report on.
+function local_repo_path(url::String, manifest_file::String)
+    if startswith(url, "file://")
+        path = chop(url; head = ncodeunits("file://"), tail = 0)
+        # A Windows file URL carries a leading slash before the drive letter
+        return Sys.iswindows() ? lstrip(path, '/') : path
+    end
+    isurl(url) && return nothing
+    # A relative repo path is relative to the manifest, like elsewhere for `repo.source`
+    return isabspath(url) ? url : normpath(joinpath(dirname(abspath(manifest_file)), url))
+end
+
 function get_path_repo(project::Project, project_file::String, manifest_file::String, name::String)
     source = get(project.sources, name, nothing)
     if source === nothing
@@ -13,8 +31,21 @@ function get_path_repo(project::Project, project_file::String, manifest_file::St
     url = get(source, "url", nothing)::Union{String, Nothing}
     rev = get(source, "rev", nothing)::Union{String, Nothing}
     subdir = get(source, "subdir", nothing)::Union{String, Nothing}
-    if path !== nothing && url !== nothing
-        pkgerror("`path` and `url` are conflicting specifications")
+    if !isnothing(path) && (!isnothing(url) || !isnothing(rev))
+        # An entry may include both a local `path` and a repo (`url`/`rev`): `path` takes
+        # precedence if it exists, otherwise the package is tracked by the repo
+        if isdir(joinpath(dirname(abspath(project_file)), path))
+            url = rev = nothing
+        else
+            repo_path = isnothing(url) ? nothing : local_repo_path(url, manifest_file)
+            if !isnothing(repo_path) && !isdir(repo_path)
+                pkgerror(
+                    "neither source listed for `$(name)` in `$(project_file)` exists ",
+                    "(path `$(path)`", isnothing(url) ? "" : ", url `$(url)`", ")"
+                )
+            end
+            path = nothing
+        end
     end
     repo = GitRepo(url, rev, subdir)
     # Convert path from project-relative to manifest-relative
@@ -135,9 +166,6 @@ function read_project_sources(raw::Dict{String, Any}, project::Project)
         end
         for key in keys(source)
             key in valid_keys || pkgerror("Invalid key `$key` in `source` section")
-        end
-        if haskey(source, "path") && (haskey(source, "url") || haskey(source, "rev"))
-            pkgerror("Both `path` and `url` or `rev` are specified in `source` section")
         end
         sources[name] = source
     end

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -310,6 +310,101 @@ temp_pkg_dir() do project_path
             end
         end
     end
+
+    # Regression test for https://github.com/JuliaLang/Pkg.jl/issues/4089
+    # A `[sources]` entry may list a local `path` as well as a `url`/`rev` to fall back on
+    @testset "[sources] path with a repo to fall back on (#4089)" begin
+        mktempdir() do dir
+            path = copy_test_package(dir, "WithSources")
+            local_pkg = joinpath(path, "LocalPkg")
+            local_uuid = UUID("fcf55292-0d03-4e8a-9e0b-701580031fc3")
+            remote_uuid = UUID("00000000-0000-0000-0000-000000004089")
+
+            # `LocalPkg` is checked out in the environment and has a clone to fall back on,
+            # while `RemotePkg` only exists as a clone. Since the two say different things
+            # in `greet`, loading them shows which of the two sources is really in use.
+            local_url = make_file_url(git_init_package(dir, local_pkg))
+            remote_pkg = joinpath(dir, "RemotePkg")
+            mkpath(joinpath(remote_pkg, "src"))
+            write(
+                joinpath(remote_pkg, "Project.toml"), """
+                name = "RemotePkg"
+                uuid = "$(remote_uuid)"
+                version = "0.1.0"
+                """
+            )
+            write(
+                joinpath(remote_pkg, "src", "RemotePkg.jl"), """
+                module RemotePkg
+                greet() = "Hello World from url!"
+                end
+                """
+            )
+            git_init_and_commit(remote_pkg)
+            remote_url = make_file_url(remote_pkg)
+
+            local_source(url) = Dict("path" => "LocalPkg", "url" => url, "rev" => "HEAD")
+            remote_source = Dict("path" => "RemotePkg", "url" => remote_url, "rev" => "HEAD")
+            # `RemotePkg` lists a path that is not there, so only its repo can be used
+            function set_project(local_url)
+                return write(
+                    joinpath(path, "Project.toml"), """
+                    [deps]
+                    LocalPkg = "$(local_uuid)"
+                    RemotePkg = "$(remote_uuid)"
+
+                    [sources]
+                    LocalPkg = {path = "LocalPkg", url = "$(local_url)", rev = "HEAD"}
+                    RemotePkg = {path = "RemotePkg", url = "$(remote_url)", rev = "HEAD"}
+                    """
+                )
+            end
+            set_project(local_url)
+
+            cd(path) do
+                with_current_env() do
+                    Pkg.resolve()
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+
+                    # `LocalPkg` is checked out, so its `path` takes precedence over the repo
+                    @test manifest[local_uuid].path == "LocalPkg"
+                    @test manifest[local_uuid].repo.source === nothing
+                    # `RemotePkg` is not, so it is tracked by its repo instead
+                    @test manifest[remote_uuid].path === nothing
+                    @test manifest[remote_uuid].repo.source == remote_url
+                    # ... and neither entry loses the source it does not use
+                    @test Pkg.project().sources["LocalPkg"] == local_source(local_url)
+                    @test Pkg.project().sources["RemotePkg"] == remote_source
+
+                    # the source that wins is the one that is loaded
+                    @test include_string(Module(), "using LocalPkg; LocalPkg.greet()") == "Hello World!"
+                    @test include_string(Module(), "using RemotePkg; RemotePkg.greet()") == "Hello World from url!"
+
+                    # with the checkout gone, `LocalPkg` falls back on its repo as well
+                    rm(local_pkg; recursive = true)
+                    Pkg.resolve()
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+                    @test manifest[local_uuid].path === nothing
+                    @test manifest[local_uuid].repo.source == local_url
+                    @test Pkg.project().sources["LocalPkg"] == local_source(local_url)
+
+                    # neither source can be used
+                    wrong_url = make_file_url(joinpath(dir, "NoSuchPkg"))
+                    set_project(wrong_url)
+                    rm("Manifest.toml")
+                    err = try
+                        Pkg.resolve()
+                    catch e
+                        e
+                    end
+                    @test err isa Pkg.Types.PkgError
+                    @test occursin("neither source listed for `LocalPkg`", err.msg)
+                    @test occursin("path `LocalPkg`, url `$(wrong_url)`", err.msg)
+                    @test occursin("NoSuchPkg", err.msg)
+                end
+            end
+        end
+    end
 end
 
 end # module

--- a/test/test_packages/WithSources/LocalPkg/src/LocalPkg.jl
+++ b/test/test_packages/WithSources/LocalPkg/src/LocalPkg.jl
@@ -1,5 +1,5 @@
 module LocalPkg
 
-greet() = print("Hello World!")
+greet() = "Hello World!"
 
 end # module LocalPkg


### PR DESCRIPTION
This is a stab at implementing the feature I hoped for in #4089: if a `[sources]` entry contains *both* a `path` and an `url`, then Pkg will first attempt to use `path` - and, if that folder doesn't exist, fall back to `url`.

Generated with Claude Opus, and checked & revised subsequently. Robot summary (~ commit message) below.

I'm not very familiar with the code here, so there could well be issues, despite my checking. E.g., I highlight uncertainties on whether:
- the implementation handles present `rev` but absent `url` correctly, 
- the new tests are idiomatic and robust,
- the handling of the error message if neither `path` nor `url` could be found.

---

🤖 An entry listing both `path` and `url` was rejected when the project file was read. Allow it, with the meaning asked for in #4089: the `path` is used when it exists locally, the repository when it does not, so a local checkout can shadow the repository without the entry being edited.

Downstream uses all assume only one of the two is set, so the choice is made in the one place they funnel through, `get_path_repo`, which still returns either a path or a `GitRepo` but never both. It also raises the error for when neither is there, as far as that can be told locally. `write_env` and `update_source_if_set` both reconstruct an entry from whichever source is in use, and now leave an entry with a fallback alone so the unused key survives the next write.
