### PR TITLE
sources: resolve a stdlib tracking a repo instead of using the bundled copy

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -131,6 +131,9 @@ end
 function source_path(manifest_file::String, pkg::Union{PackageSpec, PackageEntry}, julia_version = VERSION)
     return pkg.tree_hash !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
         pkg.path !== nothing ? normpath(joinpath(dirname(manifest_file), pkg.path)) :
+        # a stdlib tracking a repo (a `[sources]` url) lives in the checkout of that repo,
+        # which is `nothing` until the repo has been fetched, not the bundled stdlib
+        pkg.repo.source !== nothing ? nothing :
         is_or_was_stdlib(pkg.uuid, julia_version) ? Types.stdlib_path(pkg.name) :
         nothing
 end

--- a/test/sources.jl
+++ b/test/sources.jl
@@ -156,6 +156,36 @@ temp_pkg_dir() do project_path
 
     # Regression test for https://github.com/JuliaLang/Pkg.jl/issues/4337
     # Switching between path and repo sources should not cause assertion error
+    @testset "[sources] url for a stdlib, resolved from scratch" begin
+        # `source_path` used to answer with the bundled stdlib for a stdlib tracking a repo, so
+        # the repo was never fetched and the manifest entry had a source but no tree hash
+        mktempdir() do tmp
+            cd(tmp) do
+                base64_uuid = UUID("2a0f44e3-6c83-55bd-87e4-b1978d98bd5f")
+                cp(joinpath(Sys.STDLIB, "Base64"), "Base64")
+                chmod("Base64", 0o755; recursive = true)
+                git_init_and_commit("Base64")
+                write(
+                    "Project.toml", """
+                    [deps]
+                    Base64 = "$base64_uuid"
+
+                    [sources]
+                    Base64 = { url = "$(make_file_url(abspath("Base64")))" }
+                    """
+                )
+                with_current_env() do
+                    Pkg.instantiate()
+                    manifest = Pkg.Types.read_manifest("Manifest.toml")
+                    @test manifest[base64_uuid].tree_hash !== nothing
+                    @test manifest[base64_uuid].repo.source !== nothing
+                    @test Pkg.dependencies()[base64_uuid].source != Pkg.Types.stdlib_path("Base64")
+                    Pkg.instantiate() # and again, with the manifest in place
+                end
+            end
+        end
+    end
+
     @testset "switching between path and repo sources (#4337)" begin
         mktempdir() do tmp
             cd(tmp) do


### PR DESCRIPTION
I can't imagine this being needed outside of CI for stdlib repos during PR development, but nice to make that work.

Claude:

---

A `[sources]` entry pointing a stdlib at a git repository could not be resolved from scratch: with no manifest, `Pkg.instantiate()` failed with `AssertionError: !(entry.repo.source !== nothing && entry.tree_hash === nothing)` while writing the manifest. `Pkg.add(url = ...)` of the same stdlib worked, and so did instantiating once that manifest existed.

`source_path` answered with the bundled stdlib for any stdlib without a tree hash, including one tracking a repo, so `collect_fixed!` saw an existing path and never fetched the repo; the manifest entry it produced had a source but no tree hash. It now falls back to the bundled stdlib only for a stdlib that tracks no repo. For one that does, the path is `nothing` until the repo has been fetched, which is what `collect_fixed!` and the instantiate check for stale sources already expect.

Test: a local git copy of `Base64` as the url of a `[sources]` entry, instantiated from scratch; it fails with the assertion above without the fix.

Found while pointing Pkg's own `[sources]` at JuliaLang/Downloads.jl#299 for #4775's CI.
