### PR TITLE
Run the "Artifact Creation" test in a fresh artifacts directory

### DIFF
--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -107,20 +107,27 @@ end
         end
     end
 
-    for (creator, known_hash) in creators
-        # Create artifact
-        hash = create_artifact_chmod(creator)
+    # Use a fresh artifacts directory: `create_artifact` keeps an existing directory
+    # for the same hash, so the verification below would otherwise inspect whatever
+    # an earlier run (or a restored CI cache) left in the depot.
+    mktempdir() do artifacts_dir
+        with_artifacts_directory(artifacts_dir) do
+            for (creator, known_hash) in creators
+                # Create artifact
+                hash = create_artifact_chmod(creator)
 
-        # Ensure it hashes to the correct gitsha:
-        @test all(hash.bytes .== hex2bytes(known_hash))
+                # Ensure it hashes to the correct gitsha:
+                @test all(hash.bytes .== hex2bytes(known_hash))
 
-        # Test that we can look it up and that it sits in the right place
-        @test basename(dirname(artifact_path(hash))) == "artifacts"
-        @test basename(artifact_path(hash)) == known_hash
-        @test artifact_exists(hash)
+                # Test that we can look it up and that it sits in the right place
+                @test dirname(artifact_path(hash)) == artifacts_dir
+                @test basename(artifact_path(hash)) == known_hash
+                @test artifact_exists(hash)
 
-        # Test that the artifact verifies
-        @test verify_artifact(hash)
+                # Test that the artifact verifies
+                @test verify_artifact(hash)
+            end
+        end
     end
 
     @testset "File permissions" begin


### PR DESCRIPTION
Fixes #4765.

Since #4760 the Windows x64 nightly job fails intermittently in `test/artifacts.jl` at `verify_artifact(hash)` in the "Artifact Creation" testset, always for the same three non-empty artifacts while the empty one passes. Master, this PR's parent branches and unrelated PRs all show the same signature; the x86 Windows job and other platforms pass.

The testset creates artifacts in the primary depot's `artifacts` directory. Two things changed in #4760: the suite now runs in parallel workers that share that depot, and `julia-actions/cache` now restores `~/.julia/artifacts` from the previous run, so those directories already exist when the test runs. `create_artifact` keeps an existing directory for the same hash (`mv_temp_dir_retries` returns early), so the test hashes at creation time verify against whatever the earlier run or the restored cache left on disk rather than the directory it just built. On Windows, file modes come from an ACL access check, so a cache round-trip can change the tree hash of an otherwise identical directory. The first run after #4760, which had no cache to restore, passed; every later cached x64 run but one failed.

This is reproducible on Linux by pre-populating the artifacts directory with the same hashes under different file modes: the creation hash still matches, `artifact_exists` is true, and `verify_artifact` fails for exactly the non-empty artifacts. Give the testset its own temporary artifacts directory, as its "File permissions" sub-testset already does, so it verifies the directory it created. With the stale directories present, the original testset fails and the isolated one passes.