### PR TITLE
Backports for 1.13

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -1349,6 +1349,18 @@ function instantiate(
         repo_source = pkg.repo.source
         repo_source !== nothing || continue
         sourcepath = Operations.source_path(ctx.env.manifest_file, pkg, ctx.julia_version)
+        if sourcepath === nothing
+            # `source_path` returns `nothing` when the package tracks a repo but the
+            # manifest entry has no recorded tree hash. This happens when a `[sources]`
+            # entry is changed (e.g. from a `path` to a `url`) without re-resolving, so
+            # the manifest is stale and we cannot determine which tree to check out.
+            resolve_cmd = Pkg.in_repl_mode() ? "pkg> resolve" : "Pkg.resolve()"
+            update_cmd = Pkg.in_repl_mode() ? "pkg> update" : "Pkg.update()"
+            pkgerror(
+                "The source of $(err_rep(pkg)) has changed but the manifest has not been updated to match.",
+                " Run `$resolve_cmd` (or `$update_cmd`) to update the manifest, then try again."
+            )
+        end
         isdir(sourcepath) && continue
         ## Download repo at tree hash
         # determine canonical form of repo source

--- a/src/Apps/Apps.jl
+++ b/src/Apps/Apps.jl
@@ -15,9 +15,12 @@ import Pkg.Registry
 public add, rm, status, update, develop
 
 app_env_folder() = joinpath(first(DEPOT_PATH), "environments", "apps")
+app_env_dir(pkgname) = joinpath(app_env_folder(), pkgname)
 app_manifest_file() = joinpath(app_env_folder(), "AppManifest.toml")
 julia_bin_path() = joinpath(first(DEPOT_PATH), "bin")
 julia_executable() = joinpath(Sys.BINDIR, "julia" * (Sys.iswindows() ? ".exe" : ""))
+shim_filename(name) = name * (Sys.iswindows() ? ".bat" : "")
+shim_path(name) = joinpath(julia_bin_path(), shim_filename(name))
 
 app_context() = Context(env = EnvCache(joinpath(app_env_folder(), "Project.toml")))
 
@@ -69,7 +72,7 @@ end
 
 function rm_shim(name; kwargs...)
     validate_app_name(name)
-    return Base.rm(joinpath(julia_bin_path(), name * (Sys.iswindows() ? ".bat" : "")); kwargs...)
+    return Base.rm(shim_path(name); kwargs...)
 end
 
 function get_project(sourcepath)
@@ -97,8 +100,7 @@ end
 
 function check_apps_in_path(apps)
     for app_name in keys(apps)
-        which_name = app_name * (Sys.iswindows() ? ".bat" : "")
-        which_result = Sys.which(which_name)
+        which_result = Sys.which(shim_filename(app_name))
         if which_result === nothing
             @warn """
             App '$app_name' was installed but is not available in PATH.
@@ -107,7 +109,7 @@ function check_apps_in_path(apps)
             break  # Only show warning once per installation
         else
             # Check for collisions
-            expected_path = joinpath(julia_bin_path(), app_name * (Sys.iswindows() ? ".bat" : ""))
+            expected_path = shim_path(app_name)
             if which_result != expected_path
                 @warn """
                 App '$app_name' collision detected:
@@ -119,6 +121,12 @@ function check_apps_in_path(apps)
         end
     end
     return
+end
+
+# PackageEntry requires version::Union{VersionNumber, Nothing}, but project.version can be a VersionSpec
+function package_entry(pkg::PackageSpec, project, path)
+    version = project.version isa VersionNumber ? project.version : nothing
+    return PackageEntry(; apps = project.apps, name = pkg.name, version, tree_hash = pkg.tree_hash, path, repo = pkg.repo, uuid = pkg.uuid)
 end
 
 function get_max_version_register(pkg::PackageSpec, regs)
@@ -186,7 +194,7 @@ function _resolve(manifest::Manifest, pkgname = nothing)
 
         # TODO: Add support for existing manifest
 
-        projectfile = joinpath(app_env_folder(), pkg.name, "Project.toml")
+        projectfile = joinpath(app_env_dir(pkg.name), "Project.toml")
 
         sourcepath = source_path(app_manifest_file(), pkg)
         original_project_file = projectfile_path(sourcepath)
@@ -249,7 +257,7 @@ function _resolve(manifest::Manifest, pkgname = nothing)
         end
 
         # Create a manifest with the manifest entry
-        Pkg.activate(joinpath(app_env_folder(), pkg.name)) do
+        Pkg.activate(app_env_dir(pkg.name)) do
             ctx = Context()
             ctx.env.manifest.deps[uuid] = pkg
             Pkg.resolve(ctx)
@@ -314,16 +322,12 @@ function _add(pkg::PackageSpec)
         new = Pkg.Operations.download_source(ctx, pkgs)
     end
 
-    # Run Pkg.build()?
-
-    Base.rm(joinpath(app_env_folder(), pkg.name); force = true, recursive = true)
+    Base.rm(app_env_dir(pkg.name); force = true, recursive = true)
     sourcepath = source_path(ctx.env.manifest_file, pkg)
     project = get_project(sourcepath)
     reconcile_shims(manifest, pkg, project)
     # TODO: Wrong if package itself has a sourcepath?
-    # PackageEntry requires version::Union{VersionNumber, Nothing}, but project.version can be VersionSpec
-    entry = PackageEntry(; apps = project.apps, name = pkg.name, version = project.version isa VersionNumber ? project.version : nothing, tree_hash = pkg.tree_hash, path = pkg.path, repo = pkg.repo, uuid = pkg.uuid)
-    manifest.deps[pkg.uuid] = entry
+    manifest.deps[pkg.uuid] = package_entry(pkg, project, pkg.path)
 
     _resolve(manifest, pkg.name)
     if new === true || (new isa Set{UUID} && pkg.uuid in new)
@@ -364,7 +368,7 @@ function _develop(pkg::PackageSpec)
     handle_package_input!(pkg)
     ctx = app_context()
     handle_repo_develop!(ctx, pkg, #=shared =# true)
-    Base.rm(joinpath(app_env_folder(), pkg.name); force = true, recursive = true)
+    Base.rm(app_env_dir(pkg.name); force = true, recursive = true)
     sourcepath = abspath(source_path(ctx.env.manifest_file, pkg))
     project = get_project(sourcepath)
 
@@ -376,11 +380,9 @@ function _develop(pkg::PackageSpec)
         pkg.repo.source = nothing
     end
 
-    # PackageEntry requires version::Union{VersionNumber, Nothing}, but project.version can be VersionSpec
-    entry = PackageEntry(; apps = project.apps, name = pkg.name, version = project.version isa VersionNumber ? project.version : nothing, tree_hash = pkg.tree_hash, path = sourcepath, repo = pkg.repo, uuid = pkg.uuid)
     manifest = ctx.env.manifest
     reconcile_shims(manifest, pkg, project)
-    manifest.deps[pkg.uuid] = entry
+    manifest.deps[pkg.uuid] = package_entry(pkg, project, sourcepath)
 
     # For dev, we don't create an app environment - just point shims directly to the dev'd project
     write_manifest(manifest, app_manifest_file())
@@ -518,7 +520,7 @@ function precompile(pkg::Union{Nothing, String} = nothing)
         end
         # Developed apps run directly from their project, tracked ones from the app environment
         env_dir = info.path !== nothing ? abspath(source_path(app_manifest_file(), info)) :
-            joinpath(app_env_folder(), info.name)
+            app_env_dir(info.name)
         Pkg.activate(env_dir) do
             Pkg.instantiate()
             Pkg.precompile()
@@ -569,7 +571,7 @@ function _rm(pkg_or_app::Union{PackageSpec, Nothing})
             rm_shim(appname; force = true)
         end
         if dep.path === nothing
-            Base.rm(joinpath(app_env_folder(), dep.name); recursive = true, force = true)
+            Base.rm(app_env_dir(dep.name); recursive = true, force = true)
         end
     else
         found = false
@@ -584,7 +586,7 @@ function _rm(pkg_or_app::Union{PackageSpec, Nothing})
             if isempty(pkg.apps)
                 delete!(manifest.deps, uuid)
                 if pkg.path === nothing
-                    Base.rm(joinpath(app_env_folder(), pkg.name); recursive = true, force = true)
+                    Base.rm(app_env_dir(pkg.name); recursive = true, force = true)
                 end
             end
         end
@@ -593,7 +595,7 @@ function _rm(pkg_or_app::Union{PackageSpec, Nothing})
         end
     end
     # XXX: What happens if something fails above and we do not write out the updated manifest?
-    Pkg.Types.write_manifest(manifest, app_manifest_file())
+    write_manifest(manifest, app_manifest_file())
     return
 end
 
@@ -625,7 +627,7 @@ end
 #########
 
 const SHIM_COMMENT = Sys.iswindows() ? "REM " : "#"
-const SHIM_VERSION = 1.3
+const SHIM_VERSION = 1.4
 const SHIM_HEADER = """$SHIM_COMMENT This file is generated by the Julia package manager.
 $SHIM_COMMENT Shim version: $SHIM_VERSION"""
 
@@ -637,7 +639,7 @@ function stacked_depots()
 end
 
 function generate_shims_for_apps(pkgname, apps, env, julia)
-    for (_, app) in apps
+    for app in values(apps)
         generate_shim(pkgname, app, env, julia)
     end
     return
@@ -650,18 +652,9 @@ function generate_shim(pkgname, app::AppInfo, env, julia)
 
     module_spec = app.submodule === nothing ? pkgname : "$(pkgname).$(app.submodule)"
 
-    filename = app.name * (Sys.iswindows() ? ".bat" : "")
-    julia_bin_filename = joinpath(julia_bin_path(), filename)
-    mkpath(dirname(julia_bin_filename))
-    content = if Sys.iswindows()
-        julia_escaped = "\"$(Base.shell_escape_wincmd(julia))\""
-        module_spec_escaped = "\"$(Base.shell_escape_wincmd(module_spec))\""
-        windows_shim(julia_escaped, module_spec_escaped, env, app.julia_flags)
-    else
-        julia_escaped = Base.shell_escape(julia)
-        module_spec_escaped = Base.shell_escape(module_spec)
-        shell_shim(julia_escaped, module_spec_escaped, env, app.julia_flags)
-    end
+    julia_bin_filename = shim_path(app.name)
+    content = Sys.iswindows() ? windows_shim(julia, module_spec, env, app.julia_flags) :
+        shell_shim(julia, module_spec, env, app.julia_flags)
     overwrite_file_if_different(julia_bin_filename, content)
     return if Sys.isunix()
         chmod(julia_bin_filename, 0o755)
@@ -669,7 +662,9 @@ function generate_shim(pkgname, app::AppInfo, env, julia)
 end
 
 
-function shell_shim(julia_escaped::String, module_spec_escaped::String, env, julia_flags::Vector{String})
+function shell_shim(julia::String, module_spec::String, env, julia_flags::Vector{String})
+    julia_escaped = Base.shell_escape(julia)
+    module_spec_escaped = Base.shell_escape(module_spec)
     julia_flags_escaped = join(Base.shell_escape.(julia_flags), " ")
     julia_flags_part = isempty(julia_flags) ? "" : " $julia_flags_escaped"
 
@@ -739,13 +734,16 @@ function shell_shim(julia_escaped::String, module_spec_escaped::String, env, jul
     """
 end
 
-function windows_shim(
-        julia_escaped::String,
-        module_spec_escaped::String,
-        env,
-        julia_flags::Vector{String},
-    )
-    flags_escaped = join(Base.shell_escape_wincmd.(julia_flags), " ")
+# Escape a value for `set "var=..."` in a batch script: the quotes keep cmd
+# metacharacters literal so only `%` needs doubling
+function escape_batch_set_value(s::AbstractString)
+    occursin(r"[\"\r\n\0]", s) && pkgerror("cannot use $(repr(s)) in a Windows batch script")
+    return replace(s, "%" => "%%")
+end
+
+function windows_shim(julia::String, module_spec::String, env, julia_flags::Vector{String})
+    # Flags end up unquoted on the command line so escape cmd metacharacters
+    flags_escaped = join((replace(Base.shell_escape_wincmd(f), "%" => "%%") for f in julia_flags), " ")
     flags_part = isempty(julia_flags) ? "" : " $flags_escaped"
 
     depot = normpath(first(DEPOT_PATH))
@@ -753,13 +751,13 @@ function windows_shim(
     # Environments inside the depot are located relative to it so that the
     # depot can be relocated (developed projects keep their absolute path)
     load_path = if startswith(env, joinpath(depot, ""))
-        "%depot%\\$(relpath(env, depot))"
+        "%depot%\\$(escape_batch_set_value(relpath(env, depot)))"
     else
-        env
+        escape_batch_set_value(env)
     end
 
     # Stacked depots stay baked in so packages installed in them remain loadable
-    depot_path = "%depot%;" * join(d * ";" for d in stacked_depots())
+    depot_path = "%depot%;" * join(escape_batch_set_value(d) * ";" for d in stacked_depots())
 
     return """
     @echo off
@@ -770,7 +768,7 @@ function windows_shim(
     rem --- Locate the depot from the location of this script (<depot>\\bin\\<app>) so
     rem --- that a relocated depot keeps working; fall back to the install time depot
     for %%I in ("%~dp0..") do set "depot=%%~fI"
-    if not exist "%depot%\\environments\\apps\\AppManifest.toml" set "depot=$depot"
+    if not exist "%depot%\\environments\\apps\\AppManifest.toml" set "depot=$(escape_batch_set_value(depot))"
 
     rem --- Environment (no delayed expansion here to keep '!' literal) ---
     rem --- (the trailing ';' appends the default system depots) ---
@@ -778,10 +776,11 @@ function windows_shim(
     set "JULIA_DEPOT_PATH=$depot_path"
 
     rem --- Allow overriding Julia executable via environment variable ---
+    rem --- julia_cmd holds an unquoted path; the call sites add the quotes ---
     if defined JULIA_APPS_JULIA_CMD (
         set "julia_cmd=%JULIA_APPS_JULIA_CMD%"
     ) else (
-        set "julia_cmd=$julia_escaped"
+        set "julia_cmd=$(escape_batch_set_value(julia))"
     )
 
     rem --- Now enable delayed expansion for string building below ---
@@ -826,12 +825,12 @@ function windows_shim(
     if defined found_sep (
         "%julia_cmd%" ^
             --startup-file=no$flags_part !julia_args! ^
-            -m $module_spec_escaped ^
+            -m "$module_spec" ^
             !app_args!
     ) else (
         "%julia_cmd%" ^
             --startup-file=no$flags_part ^
-            -m $module_spec_escaped ^
+            -m "$module_spec" ^
             %*
     )
     """

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -512,11 +512,21 @@ function reset_all_compat!(proj::Project)
     return nothing
 end
 
-function collect_project(pkg::Union{PackageSpec, Nothing}, path::String, manifest_file::String, julia_version)
+function collect_project(
+        pkg::Union{PackageSpec, Nothing}, path::String, manifest_file::String, julia_version;
+        # For projects that are loaded into the env (the active project and the workspace
+        # members) the caller passes the in-memory project and its file, since the project
+        # may have modifications that have not been written to disk yet.
+        loaded::Union{Nothing, Tuple{String, Project}} = nothing
+    )
     deps = PackageSpec[]
     weakdeps = Set{UUID}()
-    project_file = projectfile_path(path; strict = true)
-    project = project_file === nothing ? Project() : read_project(project_file)
+    project_file, project = if loaded === nothing
+        file = projectfile_path(path; strict = true)
+        file, file === nothing ? Project() : read_project(file)
+    else
+        loaded
+    end
     julia_compat = get_compat(project, "julia")
     if !isnothing(julia_compat) && !isnothing(julia_version) && !(julia_version in julia_compat)
         pkgerror("julia version requirement for package at `$path` not satisfied: compat entry \"julia = $(get_compat_str(project, "julia"))\" does not include Julia version $julia_version")
@@ -584,18 +594,26 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
     deps_map = Dict{UUID, Vector{PackageSpec}}()
     weak_map = Dict{UUID, Set{UUID}}()
 
+    # The active project and the workspace projects are already loaded into the env and may
+    # have unwritten modifications (e.g. a dep that `add` just recorded), so their deps must
+    # be read from memory rather than from their project files.
+    loaded_projects = Dict{UUID, Tuple{String, Project}}(Types.project_uuid(env) => (env.project_file, env.project))
+    for (project_file, project) in env.workspace
+        loaded_projects[Types.project_uuid(project, project_file)] = (project_file, project)
+    end
+
     uuid = Types.project_uuid(env)
-    deps, weakdeps = collect_project(env.pkg, dirname(env.project_file), env.manifest_file, julia_version)
+    deps, weakdeps = collect_project(env.pkg, dirname(env.project_file), env.manifest_file, julia_version; loaded = loaded_projects[uuid])
     deps_map[uuid] = deps
     weak_map[uuid] = weakdeps
     names[uuid] = env.pkg === nothing ? "project" : env.pkg.name
 
-    for (path, project) in env.workspace
-        uuid = Types.project_uuid(project, path)
+    for (project_file, project) in env.workspace
+        uuid = Types.project_uuid(project, project_file)
         pkg = project.name === nothing ? nothing : PackageSpec(name = project.name, uuid = uuid)
-        deps, weakdeps = collect_project(pkg, path, env.manifest_file, julia_version)
-        deps_map[Types.project_uuid(env)] = deps
-        weak_map[Types.project_uuid(env)] = weakdeps
+        deps, weakdeps = collect_project(pkg, dirname(project_file), env.manifest_file, julia_version; loaded = (project_file, project))
+        deps_map[uuid] = deps
+        weak_map[uuid] = weakdeps
         names[uuid] = project.name === nothing ? "project" : project.name
     end
 
@@ -641,7 +659,7 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
             end
             pkgerror(error_msg)
         end
-        deps, weakdeps = collect_project(pkg, path, env.manifest_file, julia_version)
+        deps, weakdeps = collect_project(pkg, path, env.manifest_file, julia_version; loaded = get(loaded_projects, pkg.uuid, nothing))
         deps_map[pkg.uuid] = deps
         weak_map[pkg.uuid] = weakdeps
         for dep in deps
@@ -1985,6 +2003,14 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec}; mode::PackageMode)
     filter!(ctx.env.project.targets) do (target, deps)
         !isempty(filter!(in(deps_names), deps))
     end
+    # the project may have an entry in the manifest (e.g. if something depends back on it),
+    # which mirrors the project deps and therefore needs the drops removed as well
+    proj_entry = manifest_info(ctx.env.manifest, Types.project_uuid(ctx.env))
+    if proj_entry !== nothing
+        filter!(proj_entry.deps) do (_, uuid)
+            uuid ∉ drop
+        end
+    end
     # only keep reachable manifest entries
     prune_manifest(ctx.env)
     record_project_hash(ctx.env)
@@ -2263,6 +2289,12 @@ function add(
         # All packages are already in manifest with compatible versions
         # Just promote to direct dependencies without resolving
         foreach(pkg -> target_field[pkg.name] = pkg.uuid, pkgs) # update set of deps/weakdeps/extras
+
+        # keep the manifest entry of the project itself (if any) in sync with the project deps
+        proj_entry = manifest_info(ctx.env.manifest, Types.project_uuid(ctx.env))
+        if proj_entry !== nothing
+            foreach(pkg -> proj_entry.deps[pkg.name] = pkg.uuid, pkgs)
+        end
 
         # if env is a package add compat entries
         add_compat_entries!(ctx, pkgs)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -590,7 +590,12 @@ function collect_developed(env::EnvCache, pkgs::Vector{PackageSpec})
     return developed
 end
 
-function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version)
+function collect_fixed!(
+        env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UUID, String}, julia_version;
+        # A `[sources]` entry in a dependency's project file must not take over such a
+        # package for which the environment already has a source for, see #4750.
+        env_uuids::Set{UUID} = Set{UUID}()
+    )
     deps_map = Dict{UUID, Vector{PackageSpec}}()
     weak_map = Dict{UUID, Set{UUID}}()
 
@@ -624,7 +629,8 @@ function collect_fixed!(env::EnvCache, pkgs::Vector{PackageSpec}, names::Dict{UU
         pkg_by_uuid[pkg.uuid] = pkg
     end
     new_fixed_pkgs = PackageSpec[]
-    seen = Set(keys(pkg_by_uuid))
+    seen = Set{UUID}(keys(pkg_by_uuid))
+    union!(seen, env_uuids)
     while !isempty(pkg_queue)
         pkg = popfirst!(pkg_queue)
         pkg.uuid === nothing && continue
@@ -766,7 +772,12 @@ function resolve_versions!(
     end
     # this also sets pkg.version for fixed packages
     pkgs_fixed = filter(!is_tracking_registry, pkgs)
-    fixed, new_fixed_pkgs = collect_fixed!(env, pkgs_fixed, names, julia_version)
+    env_uuids = Set{UUID}()
+    for pkg in pkgs
+        pkg.uuid === nothing && continue
+        push!(env_uuids, pkg.uuid)
+    end
+    fixed, new_fixed_pkgs = collect_fixed!(env, pkgs_fixed, names, julia_version; env_uuids)
     for new_pkg in new_fixed_pkgs
         any(x -> x.uuid == new_pkg.uuid, pkgs) && continue
         push!(pkgs, new_pkg)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -897,6 +897,7 @@ function deps_graph(
     end
 
     # Collect all weak dependency UUIDs from fixed packages
+    # (weak deps of registry packages and stdlibs are added during graph traversal below)
     all_weak_uuids = Set{UUID}()
     for fx in values(fixed)
         union!(all_weak_uuids, fx.weak)
@@ -966,6 +967,7 @@ function deps_graph(
                     for other_uuid in stdlib_info.weakdeps
                         push!(uuids, other_uuid)
                         push!(weak_deps_set, other_uuid)
+                        push!(all_weak_uuids, other_uuid)
                     end
                     stdlib_weak_deps[vrange] = weak_deps_set
                     stdlib_weak_compat[vrange] = Dict{UUID, VersionSpec}()
@@ -1031,10 +1033,12 @@ function deps_graph(
                     end
 
                     # Collect all dependency UUIDs for discovery
-                    for deps_dict in (info.deps, info.weak_deps)
-                        for (vrange, deps_set) in deps_dict
-                            union!(uuids, deps_set)
-                        end
+                    for (vrange, deps_set) in info.deps
+                        union!(uuids, deps_set)
+                    end
+                    for (vrange, deps_set) in info.weak_deps
+                        union!(uuids, deps_set)
+                        union!(all_weak_uuids, deps_set)
                     end
                 end
 
@@ -1077,7 +1081,7 @@ function deps_graph(
     if !isempty(unavailable_weak_uuids)
         fixed_filtered = Dict{UUID, Resolve.Fixed}()
         for (uuid, fx) in fixed
-            filtered_requires = Requires()
+            filtered_requires = Resolve.Requires()
             for (req_uuid, req_spec) in fx.requires
                 if !(req_uuid in unavailable_weak_uuids)
                     filtered_requires[req_uuid] = req_spec

--- a/test/apps.jl
+++ b/test/apps.jl
@@ -294,6 +294,37 @@ using Test
         end
     end
 
+    @testset "windows shim quoting (#4741)" begin
+        julia = "C:\\Users\\test user\\.julia\\juliaup\\julia-1.12.6+0.x64.w64.mingw32\\bin\\julia.exe"
+        content = Pkg.Apps.windows_shim(julia, "Rot13", pwd(), String[])
+        # julia_cmd must be stored unquoted; the call sites add the quotes
+        @test occursin("set \"julia_cmd=$julia\"", content)
+        @test occursin("\"%julia_cmd%\"", content)
+        @test !occursin("julia_cmd=\"", content)
+        # a literal `%` is doubled for the batch parser
+        content = Pkg.Apps.windows_shim("C:\\julia %20\\bin\\julia.exe", "Rot13", pwd(), String[])
+        @test occursin("set \"julia_cmd=C:\\julia %%20\\bin\\julia.exe\"", content)
+    end
+
+    if Sys.iswindows()
+        # Run a shim whose julia executable path contains a space (#4741)
+        isolate(loaded_depot = true) do
+            mktempdir() do tmpdir
+                mock_dir = joinpath(tmpdir, "dir with space")
+                mkpath(mock_dir)
+                mock_julia = joinpath(mock_dir, "julia.bat")
+                write(mock_julia, "@echo off\r\necho MOCK_JULIA_EXECUTED %*\r\n")
+                app = Pkg.Types.AppInfo("spacequote", nothing, nothing, String[], Dict{String, Any}())
+                Pkg.Apps.generate_shim("SpaceQuote", app, tmpdir, mock_julia)
+                shim = joinpath(first(DEPOT_PATH), "bin", "spacequote.bat")
+                @test isfile(shim)
+                out = read(`$shim arg1`, String)
+                @test contains(out, "MOCK_JULIA_EXECUTED")
+                @test contains(out, "arg1")
+            end
+        end
+    end
+
     isolate(loaded_depot = true) do
         Pkg.Registry.add("General")
         Pkg.Apps.add(name = "Runic", version = "1.5.1")

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -1,6 +1,7 @@
 using .Utils
 using Test
 using UUIDs
+import LibGit2
 
 @testset "weak deps" begin
     he_root = joinpath(@__DIR__, "test_packages", "ExtensionExamples", "HasExtensions.jl")
@@ -154,6 +155,93 @@ using UUIDs
             # because it's only a weak dependency
             Pkg.develop(path = test_pkg_path)
             @test haskey(Pkg.dependencies(), UUID("10000000-0000-0000-0000-000000000001"))
+        end
+    end
+
+    # Adding a package from a registry should also work when its weak dependency is only
+    # registered in a registry that is not available (e.g. a private registry)
+    isolate(loaded_depot = false) do
+        mktempdir() do dir
+            pub_uuid = "10000000-0000-0000-0000-000000000002"
+            priv_weak_uuid = "00000000-0000-0000-0000-000000000002"
+
+            pkg_repo_path = joinpath(dir, "PubPkg")
+            mkpath(joinpath(pkg_repo_path, "src"))
+            write(
+                joinpath(pkg_repo_path, "Project.toml"), """
+                name = "PubPkg"
+                uuid = "$pub_uuid"
+                version = "0.1.0"
+
+                [weakdeps]
+                PrivWeak = "$priv_weak_uuid"
+
+                [extensions]
+                PrivExt = "PrivWeak"
+
+                [compat]
+                PrivWeak = "0.1"
+                """
+            )
+            write(
+                joinpath(pkg_repo_path, "src", "PubPkg.jl"), """
+                module PubPkg
+                end
+                """
+            )
+            git_init_and_commit(pkg_repo_path)
+            pkg_tree_hash = LibGit2.with(LibGit2.GitRepo(pkg_repo_path)) do repo
+                string(LibGit2.GitHash(LibGit2.peel(LibGit2.GitTree, LibGit2.head(repo))))
+            end
+
+            # A registry containing PubPkg, where PubPkg's weak dependency PrivWeak
+            # is not registered here (nor anywhere else reachable)
+            regpath = joinpath(dir, "PubReg")
+            mkpath(joinpath(regpath, "PubPkg"))
+            regpath_toml = replace(regpath, "\\" => "/")
+            pkg_repo_path_toml = replace(pkg_repo_path, "\\" => "/")
+            write(
+                joinpath(regpath, "Registry.toml"), """
+                name = "PubReg"
+                uuid = "20000000-0000-0000-0000-000000000002"
+                repo = "$regpath_toml"
+                [packages]
+                $pub_uuid = { name = "PubPkg", path = "PubPkg" }
+                """
+            )
+            write(
+                joinpath(regpath, "PubPkg", "Package.toml"), """
+                name = "PubPkg"
+                uuid = "$pub_uuid"
+                repo = "$pkg_repo_path_toml"
+                """
+            )
+            write(
+                joinpath(regpath, "PubPkg", "Versions.toml"), """
+                ["0.1.0"]
+                git-tree-sha1 = "$pkg_tree_hash"
+                """
+            )
+            write(
+                joinpath(regpath, "PubPkg", "WeakDeps.toml"), """
+                [0]
+                PrivWeak = "$priv_weak_uuid"
+                """
+            )
+            write(
+                joinpath(regpath, "PubPkg", "WeakCompat.toml"), """
+                [0]
+                PrivWeak = "0.1"
+                """
+            )
+            git_init_and_commit(regpath)
+
+            Pkg.Registry.add(url = regpath)
+            Pkg.activate(; temp = true)
+            Pkg.add(name = "PubPkg", uuid = UUID(pub_uuid))
+            @test haskey(Pkg.dependencies(), UUID(pub_uuid))
+            Pkg.instantiate()
+            Pkg.resolve()
         end
     end
 end

--- a/test/new.jl
+++ b/test/new.jl
@@ -2411,6 +2411,20 @@ end
             @test pkg.is_tracking_registry
         end
     end
+    # free developed package when the active project is itself a package (#4686)
+    isolate(loaded_depot = true) do
+        cd_tempdir() do dir
+            Pkg.generate("MyPkg")
+            Pkg.activate("MyPkg")
+            Pkg.develop("Example")
+            Pkg.free("Example")
+            Pkg.dependencies(exuuid) do pkg
+                @test pkg.name == "Example"
+                @test pkg.is_tracking_registry
+            end
+            @test !haskey(Pkg.project().sources, "Example")
+        end
+    end
     # free should error when called on packages tracking unregistered packages
     isolate(loaded_depot = true) do
         Pkg.add(url = "https://github.com/00vareladavid/Unregistered.jl")
@@ -3409,6 +3423,33 @@ end
             manifest_b = Pkg.Types.read_manifest("Cycle_B/Manifest.toml")
             @test cycle_a_uuid in keys(manifest_b)
             @test_broken !(cycle_b_uuid in keys(manifest_b))
+        end
+    end
+end
+
+@testset "manifest entry of the active project tracks its deps" begin
+    isolate(loaded_depot = true) do
+        cd_tempdir() do dir
+            Pkg.generate("MyProject")
+            Pkg.activate("MyProject")
+            uuid = Pkg.Types.read_project(joinpath("MyProject", "Project.toml")).uuid
+            manifest() = Pkg.Types.read_manifest(joinpath("MyProject", "Manifest.toml"))
+            project_deps() = sort!(collect(keys(manifest()[uuid].deps)))
+            Pkg.resolve()
+            @test project_deps() == String[]
+            # the entry must be updated by the same operation that adds the dep, not the next one
+            Pkg.add("JSON")
+            @test project_deps() == ["JSON"]
+            @test "Unicode" in keys(manifest()[json_uuid].deps)
+            Pkg.add("Example")
+            @test project_deps() == ["Example", "JSON"]
+            # promoting an indirect dep skips resolving entirely
+            Pkg.add("Unicode")
+            @test project_deps() == ["Example", "JSON", "Unicode"]
+            # a stale entry would keep JSON reachable and thus unpruned
+            Pkg.rm("JSON")
+            @test project_deps() == ["Example", "Unicode"]
+            @test !haskey(manifest(), json_uuid)
         end
     end
 end

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -210,6 +210,17 @@ temp_pkg_dir() do project_path
                         """
                     )
 
+                    # Regression test for: https://github.com/JuliaLang/Pkg.jl/issues/4688
+                    # Check behaviour with a stale manifest.
+                    err = try
+                        Pkg.precompile()
+                        nothing
+                    catch e
+                        e
+                    end
+                    @test err isa Pkg.Types.PkgError
+                    @test occursin("manifest", err.msg)
+
                     # This should NOT cause an assertion error about tree_hash and path both being set
                     Pkg.update()
                     manifest = Pkg.Types.read_manifest("Manifest.toml")

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -249,6 +249,67 @@ temp_pkg_dir() do project_path
             end
         end
     end
+
+    # Regression test for https://github.com/JuliaLang/Pkg.jl/issues/4750
+    # A `[sources]` entry in a dependency's project file must not take over a package that
+    # the environment being resolved already tracks itself (here: from a registry).
+    @testset "dependency [sources] don't hijack a registered direct dep (#4750)" begin
+        isolate() do
+            mktempdir() do tmp
+                example_uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a")
+                main_uuid = UUID("00000000-0000-0000-0000-000000004750")
+                main = joinpath(tmp, "MainPkg")
+
+                # MainPkg ships a copy of the registered package `Example` in a subdirectory
+                # and points at it with `[sources]`, like KernelAbstractions does for
+                # KernelInterface.
+                mkpath(joinpath(main, "src"))
+                mkpath(joinpath(main, "lib", "Example", "src"))
+                write(
+                    joinpath(main, "Project.toml"), """
+                    name = "MainPkg"
+                    uuid = "$main_uuid"
+                    version = "0.1.0"
+
+                    [deps]
+                    Example = "$example_uuid"
+
+                    [sources]
+                    Example = {path = "lib/Example"}
+                    """
+                )
+                write(joinpath(main, "src", "MainPkg.jl"), "module MainPkg\nusing Example\nend")
+                write(
+                    joinpath(main, "lib", "Example", "Project.toml"), """
+                    name = "Example"
+                    uuid = "$example_uuid"
+                    version = "999.0.0-dev"
+                    """
+                )
+                write(joinpath(main, "lib", "Example", "src", "Example.jl"), "module Example end")
+                git_init_and_commit(main)
+
+                Pkg.activate(joinpath(tmp, "env"))
+                # Adding the registered `Example` alongside `MainPkg` used to error with
+                # "could not find source path for package Example based on manifest ..."
+                Pkg.add(
+                    [
+                        PackageSpec(name = "Example", uuid = example_uuid),
+                        PackageSpec(url = make_file_url(main)),
+                    ]
+                )
+                manifest = Pkg.Types.read_manifest(joinpath(tmp, "env", "Manifest.toml"))
+                # `Example` stays tracked by the registry, not by MainPkg's `[sources]` path
+                # (the vendored copy carries an impossible version so a regression that
+                # resolves to it is also caught by the version check below)
+                @test manifest[example_uuid].path === nothing
+                @test manifest[example_uuid].tree_hash !== nothing
+                @test manifest[example_uuid].version < v"999"
+                @test !haskey(Pkg.project().sources, "Example")
+                @test manifest[main_uuid].repo.source !== nothing
+            end
+        end
+    end
 end
 
 end # module


### PR DESCRIPTION
<!-- BACKPORTER:BEGIN -->
Backported PRs:
- [x] #4739 <!-- Keep the project's own manifest entry in sync with its deps -->
- [x] #4753 <!-- also allow adding packages that has weak deps not in a known registry -->
- [x] #4693 <!-- Handle stale manifest entries for `[sources]` -->
- [x] #4756 <!-- Don't let a dependency's [sources] override already-tracked packages -->
- [x] #4763 <!-- avoid apps breaking on Windows on julia paths with space -->

Non-merged PRs with backport label:
- [ ] #4757 <!-- artifacts: tear down the progress bar when installation is interrupted -->
- [ ] #4758 <!-- artifacts: cancel in-flight downloads when installation is interrupted -->
- [ ] #4762 <!-- Make `atomic_toml_write()` preserve the process umask -->

_Updated 2026-09-09 07:36 UTC by [Backporter](https://github.com/KristofferC/Backporter)._
<!-- BACKPORTER:END -->